### PR TITLE
indentation issue in example

### DIFF
--- a/_docs/reference/config/istio.networking.v1alpha3.html
+++ b/_docs/reference/config/istio.networking.v1alpha3.html
@@ -1201,9 +1201,9 @@ spec:
   - match:
     - uri:
         exact: /v1/getProductRatings
-  redirect:
-    uri: /v1/bookRatings
-    authority: newratings.default.svc.cluster.local
+    redirect:
+      uri: /v1/bookRatings
+      authority: newratings.default.svc.cluster.local
   ...
 </code></pre>
 


### PR DESCRIPTION
There's a little mistake with the indentation in the `HTTPRedirect`. The `redirect:` entry should be at the same level as `- uri:`