### PR TITLE
add golang vanity redirects to netlify config

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,7 @@
+/istio/* go-get=1 /golang/istio.html 200
+/fortio/* go-get=1 /golang/fortio.html 200
+/api/* go-get=1 /golang/api.html 200
+/gogo-genproto/* go-get=1 /golang/gogo-genproto.html 200
+/extensions/* go-get=1 /golang/extensions.html 200
+/contrib/* go-get=1 /golang/contrib.html 200
+/test-infra/* go-get=1 /golang/test-infra.html 200

--- a/static/golang/api.html
+++ b/static/golang/api.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="istio.io/api git https://github.com/istio/api">
+    <meta name="go-source" content="istio.io/api     https://github.com/istio/api https://github.com/istio/api/tree/master{/dir} https://github.com/istio/api/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/contrib.html
+++ b/static/golang/contrib.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="istio.io/contrib git https://github.com/istio/contrib">
+    <meta name="go-source" content="istio.io/contrib     https://github.com/istio/contrib https://github.com/istio/contrib/tree/master{/dir} https://github.com/istio/contrib/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/extensions.html
+++ b/static/golang/extensions.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="istio.io/extensions git https://github.com/istio/extensions">
+    <meta name="go-source" content="istio.io/extensions     https://github.com/istio/extensions https://github.com/istio/extensions/tree/master{/dir} https://github.com/istio/extensions/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/fortio.html
+++ b/static/golang/fortio.html
@@ -1,0 +1,6 @@
+<html><head>
+    <meta name="go-import" content="istio.io/fortio git https://github.com/istio/fortio">
+    <meta name="go-source" content="istio.io/fortio     https://github.com/istio/fortio https://github.com/istio/fortio/tree/master{/dir} https://github.com/istio/fortio/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="istio.io/fortio/vendor git https://github.com/istio/vendor-fortio">
+    <meta name="go-source" content="istio.io/fortio/vendor     https://github.com/istio/vendor-fortio https://github.com/istio/vendor-fortio/tree/master{/dir} https://github.com/istio/vendor-fortio/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/gogo-genproto.html
+++ b/static/golang/gogo-genproto.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="istio.io/gogo-genproto git https://github.com/istio/gogo-genproto">
+    <meta name="go-source" content="istio.io/gogo-genproto     https://github.com/istio/gogo-genproto https://github.com/istio/gogo-genproto/tree/master{/dir} https://github.com/istio/gogo-genproto/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/istio.html
+++ b/static/golang/istio.html
@@ -1,0 +1,6 @@
+<html><head>
+    <meta name="go-import" content="istio.io/istio git https://github.com/istio/istio">
+    <meta name="go-source" content="istio.io/istio     https://github.com/istio/istio https://github.com/istio/istio/tree/master{/dir} https://github.com/istio/istio/blob/master{/dir}/{file}#L{line}">
+    <meta name="go-import" content="istio.io/istio/vendor git https://github.com/istio/vendor-istio">
+    <meta name="go-source" content="istio.io/istio/vendor     https://github.com/istio/vendor-istio https://github.com/istio/vendor-istio/tree/master{/dir} https://github.com/istio/vendor-istio/blob/master{/dir}/{file}#L{line}">
+</head></html>

--- a/static/golang/test-infra.html
+++ b/static/golang/test-infra.html
@@ -1,0 +1,4 @@
+<html><head>
+    <meta name="go-import" content="istio.io/test-infra git https://github.com/istio/test-infra">
+    <meta name="go-source" content="istio.io/test-infra     https://github.com/istio/test-infra https://github.com/istio/test-infra/tree/master{/dir} https://github.com/istio/test-infra/blob/master{/dir}/{file}#L{line}">
+</head></html>


### PR DESCRIPTION
Let's verify redirects are working on istio.io (release-0.8) first. Then we can backport to master so subsequent releases have the proper settings.