### PR TITLE
Add a note about mTLS in the Circuit Breaking task

### DIFF
--- a/content/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -40,6 +40,8 @@ configuration by intentionally "tripping" the circuit breaker.
 1.  Create a [destination rule](/docs/reference/config/istio.networking.v1alpha3/#DestinationRule) to apply circuit breaking settings
 when calling the `httpbin` service:
 
+    > If you installed/configured Istio with mutual TLS Authentication enabled, you must add a TLS traffic policy `mode: ISTIO_MUTUAL` to the `DestinationRule` before applying it. Otherwise requests will generate 503 errors as described [here](/help/ops/traffic-management/deploy-guidelines/#503-errors-after-setting-destination-rule).
+
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -f -
     apiVersion: networking.istio.io/v1alpha3

--- a/content/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/docs/tasks/traffic-management/mirroring/index.md
@@ -125,6 +125,8 @@ In this step, you will change that behavior so that all traffic goes to `v1`.
 
 1.  Create a default route rule to route all traffic to `v1` of the service:
 
+    > If you installed/configured Istio with mutual TLS Authentication enabled, you must add a TLS traffic policy `mode: ISTIO_MUTUAL` to the `DestinationRule` before applying it. Otherwise requests will generate 503 errors as described [here](/help/ops/traffic-management/deploy-guidelines/#503-errors-after-setting-destination-rule).
+
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -f -
     apiVersion: networking.istio.io/v1alpha3
@@ -156,8 +158,6 @@ In this step, you will change that behavior so that all traffic goes to `v1`.
           version: v2
     EOF
     {{< /text >}}
-
-    > NOTE: If you installed/configured Istio with mutual TLS Authentication enabled, you must add the [TLSSettings.TLSmode]( /docs/reference/config/istio.networking.v1alpha3/#TLSSettings-TLSmode), `mode: ISTIO_MUTUAL` as noted in the [TLSSettings](/docs/reference/config/istio.networking.v1alpha3/#TLSSettings) reference.
 
     Now all traffic goes to the `httpbin v1` service.
 


### PR DESCRIPTION
If mTLS is enabled we need an additional instruction in the
DestinationRule object, otherwise we break traffic to httpbin
service.
    
While on that, also change the Mirroring task note to be the same.