### PR TITLE
Added default mTLS behavior with no MeshPolicy.

### DIFF
--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -367,7 +367,9 @@ namespace. Policies in mesh-scope can affect all services in the mesh. To
 prevent conflict and misuse, only one policy can be defined in mesh-scope
 storage. That policy must be named `default` and have an empty
 `targets:` section. You can find more information on our
-[target selectors section](/docs/concepts/security/#target-selectors).
+[target selectors section](/docs/concepts/security/#target-selectors). By
+default if a mesh-scoped policy is not installed, mutual TLS is considered
+disabled.
 
 Kubernetes currently implements the Istio configuration on Custom Resource
 Definitions (CRDs). These CRDs correspond to namespace-scope and


### PR DESCRIPTION
Fixes #2542

The default mutual TLS behavior when no MeshPolicy is defined is implied, but
not explicitly documented. This default behavior documentation has been added
under Concepts -> Security -> Authentication in the Policy storage scope
section.