### PR TITLE
add apply destination rule section for traffic management

### DIFF
--- a/content/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/docs/tasks/traffic-management/request-routing/index.md
@@ -39,21 +39,13 @@ In this case, the virtual services will route all traffic to `v1` of each micros
 1.  Run the following command to apply the virtual services:
 
     {{< text bash >}}
-    $ kubectl apply -f @samples/bookinfo/networking/destination-rule-all.yaml@
-    {{< /text >}}
-
-    If you have enabled 'mTLS', please run below command instead:
-
-    {{< text bash >}}
-    $ kubectl apply -f @samples/bookinfo/networking/destination-rule-all-mtls.yaml@
-    {{< /text >}}
-
-    {{< text bash >}}
     $ kubectl apply -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
     {{< /text >}}
 
     Because configuration propagation is eventually consistent, wait a few seconds
     for the virtual services to take effect.
+
+    __NOTE__: If you haven't already applied destination rules, follow the [apply the default destination rules instructions](/docs/examples/bookinfo/#apply-default-destination-rules/).
 
 1. Display the defined routes with the following command:
 

--- a/content/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/docs/tasks/traffic-management/request-routing/index.md
@@ -45,7 +45,7 @@ In this case, the virtual services will route all traffic to `v1` of each micros
     Because configuration propagation is eventually consistent, wait a few seconds
     for the virtual services to take effect.
 
-    __NOTE__: If you haven't already applied destination rules, follow the [Apply default destination rules](/docs/examples/bookinfo/#apply-default-destination-rules).
+    {{< idea_icon >}} If you haven't already applied destination rules, follow follow the instructions in [Apply Default Destination Rules](/docs/examples/bookinfo/#apply-default-destination-rules).
 
 1. Display the defined routes with the following command:
 

--- a/content/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/docs/tasks/traffic-management/request-routing/index.md
@@ -46,7 +46,7 @@ In this case, the virtual services will route all traffic to `v1` of each micros
 
     {{< text bash >}}
     $ kubectl apply -f @samples/bookinfo/networking/destination-rule-all-mtls.yaml@
-    {{< /text >
+    {{< /text >}}
 
     {{< text bash >}}
     $ kubectl apply -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@

--- a/content/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/docs/tasks/traffic-management/request-routing/index.md
@@ -39,6 +39,16 @@ In this case, the virtual services will route all traffic to `v1` of each micros
 1.  Run the following command to apply the virtual services:
 
     {{< text bash >}}
+    $ kubectl apply -f @samples/bookinfo/networking/destination-rule-all.yaml@
+    {{< /text >}}
+
+    If you have enabled 'mTLS', please run below command instead:
+
+    {{< text bash >}}
+    $ kubectl apply -f @samples/bookinfo/networking/destination-rule-all-mtls.yaml@
+    {{< /text >
+
+    {{< text bash >}}
     $ kubectl apply -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
     {{< /text >}}
 

--- a/content/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/docs/tasks/traffic-management/request-routing/index.md
@@ -45,7 +45,7 @@ In this case, the virtual services will route all traffic to `v1` of each micros
     Because configuration propagation is eventually consistent, wait a few seconds
     for the virtual services to take effect.
 
-    __NOTE__: If you haven't already applied destination rules, follow the [apply the default destination rules instructions](/docs/examples/bookinfo/#apply-default-destination-rules/).
+    __NOTE__: If you haven't already applied destination rules, follow the [Apply default destination rules](/docs/examples/bookinfo/#apply-default-destination-rules).
 
 1. Display the defined routes with the following command:
 


### PR DESCRIPTION
Many users are having issues when trying istio traffic management guide as we have not added the destination rule part: eg: https://github.com/istio/istio/issues/8660,

this PR is used for adding this info.