### PR TITLE
Fix match expression in the TCP metrics guide

### DIFF
--- a/content/docs/tasks/telemetry/tcp-metrics/index.md
+++ b/content/docs/tasks/telemetry/tcp-metrics/index.md
@@ -90,7 +90,7 @@ will generate and collect automatically.
       namespace: default
     spec:
       match: context.protocol == "tcp"
-             && destination.service == "mongodb.default.svc.cluster.local"
+             && destination.service.host == "mongodb.default.svc.cluster.local"
       actions:
       - handler: mongohandler.prometheus
         instances:

--- a/content_zh/docs/tasks/telemetry/tcp-metrics/index.md
+++ b/content_zh/docs/tasks/telemetry/tcp-metrics/index.md
@@ -81,7 +81,7 @@ keywords: [遥测,指标,tcp]
       namespace: default
     spec:
       match: context.protocol == "tcp"
-             && destination.service == "mongodb.default.svc.cluster.local"
+             && destination.service.host == "mongodb.default.svc.cluster.local"
       actions:
       - handler: mongohandler.prometheus
         instances:


### PR DESCRIPTION
The `destination.service` attribute is being deprecated in the favor of `destination.service.host`. This PR updates the match expression in the [TCP metrics guide](https://istio.io/docs/tasks/telemetry/tcp-metrics/) to reflect the same.

Signed-off-by: Venil Noronha <veniln@vmware.com>

See istio/istio#9125 for more information.

/cc @kyessenov @mandarjog 