### PR TITLE
broke up long command line

### DIFF
--- a/content/docs/tasks/traffic-management/egress/index.md
+++ b/content/docs/tasks/traffic-management/egress/index.md
@@ -210,7 +210,8 @@ The values used for internal IP range(s), however, depends on where your cluster
 For example, with Minikube the range is 10.0.0.1&#47;24, so you would update your `ConfigMap` _istio-sidecar-injector_ like this:
 
 {{< text bash >}}
-$ helm template install/kubernetes/helm/istio <the flags you used to install Istio> --set global.proxy.includeIPRanges="10.0.0.1/24" -x templates/sidecar-injector-configmap.yaml | kubectl apply -f -
+$ helm template install/kubernetes/helm/istio <the flags you used to install Helm> --set global.proxy.includeIPRanges="10.0.0.1/24" -x templates/sidecar-injector-configmap.yaml
+$ kubectl apply -f /tmp/istio.yaml
 {{< /text >}}
 
 Note that you should use the same Helm command you used [to install Istio](/docs/setup/kubernetes/helm-install),


### PR DESCRIPTION
At the suggestion of mjog@google.com, I broke the long helm command into two separate commands. I also changed "<the flags you used to install Istio>" to "<the flags you used to install Helm>" because I didn't use Helm to install Istio, and I found that confusing.

Signed-off-by: Nancy Avinger <navinger@google.com>