### PR TITLE
Fix feature status of multicluster mesh

### DIFF
--- a/content/about/feature-stages/index.md
+++ b/content/about/feature-stages/index.md
@@ -82,7 +82,7 @@ Below is our list of existing features and their current phases. This informatio
 | [Attribute Expression Language](/docs/reference/config/policy-and-telemetry/expression-language/)        | Stable
 | [Mixer Adapter Authoring Model](/blog/2017/adapter-model/)        | Stable
 | [Helm](/docs/setup/kubernetes/helm-install/) | Beta
-| [Multicluster Mesh](/docs/setup/kubernetes/multicluster-install/) | Beta
+| [Multicluster Mesh over VPN](/docs/setup/kubernetes/multicluster-install/) | Alpha
 | [Kubernetes: Istio Control Plane Upgrade](/docs/setup/kubernetes/) | Beta
 | [Consul Integration](/docs/setup/consul/quick-start/) | Alpha
 | [Cloud Foundry Integration](/docs/setup/consul/quick-start/)    | Alpha


### PR DESCRIPTION
It says its in Beta, which I think was accidental.
Given that this area is evolving a lot, demoting it to alpha as it doesn't satisfy the beta conditions (of production usage) as there is no DNS solution/doc, no Istio policy starting with DNS, lack of mixer policies, and scale issues in Pilot.