### PR TITLE
feat: reflect option name chage for kubernetes 1.10

### DIFF
--- a/content/docs/setup/kubernetes/platform-setup/aws/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/aws/index.md
@@ -63,9 +63,20 @@ Nevertheless, you must update the list of admission controllers.
 
 1. Review the output:
 
+    Kubernetes up to 1.9:
     {{< text plain >}}
     [...]
     --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,
+    PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,
+    MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,
+    NodeRestriction,Priority
+    [...]
+    {{< /text >}}
+
+    Kubernetes 1.10+:
+    {{< text plain >}}
+    [...]
+    --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,
     PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,
     MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,
     NodeRestriction,Priority

--- a/content_zh/docs/setup/kubernetes/platform-setup/aws/index.md
+++ b/content_zh/docs/setup/kubernetes/platform-setup/aws/index.md
@@ -62,9 +62,20 @@ keywords: [platform-setup,aws]
 
 1. 查看输出内容：
 
+    Kubernetes up to 1.9:
     {{< text plain >}}
     [...]
     --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,
+    PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,
+    MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,
+    NodeRestriction,Priority
+    [...]
+    {{< /text >}}
+
+    Kubernetes 1.10+:
+    {{< text plain >}}
+    [...]
+    --enable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,
     PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,
     MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,
     NodeRestriction,Priority


### PR DESCRIPTION
The `apiserver` option `--admission-control` was changed to `--enable-admission-plugins` in Kubernetes 1.10+ (https://github.com/kubernetes/apiserver/commit/b6363117087119b67c0c72ba06b101e69c2f628f#diff-1dd232fa2a447fdcb464a4682d43fedf).

I know nothing of the Chinese language, so, if you can help, let me know to properly update the titles :)
