### PR TITLE
enable RBAC on Minikube

### DIFF
--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -35,5 +35,11 @@ Follow these instructions to prepare Minikube for Istio.
     $ minikube start --memory=8192 --cpus=4 --kubernetes-version=v1.10.0 \
         --extra-config=controller-manager.cluster-signing-cert-file="/var/lib/localkube/certs/ca.crt" \
         --extra-config=controller-manager.cluster-signing-key-file="/var/lib/localkube/certs/ca.key" \
+        --extra-config=apiserver.Authorization.Mode=RBAC \
         --vm-driver=`your_vm_driver_choice`
     {{< /text >}}
+    
+    {{< text bash >}}
+    $ kubectl create clusterrolebinding add-on-cluster-admin --clusterrole=cluster-admin \
+      --serviceaccount=kube-system:default
+    {{< /text >}} 


### PR DESCRIPTION
RBAC on Minikube must be enabled, otherwise helm deployment fails:
```
$ helm install istio-1.0.2/install/kubernetes/helm/istio --name istio --namespace istio-system --set gateways.istio-ingressgateway.type=NodePort --set gateways.istio-egressgateway.type=NodePort
Error: release istio failed: clusterroles.rbac.authorization.k8s.io "istio-galley-istio-system" is forbidden: attempt to grant extra privileges: [PolicyRule{APIGroups:["admissionregistration.k8s.io"], Resources:["validatingwebhookconfigurations"], Verbs:["*"]} PolicyRule{APIGroups:["config.istio.io"], Resources:["*"], Verbs:["get"]} PolicyRule{APIGroups:["config.istio.io"], Resources:["*"], Verbs:["list"]} PolicyRule{APIGroups:["config.istio.io"], Resources:["*"], Verbs:["watch"]} PolicyRule{APIGroups:["*"], Resources:["deployments"], ResourceNames:["istio-galley"], Verbs:["get"]} PolicyRule{APIGroups:["*"], Resources:["endpoints"], ResourceNames:["istio-galley"], Verbs:["get"]}] user=&{system:serviceaccount:kube-system:default 82687c9f-adff-11e7-8299-080027cd3244 [system:serviceaccounts system:serviceaccounts:kube-system system:authenticated] map[]} ownerrules=[] ruleResolutionErrors=[]```

Once RBAC is enable and cluster-admin role is bound to the `kube-system`, helm deployment seems to work well
```
$ helm install istio-1.0.2/install/kubernetes/helm/istio --name istio --namespace istio-system --set gateways.istio-ingressgateway.type=NodePort --set gateways.istio-egressgateway.type=NodePort
NAME:   istio
LAST DEPLOYED: Wed Oct 10 12:24:00 2018
NAMESPACE: istio-system
STATUS: DEPLOYED
....
```
