### PR TITLE
refs: add Wavefront to adapters list

### DIFF
--- a/content/docs/reference/config/policy-and-telemetry/adapters/wavefront/index.html
+++ b/content/docs/reference/config/policy-and-telemetry/adapters/wavefront/index.html
@@ -1,0 +1,320 @@
+---
+title: Wavefront by VMware
+description: Adapter to deliver metrics to Wavefront by VMware.
+location: https://istio.io/docs/reference/config/policy-and-telemetry/adapters/wavefront.html
+layout: protoc-gen-docs
+generator: protoc-gen-docs
+provider: VMware, Inc.
+contact_email: veniln@vmware.com
+support_link:
+source_link: https://github.com/vmware/wavefront-adapter-for-istio
+latest_release_link: https://github.com/vmware/wavefront-adapter-for-istio/releases/tag/0.1.0
+helm_chart_link:
+istio_versions: "1.0.1"
+supported_templates: metric
+logo_link: https://github.com/vmware/wavefront-adapter-for-istio/raw/master/docs/images/logo.png
+number_of_entries: 8
+---
+<p>The <code>wavefront</code> adapter collects metrics and makes them available to
+<a href="https://www.wavefront.com/">Wavefront by VMware</a>.</p>
+
+<p>This adapter supports the <a href="/docs/reference/config/policy-and-telemetry/templates/metric/">metric template</a>.</p>
+
+<h2 id="Params">Params</h2>
+<section>
+<p>Configuration format for the <code>wavefront</code> adapter.</p>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="Params-direct" class="oneof oneof-start">
+<td><code>direct</code></td>
+<td><code><a href="#Params-WavefrontDirect">Params.WavefrontDirect (oneof)</a></code></td>
+<td>
+<p>The credentials for direct ingestion.</p>
+
+</td>
+</tr>
+<tr id="Params-proxy" class="oneof">
+<td><code>proxy</code></td>
+<td><code><a href="#Params-WavefrontProxy">Params.WavefrontProxy (oneof)</a></code></td>
+<td>
+<p>The credentials for ingestion via a Wavefront Proxy.</p>
+
+</td>
+</tr>
+<tr id="Params-flush_interval">
+<td><code>flushInterval</code></td>
+<td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">google.protobuf.Duration</a></code></td>
+<td>
+<p>The metrics flush interval.</p>
+
+</td>
+</tr>
+<tr id="Params-source">
+<td><code>source</code></td>
+<td><code>string</code></td>
+<td>
+<p>The source tag for all metrics handled by this adapter.</p>
+
+</td>
+</tr>
+<tr id="Params-prefix">
+<td><code>prefix</code></td>
+<td><code>string</code></td>
+<td>
+<p>The prefix to prepend all metrics handled by the adapter.</p>
+
+</td>
+</tr>
+<tr id="Params-metrics">
+<td><code>metrics</code></td>
+<td><code><a href="#Params-MetricInfo">Params.MetricInfo[]</a></code></td>
+<td>
+<p>The set of metrics to publish to Wavefront.</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="Params-MetricInfo">Params.MetricInfo</h2>
+<section>
+<p>Describes how a metric should be represented on Wavefront.</p>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="Params-MetricInfo-name">
+<td><code>name</code></td>
+<td><code>string</code></td>
+<td>
+<p>The metric name.</p>
+
+</td>
+</tr>
+<tr id="Params-MetricInfo-type">
+<td><code>type</code></td>
+<td><code><a href="#Params-MetricInfo-Type">Params.MetricInfo.Type</a></code></td>
+<td>
+<p>The metric type.</p>
+
+</td>
+</tr>
+<tr id="Params-MetricInfo-sample">
+<td><code>sample</code></td>
+<td><code><a href="#Params-MetricInfo-Sample">Params.MetricInfo.Sample</a></code></td>
+<td>
+<p>For metrics with type HISTOGRAM, this describes the sample definition.</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="Params-MetricInfo-Sample">Params.MetricInfo.Sample</h2>
+<section>
+<p>Describes a sample as in the <a href="https://github.com/rcrowley/go-metrics">rcrowley/go-metrics</a> library.</p>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="Params-MetricInfo-Sample-exp_decay" class="oneof oneof-start">
+<td><code>expDecay</code></td>
+<td><code><a href="#Params-MetricInfo-Sample-ExpDecay">Params.MetricInfo.Sample.ExpDecay (oneof)</a></code></td>
+<td>
+<p>Definition of an exponentially decaying sample.</p>
+
+</td>
+</tr>
+<tr id="Params-MetricInfo-Sample-uniform" class="oneof">
+<td><code>uniform</code></td>
+<td><code><a href="#Params-MetricInfo-Sample-Uniform">Params.MetricInfo.Sample.Uniform (oneof)</a></code></td>
+<td>
+<p>Definition of a uniform sample.</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="Params-MetricInfo-Sample-ExpDecay">Params.MetricInfo.Sample.ExpDecay</h2>
+<section>
+<p>Describes an exponentially decaying sample.</p>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="Params-MetricInfo-Sample-ExpDecay-reservoir_size">
+<td><code>reservoirSize</code></td>
+<td><code>int32</code></td>
+<td>
+<p>The reservoir size.</p>
+
+</td>
+</tr>
+<tr id="Params-MetricInfo-Sample-ExpDecay-alpha">
+<td><code>alpha</code></td>
+<td><code>double</code></td>
+<td>
+<p>The alpha.</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="Params-MetricInfo-Sample-Uniform">Params.MetricInfo.Sample.Uniform</h2>
+<section>
+<p>Describes a uniform sample.</p>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="Params-MetricInfo-Sample-Uniform-reservoir_size">
+<td><code>reservoirSize</code></td>
+<td><code>int32</code></td>
+<td>
+<p>The reservoir size</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="Params-MetricInfo-Type">Params.MetricInfo.Type</h2>
+<section>
+<p>Describes metric types as in <a href="https://docs.wavefront.com/metric_types.html">Wavefront</a>.</p>
+
+<table class="enum-values">
+<thead>
+<tr>
+<th>Name</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="Params-MetricInfo-Type-UNKNOWN">
+<td><code>UNKNOWN</code></td>
+<td>
+<p>Reserved for unknown metric types.</p>
+
+</td>
+</tr>
+<tr id="Params-MetricInfo-Type-GAUGE">
+<td><code>GAUGE</code></td>
+<td>
+<p>Represents a gauge metric type.</p>
+
+</td>
+</tr>
+<tr id="Params-MetricInfo-Type-COUNTER">
+<td><code>COUNTER</code></td>
+<td>
+<p>Represents a counter metric type.</p>
+
+</td>
+</tr>
+<tr id="Params-MetricInfo-Type-DELTA_COUNTER">
+<td><code>DELTA_COUNTER</code></td>
+<td>
+<p>Represents a delta counter metric type.</p>
+
+</td>
+</tr>
+<tr id="Params-MetricInfo-Type-HISTOGRAM">
+<td><code>HISTOGRAM</code></td>
+<td>
+<p>Represents a histogram metric type.</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="Params-WavefrontDirect">Params.WavefrontDirect</h2>
+<section>
+<p>Describes Wavefront Server credentials.</p>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="Params-WavefrontDirect-server">
+<td><code>server</code></td>
+<td><code>string</code></td>
+<td>
+<p>The Wavefront server URL. Ex: https://mydomain.wavefront.com</p>
+
+</td>
+</tr>
+<tr id="Params-WavefrontDirect-token">
+<td><code>token</code></td>
+<td><code>string</code></td>
+<td>
+<p>The Wavefront API token.</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>
+<h2 id="Params-WavefrontProxy">Params.WavefrontProxy</h2>
+<section>
+<p>Describes Wavefront Proxy credentials.</p>
+
+<table class="message-fields">
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr id="Params-WavefrontProxy-address">
+<td><code>address</code></td>
+<td><code>string</code></td>
+<td>
+<p>The wavefront proxy address. Ex: 192.168.99.100:2878</p>
+
+</td>
+</tr>
+</tbody>
+</table>
+</section>

--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -34,6 +34,7 @@ cd istio
 git checkout $ISTIO_BRANCH
 cd ..
 git clone https://github.com/apigee/istio-mixer-adapter.git
+git clone https://github.com/vmware/wavefront-adapter-for-istio.git
 popd
 
 # Given the name of a .pb.html file, extracts the $location marker and then proceeds to
@@ -100,6 +101,12 @@ do
 done
 
 for f in `find $WORK_DIR/istio-mixer-adapter -type f -name '*.pb.html'`
+do
+    echo "processing $f"
+    locate_file ${f}
+done
+
+for f in `find $WORK_DIR/wavefront-adapter-for-istio -type f -name '*.pb.html'`
 do
     echo "processing $f"
     locate_file ${f}


### PR DESCRIPTION
This PR updates the `grab_reference_docs.sh` script to fetch docs for the Wavefront by VMware adapter in order to publish it under the adapters list.