### PR TITLE
Instructions apply productpage, but deletes ratings yaml

### DIFF
--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -402,7 +402,7 @@ namespace.
 1. If using `memquota`, remove the `memquota` rate limit configuration:
 
     {{< text bash >}}
-    $ kubectl delete -f @samples/bookinfo/policy/mixer-rule-ratings-ratelimit.yaml@
+    $ kubectl delete -f @samples/bookinfo/policy/mixer-rule-productpage-ratelimit.yaml@
     {{< /text >}}
 
     Or


### PR DESCRIPTION
The instructions applies `mixer-rule-productpage-ratelimit.yaml`, but deletes `mixer-rule-ratings-ratelimit.yaml` during cleanup.  Changed cleanup reference to delete `mixer-rule-productpage-ratelimit.yaml` as well.