### PR TITLE
Fixing curl command to set debug mode for proxy

### DIFF
--- a/content/help/ops/security/debugging-authorization/index.md
+++ b/content/help/ops/security/debugging-authorization/index.md
@@ -178,7 +178,7 @@ otherwise you should replace `"-l app=productpage"` with your actual pod.
 1. Turn on the authorization debug logging in proxy with the following command:
 
     {{< text bash >}}
-    $ kubectl exec  $(kubectl get pods -l app=productpage -o jsonpath='{.items[0].metadata.name}') -c istio-proxy -- curl localhost:15000/logging?rbac=debug -s
+    $ kubectl exec  $(kubectl get pods -l app=productpage -o jsonpath='{.items[0].metadata.name}') -c istio-proxy -- curl -X POST localhost:15000/logging?rbac=debug -s
     {{< /text >}}
 
 1. Verify you see the following output:


### PR DESCRIPTION
Trivial MR: curl command for setting debug mode for proxy should be a POST not a GET