### PR TITLE
[WIP] remove references to envoyproxy.io api-v1

### DIFF
--- a/content/about/notes/1.0.1/index.md
+++ b/content/about/notes/1.0.1/index.md
@@ -16,7 +16,7 @@ This release addresses some critical issues found by the community when using Is
 
 - Added limited support for [merging multiple virtual service or destination rule definitions](/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host) for the same host.
 
-- Allow [outlier](https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/cluster_outlier_detection.html) consecutive gateway failures when using HTTP.
+- Allow [outlier](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/outlier.html) consecutive gateway failures when using HTTP.
 
 ## Environment
 

--- a/content/docs/concepts/traffic-management/index.md
+++ b/content/docs/concepts/traffic-management/index.md
@@ -75,7 +75,7 @@ Kubernetes API server for changes to the pod registration information, ingress
 resources, and third-party resources that store traffic management rules.
 This data is translated into the canonical representation. An Envoy-specific configuration is then generated based on the canonical representation.
 
-Pilot enables [service discovery](https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/sds),
+Pilot enables [service discovery](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/service_discovery#arch-overview-service-discovery-types-eds),
 dynamic updates to [load balancing pools](https://www.envoyproxy.io/docs/envoy/latest/configuration/cluster_manager/cds)
 and [routing tables](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/rds).
 

--- a/content_zh/about/notes/1.0.1/index.md
+++ b/content_zh/about/notes/1.0.1/index.md
@@ -14,7 +14,7 @@ icon: notes
 
 - 添加了同一个主机内对 [合并多个 `VirtualService` 或 `DestinationRule` 定义](/help/ops/traffic-management/deploy-guidelines/#multiple-virtual-services-and-destination-rules-for-the-same-host) 的有限支持。
 
-- 允许在使用 HTTP 时，连续的出现 Gateway failures [outlier](https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/cluster_outlier_detection.html) 。
+- 允许在使用 HTTP 时，连续的出现 Gateway failures [outlier](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/outlier.html) 。
 
 ## 环境
 

--- a/content_zh/docs/concepts/traffic-management/index.md
+++ b/content_zh/docs/concepts/traffic-management/index.md
@@ -35,7 +35,7 @@ Pilot 负责管理通过 Istio 服务网格发布的 Envoy 实例的生命周期
 
 如上图所示，在网格中 Pilot 维护了一个服务的规则表示并独立于底层平台。Pilot中的特定于平台的适配器负责适当地填充这个规范模型。例如，在 Pilot 中的 Kubernetes 适配器实现了必要的控制器，来观察 Kubernetes API 服务器，用于更改 pod 的注册信息、入口资源以及存储流量管理规则的第三方资源。这些数据被转换为规范表示。然后根据规范表示生成特定的 Envoy 的配置。
 
-Pilot 公开了用于[服务发现](https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/sds) 、[负载均衡池](https://www.envoyproxy.io/docs/envoy/latest/configuration/cluster_manager/cds)和[路由表](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/rds)的动态更新的 API。
+Pilot 公开了用于[服务发现](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/service_discovery#arch-overview-service-discovery-types-eds) 、[负载均衡池](https://www.envoyproxy.io/docs/envoy/latest/configuration/cluster_manager/cds)和[路由表](https://www.envoyproxy.io/docs/envoy/latest/configuration/http_conn_man/rds)的动态更新的 API。
 
 运维人员可以通过 [Pilot 的 Rules API](/zh/docs/reference/config/istio.networking.v1alpha3/) 指定高级流量管理规则。这些规则被翻译成低级配置，并通过 discovery API 分发到 Envoy 实例。
 


### PR DESCRIPTION
in the latest envoyproxy.io (1.9) api-v1 was removed

dependent on https://github.com/istio/api/pull/694