### PR TITLE
Remove the canned credentials in Kiali Task instructions.

### DIFF
--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -24,13 +24,13 @@ authenticate to Kiali.
 
 First define the credentials you want to use for the Kiali username and passphrase:
 
-```bash
-KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo $uval | base64)
-```
+{{< text bash >}}
+$ KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo $uval | base64)
+{{< /text >}}
 
-```bash
-KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo $pval | base64)
-```
+{{< text bash >}}
+$ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo $pval | base64)
+{{< /text >}}
 
 And then run the following commands to create a secret:
 

--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -25,11 +25,11 @@ authenticate to Kiali.
 First, define the credentials you want to use as the Kiali username and passphrase:
 
 {{< text bash >}}
-$ KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo $uval | base64)
+$ KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo -n $uval | base64)
 {{< /text >}}
 
 {{< text bash >}}
-$ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo $pval | base64)
+$ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo -n $pval | base64)
 {{< /text >}}
 
 To create a secret, run the following commands:

--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -20,9 +20,7 @@ This task uses the [Bookinfo](/docs/examples/bookinfo/) sample application as th
 To install Kiali without using Helm, following the [Kiali install instructions](https://www.kiali.io/gettingstarted/).
 
 Create a secret in your Istio namespace with the credentials that you use to
-authenticate to Kiali. See the
-[Helm README](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/README.md#installing-the-chart)
-for details.
+authenticate to Kiali.
 
 First define the credentials you want to use for the Kiali username and passphrase:
 

--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -22,7 +22,7 @@ To install Kiali without using Helm, following the [Kiali install instructions](
 Create a secret in your Istio namespace with the credentials that you use to
 authenticate to Kiali.
 
-First define the credentials you want to use for the Kiali username and passphrase:
+First, define the credentials you want to use as the Kiali username and passphrase:
 
 {{< text bash >}}
 $ KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo $uval | base64)
@@ -32,7 +32,7 @@ $ KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo $uval | base64)
 $ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo $pval | base64)
 {{< /text >}}
 
-And then run the following commands to create a secret:
+To create a secret, run the following commands:
 
 ```bash
 NAMESPACE=istio-system
@@ -112,7 +112,7 @@ Once you install Istio and Kiali, deploy the [Bookinfo](/docs/examples/bookinfo/
 
 1.  Visit <http://localhost:20001> in your web browser.
 
-1.  To log into the Kiali UI, enter the username and passphrase you stored in the Kiali secret in the Kiali login screen.
+1.  To log into the Kiali UI, go to the Kiali login screen and enter the username and passphrase stored in the Kiali secret.
 
 1.  View the overview of your mesh in the **Overview** page that appears immediately after you log in.
     The **Overview** page displays all the namespaces that have services in your mesh.

--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -22,11 +22,21 @@ To install Kiali without using Helm, following the [Kiali install instructions](
 Create a secret in your Istio namespace with the credentials that you use to
 authenticate to Kiali. See the
 [Helm README](https://github.com/istio/istio/blob/master/install/kubernetes/helm/istio/README.md#installing-the-chart)
-for details. Modify and run the following example commands to create a secret:
+for details.
+
+First define the credentials you want to use for the Kiali username and passphrase:
 
 ```bash
-USERNAME=$(echo -n 'admin' | base64)
-PASSPHRASE=$(echo -n 'mysecret' | base64)
+KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo $uval | base64)
+```
+
+```bash
+KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo $pval | base64)
+```
+
+And then run the following commands to create a secret:
+
+```bash
 NAMESPACE=istio-system
 kubectl create namespace $NAMESPACE
 cat <<EOF | kubectl apply -f -
@@ -39,8 +49,8 @@ metadata:
     app: kiali
 type: Opaque
 data:
-  username: $USERNAME
-  passphrase: $PASSPHRASE
+  username: $KIALI_USERNAME
+  passphrase: $KIALI_PASSPHRASE
 EOF
 ```
 
@@ -104,7 +114,7 @@ Once you install Istio and Kiali, deploy the [Bookinfo](/docs/examples/bookinfo/
 
 1.  Visit <http://localhost:20001> in your web browser.
 
-1.  To log into the Kiali UI, enter the username and passphrase you stored in the Kiali secret in the Kiali login screen. If you used the example secret above, enter a username of `admin` with a passphrase of `mysecret`.
+1.  To log into the Kiali UI, enter the username and passphrase you stored in the Kiali secret in the Kiali login screen.
 
 1.  View the overview of your mesh in the **Overview** page that appears immediately after you log in.
     The **Overview** page displays all the namespaces that have services in your mesh.


### PR DESCRIPTION
So a user can't just copy-n-paste the instructions and always get the same credentials - they have to enter their own username and passphrase.

This is to address concerns brought up in this ML thread: https://groups.google.com/d/msg/istio-dev/3fw3fmf8wgs/e-ZTT-dvDgAJ