### PR TITLE
Add baseURL for develop mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint:
 	$(docker) scripts/lint_site.sh
 
 serve:
-	docker run -t -i --sig-proxy=true --rm -v $(shell pwd):/site -w /site -p 1313:1313 $(img) hugo serve --bind 0.0.0.0 --disableFastRender
+	docker run -t -i --sig-proxy=true --rm -v $(shell pwd):/site -w /site -p 1313:1313 $(img) hugo serve --baseURL "http://localhost:1313/" --bind 0.0.0.0 --disableFastRender
 
 netlify:
 	scripts/gen_site.sh "$(baseurl)"


### PR DESCRIPTION
Add baseURL for `hugo serve` command to have `http://localhost:1313/` instead of `//localhost:1313/`
Before Fix:
`make serve`
```
docker run -t -i --sig-proxy=true --rm -v /Users/clyang/go/src/istio.io/istio.io:/site -w /site -p 1313:1313 gcr.io/istio-testing/website-builder:2018-10-08 hugo serve --bind 0.0.0.0 --disableFastRender

                   | EN  | ZH   
+------------------+-----+-----+
  Pages            | 520 | 503  
  Paginator pages  |   0 |   0  
  Non-page files   | 122 | 119  
  Static files     |  56 |  56  
  Processed images |   0 |   0  
  Aliases          | 139 |   1  
  Sitemaps         |   2 |   1  
  Cleaned          |   0 |   0  

Total in 3563 ms
Watching for changes in /site/{assets,content,content_zh,data,i18n,layouts,static}
Watching for config changes in /site/config.toml
Serving pages from memory
Web Server is available at //localhost:1313/ (bind address 0.0.0.0)
Press Ctrl+C to stop

```

After Fix:
```
docker run -t -i --sig-proxy=true --rm -v /Users/clyang/go/src/istio.io/istio.io:/site -w /site -p 1313:1313 gcr.io/istio-testing/website-builder:2018-10-08 hugo serve --baseURL "http://localhost:1313/" --bind 0.0.0.0 --disableFastRender

                   | EN  | ZH   
+------------------+-----+-----+
  Pages            | 520 | 503  
  Paginator pages  |   0 |   0  
  Non-page files   | 122 | 119  
  Static files     |  56 |  56  
  Processed images |   0 |   0  
  Aliases          | 139 |   1  
  Sitemaps         |   2 |   1  
  Cleaned          |   0 |   0  

Total in 3690 ms
Watching for changes in /site/{assets,content,content_zh,data,i18n,layouts,static}
Watching for config changes in /site/config.toml
Serving pages from memory
Web Server is available at http://localhost:1313/ (bind address 0.0.0.0)
Press Ctrl+C to stop
```

Signed-off-by: clyang82 <clyang@cn.ibm.com>