### PR TITLE
Correct Kiali URL

### DIFF
--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -102,7 +102,7 @@ Once you install Istio and Kiali, deploy the [Bookinfo](/docs/examples/bookinfo/
     $ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=kiali -o jsonpath='{.items[0].metadata.name}') 20001:20001
     {{< /text >}}
 
-1.  Visit https://localhost:20001 in your web browser.
+1.  Visit http://localhost:20001 in your web browser.
 
 1.  To log into the Kiali UI, enter the username and passphrase you stored in the Kiali secret in the Kiali login screen. If you used the example secret above, enter a username of `admin` with a passphrase of `mysecret`.
 


### PR DESCRIPTION
https://preliminary.istio.io/docs/tasks/telemetry/kiali/

The kiali access URL should be http://localhost:20001 instead of https


Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>