### PR TITLE
Clarify scope of consul install

### DIFF
--- a/content/docs/setup/consul/install/index.md
+++ b/content/docs/setup/consul/install/index.md
@@ -86,7 +86,9 @@ achieve high availability, each control plane service could be run as a
 [job](https://www.nomadproject.io/docs/job-specification/index.html) in
 Nomad, where the
 [service stanza](https://www.nomadproject.io/docs/job-specification/service.html)
-can be used to describe the desired properties of the control plane services.
+can be used to describe the desired properties of the control plane services. Some
+of these components may require additional install artifacts to be present in the
+Istio API server to function appropriately.
 
 ## Adding sidecars to service instances
 

--- a/content/docs/setup/consul/quick-start/index.md
+++ b/content/docs/setup/consul/quick-start/index.md
@@ -5,7 +5,7 @@ weight: 10
 keywords: [consul]
 ---
 
-Quick Start instructions to install and configure Istio in a Docker Compose setup.
+Quick Start instructions to install and configure Istio networking in a Docker Compose setup.
 
 ## Prerequisites
 
@@ -48,11 +48,14 @@ For example, run the following command on a macOS or Linux system:
 
 1. Change directory to the root of the Istio installation directory.
 
-1.  Bring up the Istio control plane containers:
+1.  Bring up the Istio networking control plane containers:
 
     {{< text bash >}}
     $ docker-compose -f install/consul/istio.yaml up -d
     {{< /text >}}
+
+    > Note: The Consul install only configures Istio Pilot. To use Istio Mixer (policy enforcement and telemetry reporting) or Istio Galley, further installation steps
+    > will be necessary. Those steps are beyond the scope of this guide.
 
 1.  Confirm that all docker containers are running:
 

--- a/content/docs/setup/consul/quick-start/index.md
+++ b/content/docs/setup/consul/quick-start/index.md
@@ -54,7 +54,7 @@ For example, run the following command on a macOS or Linux system:
     $ docker-compose -f install/consul/istio.yaml up -d
     {{< /text >}}
 
-    > Note: The Consul install only configures Istio Pilot. To use Istio Mixer (policy enforcement and telemetry reporting) or Istio Galley, further installation steps
+    > {{< warning_icon >}} The Consul install only configures Istio Pilot. To use Istio Mixer (policy enforcement and telemetry reporting) or Istio Galley, further installation steps
     > will be necessary. Those steps are beyond the scope of this guide.
 
 1.  Confirm that all docker containers are running:


### PR DESCRIPTION
As motivated from mailing-list discussions, this PR attempts to clarify that the Consul installation does not cover the full set of install steps for using Mixer, etc.