### PR TITLE
[Kiali] change in the root context path

### DIFF
--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -110,7 +110,7 @@ Once you install Istio and Kiali, deploy the [Bookinfo](/docs/examples/bookinfo/
     $ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=kiali -o jsonpath='{.items[0].metadata.name}') 20001:20001
     {{< /text >}}
 
-1.  Visit <http://localhost:20001> in your web browser.
+1.  Visit <http://localhost:20001/kiali> in your web browser.
 
 1.  To log into the Kiali UI, go to the Kiali login screen and enter the username and passphrase stored in the Kiali secret.
 


### PR DESCRIPTION
Last week, this changed from "/" to "/kiali" (see PR istio/istio#9588)
This reflects that change.

Thanks, @salrashid123 !