### PR TITLE
Clarify 1.0.3 ServiceEntry patch notes

### DIFF
--- a/content/about/notes/1.0.3/index.md
+++ b/content/about/notes/1.0.3/index.md
@@ -13,7 +13,7 @@ This release note describes what's different between Istio 1.0.2 and Istio 1.0.3
 
 - [Validating webhook](/help/ops/setup/validation) is now mandatory. Disabling it may result in Pilot crashes.
 
-- [Service entry](/docs/reference/config/istio.networking.v1alpha3/#ServiceEntry) no longer allows wildcard (`*`) DNS resolution. The API has never allowed this, however `ServiceEntry` was erroneously excluded from validation in the previous release.
+- [Service entry](/docs/reference/config/istio.networking.v1alpha3/#ServiceEntry) validation now rejects the wildcard hostname (`*`) when configuring DNS resolution. The API has never allowed this, however `ServiceEntry` was erroneously excluded from validation in the previous release. Use of wildcards as part of a hostname, e.g. `*.bar.com`, remains unchanged.
 
 - The core dump path for `istio-proxy` has changed to `/var/lib/istio`.
 


### PR DESCRIPTION
clarify the patch notes to make it obvious that wildcards are still allowed in service entries