### PR TITLE
Fix grammar error

### DIFF
--- a/content/docs/setup/kubernetes/multicluster-install/vpn/index.md
+++ b/content/docs/setup/kubernetes/multicluster-install/vpn/index.md
@@ -453,7 +453,7 @@ Istio Helm charts or the Istio manifests.
 
 This method uses the Istio ingress gateway functionality. The remote clusters
 have the `istio-pilot`, `istio-telemetry`, `istio-policy`,
-`istio-statsd-prom-bridge`, and `zipkin` services pointing to the load balanced
+`istio-statsd-prom-bridge` and `zipkin` services pointing to the load balanced
 IP of the Istio ingress gateway. Then, all the services point to the same IP.
 You must then create the destination rules to reach the proper Istio service in
 the main cluster in the ingress gateway.


### PR DESCRIPTION
`, and` should be connected to two sentences on both sides, but `, and` is followed by a noun.
If `service` of the second sentence is a verb, the meaning of the word is unreasonable.