### PR TITLE
Use Hugo's errorf command instead of injecting magic error strings in…

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
 
         {{ with .Page.Description }}
             {{ if not (or (strings.HasSuffix . ".") (strings.HasSuffix . "。")) }}
-                MARKDOWN ERROR: page description doesn't end with a period
+                {{ errorf "Page description doesn't end with a period: '%s'" .Page.Description }}
             {{ end }}
         {{ end }}
 

--- a/layouts/partials/adapter_list.html
+++ b/layouts/partials/adapter_list.html
@@ -16,6 +16,6 @@
     {{ if $target }}
         <a href="{{ $target.Permalink }}" title="{{ $target.Description }}">{{ $target.Title }}</a>{{- if ne $adap $last -}},{{- end -}}
     {{ else }}
-        MARKDOWN ERROR: Invalid adapter name: '{{ $adap }}'
+        {{ errorf "Invalid adapter name: %s" $adap }}
     {{ end }}
 {{ end }}

--- a/layouts/partials/primary-top.html
+++ b/layouts/partials/primary-top.html
@@ -45,7 +45,7 @@
 
                 {{ if .Params.subtitle }}
                     {{ if (strings.HasSuffix .Params.subtitle ".") }}
-                        <P>MARKDOWN ERROR: subtitles should not end in a period</p>
+                        {{ errorf "Subtitles should not end in a period: '%s" .Params.subtitle }}
                     {{ else }}
                         <p class="subtitle">{{ .Params.subtitle }}</p>
                     {{ end }}

--- a/layouts/partials/template_list.html
+++ b/layouts/partials/template_list.html
@@ -16,6 +16,6 @@
     {{ if $target }}
         <a href="{{ $target.Permalink }}" title="{{ $target.Description }}"><code>{{ $target.Title }}</code></a>{{- if ne $temp $last -}},{{- end -}}
     {{ else }}
-        MARKDOWN ERROR: Invalid template name: '{{ $temp }}'
+        {{ errorf "Invalid template name: %s" $temp }}
     {{ end }}
 {{ end }}

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -33,7 +33,7 @@ parameter.
 
 {{- with $caption -}}
 {{- if (strings.HasSuffix . ".") -}}
-MARKDOWN ERROR: image caption ends with a period.
+{{- errorf "Image caption ends with a period (%s)" .Position -}}
 {{- end -}}
 {{- end -}}
 
@@ -80,6 +80,6 @@ MARKDOWN ERROR: image caption ends with a period.
             <figcaption>{{- $caption -}}</figcaption>
         </figure>
     {{- else -}}
-        MARKDOWN ERROR: missing ratio for PNG or JPG image
+        {{- errorf "Missing ratio for PNG or JPG image (%s)" .Position -}}
     {{- end -}}
 {{- end -}}

--- a/layouts/shortcodes/text.html
+++ b/layouts/shortcodes/text.html
@@ -4,8 +4,8 @@
     {{- $downloadas = .Get 2 -}}
 {{- end -}}
 
-{{- $syntax := "error" -}}
-{{- $text := "MARKDOWN ERROR: text block does not specify syntax" -}}
+{{- $syntax := "" -}}
+{{- $text := "" -}}
 {{- $output := "" -}}
 
 {{- if .Get 0 -}}
@@ -32,17 +32,17 @@
     {{- $text = trim $text "\n" -}}
     {{- $syntax = .Get 0 -}}
     {{- $output = .Get 1 -}}
+{{- else -}}
+    {{- errorf "Text block does not specify a syntax (%s)" .Position -}}
 {{- end -}}
 
 {{- if (hasPrefix $text " ") -}}
-    {{- $syntax = "error" -}}
-    {{- $text = "MARKDOWN ERROR: text blocks need to not be indented, or indented by a multiple of 4 spaces" -}}
+    {{- errorf "Text blocks need to not be indented, or indented by a multiple of 4 spaces (%s)" .Position -}}
 {{- end -}}
 
 {{- if eq $syntax "bash" -}}
     {{- if not (hasPrefix $text "$") -}}
-        {{- $syntax = "error" -}}
-        {{- $text = "MARKDOWN ERROR: text block specifies a bash syntax, but first line does not start with $" -}}
+        {{- errorf "Text block specifies a bash syntax, but the first line of the block does not start with $ (%s)" .Position -}}
     {{- else -}}
         {{- if hasPrefix (trim $text " ") "$ cat <<EOF " -}}
             {{- $text = replace $text "$ cat" "cat" -}}

--- a/scripts/lint_site.sh
+++ b/scripts/lint_site.sh
@@ -63,13 +63,6 @@ check_content() {
 check_content content --en-us
 check_content content_zh --zh-cn
 
-grep -nr -e "MARKDOWN ERROR:" ./public
-if [ "$?" == "0" ]
-then
-    echo "Errors found in the markdown content"
-    FAILED=1
-fi
-
 grep -nr -e "“" ./content
 if [ "$?" == "0" ]
 then


### PR DESCRIPTION
…to the generated HTML.

This produces better errors with source file & line info when shortcodes are misused by
markdown files.