### PR TITLE
Improve `curl` command for testing the application

### DIFF
--- a/content/docs/examples/bookinfo/index.md
+++ b/content/docs/examples/bookinfo/index.md
@@ -197,8 +197,9 @@ is used for this purpose.
 To confirm that the Bookinfo application is running, run the following `curl` command:
 
 {{< text bash >}}
-$ curl -o /dev/null -s -w "%{http_code}\n" http://${GATEWAY_URL}/productpage
-200
+$ curl -I http://${GATEWAY_URL}/productpage
+HTTP/1.1 200 OK
+...
 {{< /text >}}
 
 You can also point your browser to `http://$GATEWAY_URL/productpage`


### PR DESCRIPTION
When I tried testing the application with `curl`, I got `000` as response.
For my environment, escaping the braces results in the variable not being expanded.
But because of outputting to `/dev/null`, I didn't see the error message `curl: (6) Could not resolve host: ${GATEWAY_URL}`

I'm using zsh under macOS.