### PR TITLE
Gateway service support externalIps in helm charts #2947

### DIFF
--- a/content/docs/reference/config/installation-options/index.md
+++ b/content/docs/reference/config/installation-options/index.md
@@ -39,6 +39,7 @@ To customize Istio install using Helm, use the `--set <key>=<value>` option in H
 | `gateways.istio-ingressgateway.autoscaleMax` | `5` |  |
 | `gateways.istio-ingressgateway.resources` | `{}` |  |
 | `gateways.istio-ingressgateway.loadBalancerIP` | `""` |  |
+| `gateways.istio-ingressgateway.externalIPs` | [] |  |
 | `gateways.istio-ingressgateway.serviceAnnotations` | `{}` |  |
 | `gateways.istio-ingressgateway.type` | `LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be` |  |
 | `gateways.istio-ingressgateway.ports.targetPort` | `80` |  |

--- a/content_zh/docs/reference/config/installation-options/index.md
+++ b/content_zh/docs/reference/config/installation-options/index.md
@@ -41,6 +41,7 @@ keywords: [kubernetes,helm]
 | `gateways.istio-ingressgateway.autoscaleMax` | `5` |  |
 | `gateways.istio-ingressgateway.resources` | `{}` |  |
 | `gateways.istio-ingressgateway.loadBalancerIP` | `""` |  |
+| `gateways.istio-ingressgateway.externalIPs` | [] |  |
 | `gateways.istio-ingressgateway.serviceAnnotations` | `{}` |  |
 | `gateways.istio-ingressgateway.type` | `LoadBalancer` | `如果需要，请更改为 NodePort，ClusterIP 或 LoadBalancer` |
 | `gateways.istio-ingressgateway.ports.targetPort` | `80` |  |


### PR DESCRIPTION
Add document for `gateways.istio-ingressgateway.externalIPs` in `reference/config/installation-options/index.md`. 
Related to istio issue: https://github.com/istio/istio/issues/9557