### PR TITLE
fix delete CRD step

### DIFF
--- a/content/docs/setup/kubernetes/minimal-install/index.md
+++ b/content/docs/setup/kubernetes/minimal-install/index.md
@@ -117,5 +117,5 @@ istio-pilot-58c65f74bc-2f5xn             1/1       Running   0          1m
 * If desired, delete the CRDs:
 
     {{< text bash >}}
-    $ kubectl delete -f install/kubernetes/helm/istio/templates/crds.yaml -n istio-system
+    $ kubectl delete -f install/kubernetes/helm/istio/templates/crds.yaml
     {{< /text >}}

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -171,5 +171,5 @@ non-existent resources because they may have been deleted hierarchically.
 * If desired, delete the CRDs:
 
     {{< text bash >}}
-    $ kubectl delete -f install/kubernetes/helm/istio/templates/crds.yaml -n istio-system
+    $ kubectl delete -f install/kubernetes/helm/istio/templates/crds.yaml
     {{< /text >}}


### PR DESCRIPTION
Kubernetes CRD itself is unscoped, it can be accessed from all namespaced, So we don't need to specify `-n istio-system` when deleting the CRDs.