### PR TITLE
fix mc install step

### DIFF
--- a/content/docs/setup/kubernetes/multicluster-install/gateways/index.md
+++ b/content/docs/setup/kubernetes/multicluster-install/gateways/index.md
@@ -64,7 +64,6 @@ the sample root certificates as the intermediate certificate.
     {{< text bash >}}
     $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
         -f install/kubernetes/helm/istio/values-istio-multicluster-gateways.yaml > $HOME/istio.yaml
-    $ kubectl create namespace istio-system
     $ kubectl apply -f $HOME/istio.yaml
     {{< /text >}}
 


### PR DESCRIPTION
There's duplicated `kubectl create namespace istio-system` in both  Step 2 and Step 3, delete one in Step 3 to make sure right.