### PR TITLE
Add a review process to our contribution guide.

### DIFF
--- a/content/about/contribute/github/index.md
+++ b/content/about/contribute/github/index.md
@@ -83,7 +83,7 @@ content in detail, follow these steps:
 
     {{< text markdown >}}
     Use present tense to avoid verb congruence issues and
-    make the text easier to understand:
+    to make the text easier to understand:
 
     ```suggestion
 
@@ -98,7 +98,7 @@ content in detail, follow these steps:
     {{< warning_icon >}} If you do not publish your review, the PR owner and
     the community cannot see your comments.
 
-1.  Once you publish your review, leave a comment with the words:
+1.  Once you publish your review, leave a comment with the text:
     `/hold cancel`. That command unblocks the PR from being merged.
 
 ## Previewing your work

--- a/content/about/contribute/github/index.md
+++ b/content/about/contribute/github/index.md
@@ -82,7 +82,8 @@ content in detail, follow these steps:
     example:
 
     {{< text markdown >}}
-    Use present tense to avoid verb congruence issues:
+    Use present tense to avoid verb congruence issues and
+    make the text easier to understand:
 
     ```suggestion
 
@@ -92,12 +93,12 @@ content in detail, follow these steps:
     {{< /text >}}
 
 1.  Publish your review to share your comments and suggestions with us and the
-    PR owner.
+    PR owner. Request changes as the review warrants.
 
     {{< warning_icon >}} If you do not publish your review, the PR owner and
     the community cannot see your comments.
 
-1.  Once your comments have been addressed, leave a comment with the words:
+1.  Once you publish your review, leave a comment with the words:
     `/hold cancel`. That command unblocks the PR from being merged.
 
 ## Previewing your work

--- a/content/about/contribute/github/index.md
+++ b/content/about/contribute/github/index.md
@@ -52,11 +52,11 @@ To add content you must create a fork of the repository and a PR from
 your fork to the docs main repository. The following steps describe the
 process:
 
-1.  Click the button below to visit the GitHub repository.
+<a class="btn btn-istio"
+href="https://github.com/istio/istio.io/">Browse this site's source
+code</a>
 
-    <a class="btn btn-istio"
-    href="https://github.com/istio/istio.io/">Browse this site's source
-    code</a>
+1.  Click the button above to visit the GitHub repository.
 
 1.  Click the **Fork** button in the upper-right corner of the screen to
     create a copy of our repository in your GitHub account.

--- a/content/about/contribute/github/index.md
+++ b/content/about/contribute/github/index.md
@@ -28,29 +28,77 @@ The documentation is published under the [Apache
 
 ## How to contribute
 
-There are two ways you can contribute to the Istio documentation:
+There are three ways you can contribute to the Istio documentation:
 
 * If you want to edit an existing page, you can open up the page in your
   browser and select the **Edit This Page on GitHub** option from the gear menu
   at the top right of each page. This takes you to GitHub to edit and
   submit the changes.
 
-* If you want to work on the site in general, you must create a fork of the
-  repository. Click the button below to visit the GitHub repository. Then, you
-  must click the **Fork** button in the upper-right corner of the screen to
-  create a copy of our repository in your GitHub account. Create a clone of
-  your fork and make any changes you want. When you are ready to send those
-  changes to us, push the changes to your fork, go to the index page for your
-  fork, and click **New Pull Request** to let us know about it.
+* If you want to work on the site in general, follow the steps in our
+  [How to add content section](#add).
 
-<a class="btn btn-istio"
-href="https://github.com/istio/istio.io/">Browse this site's source
-code</a>
+* If you want to review an existing pull request (PR), follow the steps in our
+  [How to review content section](#review)
 
 Once your changes are merged, they show up immediately on
 `preliminary.istio.io`. However, the changes only
 show up on `istio.io` the next time we produce a new
 release, which happens around once a quarter.
+
+### How to add content {#add}
+
+To add content you must create a fork of the repository and a PR from
+your fork to the docs main repository. The following steps describe the
+process:
+
+1.  Click the button below to visit the GitHub repository.
+
+    <a class="btn btn-istio"
+    href="https://github.com/istio/istio.io/">Browse this site's source
+    code</a>
+
+1.  Click the **Fork** button in the upper-right corner of the screen to
+    create a copy of our repository in your GitHub account.
+
+1.  Create a clone of your fork and make any changes you want.
+1.  When you are ready to send those changes to us, push the changes to your
+    fork.
+1.  Go to the index page for your fork, and click **New Pull Request** to let
+    us know about it.
+
+### How to review content {#review}
+
+If your review is small, simply comment on the PR directly. If you review the
+content in detail, follow these steps:
+
+1.  Leave a comment on the PR with the text `/hold`. This command prevents the
+    PR from being merged before you are able to complete your review.
+
+1.  Perform your detailed review. When possible leave specific comments
+    directly on the files and lines affected.
+
+1.  Provide suggestions to the PR owner in your comments when appropriate. For
+    example:
+
+    {{< text markdown >}}
+    Use present tense to avoid verb congruence issues:
+
+    ```suggestion
+
+    Pilot maintains an abstract model of the mesh.
+
+    ```
+    {{< /text >}}
+
+1.  Publish your review to share your comments and suggestions with us and the
+    PR owner.
+
+    {{< warning_icon >}} If you do not publish your review, the PR owner and
+    the community cannot see your comments.
+
+1.  Once your comments have been addressed, leave a comment with the words:
+    `/hold cancel`. That command unblocks the PR from being merged.
 
 ## Previewing your work
 


### PR DESCRIPTION
To avoid PRs from being merged before the content has been reviewed, contributors
must add a comment with the appropriate command beforehand. I've added this
process. Additionally, I cleaned up the process on how to contribute new
documents.

Signed-off-by: rcaballeromx <grca@google.com>