### PR TITLE
Add info about grafana add-on

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -201,6 +201,7 @@ accesslogs
 accounts.my
 addon
 addons
+add-ons
 strongSwan
 admissionregistration
 admissionregistration.k8s.io
@@ -547,4 +548,3 @@ gcse
 MB
 CPU
 CPUs
-add-ons

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -110,7 +110,7 @@ to manage the lifecycle of Istio.
     {{< text bash >}}
     $ helm install install/kubernetes/helm/istio --name istio --namespace istio-system --set global.mtls.enabled=true
     {{< /text >}}
-    
+
 ## Uninstall
 
 * For option 1, uninstall using `kubectl`:

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -56,6 +56,8 @@ via `kubectl apply`, and wait a few seconds for the CRDs to be committed in the 
 1. Choose one of the following two
 **mutually exclusive** options described below.
 
+    To customize Istio and install add-ons, use the `--set <key>=<value>` option in the helm template or install command. [Installation Options](/docs/reference/config/installation-options/) references supported installation key and value pairs.
+
 ### Option 1: Install with Helm via `helm template`
 
 1. Render Istio's core components to a Kubernetes manifest called `istio.yaml`:
@@ -108,10 +110,6 @@ to manage the lifecycle of Istio.
     {{< text bash >}}
     $ helm install install/kubernetes/helm/istio --name istio --namespace istio-system --set global.mtls.enabled=true
     {{< /text >}}
-
-## Installation Options
-
-To customize Istio and install add-ons, use the `--set <key>=<value>` option in the helm template or install command. [Installation Options](/docs/reference/config/installation-options/) references supported installation key and value pairs.
     
 ## Uninstall
 

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -56,7 +56,7 @@ via `kubectl apply`, and wait a few seconds for the CRDs to be committed in the 
 1. Choose one of the following two
 **mutually exclusive** options described below.
 
-    To customize Istio and install add-ons, use the `--set <key>=<value>` option in the helm template or install command. [Installation Options](/docs/reference/config/installation-options/) references supported installation key and value pairs.
+    > To customize Istio and install add-ons, use the `--set <key>=<value>` option in the helm template or install command. [Installation Options](/docs/reference/config/installation-options/) references supported installation key and value pairs.
 
 ### Option 1: Install with Helm via `helm template`
 

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -111,7 +111,7 @@ to manage the lifecycle of Istio.
 
 ## Installation Options
 
-To customize Istio and install add-ons, use the --set <key>=<value> option in the helm template or install command. See [Installation Options](/docs/reference/config/installation-options/) for the list of supported keys.
+To customize Istio and install add-ons, use the `--set <key>=<value>` option in the helm template or install command. [Installation Options](/docs/reference/config/installation-options/) references supported installation key and value pairs.
     
 ## Uninstall
 

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -109,6 +109,10 @@ to manage the lifecycle of Istio.
     $ helm install install/kubernetes/helm/istio --name istio --namespace istio-system --set global.mtls.enabled=true
     {{< /text >}}
 
+## Installation Options
+
+To customize Istio and install add-ons, use the --set <key>=<value> option in the helm template or install command. See [Installation Options](/docs/reference/config/installation-options/) for the list of supported keys.
+    
 ## Uninstall
 
 * For option 1, uninstall using `kubectl`:

--- a/content/docs/tasks/telemetry/using-istio-dashboard/index.md
+++ b/content/docs/tasks/telemetry/using-istio-dashboard/index.md
@@ -14,7 +14,7 @@ the example application throughout this task.
 
 ## Before you begin
 
-* [Install Istio](/docs/setup/) in your cluster. Either use the istio-demo.yaml or istio-demo-auth.yaml template, which includes the Grafana Istio add-on, or use the Helm chart with Grafana add-on by setting the `--set grafana.enabled=true` [option](/docs/reference/config/installation-options/).
+* [Install Istio](/docs/setup) in your cluster. If you are installing using Helm, enable the Grafana add-on `--set grafana.enabled=true` [option](/docs/reference/config/installation-options/).
 * Deploy [Bookinfo](/docs/examples/bookinfo/) application.
 
 ## Viewing the Istio Dashboard

--- a/content/docs/tasks/telemetry/using-istio-dashboard/index.md
+++ b/content/docs/tasks/telemetry/using-istio-dashboard/index.md
@@ -6,7 +6,7 @@ keywords: [telemetry,visualization]
 ---
 
 This task shows you how to setup and use the Istio Dashboard to monitor mesh
-traffic. As part of this task, you will install the Grafana Istio add-on and use
+traffic. As part of this task, you will use the Grafana Istio add-on and
 the web-based interface for viewing service mesh traffic data.
 
 The [Bookinfo](/docs/examples/bookinfo/) sample application is used as
@@ -14,8 +14,8 @@ the example application throughout this task.
 
 ## Before you begin
 
-* [Install Istio](/docs/setup/) in your cluster and deploy an
-  application.
+* [Install Istio](/docs/setup/) in your cluster. Either use the istio-demo.yaml or istio-demo-auth.yaml template, which includes the Grafana Istio add-on, or use the Helm chart with Grafana add-on by setting the `--set grafana.enabled=true` [option](/docs/reference/config/installation-options/).
+* Deploy [Bookinfo](/docs/examples/bookinfo/) application.
 
 ## Viewing the Istio Dashboard
 


### PR DESCRIPTION
Aims to address #2425 
1. Add grafana add-on to prereqs in the [Visualizing Metrics with Grafana](https://istio.io/docs/tasks/telemetry/using-istio-dashboard/) page
2. Add information to the [helm install page](https://istio.io/docs/setup/kubernetes/helm-install/) about add-ons