### PR TITLE
Fix the typo on the secure ingress page

### DIFF
--- a/content/docs/tasks/traffic-management/secure-ingress/index.md
+++ b/content/docs/tasks/traffic-management/secure-ingress/index.md
@@ -480,7 +480,7 @@ they have valid values, according to the output of the following commands:
 1.  Verify that the proxy of the ingress gateway is aware of the certificates:
 
     {{< text bash >}}
-    $ kubectl exec -ti $(kubectl get po -l istio=ingressgateway -n istio-system -o jsonpath={.items[0]..metadata.name}) -n istio-system -- curl  127.0.0.1:15000/certs
+    $ kubectl exec -ti $(kubectl get po -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system -- curl  127.0.0.1:15000/certs
     {
       "ca_cert": "",
       "cert_chain": "Certificate Path: /etc/istio/ingressgateway-certs/tls.crt, Serial Number: 100212, Days until Expiration: 370"


### PR DESCRIPTION
Fixed in the documentation command
- Typo, the `jsonpath` contain extra dot char: `.items[0]..metadata.name` instead of `.items[0].metadata.name`
- The jsonpath without a weapping in quote chars won't work on all the systems and could lead to some errors of type: `no matches found: jsonpath={.items[0].metadata.name}`