### PR TITLE
add targetAverageUtilization to deployment of egress gateway with SNI proxy

### DIFF
--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -842,6 +842,8 @@ to hold the configuration of the Nginx SNI proxy:
         replicaCount: 1
         autoscaleMin: 1
         autoscaleMax: 5
+        cpu:
+          targetAverageUtilization: 80
         serviceAnnotations: {}
         type: ClusterIP
         ports:


### PR DESCRIPTION
In the same way as in https://preliminary.istio.io/docs/examples/advanced-gateways/wildcard-egress-hosts/#setup-egress-gateway-with-sni-proxy