### PR TITLE
Fix GKE cluster create command (platform setup)

### DIFF
--- a/content/docs/setup/kubernetes/platform-setup/gke/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/gke/index.md
@@ -12,8 +12,8 @@ Follow these instructions to prepare an GKE cluster for Istio.
 
     {{< text bash >}}
     $ gcloud container clusters create <cluster-name> \
-      --cluster-version latest \ 
-      --num-nodes 4 \ 
+      --cluster-version latest \
+      --num-nodes 4 \
       --zone <zone> \
       --project <project-id>
     {{< /text >}}

--- a/content/docs/setup/kubernetes/platform-setup/gke/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/gke/index.md
@@ -12,6 +12,7 @@ Follow these instructions to prepare an GKE cluster for Istio.
 
     {{< text bash >}}
     $ gcloud container clusters create <cluster-name> \
+      --cluster-version latest \ 
       --num-nodes 4 \ 
       --zone <zone> \
       --project <project-id>

--- a/content/docs/setup/kubernetes/platform-setup/gke/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/gke/index.md
@@ -12,7 +12,7 @@ Follow these instructions to prepare an GKE cluster for Istio.
 
     {{< text bash >}}
     $ gcloud container clusters create <cluster-name> \
-      --num-nodes 4
+      --num-nodes 4 \ 
       --zone <zone> \
       --project <project-id>
     {{< /text >}}


### PR DESCRIPTION
Fixes cluster create command in: https://preliminary.istio.io/docs/setup/kubernetes/platform-setup/gke/ 

Bug: without a trailing slash after `num-nodes`, any other arguments after (zone, project) are ignored.  (And thus defaults to a different zone, eg. `us-central1-b`, not the zone specified in the flag.) 

Solution: 
- Add trailing slash after `num-nodes` 
- Also added `cluster-version=latest` for best-practices reasons.