### PR TITLE
Add OCI platform setup to documentation

### DIFF
--- a/content/docs/setup/kubernetes/platform-setup/oci/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/oci/index.md
@@ -1,0 +1,36 @@
+---
+title: Oracle Cloud Infrastructure
+description: Instructions to setup an OKE cluster for Istio.
+weight: 9
+skip_seealso: true
+keywords: [platform-setup,kubernetes,oke,oci,oracle]
+---
+
+Follow these instructions to prepare an OKE cluster for Istio.
+
+1. Create a new OKE cluster within your OCI tenancy. The simplest way to do this is by using the 'Quick Cluster' option within the [web console](https://docs.cloud.oracle.com/iaas/Content/ContEng/Tasks/contengcreatingclusterusingoke.htm). You may also use the [OCI cli](https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/cliinstall.htm) as shown below.
+
+    {{< text bash >}}
+    $ oci ce cluster create --name oke-cluster1 \
+        --kubernetes-version <preferred version> \
+        --vcn-id <vcn-ocid> \
+        --service-lb-subnet-ids [] \
+        ..
+    {{< /text >}}
+
+1. Retrieve your credentials for `kubectl` using the OCI cli.
+
+    {{< text bash >}}
+    $ oci ce cluster create-kubeconfig \
+        --file <path/to/config> \
+        --cluster-id <cluster-ocid>
+    {{< /text >}}
+
+1. Grant cluster administrator (admin) permissions to the current user. To create the necessary RBAC rules for Istio, the current user requires admin permissions.
+
+    {{< text bash >}}
+    $ kubectl create clusterrolebinding cluster-admin-binding \
+        --clusterrole=cluster-admin \
+        --user=<user_ocid>
+    {{< /text >}}
+

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -14,14 +14,15 @@ To install and configure Istio in a Kubernetes cluster, follow these instruction
 1. [Download the Istio release](/docs/setup/kubernetes/download-release/).
 
 1. [Kubernetes platform setup](/docs/setup/kubernetes/platform-setup/):
-  * [Minikube](/docs/setup/kubernetes/platform-setup/minikube/)
-  * [Google Container Engine (GKE)](/docs/setup/kubernetes/platform-setup/gke/)
-  * [IBM Cloud](/docs/setup/kubernetes/platform-setup/ibm/)
-  * [OpenShift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
+  * [Alibaba Cloud](/docs/setup/kubernetes/platform-setup/alicloud/)
   * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/platform-setup/aws/)
   * [Azure](/docs/setup/kubernetes/platform-setup/azure/)
-  * [Alibaba Cloud](/docs/setup/kubernetes/platform-setup/alicloud/)
   * [Docker For Desktop](/docs/setup/kubernetes/platform-setup/docker-for-desktop/)
+  * [Google Container Engine (GKE)](/docs/setup/kubernetes/platform-setup/gke/)
+  * [IBM Cloud](/docs/setup/kubernetes/platform-setup/ibm/)
+  * [Minikube](/docs/setup/kubernetes/platform-setup/minikube/)
+  * [OpenShift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
+  * [Oracle Cloud Infrastructure (OKE)](/docs/setup/kubernetes/platform-setup/oci/)
 
 1. Check the [Requirements for Pods and Services](/docs/setup/kubernetes/spec-requirements/).
 


### PR DESCRIPTION
Add OCI OKE (Container Engine for Kubernetes) to the list of platforms with setup instructions for Istio.