### PR TITLE
add OCI OKE to platform setup section of docs

### DIFF
--- a/content/docs/setup/kubernetes/platform-setup/aws/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/aws/index.md
@@ -1,7 +1,7 @@
 ---
 title: Amazon Web Services
 description: Instructions to setup an AWS cluster with Kops cluster for Istio.
-weight: 3
+weight: 6
 skip_seealso: true
 keywords: [platform-setup,aws]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/azure/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/azure/index.md
@@ -1,7 +1,7 @@
 ---
 title: Azure
 description: Instructions to setup an Azure cluster for Istio.
-weight: 6
+weight: 9
 skip_seealso: true
 keywords: [platform-setup,azure]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/gke/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/gke/index.md
@@ -1,7 +1,7 @@
 ---
 title: Google Kubernetes Engine
 description: Instructions to setup a Google Kubernetes Engine cluster for Istio.
-weight: 9
+weight: 12 
 skip_seealso: true
 keywords: [platform-setup,kubernetes,gke,google]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/ibm/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/ibm/index.md
@@ -1,7 +1,7 @@
 ---
 title: IBM Cloud
 description: Instructions to setup an IBM Cloud cluster for Istio.
-weight: 12
+weight: 15
 skip_seealso: true
 keywords: [platform-setup,ibm,iks]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -1,7 +1,7 @@
 ---
 title: Minikube
 description: Instructions to setup Minikube for use with Istio.
-weight: 15
+weight: 18
 skip_seealso: true
 keywords: [platform-setup,kubernetes,minikube]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/oci/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/oci/index.md
@@ -1,0 +1,35 @@
+---
+title: Oracle Cloud Infrastructure
+description: Instructions to setup an OKE cluster for Istio.
+weight: 21 
+skip_seealso: true
+keywords: [platform-setup,kubernetes,oke,oci,oracle]
+---
+
+Follow these instructions to prepare an OKE cluster for Istio.
+
+1. Create a new OKE cluster within your OCI tenancy. The simplest way to do this is by using the 'Quick Cluster' option within the [web console](https://docs.cloud.oracle.com/iaas/Content/ContEng/Tasks/contengcreatingclusterusingoke.htm). You may also use the [OCI cli](https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/cliinstall.htm) as shown below.
+
+    {{< text bash >}}
+    $ oci ce cluster create --name oke-cluster1 \
+        --kubernetes-version <preferred version> \
+        --vcn-id <vcn-ocid> \
+        --service-lb-subnet-ids [] \
+        ..
+    {{< /text >}}
+
+1. Retrieve your credentials for `kubectl` using the OCI cli.
+
+    {{< text bash >}}
+    $ oci ce cluster create-kubeconfig \
+        --file <path/to/config> \
+        --cluster-id <cluster-ocid>
+    {{< /text >}}
+
+1. Grant cluster administrator (admin) permissions to the current user. To create the necessary RBAC rules for Istio, the current user requires admin permissions.
+
+    {{< text bash >}}
+    $ kubectl create clusterrolebinding cluster-admin-binding \
+        --clusterrole=cluster-admin \
+        --user=<user_ocid>
+    {{< /text >}}

--- a/content/docs/setup/kubernetes/platform-setup/oci/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/oci/index.md
@@ -1,7 +1,7 @@
 ---
 title: Oracle Cloud Infrastructure
 description: Instructions to setup an OKE cluster for Istio.
-weight: 21 
+weight: 24 
 skip_seealso: true
 keywords: [platform-setup,kubernetes,oke,oci,oracle]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/openshift/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/openshift/index.md
@@ -1,7 +1,7 @@
 ---
 title: OpenShift
 description: Instructions to setup an OpenShift cluster for Istio.
-weight: 18
+weight: 21
 skip_seealso: true
 keywords: [platform-setup,openshift]
 ---

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -12,13 +12,14 @@ To install and configure Istio in a Kubernetes cluster, follow these instruction
 1. [Download the Istio release](/docs/setup/kubernetes/download-release/).
 
 1. [Kubernetes platform setup](/docs/setup/kubernetes/platform-setup/):
-  * [Minikube](/docs/setup/kubernetes/platform-setup/minikube/)
-  * [Google Container Engine (GKE)](/docs/setup/kubernetes/platform-setup/gke/)
-  * [IBM Cloud](/docs/setup/kubernetes/platform-setup/ibm/)
-  * [OpenShift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
+  * [Alibaba Cloud](/docs/setup/kubernetes/platform-setup/alicloud/)
   * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/platform-setup/aws/)
   * [Azure](/docs/setup/kubernetes/platform-setup/azure/)
-  * [Alibaba Cloud](/docs/setup/kubernetes/platform-setup/alicloud/)
+  * [Google Container Engine (GKE)](/docs/setup/kubernetes/platform-setup/gke/)
+  * [IBM Cloud](/docs/setup/kubernetes/platform-setup/ibm/)
+  * [Minikube](/docs/setup/kubernetes/platform-setup/minikube/)
+  * [OpenShift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
+  * [Oracle Cloud Infrastructure (OKE)](/docs/setup/kubernetes/platform-setup/oci/)
 
 1. Check the [Requirements for Pods and Services](/docs/setup/kubernetes/spec-requirements/).
 


### PR DESCRIPTION
Add OCI OKE (Container Engine for Kubernetes) to the list of platforms with setup instructions for Istio. This is in preliminary.istio.io, this PR requests to add to the current 1.0 release.

This commit also alphabetizes the various platforms and providers in the quickstart guide.