### PR TITLE
option: let linter ignore the external links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ If you get spelling errors, you have three choices to address each:
 
 * It's really valid, so go add the word to the `.spelling` file at the root of the repo.
 
+And you can set any value to an enviroment variable named "INTERNAL_ONLY", then the linter will not check external links. It looks like that:
+
+```bash
+$ make INTERNAL_ONLY=True lint
+```
+
 ## Site infrastructure
 
 Here's how things work:

--- a/scripts/lint_site.sh
+++ b/scripts/lint_site.sh
@@ -8,6 +8,9 @@ echo -ne "mdl "
 mdl --version
 htmlproofer --version
 
+if [ -z ${INTERNAL_ONLY+x} ]; then DISABLE_EXTERNAL=true; else DISABLE_EXTERNAL=false; fi
+
+
 # This performs spell checking and style checking over markdown files in a content
 # directory. It transforms the shortcode sequences we use to annotate code blocks
 # blocks into classic markdown ``` code blocks, so that the linters aren't confused
@@ -76,8 +79,7 @@ then
     echo "Ensure markdown content only uses standard quotation marks and not “"
     FAILED=1
 fi
-
-htmlproofer ./public --assume-extension --check-html --check-external-hash --check-opengraph --timeframe 2d --storage-dir .htmlproofer --url-ignore "/localhost/,/github.com/istio/istio.io/edit/master/,/github.com/istio/istio/issues/new/choose/,/groups.google.com/forum/,/www.trulia.com/"
+htmlproofer ./public --assume-extension --check-html --disable_external ${DISABLE_EXTERNAL} --check-external-hash --check-opengraph --timeframe 2d --storage-dir .htmlproofer --url-ignore "/localhost/,/github.com/istio/istio.io/edit/master/,/github.com/istio/istio/issues/new/choose/,/groups.google.com/forum/,/www.trulia.com/"
 if [ "$?" != "0" ]
 then
     FAILED=1


### PR DESCRIPTION
Some sites can't been accessed in China, so we can't run `make lint` locally. 

I'd added an environment variable, the linter will skip the external links when we set any value to it.