### PR TITLE
New option: Let linter ignore the external links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-
 img := gcr.io/istio-testing/website-builder:2018-11-26
+docker := docker run -e INTERNAL_ONLY=true -t -i --sig-proxy=true --rm -v $(shell pwd):/site -w /site $(img)
+
+ifeq ($(INTERNAL_ONLY),)
 docker := docker run -t -i --sig-proxy=true --rm -v $(shell pwd):/site -w /site $(img)
+endif
 
 ifeq ($(CONTEXT),production)
 baseurl := "$(URL)"

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ If you get spelling errors, you have three choices to address each:
 
 * It's really valid, so go add the word to the `.spelling` file at the root of the repo.
 
+And you can set any value to an enviroment variable named "INTERNAL_ONLY", then the linter will not check external links. It looks like that:
+
+```bash
+$ make INTERNAL_ONLY=True lint
+```
+
 ## Site infrastructure
 
 Here's how things work:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you get spelling errors, you have three choices to address each:
 
 * It's really valid, so go add the word to the `.spelling` file at the root of the repo.
 
-And you can set any value to an enviroment variable named "INTERNAL_ONLY", then the linter will not check external links. It looks like that:
+And you can set any value to an environment variable named "INTERNAL_ONLY", then the linter will not check external links. It looks like that:
 
 ```bash
 $ make INTERNAL_ONLY=True lint

--- a/scripts/lint_site.sh
+++ b/scripts/lint_site.sh
@@ -7,6 +7,8 @@ mdspell --version
 echo -ne "mdl "
 mdl --version
 htmlproofer --version
+DISABLE_EXTERNAL=${INTERNAL_ONLY:-false}
+
 
 # This performs spell checking and style checking over markdown files in a content
 # directory. It transforms the shortcode sequences we use to annotate code blocks
@@ -76,8 +78,7 @@ then
     echo "Ensure markdown content only uses standard quotation marks and not “"
     FAILED=1
 fi
-
-htmlproofer ./public --assume-extension --check-html --check-external-hash --check-opengraph --timeframe 2d --storage-dir .htmlproofer --url-ignore "/localhost/,/github.com/istio/istio.io/edit/master/,/github.com/istio/istio/issues/new/choose/,/groups.google.com/forum/,/www.trulia.com/"
+htmlproofer ./public --assume-extension --check-html --disable_external ${DISABLE_EXTERNAL} --check-external-hash --check-opengraph --timeframe 2d --storage-dir .htmlproofer --url-ignore "/localhost/,/github.com/istio/istio.io/edit/master/,/github.com/istio/istio/issues/new/choose/,/groups.google.com/forum/,/www.trulia.com/"
 if [ "$?" != "0" ]
 then
     FAILED=1


### PR DESCRIPTION
Some url can't be accessed in China, so we can't run `make lint` locally, it always failed.

With this patch, you can set any value to an environment variable named "INTERNAL_ONLY", then the linter will not check external links.