### PR TITLE
shift platform page weights to maintain alphabetized sidebar

### DIFF
--- a/content/docs/setup/kubernetes/platform-setup/aws/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/aws/index.md
@@ -1,7 +1,7 @@
 ---
 title: Amazon Web Services
 description: Instructions to setup an AWS cluster with Kops cluster for Istio.
-weight: 3
+weight: 6
 skip_seealso: true
 keywords: [platform-setup,aws]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/azure/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/azure/index.md
@@ -1,7 +1,7 @@
 ---
 title: Azure
 description: Instructions to setup an Azure cluster for Istio.
-weight: 6
+weight: 9
 skip_seealso: true
 keywords: [platform-setup,azure]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/docker-for-desktop/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/docker-for-desktop/index.md
@@ -1,7 +1,7 @@
 ---
 title: Docker For Desktop
 description: Instructions to setup Docker For Desktop for use with Istio.
-weight: 15
+weight: 12
 skip_seealso: true
 keywords: [platform-setup,kubernetes,docker-for-desktop]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/gke/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/gke/index.md
@@ -1,7 +1,7 @@
 ---
 title: Google Kubernetes Engine
 description: Instructions to setup a Google Kubernetes Engine cluster for Istio.
-weight: 9
+weight: 15 
 skip_seealso: true
 keywords: [platform-setup,kubernetes,gke,google]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/ibm/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/ibm/index.md
@@ -1,7 +1,7 @@
 ---
 title: IBM Cloud
 description: Instructions to setup an IBM Cloud cluster for Istio.
-weight: 12
+weight: 18
 skip_seealso: true
 keywords: [platform-setup,ibm,iks]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/minikube/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/minikube/index.md
@@ -1,7 +1,7 @@
 ---
 title: Minikube
 description: Instructions to setup Minikube for use with Istio.
-weight: 15
+weight: 21
 skip_seealso: true
 keywords: [platform-setup,kubernetes,minikube]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/oci/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/oci/index.md
@@ -1,7 +1,7 @@
 ---
 title: Oracle Cloud Infrastructure
 description: Instructions to setup an OKE cluster for Istio.
-weight: 9
+weight: 27
 skip_seealso: true
 keywords: [platform-setup,kubernetes,oke,oci,oracle]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/openshift/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/openshift/index.md
@@ -1,7 +1,7 @@
 ---
 title: OpenShift
 description: Instructions to setup an OpenShift cluster for Istio.
-weight: 18
+weight: 24
 skip_seealso: true
 keywords: [platform-setup,openshift]
 ---


### PR DESCRIPTION
Some page weights in the platform setup section are duplicated and overall do not display an alphabetized list in the sidebar. This commit fixes the weights, shifting as needed.