### PR TITLE
Add useMCP=false for minimal install

### DIFF
--- a/content/docs/setup/kubernetes/minimal-install/index.md
+++ b/content/docs/setup/kubernetes/minimal-install/index.md
@@ -41,6 +41,7 @@ via `kubectl apply`, and wait a few seconds for the CRDs to be committed in the 
       --set mixer.telemetry.enabled=false \
       --set prometheus.enabled=false \
       --set global.proxy.envoyStatsd.enabled=false \
+      --set global.useMCP=false \
       --set pilot.sidecar=false > $HOME/istio-minimal.yaml
     {{< /text >}}
 
@@ -83,6 +84,7 @@ to manage the lifecycle of Istio.
       --set mixer.telemetry.enabled=false \
       --set prometheus.enabled=false \
       --set global.proxy.envoyStatsd.enabled=false \
+      --set global.useMCP=false \
       --set pilot.sidecar=false
     {{< /text >}}
 

--- a/content_zh/docs/setup/kubernetes/minimal-install/index.md
+++ b/content_zh/docs/setup/kubernetes/minimal-install/index.md
@@ -37,6 +37,7 @@ icon: helm
       --set mixer.enabled=false \
       --set prometheus.enabled=false \
       --set global.proxy.envoyStatsd.enabled=false \
+      --set global.useMCP=false \
       --set pilot.sidecar=false > $HOME/istio-minimal.yaml
     {{< /text >}}
 
@@ -76,6 +77,7 @@ icon: helm
       --set mixer.enabled=false \
       --set prometheus.enabled=false \
       --set global.proxy.envoyStatsd.enabled=false \
+      --set global.useMCP=false \
       --set pilot.sidecar=false
     {{< /text >}}
 


### PR DESCRIPTION
useMCP is true by default in `release-1.1`. we should disable it for minimal install (only pilot).

Signed-off-by: clyang82 <clyang@cn.ibm.com>