### PR TITLE
Organize the setup/kubernetes sidebar

### DIFF
--- a/content/docs/setup/kubernetes/advanced-install/index.md
+++ b/content/docs/setup/kubernetes/advanced-install/index.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced Install Options
 description: Instructions for customizing the Istio installation.
-weight: 20
+weight: 35
 keywords: [kubernetes]
 draft: true
 ---

--- a/content/docs/setup/kubernetes/ansible-install/index.md
+++ b/content/docs/setup/kubernetes/ansible-install/index.md
@@ -1,7 +1,7 @@
 ---
 title: Installation with Ansible
 description: Install Istio with the included Ansible playbook.
-weight: 40
+weight: 25
 keywords: [kubernetes,ansible]
 ---
 

--- a/content/docs/setup/kubernetes/download-release/index.md
+++ b/content/docs/setup/kubernetes/download-release/index.md
@@ -1,7 +1,7 @@
 ---
 title: Downloading the Release
 description: Instructions to download the Istio release.
-weight: 2
+weight: 15
 keywords: [kubernetes]
 ---
 

--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -1,7 +1,7 @@
 ---
 title: Installation with Helm
 description: Install Istio with the included Helm chart.
-weight: 30
+weight: 20
 keywords: [kubernetes,helm]
 aliases:
     - /docs/setup/kubernetes/helm.html

--- a/content/docs/setup/kubernetes/mesh-expansion/index.md
+++ b/content/docs/setup/kubernetes/mesh-expansion/index.md
@@ -1,7 +1,7 @@
 ---
 title: Mesh Expansion
 description: Instructions for integrating VMs and bare metal hosts into an Istio mesh deployed on Kubernetes.
-weight: 50
+weight: 95
 keywords: [kubernetes,vms]
 ---
 

--- a/content/docs/setup/kubernetes/minimal-install/index.md
+++ b/content/docs/setup/kubernetes/minimal-install/index.md
@@ -1,7 +1,7 @@
 ---
 title: Minimal Istio Installation
 description: Install minimal Istio using Helm.
-weight: 31
+weight: 30
 keywords: [kubernetes,helm, minimal]
 icon: helm
 ---

--- a/content/docs/setup/kubernetes/multicluster-install/_index.md
+++ b/content/docs/setup/kubernetes/multicluster-install/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Multicluster Installation
 description: Configure an Istio mesh across multiple kubernetes clusters.
-weight: 60
+weight: 85
 type: section-index
 keywords: [kubernetes,multicluster,federation]
 ---

--- a/content/docs/setup/kubernetes/platform-setup/_index.md
+++ b/content/docs/setup/kubernetes/platform-setup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Platform Setup
 description: How to prepare various Kubernetes platforms before installing Istio.
-weight: 100
+weight: 17
 keywords: [platform-setup]
 ---
 

--- a/content/docs/setup/kubernetes/quick-start-alicloud-ack/index.md
+++ b/content/docs/setup/kubernetes/quick-start-alicloud-ack/index.md
@@ -1,7 +1,7 @@
 ---
 title: Quick Start with Alibaba Cloud Kubernetes Container Service
 description: How to quickly setup Istio using Alibaba Cloud Kubernetes Container Service.
-weight: 21
+weight: 60
 keywords: [kubernetes,alibabacloud,aliyun]
 ---
 

--- a/content/docs/setup/kubernetes/quick-start-gke-dm/index.md
+++ b/content/docs/setup/kubernetes/quick-start-gke-dm/index.md
@@ -1,7 +1,7 @@
 ---
 title: Quick Start with Google Kubernetes Engine
 description: How to quickly setup Istio using Google Kubernetes Engine (GKE).
-weight: 20
+weight: 65
 keywords: [kubernetes,gke,google]
 ---
 

--- a/content/docs/setup/kubernetes/quick-start-ibm/index.md
+++ b/content/docs/setup/kubernetes/quick-start-ibm/index.md
@@ -1,7 +1,7 @@
 ---
 title: Quick Start with IBM Cloud
 description: How to quickly setup Istio using IBM Cloud Public or IBM Cloud Private.
-weight: 21
+weight: 70
 keywords: [kubernetes,ibm,icp]
 ---
 

--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -1,7 +1,7 @@
 ---
 title: Quick Start with Kubernetes
 description: Instructions to setup the Istio service mesh in a Kubernetes cluster.
-weight: 5
+weight: 55
 keywords: [kubernetes]
 ---
 

--- a/content/docs/setup/kubernetes/sidecar-injection/index.md
+++ b/content/docs/setup/kubernetes/sidecar-injection/index.md
@@ -1,7 +1,7 @@
 ---
 title: Installing the sidecar
 description: Instructions for installing the Istio sidecar in application pods automatically using the sidecar injector webhook or manually using istioctl CLI.
-weight: 30
+weight: 45
 keywords: [kubernetes,sidecar,sidecar-injection]
 aliases:
     - /docs/setup/kubernetes/automatic-sidecar-inject.html

--- a/content/docs/setup/kubernetes/spec-requirements/index.md
+++ b/content/docs/setup/kubernetes/spec-requirements/index.md
@@ -1,7 +1,7 @@
 ---
 title: Requirements for Pods and Services
 description:  Describes the requirements for Kubernetes pods and services to run Istio.
-weight: 80
+weight: 50
 keywords: [kubernetes,sidecar,sidecar-injection]
 ---
 

--- a/content/docs/setup/kubernetes/upgrading-istio/index.md
+++ b/content/docs/setup/kubernetes/upgrading-istio/index.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading Istio
 description: Demonstrates how to upgrade the Istio control plane and data plane independently.
-weight: 70
+weight: 37
 keywords: [kubernetes,upgrading]
 ---
 


### PR DESCRIPTION
The docs Setup->Kubernetes sidebar is a bit muddy, with install items, maintenance items and platform quickstart guides all scrambled.

This commit resets page weights to organize the sidebar a bit, with common articles grouped together.

I had considered putting a "Quickstart Guides" subcategory in place, but I think it's better to leave them as-is. Open to either way though.