### PR TITLE
simplify the platform setup notes in helm install

### DIFF
--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -18,14 +18,7 @@ plane and the sidecars for the Istio data plane.
 
 1. [Download the Istio release](/docs/setup/kubernetes/download-release/).
 
-1. [Kubernetes platform setup](/docs/setup/kubernetes/platform-setup/):
-  * [Minikube](/docs/setup/kubernetes/platform-setup/minikube/)
-  * [Google Container Engine (GKE)](/docs/setup/kubernetes/platform-setup/gke/)
-  * [IBM Cloud Kubernetes Service (IKS)](/docs/setup/kubernetes/platform-setup/ibm/)
-  * [OpenShift Origin](/docs/setup/kubernetes/platform-setup/openshift/)
-  * [Amazon Web Services (AWS) with Kops](/docs/setup/kubernetes/platform-setup/aws/)
-  * [Azure](/docs/setup/kubernetes/platform-setup/azure/)
-  * [Docker For Desktop](/docs/setup/kubernetes/platform-setup/docker-for-desktop/)
+1. Perform any necessary [platform-specific setup](/docs/setup/kubernetes/platform-setup/).
 
 1. Check the [Requirements for Pods and Services](/docs/setup/kubernetes/spec-requirements/) on Pods and Services.
 


### PR DESCRIPTION
Change "Installation with Helm" to point to the "Platform Setup" page rather than specifying each platform in a list. This is similar to the "Installation with Ansible" page. This simplifies adding a new platform, leaving just the one list in "Quick Start with Kubernetes" to update.