### PR TITLE
fix envoy reference in docs/reference/config/istio.networking.v1alpha…

### DIFF
--- a/content/docs/reference/config/istio.networking.v1alpha3/index.html
+++ b/content/docs/reference/config/istio.networking.v1alpha3/index.html
@@ -1694,8 +1694,8 @@ number of retries attempted depends on the httpReqTimeout.</p>
 <p>Specifies the conditions under which retry takes place.
 One or more policies can be specified using a ‘,’ delimited list.
 The supported policies can be found in
-&ldquo;https://www.envoyproxy.io/docs/envoy/latest/configuration/http<em>filters/router</em>filter#x-envoy-retry-on&rdquo;
-and &ldquo;https://www.envoyproxy.io/docs/envoy/latest/configuration/http<em>filters/router</em>filter#x-envoy-retry-grpc-on&rdquo;</p>
+&ldquo;https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/router_filter#x-envoy-retry-on&rdquo;
+and &ldquo;https://www.envoyproxy.io/docs/envoy/latest/configuration/http_filters/router_filter#x-envoy-retry-grpc-on&rdquo;</p>
 
 </td>
 </tr>


### PR DESCRIPTION
The links look like `_` was replaced w/ `<em>` somehow. 
This should make them work again but maybe there is something else this is generated from which needs to be fixed?