### PR TITLE
No need to specify namespace in kubectl apply

### DIFF
--- a/content/docs/setup/kubernetes/sidecar-injection/index.md
+++ b/content/docs/setup/kubernetes/sidecar-injection/index.md
@@ -93,7 +93,7 @@ with the option `sidecarInjectorWebhook.enabled` set to `false`. E.g.
 {{< text bash >}}
 $ helm template --namespace=istio-system --set sidecarInjectorWebhook.enabled=false install/kubernetes/helm/istio > istio.yaml
 $ kubectl create ns istio-system
-$ kubectl apply -n istio-system -f istio.yaml
+$ kubectl apply -f istio.yaml
 {{< /text >}}
 
 In addition, there are some other configuration parameters defined for the sidecar injector webhook

--- a/content/docs/setup/kubernetes/upgrading-istio/index.md
+++ b/content/docs/setup/kubernetes/upgrading-istio/index.md
@@ -21,7 +21,7 @@ and change directory to the new release directory.
 via `kubectl apply`, and wait a few seconds for the CRDs to be committed in the kube-apiserver:
 
 {{< text bash >}}
-$ kubectl apply -f @install/kubernetes/helm/istio/templates/crds.yaml@ -n istio-system
+$ kubectl apply -f @install/kubernetes/helm/istio/templates/crds.yaml@
 {{< /text >}}
 
 ### Control plane upgrade

--- a/content_zh/docs/setup/kubernetes/quick-start/index.md
+++ b/content_zh/docs/setup/kubernetes/quick-start/index.md
@@ -153,5 +153,5 @@ $ istioctl kube-inject -f <your-app-spec>.yaml | kubectl apply -f -
 * 另外如有有需要，也可以删除 CRD：
 
     {{< text bash >}}
-    $ kubectl delete -f install/kubernetes/helm/istio/templates/crds.yaml -n istio-system
+    $ kubectl delete -f install/kubernetes/helm/istio/templates/crds.yaml
     {{< /text >}}

--- a/content_zh/docs/setup/kubernetes/sidecar-injection/index.md
+++ b/content_zh/docs/setup/kubernetes/sidecar-injection/index.md
@@ -74,7 +74,7 @@ admissionregistration.k8s.io/v1beta1
 {{< text bash >}}
 $ helm template --namespace=istio-system --set sidecarInjectorWebhook.enabled=false install/kubernetes/helm/istio > istio.yaml
 $ kubectl create ns istio-system
-$ kubectl apply -n istio-system -f istio.yaml
+$ kubectl apply -f istio.yaml
 {{< /text >}}
 
 另外这个 Webhook 在 `values.yaml` 中还有一些其它的配置参数。可以覆盖这些缺省值来对安装过程进行定义。

--- a/content_zh/docs/setup/kubernetes/upgrading-istio/index.md
+++ b/content_zh/docs/setup/kubernetes/upgrading-istio/index.md
@@ -18,7 +18,7 @@ keywords: [kubernetes,upgrading]
 通过 `kubectl apply` ，等待几秒钟，让 CRD 在 kube-apiserver 中提交：
 
 {{< text bash >}}
-$ kubectl apply -f @install/kubernetes/helm/istio/templates/crds.yaml@ -n istio-system
+$ kubectl apply -f @install/kubernetes/helm/istio/templates/crds.yaml@
 {{< /text >}}
 
 ### 控制平面升级


### PR DESCRIPTION
There is no need to specify namespace when use "kubectl apply -f" or "kubectl delete -f".