### PR TITLE
use -l options directly in kubectl logs

### DIFF
--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -1089,7 +1089,7 @@ to hold the configuration of the Nginx SNI proxy:
     log is:
 
     {{< text bash >}}
-    $ kubectl logs $(kubectl get pod -l istio=egressgateway-with-sni-proxy -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system -c sni-proxy
+    $ kubectl logs -l istio=egressgateway-with-sni-proxy -n istio-system -c sni-proxy
     127.0.0.1 [23/Aug/2018:03:28:18 +0000] TCP [<your MongoDB host>]200 1863 482 0.089
     127.0.0.1 [23/Aug/2018:03:28:18 +0000] TCP [<your MongoDB host>]200 2590 1248 0.095
     {{< /text >}}

--- a/content/docs/examples/advanced-gateways/egress-gateway-tls-origination/index.md
+++ b/content/docs/examples/advanced-gateways/egress-gateway-tls-origination/index.md
@@ -243,7 +243,7 @@ be done by the egress gateway, as opposed to by the sidecar in the previous exam
     If Istio is deployed in the `istio-system` namespace, the command to print the log is:
 
     {{< text bash >}}
-    $ kubectl logs $(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') istio-proxy -n istio-system | tail
+    $ kubectl logs -l istio=egressgateway -c istio-proxy -n istio-system | tail
     {{< /text >}}
 
     You should see a line similar to the following:
@@ -776,7 +776,7 @@ to hold the configuration of the NGINX server:
     If Istio is deployed in the `istio-system` namespace, the command to print the log is:
 
     {{< text bash >}}
-    $ kubectl logs $(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system | grep 'nginx.example.com' | grep HTTP
+    $ kubectl logs -l istio=egressgateway -n istio-system | grep 'nginx.example.com' | grep HTTP
     {{< /text >}}
 
     You should see a line similar to the following:

--- a/content/docs/examples/advanced-gateways/egress-gateway/index.md
+++ b/content/docs/examples/advanced-gateways/egress-gateway/index.md
@@ -227,7 +227,7 @@ First create a `ServiceEntry` to allow direct traffic to an external service.
     If Istio is deployed in the `istio-system` namespace, the command to print the log is:
 
     {{< text bash >}}
-    $ kubectl logs $(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') istio-proxy -n istio-system | tail
+    $ kubectl logs -l istio=egressgateway -c istio-proxy -n istio-system | tail
     {{< /text >}}
 
     You should see a line similar to the following:

--- a/content/docs/examples/advanced-gateways/wildcard-egress-hosts/index.md
+++ b/content/docs/examples/advanced-gateways/wildcard-egress-hosts/index.md
@@ -636,7 +636,7 @@ The SNI proxy will forward the traffic to port `443`.
     log is:
 
     {{< text bash >}}
-    $ kubectl logs $(kubectl get pod -l istio=egressgateway-with-sni-proxy -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system -c sni-proxy
+    $ kubectl logs -l istio=egressgateway-with-sni-proxy -n istio-system -c sni-proxy
     127.0.0.1 [01/Aug/2018:15:32:02 +0000] TCP [en.wikipedia.org]200 81513 280 0.600
     127.0.0.1 [01/Aug/2018:15:32:03 +0000] TCP [de.wikipedia.org]200 67745 291 0.659
     {{< /text >}}

--- a/content_zh/blog/2018/egress-mongo/index.md
+++ b/content_zh/blog/2018/egress-mongo/index.md
@@ -937,7 +937,7 @@ $ kubectl delete destinationrule egressgateway-for-mongo
 1. 检查 SNI 代理的日志。如果 Istio 部署在 `istio-system` namespace 中，打印日志的命令为：
 
     {{< text bash >}}
-    $ kubectl logs $(kubectl get pod -l istio=egressgateway-with-sni-proxy -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system -c sni-proxy
+    $ kubectl logs -l istio=egressgateway-with-sni-proxy -n istio-system -c sni-proxy
     127.0.0.1 [23/Aug/2018:03:28:18 +0000] TCP [<your MongoDB host>]200 1863 482 0.089
     127.0.0.1 [23/Aug/2018:03:28:18 +0000] TCP [<your MongoDB host>]200 2590 1248 0.095
     {{< /text >}}

--- a/content_zh/docs/examples/advanced-gateways/egress-gateway-mtls-origination/index.md
+++ b/content_zh/docs/examples/advanced-gateways/egress-gateway-mtls-origination/index.md
@@ -490,7 +490,7 @@ keywords: [流量管理,egress]
 1.  检查 `istio-egressgateway` pod 的日志，看看与我们的请求相对应的行。如果 Istio 部署在 `istio-system` 命名空间中，则打印日志的命令是：
 
     {{< text bash >}}
-    $ kubectl logs $(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system | grep 'nginx.example.com' | grep HTTP
+    $ kubectl logs -l istio=egressgateway -n istio-system | grep 'nginx.example.com' | grep HTTP
     {{< /text >}}
 
     您应该看到与您的请求相关的行，类似于以下内容：

--- a/content_zh/docs/examples/advanced-gateways/egress-gateway/index.md
+++ b/content_zh/docs/examples/advanced-gateways/egress-gateway/index.md
@@ -225,7 +225,7 @@ Istio 0.8 引入了 [Ingress 和 Egress gateway](/zh/docs/reference/config/istio
 1. 检查  `istio-egressgateway` pod 的日志，并查看与我们的请求对应的行。如果 Istio 部署在 `istio-system` 命名空间中，则打印日志的命令是：
 
     {{< text bash >}}
-    $ kubectl logs $(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') istio-proxy -n istio-system | tail
+    $ kubectl logs -l istio=egressgateway -c istio-proxy -n istio-system | tail
     {{< /text >}}
 
     我们看到与请求相关的行，类似于以下内容：
@@ -432,7 +432,7 @@ $ kubectl delete destinationrule egressgateway-for-cnn
 1. 检查 `istio-egressgateway` pod 的日志，并查看与我们的请求相对应的行。如果 Istio 部署在 `istio-system` 命名空间中，则打印日志的命令是：
 
     {{< text bash >}}
-    $ kubectl logs $(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') istio-proxy -n istio-system | tail
+    $ kubectl logs -l istio=egressgateway -c istio-proxy -n istio-system | tail
     {{< /text >}}
 
     这里会看到与之前请求相关的行，类似于以下内容：

--- a/content_zh/docs/examples/advanced-gateways/wildcard-egress-hosts/index.md
+++ b/content_zh/docs/examples/advanced-gateways/wildcard-egress-hosts/index.md
@@ -485,7 +485,7 @@ SNI 代理会将流量转发到 `443` 端口。
 1. 检查 SNI 代理的日志。如果 Istio 部署在 `istio-system` namespace 中，打印日志的命令为：
 
     {{< text bash >}}
-    $ kubectl logs $(kubectl get pod -l istio=egressgateway-with-sni-proxy -n istio-system -o jsonpath='{.items[0].metadata.name}') -n istio-system -c sni-proxy
+    $ kubectl logs -l istio=egressgateway-with-sni-proxy -n istio-system -c sni-proxy
     127.0.0.1 [01/Aug/2018:15:32:02 +0000] TCP [en.wikipedia.org]200 81513 280 0.600
     127.0.0.1 [01/Aug/2018:15:32:03 +0000] TCP [de.wikipedia.org]200 67745 291 0.659
     {{< /text >}}


### PR DESCRIPTION
do not get the pod by a subcommand