### PR TITLE
Fix a URL in the user guide for Istio Vault CA

### DIFF
--- a/content/docs/tasks/security/vault-ca/index.md
+++ b/content/docs/tasks/security/vault-ca/index.md
@@ -40,7 +40,7 @@ address `35.233.249.249`. The configuration
 the testing Vault server, so that Envoy will not intercept the traffic from
 Node Agent to Vault.
 
-The yaml file [`values-istio-example-sds-vault.yaml`]({{< github_file >}}install/kubernetes/helm/istio/values-istio-example-sds-vault.yaml)
+The yaml file [`values-istio-example-sds-vault.yaml`]({{< github_file >}}/install/kubernetes/helm/istio/values-istio-example-sds-vault.yaml)
 contains the configuration that enables SDS (secret discovery service) in Istio.
 The Vault CA related configuration is set as environmental variables:
 


### PR DESCRIPTION
Fix a URL in the user guide for Istio Vault CA that misses a '/' character.