### PR TITLE
Update index.md

### DIFF
--- a/content/help/ops/misc/index.md
+++ b/content/help/ops/misc/index.md
@@ -24,13 +24,13 @@ Verifying connectivity to Pilot is a useful troubleshooting step. Every proxy co
 1.  Test connectivity to Pilot using `curl`. The following example invokes the v1 registration API using default Pilot configuration parameters and mutual TLS enabled:
 
     {{< text bash >}}
-    $ curl -k --cert /etc/certs/cert-chain.pem --cacert /etc/certs/root-cert.pem --key /etc/certs/key.pem https://istio-pilot:15003/v1/registration
+    $ curl -k --cert /etc/certs/cert-chain.pem --cacert /etc/certs/root-cert.pem --key /etc/certs/key.pem https://istio-pilot:8080/v1/registration
     {{< /text >}}
 
     If mutual TLS is disabled:
 
     {{< text bash >}}
-    $ curl http://istio-pilot:15003/v1/registration
+    $ curl http://istio-pilot:8080/v1/registration
     {{< /text >}}
 
 You should receive a response listing the "service-key" and "hosts" for each service in the mesh.


### PR DESCRIPTION
No port 15003 on istio-pilot SVC.But ports 8080 and 9093 exist, and either 8080 or 9093 can get the "service-key" and "hosts" return for each service in the service grid