### PR TITLE
Remove $ from pasted commands

### DIFF
--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -124,10 +124,10 @@ to manage the lifecycle of Istio.
 
 * For option 2, uninstall using Helm:
 
-> Uninstalling this chart does not delete Istio's registered CRDs. Istio by design expects
-> CRDs to leak into the Kubernetes environment. As CRDs contain all runtime configuration
-> data in custom resources the Istio designers feel it is better to explicitly delete this
-> configuration rather then unexpectedly lose it.
+    > Uninstalling this chart does not delete Istio's registered CRDs. Istio by design expects
+    > CRDs to leak into the Kubernetes environment. As CRDs contain all runtime configuration
+    > data in custom resources the Istio designers feel it is better to explicitly delete this
+    > configuration rather then unexpectedly lose it.
 
     {{< text bash >}}
     $ helm delete --purge istio
@@ -136,7 +136,7 @@ to manage the lifecycle of Istio.
 
 * If desired, run the following command to delete all CRDs:
 
-> {{< warning_icon >}} Deleting CRDs will delete any configuration changes that you have made to Istio.
+    > {{< warning_icon >}} Deleting CRDs will delete any configuration changes that you have made to Istio.
 
     {{< text bash >}}
     $ for i in install/kubernetes/helm/istio-init/files/crd*yaml; do kubectl delete -f $i; done


### PR DESCRIPTION
When the cut option was selected for the text bash items and then
pasted into a terminal, the $'s were not removed. This changes removes
them.