### PR TITLE
Fix Invalid Example Manifests in Authentication Reference

### DIFF
--- a/content/docs/reference/config/istio.authentication.v1alpha1/index.html
+++ b/content/docs/reference/config/istio.authentication.v1alpha1/index.html
@@ -340,7 +340,7 @@ or origin) should be used as principal. By default, it uses peer.</p>
 <pre><code class="language-yaml">apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: mTLS_enable
+  name: mtls-enable
   namespace: frod
 spec:
   peers:
@@ -352,7 +352,7 @@ spec:
 <pre><code class="language-yaml">apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: mTLS_disable
+  name: mtls-disable
   namespace: frod
 spec:
   targets:
@@ -365,7 +365,7 @@ for productpage:9000 except the path &lsquo;/health_check&rsquo; . Principal is 
 <pre><code class="language-yaml">apiVersion: authentication.istio.io/v1alpha1
 kind: Policy
 metadata:
-  name: mTLS_enable
+  name: mtls-enable
   namespace: frod
 spec:
   targets:

--- a/content/docs/reference/config/istio.authentication.v1alpha1/index.html
+++ b/content/docs/reference/config/istio.authentication.v1alpha1/index.html
@@ -368,7 +368,7 @@ metadata:
   name: mTLS_enable
   namespace: frod
 spec:
-  target:
+  targets:
   - name: productpage
     ports:
     - number: 9000


### PR DESCRIPTION
A few **Policy** examples include invalid **Name** fields (k8s api server rejects them as they contain uppercase letters and underscores) and invalid spec fields of **target** (**targets** is the correct field, and istio will reject examples including this)