### PR TITLE
fail with 503 instead of 000 for injected-app

### DIFF
--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -125,8 +125,7 @@ You can also confirm that requests from `sleep` to `httpbin` are now failed:
 
 {{< text bash >}}
 $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name}) -c sleep -- curl httpbin:8000/headers -o /dev/null -s -w '%{http_code}\n'
-000
-command terminated with exit code 56
+503
 {{< /text >}}
 
 Before you continue, remove the bad destination rule to make mutual TLS work again with the following command:

--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -121,7 +121,7 @@ HOST:PORT                                  STATUS       SERVER     CLIENT     AU
 httpbin.default.svc.cluster.local:8000     CONFLICT     mTLS       HTTP       default/            bad-rule/default
 {{< /text >}}
 
-You can also confirm that requests from `sleep` to `httpbin` are now failed:
+You can also confirm that requests from `sleep` to `httpbin` are now failing:
 
 {{< text bash >}}
 $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name}) -c sleep -- curl httpbin:8000/headers -o /dev/null -s -w '%{http_code}\n'


### PR DESCRIPTION
As a bad destination rule is set to disable client side mTLS and receiving side is mTLS enabled. At this point, Running the curl command between sidecar injected Istio services  all requests will fail with a 503 error code as the client side is still using plain-text.