### PR TITLE
Add containerPort requirement documentation

### DIFF
--- a/content/docs/setup/kubernetes/spec-requirements/index.md
+++ b/content/docs/setup/kubernetes/spec-requirements/index.md
@@ -8,7 +8,7 @@ keywords: [kubernetes,sidecar,sidecar-injection]
 To be a part of the service mesh, pods and services in a Kubernetes
 cluster must satisfy the following requirements:
 
-* _**Named ports**:_ Service ports must be named. The port names must be of
+* _**Named service ports**:_ Service ports must be named. The port names must be of
   the form `<protocol>[-<suffix>]` with `grpc`, `http`, `http2`, `https`, `mongo`, `redis`, `tcp`, `tls` or `udp`
   as the `<protocol>` in order to take advantage of Istio's routing features.
   For example, `name: http2-foo` or `name: http` are valid port names, but
@@ -16,6 +16,10 @@ cluster must satisfy the following requirements:
   prefix or if the port is unnamed, traffic on the port will be treated as
   plain TCP traffic (unless the port [explicitly](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
   uses `Protocol: UDP` to signify a UDP port).
+
+* _**Pod ports**:_ Pods must include an explicit list of ports each container will listen on.
+  Use a `containerPort` in the container spec for each port.  Any unlisted ports will bypass the Istio
+  Proxy.
 
 * _**Service association**:_ If a pod belongs to multiple
   [Kubernetes services](https://kubernetes.io/docs/concepts/services-networking/service/),


### PR DESCRIPTION
This little gotcha just burned a member of my team, so I think we should make sure it is included in the docs!

If you leave off the list of ports, the incoming traffic bypasses the proxy, which manifests itself as 503s if you have mTLS turned on.