### PR TITLE
Update tablegen.py to update the installation option table for 1.1

### DIFF
--- a/content/docs/reference/config/installation-options/index.md
+++ b/content/docs/reference/config/installation-options/index.md
@@ -8,15 +8,17 @@ keywords: [kubernetes,helm]
 To customize Istio install using Helm, use the `--set <key>=<value>` option in Helm command to override one or more values. The set of supported keys is shown in the table below.
 
 <!-- Run python scripts/tablegen.py to generate this table -->
+
 <!-- AUTO-GENERATED-START -->
 ## `certmanager` options
 
 | Key | Default Value | Description |
 | --- | --- | --- |
-| `certmanager.enabled` | `true` |  |
+| `certmanager.enabled` | `false` |  |
 | `certmanager.hub` | `quay.io/jetstack` |  |
-| `certmanager.tag` | `v0.3.1` |  |
+| `certmanager.tag` | `v0.5.0` |  |
 | `certmanager.resources` | `{}` |  |
+| `certmanager.nodeSelector` | `{}` |  |
 
 ## `galley` options
 
@@ -25,6 +27,7 @@ To customize Istio install using Helm, use the `--set <key>=<value>` option in H
 | `galley.enabled` | `true` |  |
 | `galley.replicaCount` | `1` |  |
 | `galley.image` | `galley` |  |
+| `galley.nodeSelector` | `{}` |  |
 
 ## `gateways` options
 
@@ -32,15 +35,21 @@ To customize Istio install using Helm, use the `--set <key>=<value>` option in H
 | --- | --- | --- |
 | `gateways.enabled` | `true` |  |
 | `gateways.istio-ingressgateway.enabled` | `true` |  |
+| `gateways.istio-ingressgateway.sds.enabled` | `false` |  |
+| `gateways.istio-ingressgateway.sds.image` | `node-agent-k8s` |  |
 | `gateways.istio-ingressgateway.labels.app` | `istio-ingressgateway` |  |
 | `gateways.istio-ingressgateway.labels.istio` | `ingressgateway` |  |
 | `gateways.istio-ingressgateway.replicaCount` | `1` |  |
 | `gateways.istio-ingressgateway.autoscaleMin` | `1` |  |
 | `gateways.istio-ingressgateway.autoscaleMax` | `5` |  |
 | `gateways.istio-ingressgateway.resources` | `{}` |  |
+| `gateways.istio-ingressgateway.cpu.targetAverageUtilization` | `80` |  |
+| `gateways.istio-ingressgateway.podDisruptionBudget` | `{}` |  |
 | `gateways.istio-ingressgateway.loadBalancerIP` | `""` |  |
-| `gateways.istio-ingressgateway.externalIPs` | [] |  |
+| `gateways.istio-ingressgateway.loadBalancerSourceRanges` | `[]` |  |
+| `gateways.istio-ingressgateway.externalIPs` | `[]` |  |
 | `gateways.istio-ingressgateway.serviceAnnotations` | `{}` |  |
+| `gateways.istio-ingressgateway.podAnnotations` | `{}` |  |
 | `gateways.istio-ingressgateway.type` | `LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be` |  |
 | `gateways.istio-ingressgateway.ports.targetPort` | `80` |  |
 | `gateways.istio-ingressgateway.ports.name` | `http2` |  |
@@ -49,116 +58,190 @@ To customize Istio install using Helm, use the `--set <key>=<value>` option in H
 | `gateways.istio-ingressgateway.ports.nodePort` | `31390` |  |
 | `gateways.istio-ingressgateway.ports.name` | `tcp` |  |
 | `gateways.istio-ingressgateway.ports.nodePort` | `31400` |  |
-| `gateways.istio-ingressgateway.ports.targetPort` | `15011` |  |
-| `gateways.istio-ingressgateway.ports.name` | `tcp-pilot-grpc-tls` |  |
-| `gateways.istio-ingressgateway.ports.targetPort` | `8060` |  |
-| `gateways.istio-ingressgateway.ports.name` | `tcp-citadel-grpc-tls` |  |
+| `gateways.istio-ingressgateway.ports.targetPort` | `15029` |  |
+| `gateways.istio-ingressgateway.ports.name` | `https-kiali` |  |
 | `gateways.istio-ingressgateway.ports.targetPort` | `15030` |  |
-| `gateways.istio-ingressgateway.ports.name` | `http2-prometheus` |  |
+| `gateways.istio-ingressgateway.ports.name` | `https-prometheus` |  |
 | `gateways.istio-ingressgateway.ports.targetPort` | `15031` |  |
-| `gateways.istio-ingressgateway.ports.name` | `http2-grafana` |  |
+| `gateways.istio-ingressgateway.ports.name` | `https-grafana` |  |
+| `gateways.istio-ingressgateway.ports.targetPort` | `15032` |  |
+| `gateways.istio-ingressgateway.ports.name` | `https-tracing` |  |
+| `gateways.istio-ingressgateway.ports.targetPort` | `15443` |  |
+| `gateways.istio-ingressgateway.ports.name` | `tls` |  |
+| `gateways.istio-ingressgateway.meshExpansionPorts.targetPort` | `15011` |  |
+| `gateways.istio-ingressgateway.meshExpansionPorts.name` | `tcp-pilot-grpc-tls` |  |
+| `gateways.istio-ingressgateway.meshExpansionPorts.targetPort` | `8060` |  |
+| `gateways.istio-ingressgateway.meshExpansionPorts.name` | `tcp-citadel-grpc-tls` |  |
+| `gateways.istio-ingressgateway.meshExpansionPorts.targetPort` | `853` |  |
+| `gateways.istio-ingressgateway.meshExpansionPorts.name` | `tcp-dns-tls` |  |
 | `gateways.istio-ingressgateway.secretVolumes.secretName` | `istio-ingressgateway-certs` |  |
 | `gateways.istio-ingressgateway.secretVolumes.mountPath` | `/etc/istio/ingressgateway-certs` |  |
 | `gateways.istio-ingressgateway.secretVolumes.secretName` | `istio-ingressgateway-ca-certs` |  |
 | `gateways.istio-ingressgateway.secretVolumes.mountPath` | `/etc/istio/ingressgateway-ca-certs` |  |
+| `gateways.istio-ingressgateway.env.ISTIO_META_ROUTER_MODE` | `"sni-dnat"` |  |
+| `gateways.istio-ingressgateway.nodeSelector` | `{}` |  |
 | `gateways.istio-egressgateway.enabled` | `true` |  |
 | `gateways.istio-egressgateway.labels.app` | `istio-egressgateway` |  |
 | `gateways.istio-egressgateway.labels.istio` | `egressgateway` |  |
 | `gateways.istio-egressgateway.replicaCount` | `1` |  |
 | `gateways.istio-egressgateway.autoscaleMin` | `1` |  |
 | `gateways.istio-egressgateway.autoscaleMax` | `5` |  |
+| `gateways.istio-egressgateway.cpu.targetAverageUtilization` | `80` |  |
+| `gateways.istio-egressgateway.podDisruptionBudget` | `{}` |  |
 | `gateways.istio-egressgateway.serviceAnnotations` | `{}` |  |
+| `gateways.istio-egressgateway.podAnnotations` | `{}` |  |
 | `gateways.istio-egressgateway.type` | `ClusterIP #change to NodePort or LoadBalancer if need be` |  |
 | `gateways.istio-egressgateway.ports.name` | `http2` |  |
-| `gateways.istio-egressgateway.ports.name.name` | `https` |  |
+| `gateways.istio-egressgateway.ports.name` | `https` |  |
+| `gateways.istio-egressgateway.ports.targetPort` | `15443` |  |
+| `gateways.istio-egressgateway.ports.name` | `tls` |  |
 | `gateways.istio-egressgateway.secretVolumes.secretName` | `istio-egressgateway-certs` |  |
-| `gateways.istio-egressgateway.secretVolumes.secretName.mountPath` | `/etc/istio/egressgateway-certs` |  |
-| `gateways.istio-egressgateway.secretVolumes.secretName.secretName` | `istio-egressgateway-ca-certs` |  |
-| `gateways.istio-egressgateway.secretVolumes.secretName.mountPath` | `/etc/istio/egressgateway-ca-certs` |  |
+| `gateways.istio-egressgateway.secretVolumes.mountPath` | `/etc/istio/egressgateway-certs` |  |
+| `gateways.istio-egressgateway.secretVolumes.secretName` | `istio-egressgateway-ca-certs` |  |
+| `gateways.istio-egressgateway.secretVolumes.mountPath` | `/etc/istio/egressgateway-ca-certs` |  |
+| `gateways.istio-egressgateway.env.ISTIO_META_ROUTER_MODE` | `"sni-dnat"` |  |
+| `gateways.istio-egressgateway.nodeSelector` | `{}` |  |
 | `gateways.istio-ilbgateway.enabled` | `false` |  |
-| `gateways.istio-ilbgateway.enabled.labels.app` | `istio-ilbgateway` |  |
-| `gateways.istio-ilbgateway.enabled.labels.istio` | `ilbgateway` |  |
-| `gateways.istio-ilbgateway.enabled.replicaCount` | `1` |  |
-| `gateways.istio-ilbgateway.enabled.autoscaleMin` | `1` |  |
-| `gateways.istio-ilbgateway.enabled.autoscaleMax` | `5` |  |
-| `gateways.istio-ilbgateway.enabled.resources.requests.cpu` | `800m` |  |
-| `gateways.istio-ilbgateway.enabled.resources.requests.memory` | `512Mi` |  |
-| `gateways.istio-ilbgateway.enabled.loadBalancerIP` | `""` |  |
-| `gateways.istio-ilbgateway.enabled.serviceAnnotations.cloud.google.com/load-balancer-type` | `"internal"` |  |
-| `gateways.istio-ilbgateway.enabled.type` | `LoadBalancer` |  |
-| `gateways.istio-ilbgateway.enabled.ports.name` | `grpc-pilot-mtls` |  |
-| `gateways.istio-ilbgateway.enabled.ports.name` | `grpc-pilot` |  |
-| `gateways.istio-ilbgateway.enabled.ports.targetPort` | `8060` |  |
-| `gateways.istio-ilbgateway.enabled.ports.name` | `tcp-citadel-grpc-tls` |  |
-| `gateways.istio-ilbgateway.enabled.ports.name` | `tcp-dns` |  |
-| `gateways.istio-ilbgateway.enabled.secretVolumes.secretName` | `istio-ilbgateway-certs` |  |
-| `gateways.istio-ilbgateway.enabled.secretVolumes.mountPath` | `/etc/istio/ilbgateway-certs` |  |
-| `gateways.istio-ilbgateway.enabled.secretVolumes.secretName` | `istio-ilbgateway-ca-certs` |  |
-| `gateways.istio-ilbgateway.enabled.secretVolumes.mountPath` | `/etc/istio/ilbgateway-ca-certs` |  |
+| `gateways.istio-ilbgateway.labels.app` | `istio-ilbgateway` |  |
+| `gateways.istio-ilbgateway.labels.istio` | `ilbgateway` |  |
+| `gateways.istio-ilbgateway.replicaCount` | `1` |  |
+| `gateways.istio-ilbgateway.autoscaleMin` | `1` |  |
+| `gateways.istio-ilbgateway.autoscaleMax` | `5` |  |
+| `gateways.istio-ilbgateway.cpu.targetAverageUtilization` | `80` |  |
+| `gateways.istio-ilbgateway.podDisruptionBudget` | `{}` |  |
+| `gateways.istio-ilbgateway.resources.requests.cpu` | `800m` |  |
+| `gateways.istio-ilbgateway.resources.requests.memory` | `512Mi` |  |
+| `gateways.istio-ilbgateway.loadBalancerIP` | `""` |  |
+| `gateways.istio-ilbgateway.serviceAnnotations.cloud.google.com/load-balancer-type` | `"internal"` |  |
+| `gateways.istio-ilbgateway.podAnnotations` | `{}` |  |
+| `gateways.istio-ilbgateway.type` | `LoadBalancer` |  |
+| `gateways.istio-ilbgateway.ports.name` | `grpc-pilot-mtls` |  |
+| `gateways.istio-ilbgateway.ports.name` | `grpc-pilot` |  |
+| `gateways.istio-ilbgateway.ports.targetPort` | `8060` |  |
+| `gateways.istio-ilbgateway.ports.name` | `tcp-citadel-grpc-tls` |  |
+| `gateways.istio-ilbgateway.ports.name` | `tcp-dns` |  |
+| `gateways.istio-ilbgateway.secretVolumes.secretName` | `istio-ilbgateway-certs` |  |
+| `gateways.istio-ilbgateway.secretVolumes.mountPath` | `/etc/istio/ilbgateway-certs` |  |
+| `gateways.istio-ilbgateway.secretVolumes.secretName` | `istio-ilbgateway-ca-certs` |  |
+| `gateways.istio-ilbgateway.secretVolumes.mountPath` | `/etc/istio/ilbgateway-ca-certs` |  |
+| `gateways.istio-ilbgateway.nodeSelector` | `{}` |  |
 
 ## `global` options
 
 | Key | Default Value | Description |
 | --- | --- | --- |
-| `global.hub` | `docker.io/istio` |  |
-| `global.tag` | `1.0.0` |  |
-| `global.k8sIngressSelector` | `ingress` |  |
-| `global.k8sIngressHttps` | `false` |  |
+| `global.hub` | `gcr.io/istio-release` |  |
+| `global.tag` | `master-latest-daily` |  |
+| `global.monitoringPort` | `9093` |  |
+| `global.k8sIngress.enabled` | `false` |  |
+| `global.k8sIngress.gatewayName` | `ingress` |  |
+| `global.k8sIngress.enableHttps` | `false` |  |
 | `global.proxy.image` | `proxyv2` |  |
+| `global.proxy.clusterDomain` | `"cluster.local"` |  |
 | `global.proxy.resources.requests.cpu` | `10m` |  |
+| `global.proxy.resources.requests.memory` | `30Mi` |  |
+| `global.proxy.concurrency` | `0` |  |
 | `global.proxy.accessLogFile` | `"/dev/stdout"` |  |
+| `global.proxy.accessLogFormat` | `""` |  |
+| `global.proxy.accessLogEncoding` | `TEXT` |  |
+| `global.proxy.privileged` | `false` |  |
 | `global.proxy.enableCoreDump` | `false` |  |
+| `global.proxy.statusPort` | `15020` |  |
+| `global.proxy.readinessInitialDelaySeconds` | `1` |  |
+| `global.proxy.readinessPeriodSeconds` | `2` |  |
+| `global.proxy.readinessFailureThreshold` | `30` |  |
 | `global.proxy.includeIPRanges` | `"*"` |  |
 | `global.proxy.excludeIPRanges` | `""` |  |
 | `global.proxy.includeInboundPorts` | `"*"` |  |
 | `global.proxy.excludeInboundPorts` | `""` |  |
 | `global.proxy.autoInject` | `enabled` |  |
-| `global.proxy.envoyStatsd.enabled` | `true` |  |
-| `global.proxy.envoyStatsd.host` | `istio-statsd-prom-bridge` |  |
-| `global.proxy.envoyStatsd.port` | `9125` |  |
+| `global.proxy.envoyStatsd.enabled` | `false` |  |
+| `global.proxy.envoyStatsd.host` | `# example: statsd-svc.istio-system` |  |
+| `global.proxy.envoyStatsd.port` | `# example: 9125` |  |
+| `global.proxy.tracer` | `"zipkin"` |  |
 | `global.proxy_init.image` | `proxy_init` |  |
 | `global.imagePullPolicy` | `IfNotPresent` |  |
-| `global.controlPlaneSecurityEnabled` | `true` |  |
+| `global.controlPlaneSecurityEnabled` | `false` |  |
 | `global.disablePolicyChecks` | `false` |  |
+| `global.policyCheckFailOpen` | `false` |  |
 | `global.enableTracing` | `true` |  |
-| `global.mtls.enabled` | `true` |  |
+| `global.tracer.lightstep.address` | `""                # example: lightstep-satellite:443` |  |
+| `global.tracer.lightstep.accessToken` | `""            # example: abcdefg1234567` |  |
+| `global.tracer.lightstep.secure` | `true               # example: true|false` |  |
+| `global.tracer.lightstep.cacertPath` | `""             # example: /etc/lightstep/cacert.pem` |  |
+| `global.tracer.zipkin.address` | `""` |  |
+| `global.mtls.enabled` | `false` |  |
 | `global.arch.amd64` | `2` |  |
 | `global.arch.s390x` | `2` |  |
 | `global.arch.ppc64le` | `2` |  |
 | `global.oneNamespace` | `false` |  |
+| `global.defaultNodeSelector` | `{}` |  |
 | `global.configValidation` | `true` |  |
-| `global.meshExpansion` | `false` |  |
-| `global.meshExpansionILB` | `false` |  |
+| `global.meshExpansion.enabled` | `false` |  |
+| `global.meshExpansion.useILB` | `false` |  |
+| `global.multiCluster.enabled` | `false` |  |
 | `global.defaultResources.requests.cpu` | `10m` |  |
-| `global.hyperkube.hub` | `quay.io/coreos` |  |
-| `global.hyperkube.tag` | `v1.7.6_coreos.0` |  |
+| `global.defaultResources.requests.memory` | `30Mi` |  |
+| `global.defaultPodDisruptionBudget.minAvailable` | `1` |  |
 | `global.priorityClassName` | `""` |  |
-| `global.crds` | `true` |  |
+| `global.useMCP` | `true` |  |
+| `global.trustDomain` | `""` |  |
+| `global.outboundTrafficPolicy.mode` | `REGISTRY_ONLY` |  |
+| `global.sds.enabled` | `false` |  |
+| `global.sds.udsPath` | `""` |  |
+| `global.sds.useTrustworthyJwt` | `false` |  |
+| `global.sds.useNormalJwt` | `false` |  |
+| `global.enableHelmTest` | `false` |  |
 
 ## `grafana` options
 
 | Key | Default Value | Description |
 | --- | --- | --- |
-| `grafana.enabled` | `true` |  |
+| `grafana.enabled` | `false` |  |
 | `grafana.replicaCount` | `1` |  |
-| `grafana.image` | `grafana` |  |
-| `grafana.security.enabled` | `true` |  |
-| `grafana.security.adminUser` | `admin` |  |
-| `grafana.security.adminPassword` | `admin` |  |
+| `grafana.image.repository` | `grafana/grafana` |  |
+| `grafana.image.tag` | `5.4.0` |  |
+| `grafana.ingress.enabled` | `false` |  |
+| `grafana.ingress.hosts` | `grafana.local` |  |
+| `grafana.persist` | `false` |  |
+| `grafana.storageClassName` | `""` |  |
+| `grafana.accessMode` | `ReadWriteMany` |  |
+| `grafana.security.enabled` | `false` |  |
+| `grafana.security.secretName` | `grafana` |  |
+| `grafana.security.usernameKey` | `username` |  |
+| `grafana.security.passphraseKey` | `passphrase` |  |
+| `grafana.nodeSelector` | `{}` |  |
+| `grafana.contextPath` | `/grafana` |  |
 | `grafana.service.annotations` | `{}` |  |
 | `grafana.service.name` | `http` |  |
 | `grafana.service.type` | `ClusterIP` |  |
 | `grafana.service.externalPort` | `3000` |  |
-| `grafana.service.internalPort` | `3000` |  |
+| `grafana.gateway.enabled` | `false` |  |
+| `grafana.datasources.datasources.apiVersion` | `1` |  |
+| `grafana.datasources.datasources.datasources.type` | `prometheus` |  |
+| `grafana.datasources.datasources.datasources.orgId` | `1` |  |
+| `grafana.datasources.datasources.datasources.url` | `http://prometheus:9090` |  |
+| `grafana.datasources.datasources.datasources.access` | `proxy` |  |
+| `grafana.datasources.datasources.datasources.isDefault` | `true` |  |
+| `grafana.datasources.datasources.datasources.jsonData.timeInterval` | `5s` |  |
+| `grafana.datasources.datasources.datasources.editable` | `true` |  |
+| `grafana.dashboardProviders.dashboardproviders.apiVersion` | `1` |  |
+| `grafana.dashboardProviders.dashboardproviders.providers.orgId` | `1` |  |
+| `grafana.dashboardProviders.dashboardproviders.providers.folder` | `'istio'` |  |
+| `grafana.dashboardProviders.dashboardproviders.providers.type` | `file` |  |
+| `grafana.dashboardProviders.dashboardproviders.providers.disableDeletion` | `false` |  |
+| `grafana.dashboardProviders.dashboardproviders.providers.options.path` | `/var/lib/grafana/dashboards/istio` |  |
 
 ## `ingress` options
 
 | Key | Default Value | Description |
 | --- | --- | --- |
-| `ingress.enabled` | `true` |  |
+| `ingress.enabled` | `false` |  |
 | `ingress.replicaCount` | `1` |  |
 | `ingress.autoscaleMin` | `1` |  |
 | `ingress.autoscaleMax` | `5` |  |
+| `ingress.nodeSelector` | `{}` |  |
+| `ingress.podDisruptionBudget` | `{}` |  |
 | `ingress.service.annotations` | `{}` |  |
 | `ingress.service.loadBalancerIP` | `""` |  |
 | `ingress.service.type` | `LoadBalancer #change to NodePort, ClusterIP or LoadBalancer if need be` |  |
@@ -167,41 +250,81 @@ To customize Istio install using Helm, use the `--set <key>=<value>` option in H
 | `ingress.service.ports.name` | `https` |  |
 | `ingress.service.selector.istio` | `ingress` |  |
 
+## `istio_cni` options
+
+| Key | Default Value | Description |
+| --- | --- | --- |
+| `istio_cni.enabled` | `false` |  |
+
+## `istiocoredns` options
+
+| Key | Default Value | Description |
+| --- | --- | --- |
+| `istiocoredns.enabled` | `false` |  |
+| `istiocoredns.replicaCount` | `1` |  |
+| `istiocoredns.coreDNSImage` | `coredns/coredns:1.1.2` |  |
+| `istiocoredns.coreDNSPluginImage` | `istio/coredns-plugin:0.1-istio-1.1` |  |
+| `istiocoredns.nodeSelector` | `{}` |  |
+
 ## `kiali` options
 
 | Key | Default Value | Description |
 | --- | --- | --- |
-| `kiali.enabled` | `false` | Note that if using the demo or demo-auth yaml when installing via Helm, this default will be `true`. |
+| `kiali.enabled` | `false` |  |
 | `kiali.replicaCount` | `1` |  |
 | `kiali.hub` | `docker.io/kiali` |  |
 | `kiali.tag` | `v0.12` |  |
+| `kiali.contextPath` | `/kiali` |  |
+| `kiali.nodeSelector` | `{}` |  |
 | `kiali.ingress.enabled` | `false` |  |
-| `kiali.contextPath` | `/kiali` | The root context path to access the Kiali UI. |
-| `kiali.dashboard.secretName` | `kiali` | You must create a secret with this name - one is not provided out-of-box.  |
-| `kiali.dashboard.usernameKey` | `username` | This is the key name within the secret whose value is the actual username. |
-| `kiali.dashboard.passphraseKey` | `passphrase` | This is the key name within the secret whose value is the actual passphrase. |
-| `kiali.dashboard.jaegerURL` | | If you have Jaeger installed and it is accessible to client browsers, then set this property to its external URL. Kiali will redirect users to this URL when Jaeger tracing is to be shown. |
-| `kiali.dashboard.grafanaURL` | | If you have Grafana installed and it is accessible to client browsers, then set this property to its external URL. Kiali will redirect users to this URL when Grafana metrics are to be shown. |
+| `kiali.ingress.hosts` | `kiali.local` |  |
+| `kiali.gateway.enabled` | `false` |  |
+| `kiali.dashboard.secretName` | `kiali` |  |
+| `kiali.dashboard.usernameKey` | `username` |  |
+| `kiali.dashboard.passphraseKey` | `passphrase` |  |
+| `kiali.prometheusAddr` | `http://prometheus:9090` |  |
+| `kiali.createDemoSecret` | `false` |  |
 
 ## `mixer` options
 
 | Key | Default Value | Description |
 | --- | --- | --- |
-| `mixer.enabled` | `true` |  |
-| `mixer.replicaCount` | `1` |  |
-| `mixer.autoscaleMin` | `1` |  |
-| `mixer.autoscaleMax` | `5` |  |
 | `mixer.image` | `mixer` |  |
-| `mixer.istio-policy.autoscaleEnabled` | `true` |  |
-| `mixer.istio-policy.autoscaleMin` | `1` |  |
-| `mixer.istio-policy.autoscaleMax` | `5` |  |
-| `mixer.istio-policy.cpu.targetAverageUtilization` | `80` |  |
-| `mixer.istio-telemetry.autoscaleEnabled` | `true` |  |
-| `mixer.istio-telemetry.autoscaleMin` | `1` |  |
-| `mixer.istio-telemetry.autoscaleMax` | `5` |  |
-| `mixer.istio-telemetry.cpu.targetAverageUtilization` | `80` |  |
-| `mixer.prometheusStatsdExporter.hub` | `docker.io/prom` |  |
-| `mixer.prometheusStatsdExporter.tag` | `v0.6.0` |  |
+| `mixer.env.GODEBUG` | `gctrace=2` |  |
+| `mixer.policy.enabled` | `true` |  |
+| `mixer.policy.replicaCount` | `1` |  |
+| `mixer.policy.autoscaleEnabled` | `true` |  |
+| `mixer.policy.autoscaleMin` | `1` |  |
+| `mixer.policy.autoscaleMax` | `5` |  |
+| `mixer.policy.cpu.targetAverageUtilization` | `80` |  |
+| `mixer.policy.podDisruptionBudget` | `{}` |  |
+| `mixer.telemetry.enabled` | `true` |  |
+| `mixer.telemetry.replicaCount` | `1` |  |
+| `mixer.telemetry.autoscaleEnabled` | `true` |  |
+| `mixer.telemetry.autoscaleMin` | `1` |  |
+| `mixer.telemetry.autoscaleMax` | `5` |  |
+| `mixer.telemetry.cpu.targetAverageUtilization` | `80` |  |
+| `mixer.telemetry.podDisruptionBudget` | `{}` |  |
+| `mixer.telemetry.sessionAffinityEnabled` | `false` |  |
+| `mixer.podAnnotations` | `{}` |  |
+| `mixer.nodeSelector` | `{}` |  |
+| `mixer.adapters.kubernetesenv.enabled` | `true` |  |
+| `mixer.adapters.stdio.enabled` | `true` |  |
+| `mixer.adapters.stdio.outputAsJson` | `true` |  |
+| `mixer.adapters.prometheus.enabled` | `true` |  |
+| `mixer.adapters.prometheus.metricsExpiryDuration` | `10m` |  |
+| `mixer.adapters.useAdapterCRDs` | `true` |  |
+
+## `nodeagent` options
+
+| Key | Default Value | Description |
+| --- | --- | --- |
+| `nodeagent.enabled` | `false` |  |
+| `nodeagent.image` | `node-agent-k8s` |  |
+| `nodeagent.env.CA_PROVIDER` | `""` |  |
+| `nodeagent.env.CA_ADDR` | `""` |  |
+| `nodeagent.env.Plugins` | `""` |  |
+| `nodeagent.nodeSelector` | `{}` |  |
 
 ## `pilot` options
 
@@ -210,12 +333,17 @@ To customize Istio install using Helm, use the `--set <key>=<value>` option in H
 | `pilot.enabled` | `true` |  |
 | `pilot.replicaCount` | `1` |  |
 | `pilot.autoscaleMin` | `1` |  |
-| `pilot.autoscaleMax` | `1` |  |
+| `pilot.autoscaleMax` | `5` |  |
 | `pilot.image` | `pilot` |  |
 | `pilot.sidecar` | `true` |  |
 | `pilot.traceSampling` | `100.0` |  |
 | `pilot.resources.requests.cpu` | `500m` |  |
 | `pilot.resources.requests.memory` | `2048Mi` |  |
+| `pilot.podDisruptionBudget` | `{}` |  |
+| `pilot.env.PILOT_PUSH_THROTTLE_COUNT` | `100` |  |
+| `pilot.env.GODEBUG` | `gctrace=2` |  |
+| `pilot.cpu.targetAverageUtilization` | `80` |  |
+| `pilot.nodeSelector` | `{}` |  |
 
 ## `prometheus` options
 
@@ -225,17 +353,44 @@ To customize Istio install using Helm, use the `--set <key>=<value>` option in H
 | `prometheus.replicaCount` | `1` |  |
 | `prometheus.hub` | `docker.io/prom` |  |
 | `prometheus.tag` | `v2.3.1` |  |
+| `prometheus.retention` | `6h` |  |
+| `prometheus.nodeSelector` | `{}` |  |
+| `prometheus.scrapeInterval` | `15s` |  |
+| `prometheus.contextPath` | `/prometheus` |  |
+| `prometheus.ingress.enabled` | `false` |  |
+| `prometheus.ingress.hosts` | `prometheus.local` |  |
 | `prometheus.service.annotations` | `{}` |  |
 | `prometheus.service.nodePort.enabled` | `false` |  |
 | `prometheus.service.nodePort.port` | `32090` |  |
+| `prometheus.gateway.enabled` | `false` |  |
+| `prometheus.security.enabled` | `true` |  |
 
 ## `security` options
 
 | Key | Default Value | Description |
 | --- | --- | --- |
+| `security.enabled` | `true` |  |
 | `security.replicaCount` | `1` |  |
 | `security.image` | `citadel` |  |
 | `security.selfSigned` | `true # indicate if self-signed CA is used.` |  |
+| `security.trustDomain` | `cluster.local # indicate the domain used in SPIFFE identity URL` |  |
+| `security.nodeSelector` | `{}` |  |
+
+## `servicegraph` options
+
+| Key | Default Value | Description |
+| --- | --- | --- |
+| `servicegraph.enabled` | `false` |  |
+| `servicegraph.replicaCount` | `1` |  |
+| `servicegraph.image` | `servicegraph` |  |
+| `servicegraph.nodeSelector` | `{}` |  |
+| `servicegraph.service.annotations` | `{}` |  |
+| `servicegraph.service.name` | `http` |  |
+| `servicegraph.service.type` | `ClusterIP` |  |
+| `servicegraph.service.externalPort` | `8088` |  |
+| `servicegraph.ingress.enabled` | `false` |  |
+| `servicegraph.ingress.hosts` | `servicegraph.local` |  |
+| `servicegraph.prometheusAddr` | `http://prometheus:9090` |  |
 
 ## `sidecarInjectorWebhook` options
 
@@ -245,32 +400,36 @@ To customize Istio install using Helm, use the `--set <key>=<value>` option in H
 | `sidecarInjectorWebhook.replicaCount` | `1` |  |
 | `sidecarInjectorWebhook.image` | `sidecar_injector` |  |
 | `sidecarInjectorWebhook.enableNamespacesByDefault` | `false` |  |
-
-## `telemetry-gateway` options
-
-| Key | Default Value | Description |
-| --- | --- | --- |
-| `telemetry-gateway.gatewayName` | `ingressgateway` |  |
-| `telemetry-gateway.grafanaEnabled` | `true` |  |
-| `telemetry-gateway.prometheusEnabled` | `true` |  |
+| `sidecarInjectorWebhook.nodeSelector` | `{}` |  |
 
 ## `tracing` options
 
 | Key | Default Value | Description |
 | --- | --- | --- |
-| `tracing.enabled` | `true` |  |
+| `tracing.enabled` | `false` |  |
 | `tracing.provider` | `jaeger` |  |
+| `tracing.nodeSelector` | `{}` |  |
 | `tracing.jaeger.hub` | `docker.io/jaegertracing` |  |
-| `tracing.jaeger.tag` | `1.5` |  |
+| `tracing.jaeger.tag` | `1.9` |  |
 | `tracing.jaeger.memory.max_traces` | `50000` |  |
-| `tracing.jaeger.ui.port` | `16686` |  |
-| `tracing.replicaCount` | `1` |  |
+| `tracing.zipkin.hub` | `docker.io/openzipkin` |  |
+| `tracing.zipkin.tag` | `2` |  |
+| `tracing.zipkin.probeStartupDelay` | `200` |  |
+| `tracing.zipkin.queryPort` | `9411` |  |
+| `tracing.zipkin.resources.limits.cpu` | `300m` |  |
+| `tracing.zipkin.resources.limits.memory` | `900Mi` |  |
+| `tracing.zipkin.resources.requests.cpu` | `150m` |  |
+| `tracing.zipkin.resources.requests.memory` | `900Mi` |  |
+| `tracing.zipkin.javaOptsHeap` | `700` |  |
+| `tracing.zipkin.maxSpans` | `500000` |  |
+| `tracing.zipkin.node.cpus` | `2` |  |
 | `tracing.service.annotations` | `{}` |  |
 | `tracing.service.name` | `http` |  |
 | `tracing.service.type` | `ClusterIP` |  |
 | `tracing.service.externalPort` | `9411` |  |
-| `tracing.service.internalPort` | `9411` |  |
 | `tracing.ingress.enabled` | `false` |  |
+| `tracing.gateway.enabled` | `false` |  |
+| `tracing.gateway.name` | `ingressgateway` |  |
 
 <!-- AUTO-GENERATED-END -->
 

--- a/scripts/tablegen.py
+++ b/scripts/tablegen.py
@@ -18,14 +18,23 @@ import collections
 import linecache
 import string
 import sys
+import os
 
 from ruamel.yaml import YAML
+from __builtin__ import file
 
+#
 # Reads a documented Helm values.yaml file and produces a
 # MD formatted table.  pip install ruamel to obtain the proper
 # YAML decoder.  ruamel maintains ordering and comments.  The
 # comments are needed in order to decode the commented helm
 # values.yaml file
+#
+YAML_CONFIG_DIR = "istio/install/kubernetes/helm/subcharts"
+ISTIO_CONFIG_DIR = "istio/install/kubernetes/helm/istio"
+VALUES_YAML = "values.yaml"
+ISTIO_IO_DIR = os.path.abspath(__file__ + "/../../")
+CONFIG_INDEX_DIR = "content/docs/reference/config/installation-options/index.md"
 
 def endOfTheList(context, lineNum, lastLineNum, totalNum):
     flag = 0
@@ -39,10 +48,13 @@ def endOfTheList(context, lineNum, lastLineNum, totalNum):
 
     for nextLineNum in range(lineNum + 1, totalNum):
         nextLine = context[nextLineNum]
+
         if  len(nextLine.lstrip()) != 0 and '#' != nextLine.lstrip()[0] and ':' in nextLine:
             if whitespaces >= (len(nextLine) - len(nextLine.lstrip())) / 2:
                 if flag == 0:
                     valueList.append(currentLine.split(':', 1)[1].strip())
+                return True, valueList
+            else:
                 return True, valueList
         elif len(nextLine.lstrip()) != 0 and '#' !=  nextLine.lstrip()[0] and ':' not in nextLine and len(nextLine.strip()) != 0:
             value = nextLine.replace(' ', '')
@@ -58,73 +70,152 @@ def endOfTheList(context, lineNum, lastLineNum, totalNum):
 prdict = collections.defaultdict(list)
 
 def decode_helm_yaml(s):
-    level = 0
     ret_val = ''
-    key = ''
-    storekey = ''
-    desc = ''
-    possible = ''
-    newkey = ''
-    whitespaces = 0
-    flag = 0
-    lineNum = 0
-    lastLineNum = 0
-    valueList = []
+    #
+    # Iterate through all the directories under /istio/install/kubernetes/heml/subcharts 
+    # and process the configuration options from the respective values.yaml. The
+    # configuration option name is the name of the directory that contains values.yaml.
+    # This name will be passed in to the the function process_helm_yaml
+    #
+    subchart_dir = os.path.join(ISTIO_IO_DIR, YAML_CONFIG_DIR)
+    for file in os.listdir(subchart_dir):
+        values_yaml_dir = os.path.join(subchart_dir, file)
+        values_yaml_file = os.path.join(values_yaml_dir, VALUES_YAML)
+        process_helm_yaml(values_yaml_file, file)
 
-    context = linecache.getlines('values.yaml')
-    totalNum = len(context)
-
-    for lineNum in range(0, totalNum):
-        if  context[lineNum].strip().startswith('- '):
-            pass
-        elif '#' in context[lineNum] and '#' == context[lineNum].lstrip()[0]:
-            if "Description: " in context[lineNum]:
-                desc = context[lineNum].strip()
-        elif ':' in context[lineNum] and '#' != context[lineNum].lstrip()[0]:
-            lastLineNum = lineNum
-            if flag == 1:
-                whitespaces = (len(context[lineNum]) - len(context[lineNum].lstrip())) / 2
-                periods = key.count('.')
-                while (whitespaces <= periods):
-                    key = key.rstrip(string.ascii_letters[::-1] + string.digits + '_' + '-' + '/').rstrip('.')
-                    whitespaces += 1
-                flag = 0
-
-            key = key + '.' + context[lineNum].split(':', 1)[0].strip()
-            isEnd, ValueList  = endOfTheList(context, lineNum, lastLineNum, totalNum)
-            if isEnd == True:
-                flag = 1;
-
-        storekey = key
-        sk = storekey.split('.', 2)
-        if len(sk) > 1:
-            storekey = '.'.join(sk[:1]).lstrip('.')
-        else:
-            storekey = '.'.join(sk[:0]).lstrip('.')
-        
-        if  len(context[lastLineNum].lstrip()) != 0 and '#' != context[lastLineNum].lstrip()[0]:
-            isEnd, ValueList  = endOfTheList(context, lineNum, lastLineNum, totalNum)
-            if (isEnd == True):
-                keysplit = key.split('.')
-                for kv in keysplit:
-                    if kv != '':
-                        newkey = newkey + '.' + kv
-                newkey = newkey.lstrip('.')
-
-                ValueStr = (' ').join(ValueList)
-                if ValueStr:
-                    desc = ''
-                    prdict[storekey].append("| `%s` | `%s` | %s |" % (newkey, ValueStr, desc))
-                desc = ''
-
-                key = newkey
-                newkey = ''
-
-        lineNum += 1
+    #
+    # Process configuration options in values.yaml under istio/install/kubernetes/helm/istio.
+    # The configuration option names are present in the values.yaml, hence we do not need to
+    # pass it to process_helm_yaml.
+    #
+    istio_yaml_config_dir = os.path.join(ISTIO_IO_DIR, ISTIO_CONFIG_DIR)
+    values_yaml_file = os.path.join(istio_yaml_config_dir, VALUES_YAML)
+    process_helm_yaml(values_yaml_file, '')
 
     return ret_val
 
-with open('index.md', 'r') as f:
+def process_helm_yaml(values_yaml, option):
+        ret_val = ''
+        storekey = ''
+        desc = ''
+        newkey = ''
+        whitespaces = 0
+        flag = 0
+        lineNum = 0
+        lastLineNum = 0
+        valueList = []
+        newConfigList = []
+
+        context = linecache.getlines(values_yaml)
+        totalNum = len(context)
+        lastLineNum = 0
+        key = option
+
+        for lineNum in range(0, totalNum):
+            if  context[lineNum].strip().startswith('- '):
+                pass
+            elif '#' in context[lineNum] and '#' == context[lineNum].lstrip()[0]:
+                if "Description: " in context[lineNum]:
+                    desc = context[lineNum].strip()
+            elif ':' in context[lineNum] and '#' != context[lineNum].lstrip()[0]:
+                lastLineNum = lineNum
+                if flag == 1:
+                    whitespaces = (len(context[lineNum]) - len(context[lineNum].lstrip())) / 2
+                    periods = key.count('.')
+                    if (option == ''):
+                        while (whitespaces <= periods):
+                            key = key.rstrip(string.ascii_letters[::-1] + string.digits + '_' + '-' + '/').rstrip('.')
+                            whitespaces += 1
+                    else:
+                        while (whitespaces < periods) :
+                            key = key.rstrip(string.ascii_letters[::-1] + string.digits + '_' + '-' + '/').rstrip('.')
+                            whitespaces += 1
+                        flag = 0
+
+                key = key + '.' + context[lineNum].split(':', 1)[0].strip()
+                isEnd, ValueList  = endOfTheList(context, lineNum, lastLineNum, totalNum)
+                if isEnd == True:
+                    flag = 1;
+
+            storekey = key
+            sk = storekey.split('.', 2)
+            if len(sk) > 1:
+                storekey = '.'.join(sk[:1]).lstrip('.')
+            else:
+                storekey = '.'.join(sk[:0]).lstrip('.')
+
+            #
+            # If we are processing the configurations options within the values.yaml under istio,
+            # if the options have already been processed (from the subcharts directory), then we
+            # do not want to process it again. If the configuration option has not been processed
+            # before, then it is a new configuration option which needs to be processed (for e.g,
+            # global, istiocoredns)
+            #
+            # option == '' - This condition means that we are looking at the values.yaml under the
+            #                istio directory. Hence, the configuration option names will be inside
+            #                the values.yaml file. (On the other hand, for the values.yaml file under
+            #                the subcharts directory, we get the name of the configuration option
+            #                from the name of the directories under the subcharts directory.)
+            # newConfigList - This list is used to track configuration options in istio/values.yaml
+            #                that haven't been processed before (or that does not have a corresponding
+            #                directory under subcharts directory with values.yaml. E.g: global,
+            #                istiocoredns)
+            # 
+            # This first condition checks that if this is the values.yaml file under istio directory,
+            # and the configuration option to process (storekey) has not already been processed (this
+            # conditions: "prdict.get(storekey) != None and (storekey in newConfigList)" together
+            # makes sure that the condition where some parameters for a new configuration option like
+            # 'global' has been processed and entered into the dictionary 'prdict' is still processed
+            # because it is in the newConfigList. If a configuration option was processed from
+            # the values.yaml under the subcharts directory, it will not be in the newConfigList.
+	    # subcharts directory), then go ahead and process the parameters for this option.
+            # 
+            if option == '' and prdict.get(storekey) != None and (storekey in newConfigList):
+                pass
+            #
+            # This second condition checks if this is the values.yaml file under istio directory, and
+            # the configuration option to process (storekey) has not been processed (this could
+            # happen the first time we read a configuration option from the istio/values.yaml file),
+            # then add this configuration option to the newConfigList to mark it as an option that
+            # needs to be processed.
+            #
+            elif option == '' and prdict.get(storekey) == None:
+                newConfigList.append(storekey)
+            #
+            # This third condition checks if this is the values.yaml file under istio directory,
+            # and the configuration option to process (storekey) has already been processed and if
+            # this is not a new configuration option, (this could happen if we have already 
+            # processed the corresponding values.yaml under the subcharts directory), then ignore
+            # this configuration option and do not process the values in this file.
+            #
+            elif option == '' and prdict.get(storekey) != None:
+                continue
+
+            if  len(context[lastLineNum].lstrip()) != 0 and '#' != context[lastLineNum].lstrip()[0]:
+                isEnd, ValueList  = endOfTheList(context, lineNum, lastLineNum, totalNum)
+
+                if (isEnd == True):
+                    flag = 1
+                    keysplit = key.split('.')
+                    for kv in keysplit:
+                        if kv != '':
+                            newkey = newkey + '.' + kv
+
+                    newkey = newkey.lstrip('.')
+
+                    ValueStr = (' ').join(ValueList)
+                    if ValueStr:
+                        desc = ''
+                        prdict[storekey].append("| `%s` | `%s` | %s |" % (newkey, ValueStr, desc))
+                    desc = ''
+
+                    key = newkey
+                    newkey = ''
+
+            lineNum += 1
+        return ret_val
+
+with open(os.path.join(ISTIO_IO_DIR, CONFIG_INDEX_DIR), 'r') as f:
     endReached = False
 
     data = f.read().split('\n')
@@ -133,26 +224,22 @@ with open('index.md', 'r') as f:
         if "<!-- AUTO-GENERATED-START -->" in d:
             break
 
-    with open('values.yaml', 'r') as f_v:
-        d_v = f_v.read()
+    # transform values.yaml into a encoded string dictionary
+    yaml = YAML()
+    yaml.explicit_start = True
+    yaml.dump('', sys.stdout, transform=decode_helm_yaml)
 
-        # transform values.yaml into a encoded string dictionary
-        yaml = YAML()
-        code = yaml.load(d_v)
-        yaml.explicit_start = True
-        yaml.dump(code, sys.stdout, transform=decode_helm_yaml)
+    # Order the encoded string dictionary
+    od = collections.OrderedDict(sorted(prdict.items(), key=lambda t: t[0]))
 
-        # Order the encoded string dictionary
-        od = collections.OrderedDict(sorted(prdict.items(), key=lambda t: t[0]))
-
-        # Print encoded string dictionary
-        for k, v in od.items():
-            print ("## `%s` options\n" % k)
-            print '| Key | Default Value | Description |'
-            print '| --- | --- | --- |'
-            for value in v:
-                print ('%s' % (value))
-            print ('')
+    # Print encoded string dictionary
+    for k, v in od.items():
+        print ("## `%s` options\n" % k)
+        print '| Key | Default Value | Description |'
+        print '| --- | --- | --- |'
+        for value in v:
+            print ('%s' % (value))
+        print ('')
 
     for d in data:
         if "<!-- AUTO-GENERATED-END -->" in d:


### PR DESCRIPTION
Updated tablegen.py to process the configuration options from the values.yaml
files under /istio/install/kubernetes/heml/subcharts directory and the
remaining configuration options like global, istiocoredns, istio_cni from
values.yaml under /istio/install/kubernetes/helm/istio directory.