### PR TITLE
Fix missing list in example VirtualService

### DIFF
--- a/content/docs/concepts/traffic-management/index.md
+++ b/content/docs/concepts/traffic-management/index.md
@@ -602,7 +602,7 @@ spec:
   - ratings
   http:
   - match:
-      sourceLabels:
+    - sourceLabels:
         app: reviews
     route:
     ...


### PR DESCRIPTION
`match` should take a list, but here the `-` was missing.