### PR TITLE
Updates the docs to refer to port 8080.

### DIFF
--- a/content/help/ops/misc/index.md
+++ b/content/help/ops/misc/index.md
@@ -24,13 +24,13 @@ Verifying connectivity to Pilot is a useful troubleshooting step. Every proxy co
 1.  Test connectivity to Pilot using `curl`. The following example invokes the v1 registration API using default Pilot configuration parameters and mutual TLS enabled:
 
     {{< text bash >}}
-    $ curl -k --cert /etc/certs/cert-chain.pem --cacert /etc/certs/root-cert.pem --key /etc/certs/key.pem https://istio-pilot:15003/v1/registration
+    $ curl -k --cert /etc/certs/cert-chain.pem --cacert /etc/certs/root-cert.pem --key /etc/certs/key.pem https://istio-pilot:8080/v1/registration
     {{< /text >}}
 
     If mutual TLS is disabled:
 
     {{< text bash >}}
-    $ curl http://istio-pilot:15003/v1/registration
+    $ curl http://istio-pilot:8080/v1/registration
     {{< /text >}}
 
 You should receive a response listing the "service-key" and "hosts" for each service in the mesh.


### PR DESCRIPTION
As discussed in https://github.com/istio/istio/issues/11284, Port 15003 has been deprecated. This commit updates the port mentioned in the documentation to Port 8080.

Signed-off-by: Jason Clark <jason.clark.oss@gmail.com>