### PR TITLE
Fix typo

### DIFF
--- a/content_zh/docs/reference/config/istio.networking.v1alpha3/index.md
+++ b/content_zh/docs/reference/config/istio.networking.v1alpha3/index.md
@@ -462,7 +462,7 @@ metadata:
   name: my-gateway
 spec:
   selector:
-    app: my-gatweway-controller
+    app: my-gateway-controller
   servers:
   - port:
       number: 80


### PR DESCRIPTION
Found in 1.0
Fixed in 1.1 en but not in 1.1 zh