### PR TITLE
Updating the API endpoint to /debug/edsz

### DIFF
--- a/content/help/ops/misc/index.md
+++ b/content/help/ops/misc/index.md
@@ -24,13 +24,13 @@ Verifying connectivity to Pilot is a useful troubleshooting step. Every proxy co
 1.  Test connectivity to Pilot using `curl`. The following example invokes the v1 registration API using default Pilot configuration parameters and mutual TLS enabled:
 
     {{< text bash >}}
-    $ curl -k --cert /etc/certs/cert-chain.pem --cacert /etc/certs/root-cert.pem --key /etc/certs/key.pem https://istio-pilot:8080/v1/registration
+    $ curl -k --cert /etc/certs/cert-chain.pem --cacert /etc/certs/root-cert.pem --key /etc/certs/key.pem https://istio-pilot:8080/debug/edsz
     {{< /text >}}
 
     If mutual TLS is disabled:
 
     {{< text bash >}}
-    $ curl http://istio-pilot:8080/v1/registration
+    $ curl http://istio-pilot:8080/debug/edsz
     {{< /text >}}
 
 You should receive a response listing the "service-key" and "hosts" for each service in the mesh.


### PR DESCRIPTION
Updating the API endpoint to a non-deprecated endpoint to test Pilot connectivity. 

In https://github.com/istio/istio/issues/11284, not only should the port be updated, but the endpoint used to validate Pilot connectivity should be updated as well.

See: https://github.com/istio/istio/blob/master/pilot/pkg/proxy/envoy/v2/debug.go#L54 for ref.

Signed-off-by: Jason Clark <jason.clark.oss@gmail.com>