### PR TITLE
Correct the grep for istio-init created crd jobs

### DIFF
--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -101,7 +101,7 @@ to manage the lifecycle of Istio.
 1. Verify all the Istio's CRDs have been committed to the Kubernetes API server by checking all the CRD creation jobs complete with success:
 
     {{< text bash >}}
-    $ kubectl get job --namespace istio-system | grep istio-crd
+    $ kubectl get job --namespace istio-system | grep istio-init-crd
     {{< /text >}}
 
 1. Install the `istio` chart:


### PR DESCRIPTION
While stepping through the [Install with Helm and Tiller via `helm install`](https://preliminary.istio.io/docs/setup/kubernetes/helm-install/#option-2-install-with-helm-and-tiller-via-helm-install) instructions on the preliminary site I noticed that there was a small typo in the grep for the `istio-init` CRD jobs, this fixes that:
```console
$ kubectl get job --namespace istio-system | grep istio-crd
<nothing>
```
vs
```console
$ kubectl get job --namespace istio-system | grep istio-init-crd
istio-init-crd-10               1         1            6m
istio-init-crd-11               1         1            6m
istio-init-crd-certmanager-10   1         1            6m
```