### PR TITLE
update deprecated attribute in doc.

### DIFF
--- a/content/docs/concepts/policies-and-telemetry/index.md
+++ b/content/docs/concepts/policies-and-telemetry/index.md
@@ -136,7 +136,7 @@ Attribute expressions are used when configuring [instances](#instances).
 Here's an example use of expressions:
 
 {{< text yaml >}}
-destination_service: destination.service
+destination_service: destination.service.host
 response_code: response.code
 destination_version: destination.labels["version"] | "unknown"
 {{< /text >}}


### PR DESCRIPTION
`destination.service` has been deprecated, see: https://preliminary.istio.io/docs/reference/config/policy-and-telemetry/attribute-vocabulary/#deprecated-attributes

use `destination.service.host` instead.