### PR TITLE
Tasks/Policies/Enabling Rate Limits: fix memquota and redisquota handlers [release-1.0]

### DIFF
--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -73,6 +73,8 @@ so the configuration to enable rate limiting on both adapters is the same.
       name: handler
       namespace: istio-system
     spec:
+      redisServerUrl: <redis_server_url>
+      connectionPoolSize: 10
       quotas:
       - name: requestcount.quota.istio-system
         maxAmount: 500
@@ -87,22 +89,17 @@ so the configuration to enable rate limiting on both adapters is the same.
         - dimensions:
             destination: reviews
           maxAmount: 1
-          validDuration: 5s
         # The following override applies to 'productpage' when
         # the source is a specific ip address.
         - dimensions:
             destination: productpage
             source: "10.28.11.20"
           maxAmount: 500
-          validDuration: 1s
         # The following override applies to 'productpage' regardless
         # of the source.
         - dimensions:
             destination: productpage
           maxAmount: 2
-          validDuration: 5s
-        redisServerUrl: <redis_server_url>
-        connectionPoolSize: 10
     ---
     apiVersion: "config.istio.io/v1alpha2"
     kind: quota
@@ -175,6 +172,7 @@ so the configuration to enable rate limiting on both adapters is the same.
       - name: requestcount.quota.istio-system
         maxAmount: 500
         validDuration: 1s
+        overrides:
         - dimensions:
             destination: reviews
           maxAmount: 1


### PR DESCRIPTION
redisquota handler:
- Remove validDuration field in dimensions.

- Move redisServerUrl field and connectionPoolSize field, which makes them parallel to quotas field.

memquota handler:
- Add overrides field which is missing.


References:

[https://github.com/istio/istio/blob/release-1.0/mixer/adapter/redisquota/config/config.pb.go#L96](https://github.com/istio/istio/blob/release-1.0/mixer/adapter/redisquota/config/config.pb.go#L96)
[https://github.com/istio/istio/blob/release-1.0/mixer/adapter/redisquota/config/config.pb.go#L111](https://github.com/istio/istio/blob/release-1.0/mixer/adapter/redisquota/config/config.pb.go#L111)
[https://github.com/istio/istio/blob/release-1.0/mixer/adapter/memquota/config/config.pb.go#L77](https://github.com/istio/istio/blob/release-1.0/mixer/adapter/memquota/config/config.pb.go#L77)