### PR TITLE
Tasks/Policies/Enabling Rate Limits: fix memquota and redisquota handlers

### DIFF
--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -73,9 +73,9 @@ so the configuration to enable rate limiting on both adapters is the same.
       name: handler
       namespace: istio-system
     spec:
+      redisServerUrl: <redis_server_url>
+      connectionPoolSize: 10
       quotas:
-        redisServerUrl: <redis_server_url>
-        connectionPoolSize: 10
       - name: requestcount.quota.istio-system
         maxAmount: 500
         validDuration: 1s
@@ -172,6 +172,7 @@ so the configuration to enable rate limiting on both adapters is the same.
       - name: requestcount.quota.istio-system
         maxAmount: 500
         validDuration: 1s
+        overrides:
         - dimensions:
             destination: reviews
           maxAmount: 1

--- a/content_zh/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content_zh/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -60,9 +60,9 @@ keywords: [policies,quotas]
       name: handler
       namespace: istio-system
     spec:
+      redisServiceUrl: <redis_server_url>
+      connectionPoolSize: 10
       quotas:
-        redisServiceUrl: <redis_server_url>
-        connectionPoolSize: 10
       - name: requestcount.quota.istio-system
         maxAmount: 500
         validDuration: 1s
@@ -159,6 +159,7 @@ keywords: [policies,quotas]
       - name: requestcount.quota.istio-system
         maxAmount: 500
         validDuration: 1s
+        overrides:
         - dimensions:
             destination: reviews
           maxAmount: 1


### PR DESCRIPTION
redisquota handler:

* Move redisServerUrl field and connectionPoolSize field, which makes them parallel to quotas field.

memquota handler:

* Add overrides field which is missing.

References:

[https://github.com/istio/istio/blob/master/mixer/adapter/redisquota/config/config.pb.go#L96](https://github.com/istio/istio/blob/master/mixer/adapter/redisquota/config/config.pb.go#L96)
[https://github.com/istio/istio/blob/master/mixer/adapter/memquota/config/config.pb.go#L77](https://github.com/istio/istio/blob/master/mixer/adapter/memquota/config/config.pb.go#L77)