### PR TITLE
document file names used in external certificate configuration

### DIFF
--- a/content/docs/setup/kubernetes/multicluster-install/gateways/index.md
+++ b/content/docs/setup/kubernetes/multicluster-install/gateways/index.md
@@ -44,8 +44,10 @@ on **each** Kubernetes cluster.
     across different clusters.
 
     {{< tip >}}
-    For illustration purposes, the following instructions use the root certificate from
-    the Istio samples directory as the intermediate certificates.
+    For illustration purposes, the following instructions use the certificates
+    from the Istio samples directory for both clusters. In real world deployments,
+    you would likely use a different CA certificate for each cluster, all signed
+    by a common root CA.
     {{< /tip >}}
 
 1. Generate a multicluster-gateways Istio configuration file using `helm`:
@@ -67,7 +69,7 @@ on **each** Kubernetes cluster.
 1. Run the following commands in **every cluster** to deploy an identical Istio control plane
    configuration in all of them.
 
-    * Create a Kubernetes secret for your generated CA certificates using a command similar to the following:
+    * Create a Kubernetes secret for your generated CA certificates using a command similar to the following. See [Certificate Authority (CA) certificates](/docs/tasks/security/plugin-ca-cert/#plugging-in-the-existing-certificate-and-key) for more details.
 
         {{< text bash >}}
         $ kubectl create namespace istio-system

--- a/content/docs/tasks/security/plugin-ca-cert/index.md
+++ b/content/docs/tasks/security/plugin-ca-cert/index.md
@@ -42,6 +42,14 @@ Note that if your `ca-cert.pem` is the same as `root-cert.pem`, the `cert-chain.
 
 These files are ready to use in the `samples/certs/` directory.
 
+  {{< tip >}}
+  The default Citadel installation mounts the `cacert` secret as a volume under `/etc/certs`.
+  It is configured via [command line options](/docs/reference/commands/istio_ca/index.html)
+  to load certificates and keys from the predefined file names used in the command below
+  (i.e., root certificate must be in a file named `root-cert.pem`, Citadel key in
+  `ca-key.pem`, etc.)
+  {{< /tip >}}
+
 The following steps enable plugging in the certificates and key into Citadel:
 
 1.  Create a secret `cacert` including all the input files `ca-cert.pem`, `ca-key.pem`, `root-cert.pem` and `cert-chain.pem`:

--- a/content/docs/tasks/security/plugin-ca-cert/index.md
+++ b/content/docs/tasks/security/plugin-ca-cert/index.md
@@ -43,7 +43,8 @@ Note that if your `ca-cert.pem` is the same as `root-cert.pem`, the `cert-chain.
 These files are ready to use in the `samples/certs/` directory.
 
   {{< tip >}}
-  The default Citadel installation sets [command line options](/docs/reference/commands/istio_ca/index.html) to configure the location of certificates and keys based on the predefined secret and file names used in the command below (i.e., secret named `cacert`,root certificate in a file named `root-cert.pem`, Citadel key in `ca-key.pem`, etc.)
+  The default Citadel installation sets [command line options](/docs/reference/commands/istio_ca/index.html) to configure the location of certificates and keys based on the predefined secret and file names used in the command below (i.e., secret named `cacert`, root certificate in a file named `root-cert.pem`, Citadel key in `ca-key.pem`, etc.)
+  You must use these specific secret and file names, or reconfigure Citadel when you deploy it.
   {{< /tip >}}
 
 The following steps enable plugging in the certificates and key into Citadel:

--- a/content/docs/tasks/security/plugin-ca-cert/index.md
+++ b/content/docs/tasks/security/plugin-ca-cert/index.md
@@ -43,11 +43,7 @@ Note that if your `ca-cert.pem` is the same as `root-cert.pem`, the `cert-chain.
 These files are ready to use in the `samples/certs/` directory.
 
   {{< tip >}}
-  The default Citadel installation mounts the `cacert` secret as a volume under `/etc/certs`.
-  It is configured via [command line options](/docs/reference/commands/istio_ca/index.html)
-  to load certificates and keys from the predefined file names used in the command below
-  (i.e., root certificate must be in a file named `root-cert.pem`, Citadel key in
-  `ca-key.pem`, etc.)
+  The default Citadel installation sets [command line options](/docs/reference/commands/istio_ca/index.html) to configure the location of certificates and keys based on the predefined secret and file names used in the command below (i.e., secret named `cacert`,root certificate in a file named `root-cert.pem`, Citadel key in `ca-key.pem`, etc.)
   {{< /tip >}}
 
 The following steps enable plugging in the certificates and key into Citadel:


### PR DESCRIPTION
document expected secret and certificates names when plugging in external CA.
This was the source of some confusion, especially in multicluster setup (e.g., Citadel certificate and key  file names for `cluster-01` can't be `cluster-01-cert.pem`, `cluster-01-key.pem`...).

/assign @frankbu 