### PR TITLE
Use release-1.1 charts instead of masteer charts

### DIFF
--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -49,7 +49,7 @@ via `kubectl apply`, and wait a few seconds for the CRDs to be committed in the 
 1.  Update Helm's dependencies:
 
     {{< text bash >}}
-    $ helm repo add istio.io "https://storage.googleapis.com/istio-prerelease/daily-build/master-latest-daily/charts"
+    $ helm repo add istio.io "https://gcsweb.istio.io/gcs/istio-prerelease/daily-build/release-1.1-latest-daily/charts/"
     $ helm dep update install/kubernetes/helm/istio
     {{< /text >}}
 


### PR DESCRIPTION
Since we are still in thee 1.1 release series, we should point
devs at the 1.1 daily charts.

Thanks to @hklai for pointing me at the proper location.