### PR TITLE
Kiali jaegerURL should use jaeger-query service.

### DIFF
--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -72,8 +72,8 @@ integrates with them, you must pass additional arguments to the
 {{< text bash >}}
 $ helm template \
     --set kiali.enabled=true \
-    --set "kiali.dashboard.jaegerURL=http://$(kubectl get svc jaeger-query --namespace istio-system -o jsonpath='{.spec.clusterIP}'):16686" \
-    --set "kiali.dashboard.grafanaURL=http://$(kubectl get svc grafana --namespace istio-system -o jsonpath='{.spec.clusterIP}'):3000" \
+    --set "kiali.dashboard.jaegerURL=http://jaeger-query:16686" \
+    --set "kiali.dashboard.grafanaURL=http://grafana:3000" \
     install/kubernetes/helm/istio \
     --name istio --namespace istio-system > $HOME/istio.yaml
 $ kubectl apply -f $HOME/istio.yaml

--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -72,7 +72,7 @@ integrates with them, you must pass additional arguments to the
 {{< text bash >}}
 $ helm template \
     --set kiali.enabled=true \
-    --set "kiali.dashboard.jaegerURL=http://$(kubectl get svc tracing --namespace istio-system -o jsonpath='{.spec.clusterIP}'):80" \
+    --set "kiali.dashboard.jaegerURL=http://$(kubectl get svc jaeger-query --namespace istio-system -o jsonpath='{.spec.clusterIP}'):16686" \
     --set "kiali.dashboard.grafanaURL=http://$(kubectl get svc grafana --namespace istio-system -o jsonpath='{.spec.clusterIP}'):3000" \
     install/kubernetes/helm/istio \
     --name istio --namespace istio-system > $HOME/istio.yaml


### PR DESCRIPTION
Prior to change, while using the tracing service on port 80 for the jaegerURL, kiali would never get metrics to compose the service graphs.

Switching jaegerURL to jaeger-query service on port 16686 fixes the issue.  After traffic is generated the service graphs are built and visible in kiali.