### PR TITLE
Fix too many redirects path in Kiali task

### DIFF
--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -115,7 +115,7 @@ Once you install Istio and Kiali, deploy the [Bookinfo](/docs/examples/bookinfo/
     $ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=kiali -o jsonpath='{.items[0].metadata.name}') 20001:20001
     {{< /text >}}
 
-1.  Visit <http://localhost:20001/kiali> in your web browser.
+1.  Visit <http://localhost:20001/kiali/console> in your web browser.
 
 1.  To log into the Kiali UI, go to the Kiali login screen and enter the username and passphrase stored in the Kiali secret.
 


### PR DESCRIPTION
When following along with the docs this path gives me an ERR_TOO_MANY_REDIRECTS but changing it to `/kiali/console` fixes it.

Signed-off-by: Liam White <liam@tetrate.io>