### PR TITLE
Adds documentation related to experimental RBAC

### DIFF
--- a/content/docs/reference/config/authorization/constraints-and-properties/index.md
+++ b/content/docs/reference/config/authorization/constraints-and-properties/index.md
@@ -31,12 +31,12 @@ The following table lists the currently supported keys for the `constraints` fie
 | `destination.name` | Destination workload instance name | YES | `destination.name` | `["productpage*", "*-test"]` |
 | `destination.namespace` | Destination workload instance namespace | YES | `destination.namespace` | `["default"]` |
 | `destination.user` | The identity of the destination workload | YES | `destination.user` | `["bookinfo-productpage"]` |
-| `experimental` | Experimental configuration, Values wrapped in `[]` are matched as a list | YES | `experimental.envoy.filters.network.mysql_proxy[db.table]` | `["[update]"]` |
+| `experimental.envoy.filters.*` | Experimental metadata matching for filters, values wrapped in `[]` are matched as a list | YES | `experimental.envoy.filters.network.mysql_proxy[db.table]` | `["[update]"]` |
 | `request.headers` | HTTP request headers, The actual header name is surrounded by brackets | NO | `request.headers[X-Custom-Token]` | `["abc123"]` |
 
 {{< warning >}}
-Note that no backward compatibility is guaranteed for the `experimental` key. It may be removed at
-any time, and customers are advised to use it at their own risk.
+Note that no backward compatibility is guaranteed for the `experimental.*` keys. They may be removed
+at any time, and customers are advised to use them at their own risk.
 {{< /warning >}}
 
 ## Supported Properties

--- a/content/docs/reference/config/authorization/constraints-and-properties/index.md
+++ b/content/docs/reference/config/authorization/constraints-and-properties/index.md
@@ -31,7 +31,13 @@ The following table lists the currently supported keys for the `constraints` fie
 | `destination.name` | Destination workload instance name | YES | `destination.name` | `["productpage*", "*-test"]` |
 | `destination.namespace` | Destination workload instance namespace | YES | `destination.namespace` | `["default"]` |
 | `destination.user` | The identity of the destination workload | YES | `destination.user` | `["bookinfo-productpage"]` |
+| `experimental` | Experimental configuration, Values wrapped in `[]` are matched as a list | YES | `experimental.envoy.filters.network.mysql_proxy[db.table]` | `["[update]"]` |
 | `request.headers` | HTTP request headers, The actual header name is surrounded by brackets | NO | `request.headers[X-Custom-Token]` | `["abc123"]` |
+
+{{< warning >}}
+Note that no backward compatibility is guaranteed for the `experimental` key. It may be removed at
+any time, and customers are advised to use it at their own risk.
+{{< /warning >}}
 
 ## Supported Properties
 


### PR DESCRIPTION
This adds documentation related to the newly introduced `experimental` key. See istio/istio#11459 for implementation details.

/cc @rshriram @yangminzhu @liminw 