### PR TITLE
Add support for content to be rendered about the auto-generated content in list pages

### DIFF
--- a/content/about/contribute/creating-and-editing-pages/index.md
+++ b/content/about/contribute/creating-and-editing-pages/index.md
@@ -129,6 +129,7 @@ The available front matter fields are:
 |`skip_seealso`     | Set this to true to prevent the page from having a "See also" section generated for it
 |`force_inline_toc` | Set this to true to force the generated table of contents to be inserted inline in the text instead of in a sidebar
 |`simple_list`      | Set this to true to force a generated section page to use a simple list layout rather that a gallery layout
+|`content_above`    | Set this to true to force the content portion of a section index to be rendered above the auto-generated content
 
 There are a few more front matter fields available specifically for blog posts:
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -6,6 +6,10 @@
 
 <p>{{ .Description }}</p>
 
+{{ if .Params.content_above }}
+{{ .Content }}
+{{ end }}
+
 <div class="section-index">
     {{ $pages := (where .Site.Pages "Section" .Section).ByWeight }}
     {{ $parent := .Page }}
@@ -33,7 +37,9 @@
     {{ end }}
 </div>
 
+{{ if not .Params.content_above }}
 {{ .Content }}
+{{ end }}
 
 {{ partial "primary_bottom.html" . }}
 


### PR DESCRIPTION
Adding

content_above: true

In the front-matter of an _index.md page will cause any content added to that page to be rendered above the auto-generated stuff, rather than below it as normal.

We might need to tweak some CSS depending on how this is used. We'll see and adjust as needed.