### PR TITLE
Fixed command to execute cleanup script

### DIFF
--- a/content/docs/examples/bookinfo/index.md
+++ b/content/docs/examples/bookinfo/index.md
@@ -260,7 +260,7 @@ it up using the following instructions corresponding to your Istio runtime envir
 1.  Delete the routing rules and terminate the application pods
 
     {{< text bash >}}
-    $ @samples/bookinfo/platform/kube/cleanup.sh@
+    $ @./samples/bookinfo/platform/kube/cleanup.sh@
     {{< /text >}}
 
 1.  Confirm shutdown
@@ -279,7 +279,7 @@ it up using the following instructions corresponding to your Istio runtime envir
     In a Consul setup, run the following command:
 
     {{< text bash >}}
-    $ @samples/bookinfo/platform/consul/cleanup.sh@
+    $ @./samples/bookinfo/platform/consul/cleanup.sh@
     {{< /text >}}
 
 1.  Confirm cleanup


### PR DESCRIPTION
Currently, the command for bookinfo doesn't execute verbatim because it's missing a ./. Fixes #3300