### PR TITLE
Update read command for Z Shell

### DIFF
--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -31,7 +31,8 @@ $ KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo -n $uval | base64)
 $ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo -n $pval | base64)
 {{< /text >}}
 
-If you are using the Z Shell, zsh, use the following to define the credentials:
+If you are using the Z Shell, `zsh`, use the following to define the credentials:
+
 {{< text bash >}}
 $ KIALI_USERNAME=$(read '?Kiali Username: ' uval && echo -n $uval | base64)
 $ KIALI_PASSPHRASE=$(read -s "?Kiali Passphrase: " pval && echo -n $pval | base64)

--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -31,6 +31,12 @@ $ KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo -n $uval | base64)
 $ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo -n $pval | base64)
 {{< /text >}}
 
+If you are using the Z Shell, zsh, use the following to define the credentials:
+{{< text bash >}}
+$ KIALI_USERNAME=$(read '?Kiali Username: ' uval && echo -n $uval | base64)
+$ KIALI_PASSPHRASE=$(read -s "?Kiali Passphrase: " pval && echo -n $pval | base64)
+{{< /text >}}
+
 To create a secret, run the following commands:
 
 {{< text bash >}}


### PR DESCRIPTION
The Kiali document uses the internal bash read command which fails using the Z Shell. Update the doc to specify the equivalent zsh commands.

I did search istio.io for additional read commands and did not find any.