### PR TITLE
Update document for `istioctl auth tls-check` command

### DIFF
--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -211,7 +211,7 @@ The Kubernetes API server doesn't have a sidecar, thus request from Istio servic
 requests to any non-Istio service.
 
 {{< text bash >}}
-$ TOKEN=$(kubectl describe secret $(kubectl get secrets | grep default | cut -f1 -d ' ') | grep -E '^token' | cut -f2 -d':' | tr -d '\t')
+$ TOKEN=$(kubectl describe secret $(kubectl get secrets | grep default-token | cut -f1 -d ' ' | head -1) | grep -E '^token' | cut -f2 -d':' | tr -d '\t')
 $ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl https://kubernetes.default/api --header "Authorization: Bearer $TOKEN" --insecure -s -o /dev/null -w "%{http_code}\n"
 000
 command terminated with exit code 35
@@ -241,7 +241,7 @@ this rule, together with the global authentication policy and destination rule a
 Re-run the testing command above to confirm that it returns 200 after the rule is added:
 
 {{< text bash >}}
-$ TOKEN=$(kubectl describe secret $(kubectl get secrets | grep default | cut -f1 -d ' ') | grep -E '^token' | cut -f2 -d':' | tr -d '\t')
+$ TOKEN=$(kubectl describe secret $(kubectl get secrets | grep default-token | cut -f1 -d ' ' | head -1) | grep -E '^token' | cut -f2 -d':' | tr -d '\t')
 $ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl https://kubernetes.default/api --header "Authorization: Bearer $TOKEN" --insecure -s -o /dev/null -w "%{http_code}\n"
 200
 {{< /text >}}

--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -69,18 +69,13 @@ Please check [Istio identity](/docs/concepts/security/#istio-identity) for more 
 
 ## Verify mutual TLS configuration
 
-For this task, you may want to get the pod ID of the client app (`sleep`) with the following command:
-
-{{< text bash >}}
-$ SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})
-{{< /text >}}
-
 You can use the `istioctl` tool to check the effective mutual TLS settings. The command requires the client pod as the destination rule depends on the client namespace.
 You can also provide the destination service to filter the status to that service only.
 
-To identify the authentication policy for the `httpbin.default.svc.cluster.local` service and its destination rules as seen from the `${SLEEP_POD}` pod, use the following command:
+To identify the authentication policy for the `httpbin.default.svc.cluster.local` service and its destination rules as seen from the some a pod of the `sleep` app, use the following command:
 
 {{< text bash >}}
+$ SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})
 $ istioctl authn tls-check ${SLEEP_POD} httpbin.default.svc.cluster.local
 {{< /text >}}
 

--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -83,11 +83,11 @@ In the following example output you can see that:
 
 * Mutual TLS is consistently setup for `httpbin.default.svc.cluster.local` on port 8000.
 * Istio uses the mesh-wide `default` authentication policy.
-* Istio has the `default` destination rule in the `default` namespace.
+* Istio has the `default` destination rule in the `istio-system` namespace.
 
 {{< text plain >}}
 HOST:PORT                                  STATUS     SERVER     CLIENT     AUTHN POLICY        DESTINATION RULE
-httpbin.default.svc.cluster.local:8000     OK         mTLS       mTLS       default/            default/default
+httpbin.default.svc.cluster.local:8000     OK         mTLS       mTLS       default/            default/istio-system
 {{< /text >}}
 
 The output shows:
@@ -110,6 +110,7 @@ apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:
   name: "bad-rule"
+  namespace: "default"
 spec:
   host: "httpbin.default.svc.cluster.local"
   trafficPolicy:

--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -75,7 +75,7 @@ For this task, you may want to get the pod ID of the client app (`sleep`) with t
 $ SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})
 {{< /text >}}
 
-You can use the `istioctl` tool to check the effective mutual TLS settings. The command requires the client pod as depend on the client namespace, the destination rule for it can be different.
+You can use the `istioctl` tool to check the effective mutual TLS settings. The command requires the client pod as the destination rule depends on the client namespace.
 You can also provide the destination service to filter the status to that service only.
 
 For example, to identify the authentication policy for service `httpbin.default.svc.cluster.local` and destination rules to it, as seen from pod `${SLEEP_POD}`, use the following command:

--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -72,7 +72,7 @@ Please check [Istio identity](/docs/concepts/security/#istio-identity) for more 
 Use the `istioctl` tool to check if the mutual TLS settings are in effect. The `istioctl` command needs the client's pod because the destination rule depends on the client's namespace.
 You can also provide the destination service to filter the status to that service only.
 
-To identify the authentication policy for the `httpbin.default.svc.cluster.local` service and its destination rules as seen from the some a pod of the `sleep` app, use the following command:
+To identify the authentication policy for the `httpbin.default.svc.cluster.local` service and its destination rules as seen from the some a pod of the `sleep` app, use the following commands:
 
 {{< text bash >}}
 $ SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})

--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -69,7 +69,7 @@ Please check [Istio identity](/docs/concepts/security/#istio-identity) for more 
 
 ## Verify mutual TLS configuration
 
-You can use the `istioctl` tool to check the effective mutual TLS settings. The command requires the client pod as the destination rule depends on the client namespace.
+Use the `istioctl` tool to check if the mutual TLS settings are in effect. The `istioctl` command needs the client's pod because the destination rule depends on the client's namespace.
 You can also provide the destination service to filter the status to that service only.
 
 To identify the authentication policy for the `httpbin.default.svc.cluster.local` service and its destination rules as seen from the some a pod of the `sleep` app, use the following command:

--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -72,7 +72,7 @@ Please check [Istio identity](/docs/concepts/security/#istio-identity) for more 
 Use the `istioctl` tool to check if the mutual TLS settings are in effect. The `istioctl` command needs the client's pod because the destination rule depends on the client's namespace.
 You can also provide the destination service to filter the status to that service only.
 
-To identify the authentication policy for the `httpbin.default.svc.cluster.local` service and its destination rules as seen from the some a pod of the `sleep` app, use the following commands:
+The following commands identify the authentication policy for the `httpbin.default.svc.cluster.local` service and identify the destination rules for the service as seen from the same pod of the `sleep` app:
 
 {{< text bash >}}
 $ SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})

--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -78,7 +78,7 @@ $ SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})
 You can use the `istioctl` tool to check the effective mutual TLS settings. The command requires the client pod as the destination rule depends on the client namespace.
 You can also provide the destination service to filter the status to that service only.
 
-For example, to identify the authentication policy for service `httpbin.default.svc.cluster.local` and destination rules to it, as seen from pod `${SLEEP_POD}`, use the following command:
+To identify the authentication policy for the `httpbin.default.svc.cluster.local` service and its destination rules as seen from the `${SLEEP_POD}` pod, use the following command:
 
 {{< text bash >}}
 $ istioctl authn tls-check ${SLEEP_POD} httpbin.default.svc.cluster.local

--- a/content/help/faq/security/check-policy.md
+++ b/content/help/faq/security/check-policy.md
@@ -6,9 +6,11 @@ weight: 11
 The `istioctl` tool provides an option for this purpose. You can do:
 
 {{< text bash >}}
-$ istioctl authn tls-check httpbin.default.svc.cluster.local
+$ istioctl authn tls-check $CLIENT_POD httpbin.default.svc.cluster.local
 HOST:PORT                                  STATUS     SERVER     CLIENT     AUTHN POLICY        DESTINATION RULE
 httpbin.default.svc.cluster.local:8000     OK         mTLS       mTLS       default/            default/default
 {{< /text >}}
+
+Where `$CLIENT_POD` is the ID of one of the client service's pods.
 
 Refer to [Verify mutual TLS configuration](/docs/tasks/security/mutual-tls/#verify-mutual-tls-configuration) for more information.

--- a/content/help/faq/security/check-policy.md
+++ b/content/help/faq/security/check-policy.md
@@ -8,7 +8,7 @@ The `istioctl` tool provides an option for this purpose. You can do:
 {{< text bash >}}
 $ istioctl authn tls-check $CLIENT_POD httpbin.default.svc.cluster.local
 HOST:PORT                                  STATUS     SERVER     CLIENT     AUTHN POLICY        DESTINATION RULE
-httpbin.default.svc.cluster.local:8000     OK         mTLS       mTLS       default/            istio-system/default
+httpbin.default.svc.cluster.local:8000     OK         mTLS       mTLS       default/            default/istio-system
 {{< /text >}}
 
 Where `$CLIENT_POD` is the ID of one of the client service's pods.

--- a/content/help/faq/security/check-policy.md
+++ b/content/help/faq/security/check-policy.md
@@ -8,7 +8,7 @@ The `istioctl` tool provides an option for this purpose. You can do:
 {{< text bash >}}
 $ istioctl authn tls-check $CLIENT_POD httpbin.default.svc.cluster.local
 HOST:PORT                                  STATUS     SERVER     CLIENT     AUTHN POLICY        DESTINATION RULE
-httpbin.default.svc.cluster.local:8000     OK         mTLS       mTLS       default/            default/default
+httpbin.default.svc.cluster.local:8000     OK         mTLS       mTLS       default/            istio-system/default
 {{< /text >}}
 
 Where `$CLIENT_POD` is the ID of one of the client service's pods.


### PR DESCRIPTION
This change address the issue https://github.com/istio/istio/issues/11913, and https://github.com/istio/istio/issues/11908, #11983

However, it can be used only after PR https://github.com/istio/istio/pull/11924 in the build.

Also added change to the get secret command (issue https://github.com/istio/istio/issues/11825)