### PR TITLE
Fix inconsistent namespace in rbac groups document

### DIFF
--- a/content/docs/tasks/security/rbac-groups/index.md
+++ b/content/docs/tasks/security/rbac-groups/index.md
@@ -33,7 +33,7 @@ name of the namespace, creates the namespace, and starts the two services.
 Before running the following command, you need to enter the directory
 containing the Istio installation files.
 
-1.  Set the value of the `NS` environmental variable to `rbac-listclaim-test-ns`:
+1.  Set the value of the `NS` environmental variable to `rbac-groups-test-ns`:
 
     {{< text bash >}}
     $ export NS=rbac-groups-test-ns


### PR DESCRIPTION
This PR fixes the issue: https://github.com/istio/istio/issues/11848