### PR TITLE
Reorder production install text to avoid later issues with Option 4

### DIFF
--- a/content/docs/setup/kubernetes/quick-start/index.md
+++ b/content/docs/setup/kubernetes/quick-start/index.md
@@ -28,6 +28,12 @@ To install and configure Istio in a Kubernetes cluster, follow these instruction
 
 1. Check the [Requirements for Pods and Services](/docs/setup/kubernetes/spec-requirements/).
 
+## Production install
+
+For a production setup of Istio, we recommend installing with the
+[Helm Chart](/docs/setup/kubernetes/helm-install/), to use all the
+configuration options. This permits customization of Istio to operator specific requirements.
+
 ## Installation steps
 
 1. Install all the Istio [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) (CRDs) via `kubectl apply`, and wait a few seconds for the CRDs to be committed in the Kubernetes API-server:
@@ -37,10 +43,7 @@ To install and configure Istio in a Kubernetes cluster, follow these instruction
     {{< /text >}}
 
 1. To install Istio's core components you can choose any of the following four
-**mutually exclusive** options described below. However, for a production setup of Istio,
-we recommend installing with the
-[Helm Chart](/docs/setup/kubernetes/helm-install/), to use all the
-configuration options. This permits customization of Istio to operator specific requirements.
+**mutually exclusive** options described below.
 
 ### Option 1: Install Istio with mutual TLS enabled and set to use permissive mode between sidecars
 


### PR DESCRIPTION
When running through the steps on this page, if a user runs "Installation steps" #1, and then continues to Option 4 when using Helm 2.10.0 or later, an error is encountered due to the Istio CRDs already being installed (see https://github.com/istio/istio/issues/10588), preventing the install from succeeding. Reordering the recommended production install method link will help prevent users from running into this issue, as they will not have already run step #1 before clicking on the link to https://istio.io/docs/setup/kubernetes/helm-install/