### PR TITLE
There are only 56 CRDs, not 58

### DIFF
--- a/content/docs/setup/kubernetes/helm-install/index.md
+++ b/content/docs/setup/kubernetes/helm-install/index.md
@@ -94,11 +94,11 @@ Choose this option if your cluster doesn't have [Tiller](https://github.com/kube
 
     {{< /text >}}
 
-1. Verify that all `58` Istio CRDs were committed to the Kubernetes api-server using the following command:
+1. Verify that all `56` Istio CRDs were committed to the Kubernetes api-server using the following command:
 
     {{< text bash >}}
     $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-    58
+    56
     {{< /text >}}
 
 1. Render and apply Istio's core components:


### PR DESCRIPTION
1.1 is only creating 56 CRDs, not 58. It looks like the missing ones are servicecontrolreports.config.istio.io and servicecontrols.config.istio.io, both of which have been removed. 

adapters.config.istio.io
apikeys.config.istio.io
attributemanifests.config.istio.io
authorizations.config.istio.io
bypasses.config.istio.io
certificates.certmanager.k8s.io
checknothings.config.istio.io
circonuses.config.istio.io
cloudwatches.config.istio.io
clusterissuers.certmanager.k8s.io
clusterrbacconfigs.rbac.istio.io
deniers.config.istio.io
destinationrules.networking.istio.io
dogstatsds.config.istio.io
edges.config.istio.io
envoyfilters.networking.istio.io
fluentds.config.istio.io
gateways.networking.istio.io
handlers.config.istio.io
httpapispecbindings.config.istio.io
httpapispecs.config.istio.io
instances.config.istio.io
issuers.certmanager.k8s.io
kubernetesenvs.config.istio.io
kuberneteses.config.istio.io
listcheckers.config.istio.io
listentries.config.istio.io
logentries.config.istio.io
memquotas.config.istio.io
meshpolicies.authentication.istio.io
metrics.config.istio.io
noops.config.istio.io
opas.config.istio.io
policies.authentication.istio.io
prometheuses.config.istio.io
quotas.config.istio.io
quotaspecbindings.config.istio.io
quotaspecs.config.istio.io
rbacconfigs.rbac.istio.io
rbacs.config.istio.io
redisquotas.config.istio.io
reportnothings.config.istio.io
rules.config.istio.io
serviceentries.networking.istio.io
servicerolebindings.rbac.istio.io
serviceroles.rbac.istio.io
sidecars.networking.istio.io
signalfxs.config.istio.io
solarwindses.config.istio.io
stackdrivers.config.istio.io
statsds.config.istio.io
stdios.config.istio.io
templates.config.istio.io
tracespans.config.istio.io
virtualservices.networking.istio.io
zipkins.config.istio.io