### PR TITLE
Updating the command for istio-remote generation

### DIFF
--- a/content/docs/examples/multicluster/gke/index.md
+++ b/content/docs/examples/multicluster/gke/index.md
@@ -143,8 +143,9 @@ $ kubectl get pods -n istio-system
 1.  Generate remote cluster manifest:
 
     {{< text bash >}}
-    $ helm template install/kubernetes/helm/istio-remote --namespace istio-system \
-      --name istio-remote \
+    $ helm template install/kubernetes/helm/istio \
+      --namespace istio-system --name istio-remote \
+      --values install/kubernetes/helm/istio/values-istio-remote.yaml \
       --set global.remotePilotAddress=${PILOT_POD_IP} \
       --set global.remotePolicyAddress=${POLICY_POD_IP} \
       --set global.remoteTelemetryAddress=${TELEMETRY_POD_IP} > $HOME/istio-remote.yaml


### PR DESCRIPTION
As there is no more `istio-remote` chart since 1.1.