### PR TITLE
Move up "platform setup"

### DIFF
--- a/content/docs/setup/kubernetes/platform-setup/_index.md
+++ b/content/docs/setup/kubernetes/platform-setup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Platform Setup
 description: How to prepare various Kubernetes platforms before installing Istio.
-weight: 100
+weight: 3
 keywords: [platform-setup]
 type: section-index
 ---


### PR DESCRIPTION
Put it right below "Downloading the release" to be consistent with 1.1 version https://preliminary.istio.io/docs/setup/kubernetes/