### PR TITLE
Fix the error of "https" displayed as "ps"

### DIFF
--- a/content/docs/examples/multicluster/gke/index.md
+++ b/content/docs/examples/multicluster/gke/index.md
@@ -40,17 +40,17 @@ In addition to the prerequisites for installing Istio the following setup is req
     $ gcloud container clusters create $cluster --zone $zone --username "admin" \
       --machine-type "n1-standard-2" --image-type "COS" --disk-size "100" \
       --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only",\
-"https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
-"https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
-"https://www.googleapis.com/auth/trace.append" \
+    "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
+    "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
+    "https://www.googleapis.com/auth/trace.append" \
     --num-nodes "4" --network "default" --enable-cloud-logging --enable-cloud-monitoring --enable-ip-alias --async
     $ cluster="cluster-2"
     $ gcloud container clusters create $cluster --zone $zone --username "admin" \
       --machine-type "n1-standard-2" --image-type "COS" --disk-size "100" \
       --scopes "https://www.googleapis.com/auth/compute","https://www.googleapis.com/auth/devstorage.read_only",\
-"https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
-"https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
-"https://www.googleapis.com/auth/trace.append" \
+    "https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring",\
+    "https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly",\
+    "https://www.googleapis.com/auth/trace.append" \
     --num-nodes "4" --network "default" --enable-cloud-logging --enable-cloud-monitoring --enable-ip-alias --async
     {{< /text >}}
 


### PR DESCRIPTION
Fix the error of "https" mistakenly displayed as "ps" on the section "Create the GKE Clusters" of the webpage: https://preliminary.istio.io/docs/examples/multicluster/gke/