### PR TITLE
Update the number of CRDs to expect during installation

### DIFF
--- a/content/docs/setup/kubernetes/install/helm/index.md
+++ b/content/docs/setup/kubernetes/install/helm/index.md
@@ -96,11 +96,11 @@ Choose this option if your cluster doesn't have [Tiller](https://github.com/kube
 
     {{< /text >}}
 
-1. Verify that all `56` Istio CRDs were committed to the Kubernetes api-server using the following command:
+1. Verify that all `58` Istio CRDs were committed to the Kubernetes api-server using the following command:
 
     {{< text bash >}}
     $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-    56
+    58
     {{< /text >}}
 
 1. Render and apply Istio's core components:
@@ -186,11 +186,11 @@ to manage the lifecycle of Istio.
 
     {{< /text >}}
 
-1. Verify that all `56` Istio CRDs were committed to the Kubernetes api-server using the following command:
+1. Verify that all `58` Istio CRDs were committed to the Kubernetes api-server using the following command:
 
     {{< text bash >}}
     $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-    56
+    58
     {{< /text >}}
 
 1. Install the `istio` chart:

--- a/content/docs/setup/kubernetes/install/ibm/index.md
+++ b/content/docs/setup/kubernetes/install/ibm/index.md
@@ -59,11 +59,11 @@ Make sure to use the `kubectl` CLI version that matches the Kubernetes version o
     $ helm install install/kubernetes/helm/istio-init --name istio-init --namespace istio-system
     {{< /text >}}
 
-    Verify that all `56` Istio CRDs were committed to the Kubernetes api-server using the following command:
+    Verify that all `58` Istio CRDs were committed to the Kubernetes api-server using the following command:
 
     {{< text bash >}}
     $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-    56
+    58
     {{< /text >}}
 
 1. Install the Helm chart to your cluster:

--- a/content/docs/setup/kubernetes/install/minimal/index.md
+++ b/content/docs/setup/kubernetes/install/minimal/index.md
@@ -71,11 +71,11 @@ to manage the lifecycle of Istio.
     $ helm install install/kubernetes/helm/istio-init --name istio-init --namespace istio-system
     {{< /text >}}
 
-1. Verify that all `56` Istio CRDs were committed to the Kubernetes api-server using the following command:
+1. Verify that all `58` Istio CRDs were committed to the Kubernetes api-server using the following command:
 
     {{< text bash >}}
     $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-    56
+    58
     {{< /text >}}
 
 1. Install the `istio` chart:

--- a/content_zh/docs/setup/kubernetes/install/helm/index.md
+++ b/content_zh/docs/setup/kubernetes/install/helm/index.md
@@ -78,11 +78,11 @@ icon: helm
 
     {{< /text >}}
 
-1. 用下面的命令，来确认 Istio 的 `56` 个 CRD 都已经成功的提交给 Kubernetes API Server：
+1. 用下面的命令，来确认 Istio 的 `58` 个 CRD 都已经成功的提交给 Kubernetes API Server：
 
     {{< text bash >}}
     $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-    56
+    58
     {{< /text >}}
 
 1. 渲染和提交 Istio 的核心组件：
@@ -141,11 +141,11 @@ icon: helm
 
     {{< /text >}}
 
-1. 用下面的命令，来确认 Istio 的 `56` 个 CRD 都已经成功的提交给 Kubernetes API Server：
+1. 用下面的命令，来确认 Istio 的 `58` 个 CRD 都已经成功的提交给 Kubernetes API Server：
 
     {{< text bash >}}
     $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-    56
+    58
     {{< /text >}}
 
 1. 安装 `istio` Chart：


### PR DESCRIPTION
With the upgrade of cert-manager to v0.6.2 two new CRDs are being
introduced. The total number of CRDs should now be `58`. Updating
the CRDs installation section of the documentation accordingly.