### PR TITLE
Install on Kubernetes cluster docs no longer point to nonexistent manifests

### DIFF
--- a/content/docs/setup/kubernetes/install/kubernetes/index.md
+++ b/content/docs/setup/kubernetes/install/kubernetes/index.md
@@ -67,7 +67,12 @@ To install Istio with mutual TLS enabled and set to use permissive mode
 between sidecars:
 
 {{< text bash >}}
-$ kubectl apply -f install/kubernetes/istio-demo.yaml
+$ helm template install/kubernetes/helm/istio --name istio \
+  --namespace istio-system > $HOME/istio.yaml
+{{< /text >}}
+
+{{< text bash >}}
+$ kubectl apply -f $HOME/istio.yaml
 {{< /text >}}
 
 In this option, all services, as servers, can accept both plain text and
@@ -85,7 +90,12 @@ To Install Istio and enforce [mutual TLS authentication](/docs/concepts/security
 between sidecars by default:
 
 {{< text bash >}}
-$ kubectl apply -f install/kubernetes/istio-demo-auth.yaml
+$ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
+  --set global.mtls.enabled=true --set global.controlPlaneSecurityEnabled=true > $HOME/istio-auth.yaml
+{{< /text >}}
+
+{{< text bash >}}
+$ kubectl apply -f $HOME/istio-auth.yaml
 {{< /text >}}
 
 ### Option 3: Render Kubernetes manifest with Helm and deploy with `kubectl`

--- a/content/docs/setup/kubernetes/install/kubernetes/index.md
+++ b/content/docs/setup/kubernetes/install/kubernetes/index.md
@@ -64,7 +64,7 @@ Choose this option for:
 * `StatefulSets`
 
 To install Istio with mutual TLS enabled and set to use permissive mode
-between sidecars:
+between sidecars run the following commands:
 
 {{< text bash >}}
 $ helm template install/kubernetes/helm/istio --name istio \
@@ -87,7 +87,7 @@ Use this option only on a fresh Kubernetes cluster where newly deployed
 workloads are guaranteed to have Istio sidecars installed.
 
 To Install Istio and enforce [mutual TLS authentication](/docs/concepts/security/#mutual-tls-authentication)
-between sidecars by default:
+between sidecars by default run the following commands:
 
 {{< text bash >}}
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \


### PR DESCRIPTION
Fixes #3453