### PR TITLE
race condition fix for mTLS steps

### DIFF
--- a/content/docs/tasks/traffic-management/secure-ingress/index.md
+++ b/content/docs/tasks/traffic-management/secure-ingress/index.md
@@ -85,6 +85,12 @@ with a certificate and a private key. Then you create a `Gateway` definition tha
     private key. You may want to deploy the ingress gateway in a separate namespace and create the secret there, so that
     only the ingress gateway pod will be able to mount it.
 
+    Verify that `tls.crt` and `tls.key` have been mounted in the ingress gateway pod:
+
+    {{< text bash >}}
+    $ kubectl exec -it -n istio-system $(kubectl -n istio-system get pods -l istio=ingressgateway -o jsonpath='{.items[0].metadata.name}') -- ls -al /etc/istio/ingressgateway-certs
+    {{< /text >}}
+
 1.  Define a `Gateway` with a `server` section for port 443.
 
     {{< warning >}}


### PR DESCRIPTION
Race condition exists when the secret is created, and then the Gateway rule in the following step, and when pilot tries to send the LDS update for port 443, it is rejected by the gateway if the secret has not been mounted in ingress gateway yet