### PR TITLE
Remove .b from cert path httpbin.new.example.com curl

### DIFF
--- a/content/docs/tasks/traffic-management/secure-ingress/sds/index.md
+++ b/content/docs/tasks/traffic-management/secure-ingress/sds/index.md
@@ -252,7 +252,7 @@ need to create secrets for multiple hosts and update the gateway definitions.
     {{< text bash >}}
     $ curl -v -HHost:httpbin.example.com \
     --resolve httpbin.example.com:$SECURE_INGRESS_PORT:$INGRESS_HOST \
-    --cacert httpbin.new.example.com.b/2_intermediate/certs/ca-chain.cert.pem \
+    --cacert httpbin.new.example.com/2_intermediate/certs/ca-chain.cert.pem \
     https://httpbin.example.com:$SECURE_INGRESS_PORT/status/418
     ...
     HTTP/2 418


### PR DESCRIPTION
Example curl failed since the cert path is wrong. In the previous step, the certs were created in `httpbin.new.example.com`. The curl has an added `.b`.