### PR TITLE
Restore ingress doc order

### DIFF
--- a/content/docs/tasks/traffic-management/secure-ingress/_index.md
+++ b/content/docs/tasks/traffic-management/secure-ingress/_index.md
@@ -1,5 +1,5 @@
 ---
 title: Securing Ingress Gateway
 description: Secure ingress gateway controllers using various approaches.
-weight: 15
+weight: 31
 ---


### PR DESCRIPTION
Move the "Securing Ingress Gateway" tasks below "Control Ingress Traffic" task, this is to keep the order of tasks unchanged. 