### PR TITLE
use a boilerplate for setting environment variables for kubectl contexts

### DIFF
--- a/content/boilerplates/kubectl-multicluster-contexts.md
+++ b/content/boilerplates/kubectl-multicluster-contexts.md
@@ -1,0 +1,16 @@
+* The `kubectl` command is used to access both the `cluster1` and `cluster2` clusters with the `--context` flag.
+  Use the following command to list your contexts:
+
+    {{< text bash >}}
+    $ kubectl config get-contexts
+    CURRENT   NAME       CLUSTER    AUTHINFO       NAMESPACE
+    *         cluster1   cluster1   user@foo.com   default
+              cluster2   cluster2   user@foo.com   default
+    {{< /text >}}
+
+* Export the following environment variables with the context names of your configuration:
+
+    {{< text bash >}}
+    $ export CTX_CLUSTER1=<KUBECONFIG_CONTEXT_NAME_FOR_CLUSTER_1>
+    $ export CTX_CLUSTER2=<KUBECONFIG_CONTEXT_NAME_FOR_CLUSTER_2>
+    {{< /text >}}

--- a/content/docs/examples/multicluster/gateways/index.md
+++ b/content/docs/examples/multicluster/gateways/index.md
@@ -18,22 +18,7 @@ running in a second cluster.
 * Set up a multicluster environment with two Istio clusters by following the
     [multiple control planes with gateways](/docs/setup/kubernetes/multicluster/gateways/) instructions.
 
-* The `kubectl` command is used to access both clusters with the `--context` flag.
-    Use the following command to list your contexts:
-
-    {{< text bash >}}
-    $ kubectl config get-contexts
-    CURRENT   NAME       CLUSTER    AUTHINFO       NAMESPACE
-    *         cluster1   cluster1   user@foo.com   default
-              cluster2   cluster2   user@foo.com   default
-    {{< /text >}}
-
-* Export the following environment variables with the context names of your configuration:
-
-    {{< text bash >}}
-    $ export CTX_CLUSTER1=<cluster1 context name>
-    $ export CTX_CLUSTER2=<cluster2 context name>
-    {{< /text >}}
+{{< boilerplate kubectl-multicluster-contexts >}}
 
 ## Configure the example services
 

--- a/content/docs/examples/multicluster/split-horizon-eds/index.md
+++ b/content/docs/examples/multicluster/split-horizon-eds/index.md
@@ -31,22 +31,7 @@ In addition to the prerequisites for installing Istio, the following is required
     The Kubernetes API server of `cluster2` MUST be accessible from `cluster1` in order to run this configuration.
     {{< /warning >}}
 
-* The `kubectl` command is used to access both the `cluster1` and `cluster2` clusters with the `--context` flag.
-  Use the following command to list your contexts:
-
-    {{< text bash >}}
-    $ kubectl config get-contexts
-    CURRENT   NAME       CLUSTER    AUTHINFO       NAMESPACE
-    *         cluster1   cluster1   user@foo.com   default
-              cluster2   cluster2   user@foo.com   default
-    {{< /text >}}
-
-* Export the following environment variables with the context names of your configuration:
-
-    {{< text bash >}}
-    $ export CTX_CLUSTER1=<KUBECONFIG_CONTEXT_NAME_FOR_CLUSTER_1>
-    $ export CTX_CLUSTER2=<KUBECONFIG_CONTEXT_NAME_FOR_CLUSTER_2>
-    {{< /text >}}
+{{< boilerplate kubectl-multicluster-contexts >}}
 
 ## Example multicluster setup
 


### PR DESCRIPTION
… of the two clusters

share the boilerplate for gateway connectivity and for split horizon EDS examples