### PR TITLE
update instructions for quick start

### DIFF
--- a/content/docs/setup/kubernetes/install/kubernetes/index.md
+++ b/content/docs/setup/kubernetes/install/kubernetes/index.md
@@ -61,7 +61,7 @@ Choose this option for:
 * Applications that use
   [liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/),
 * Headless services, or
-* `StatefulSets`
+* StatefulSets
 
 To install Istio with permissive mode between sidecars:
 

--- a/content/docs/setup/kubernetes/install/kubernetes/index.md
+++ b/content/docs/setup/kubernetes/install/kubernetes/index.md
@@ -1,6 +1,6 @@
 ---
-title: Install Istio on a Kubernetes Cluster
-description: Instructions to install the Istio service mesh in a Kubernetes cluster.
+title: Quick Install Istio on a Kubernetes Cluster
+description: Instructions to quick install the Istio service mesh in a Kubernetes cluster.
 weight: 55
 keywords: [kubernetes]
 aliases:
@@ -47,7 +47,7 @@ we recommend installing with the
 [Helm Chart](/docs/setup/kubernetes/install/helm/), to use all the
 configuration options. This permits customization of Istio to operator specific requirements.
 
-### Option 1: Install Istio with mutual TLS enabled and set to use permissive mode between sidecars
+### Option 1: Install Istio with permissive mode between sidecars
 
 Visit our
 [mutual TLS permissive mode page](/docs/concepts/security/#permissive-mode)
@@ -63,8 +63,7 @@ Choose this option for:
 * Headless services, or
 * `StatefulSets`
 
-To install Istio with mutual TLS enabled and set to use permissive mode
-between sidecars:
+To install Istio with permissive mode between sidecars:
 
 {{< text bash >}}
 $ kubectl apply -f install/kubernetes/istio-demo.yaml


### PR DESCRIPTION
1) I'd prefer to call it quick start so it is consistent with it when folks looking for it.  Also, since it is mainly for quick start and demo purpose :)

2) I think calling mtls enabled is confusing because within istio-values-demo yaml file we actually set it to global.mtls.enabled=false (by reusing what is in the values.yaml).