### PR TITLE
add access log task

### DIFF
--- a/content/docs/tasks/telemetry/access-log/index.md
+++ b/content/docs/tasks/telemetry/access-log/index.md
@@ -26,8 +26,7 @@ Set the value of `global.proxy.accessLogFile` to "/dev/stdout".
 Be sure to escape quotation marks with backward slashes (`\"`).
 
 You may also want to customize the
-[format](https://www.envoyproxy.io/docs/envoy/latest/configuration/access_log#format-rules) of the access log.
-To do it, edit `global.proxy.accessLogFormat`.
+[format](https://www.envoyproxy.io/docs/envoy/latest/configuration/access_log#format-rules) of the access log by editing `global.proxy.accessLogFormat`.
 
 Save the configuration map and exit the editing mode.
 

--- a/content/docs/tasks/telemetry/access-log/index.md
+++ b/content/docs/tasks/telemetry/access-log/index.md
@@ -1,0 +1,91 @@
+---
+title: Envoy's Access Logging
+description: This task shows you how to configure Envoy proxies to print access log to their standard output.
+weight: 9
+keywords: [telemetry]
+---
+
+The simplest kind of Istio logging is
+[Envoy's access logging](https://www.envoyproxy.io/docs/envoy/latest/configuration/access_log).
+Envoy proxies print access information to their standard output.
+The standard output of Envoy's containers can then be printed by the `kubectl logs` command.
+
+{{< boilerplate before-you-begin-egress >}}
+{{< boilerplate start-httpbin-service >}}
+
+## Enable Envoy's access logging
+
+Edit the `istio` config map:
+
+{{< text bash >}}
+$ kubectl edit cm istio -n istio-system
+{{< /text >}}
+
+Set the value of `global.proxy.accessLogFile` to "/dev/stdout".
+Mind escaping quotation marks with backward slashes (`\"`).
+
+You may also want to change the
+[format](https://www.envoyproxy.io/docs/envoy/latest/configuration/access_log#format-rules) of the access log.
+To do it, edit `global.proxy.accessLogFormat`.
+
+Save the config map and exit the editing mode.
+
+## Test the access log
+
+1.  Send a request from `sleep` to `httpbin`:
+
+    {{< text bash >}}
+    $ kubectl exec -it $(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name}) -c sleep -- curl -v httpbin:8000/status/418
+    *   Trying 172.21.13.94...
+    * TCP_NODELAY set
+    * Connected to httpbin (172.21.13.94) port 8000 (#0)
+    > GET /status/418 HTTP/1.1
+
+    ...
+    < HTTP/1.1 418 Unknown
+    < server: envoy
+    ...
+
+        -=[ teapot ]=-
+
+           _...._
+         .'  _ _ `.
+        | ."` ^ `". _,
+        \_;`"---"`|//
+          |       ;/
+          \_     _/
+            `"""`
+    * Connection #0 to host httpbin left intact
+    {{< /text >}}
+
+1.  Check the log of `sleep`:
+
+    {{< text bash >}}
+    $ kubectl logs -l app=sleep -c istio-proxy
+    [2019-03-06T09:31:27.354Z] "GET /status/418 HTTP/1.1" 418 - "-" 0 135 11 10 "-" "curl/7.60.0" "d209e46f-9ed5-9b61-bbdd-43e22662702a" "httpbin:8000" "172.30.146.73:80" outbound|8000||httpbin.default.svc.cluster.local - 172.21.13.94:8000 172.30.146.82:60290 -
+    {{< /text >}}
+
+1.  Check the log of `httpbin`:
+
+    {{< text bash >}}
+    $ kubectl logs -l app=httpbin -c istio-proxy
+    [2019-03-06T09:31:27.360Z] "GET /status/418 HTTP/1.1" 418 - "-" 0 135 5 2 "-" "curl/7.60.0" "d209e46f-9ed5-9b61-bbdd-43e22662702a" "httpbin:8000" "127.0.0.1:80" inbound|8000|http|httpbin.default.svc.cluster.local - 172.30.146.73:80 172.30.146.82:38618 outbound_.8000_._.httpbin.default.svc.cluster.local
+    {{< /text >}}
+
+Note that the messages corresponding to the request appear in logs of the Istio proxies of both the source and the destination, `sleep` and `httpbin`, respectively. You can see in the log the HTTP verb (`GET`), the HTTP path (`/status/418`), the response code (`418`) and other [request-related information](https://www.envoyproxy.io/docs/envoy/latest/configuration/access_log#format-rules).
+
+## Cleanup
+
+1.  Shutdown the [sleep]({{<github_tree>}}/samples/sleep) and [httpbin]({{<github_tree>}}/samples/httpbin) services:
+
+    {{< text bash >}}
+    $ kubectl delete -f @samples/sleep/sleep.yaml@
+    $ kubectl delete -f @samples/httpbin/httpbin.yaml@
+    {{< /text >}}
+
+1.  Edit the `istio` config map and set `global.proxy.accessLogFile` to `""`.
+    Mind escaping quotation marks with backward slashes (`\"`).
+
+    {{< text bash >}}
+    $ kubectl edit cm istio -n istio-system
+    {{< /text >}}

--- a/content/docs/tasks/telemetry/access-log/index.md
+++ b/content/docs/tasks/telemetry/access-log/index.md
@@ -23,7 +23,7 @@ $ kubectl edit cm istio -n istio-system
 {{< /text >}}
 
 Set the value of `global.proxy.accessLogFile` to "/dev/stdout".
-Mind escaping quotation marks with backward slashes (`\"`).
+Be sure to escape quotation marks with backward slashes (`\"`).
 
 You may also want to change the
 [format](https://www.envoyproxy.io/docs/envoy/latest/configuration/access_log#format-rules) of the access log.
@@ -85,7 +85,7 @@ Note that the messages corresponding to the request appear in logs of the Istio 
     {{< /text >}}
 
 1.  Edit the `istio` configuration map and set `global.proxy.accessLogFile` to `""`.
-    Mind escaping quotation marks with backward slashes (`\"`).
+    Be sure to escape quotation marks with backward slashes (`\"`).
 
     {{< text bash >}}
     $ kubectl edit cm istio -n istio-system

--- a/content/docs/tasks/telemetry/access-log/index.md
+++ b/content/docs/tasks/telemetry/access-log/index.md
@@ -1,5 +1,5 @@
 ---
-title: Envoy's Access Logging
+title: Getting Envoy's Access Logs
 description: This task shows you how to configure Envoy proxies to print access log to their standard output.
 weight: 9
 keywords: [telemetry]

--- a/content/docs/tasks/telemetry/access-log/index.md
+++ b/content/docs/tasks/telemetry/access-log/index.md
@@ -59,14 +59,14 @@ Save the configuration map and exit the editing mode.
     * Connection #0 to host httpbin left intact
     {{< /text >}}
 
-1.  Check the log of `sleep`:
+1.  Check `sleep`'s log:
 
     {{< text bash >}}
     $ kubectl logs -l app=sleep -c istio-proxy
     [2019-03-06T09:31:27.354Z] "GET /status/418 HTTP/1.1" 418 - "-" 0 135 11 10 "-" "curl/7.60.0" "d209e46f-9ed5-9b61-bbdd-43e22662702a" "httpbin:8000" "172.30.146.73:80" outbound|8000||httpbin.default.svc.cluster.local - 172.21.13.94:8000 172.30.146.82:60290 -
     {{< /text >}}
 
-1.  Check the log of `httpbin`:
+1.  Check `httpbin`'s log:
 
     {{< text bash >}}
     $ kubectl logs -l app=httpbin -c istio-proxy

--- a/content/docs/tasks/telemetry/access-log/index.md
+++ b/content/docs/tasks/telemetry/access-log/index.md
@@ -15,7 +15,7 @@ The standard output of Envoy's containers can then be printed by the `kubectl lo
 
 ## Enable Envoy's access logging
 
-Edit the `istio` config map:
+Edit the `istio` configuration map:
 
 {{< text bash >}}
 $ kubectl edit cm istio -n istio-system
@@ -28,7 +28,7 @@ You may also want to change the
 [format](https://www.envoyproxy.io/docs/envoy/latest/configuration/access_log#format-rules) of the access log.
 To do it, edit `global.proxy.accessLogFormat`.
 
-Save the config map and exit the editing mode.
+Save the configuration map and exit the editing mode.
 
 ## Test the access log
 
@@ -83,7 +83,7 @@ Note that the messages corresponding to the request appear in logs of the Istio 
     $ kubectl delete -f @samples/httpbin/httpbin.yaml@
     {{< /text >}}
 
-1.  Edit the `istio` config map and set `global.proxy.accessLogFile` to `""`.
+1.  Edit the `istio` configuration map and set `global.proxy.accessLogFile` to `""`.
     Mind escaping quotation marks with backward slashes (`\"`).
 
     {{< text bash >}}

--- a/content/docs/tasks/telemetry/access-log/index.md
+++ b/content/docs/tasks/telemetry/access-log/index.md
@@ -25,7 +25,7 @@ $ kubectl edit cm istio -n istio-system
 Set the value of `global.proxy.accessLogFile` to "/dev/stdout".
 Be sure to escape quotation marks with backward slashes (`\"`).
 
-You may also want to change the
+You may also want to customize the
 [format](https://www.envoyproxy.io/docs/envoy/latest/configuration/access_log#format-rules) of the access log.
 To do it, edit `global.proxy.accessLogFormat`.
 

--- a/content/docs/tasks/telemetry/access-log/index.md
+++ b/content/docs/tasks/telemetry/access-log/index.md
@@ -11,6 +11,7 @@ Envoy proxies print access information to their standard output.
 The standard output of Envoy's containers can then be printed by the `kubectl logs` command.
 
 {{< boilerplate before-you-begin-egress >}}
+
 {{< boilerplate start-httpbin-service >}}
 
 ## Enable Envoy's access logging


### PR DESCRIPTION
In 1.1, the access log is disabled by default, so this task is needed. Various other examples reference Envoy's access logs, in particular the tasks/examples related to gateways, where it is important to demonstrate that the traffic indeed went thru the gateways.

While this is a feature of Envoy/Pilot, I still propose to add it under telemetry tasks, so all the log configuration tasks will be in one place. 