### PR TITLE
Fix the Istio CNI doc per the rel-1.1 helm chart decoupling changes

### DIFF
--- a/content/docs/setup/kubernetes/additional-setup/cni/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/cni/index.md
@@ -47,15 +47,13 @@ replaces the functionality provided by the `istio-init` container.
     1.  Refer to the [Hosted Kubernetes Usage](#hosted-kubernetes-usage) section for any non-default
         settings required.
 
-1.  Update Helm's local package cache with the instructions found in the [Istio Installation with Helm procedure](/docs/setup/kubernetes/install/helm/). 
+1.  Update Helm's local package cache with the instructions found in the [Istio Installation with Helm procedure](/docs/setup/kubernetes/install/helm/).
     To install using the `helm template`, fetch the `istio-cni` template in addition
     to the other Istio templates you fetched when following [option 1 of the Istio Helm installation procedure](/docs/setup/kubernetes/install/helm/#option-1-install-with-helm-via-helm-template).
 
-
-
-        {{< text bash >}}
-        $ helm fetch istio.io/istio-cni --untar --untardir $HOME/istio-fetch
-        {{< /text >}}
+    {{< text bash >}}
+    $ helm fetch istio.io/istio-cni --untar --untardir $HOME/istio-fetch
+    {{< /text >}}
 
 1.  Create a namespace for the Istio control-plane components:
 
@@ -65,13 +63,13 @@ replaces the functionality provided by the `istio-init` container.
 
 1.  Install Istio CNI.
 
-    - Option 1.  Render and apply the Istio CNI Helm template.
+    *  Option 1.  Render and apply the Istio CNI Helm template.
 
         {{< text bash >}}
         $ helm template $HOME/istio-fetch/istio-cni --name=istio-cni --namespace=istio-system | kubectl apply -f -
         {{< /text >}}
 
-    - Option 2.  Install via Helm and Tiller via `helm install`.
+    *  Option 2.  Install via Helm and Tiller via `helm install`.
 
         {{< text bash >}}
         $ helm install istio.io/istio-cni --name=istio-cni --namespace=istio-system
@@ -155,10 +153,9 @@ of many common Kubernetes environments.
     `--set cniBinDir=/home/kubernetes/bin`. For example, the following `helm install`
     command sets the `cniBinDir` value for GKE setups:
 
-
-        {{< text bash >}}
-        $ helm install istio.io/istio-cni --name=istio-cni --namespace=istio-system --set cniBinDir=/home/kubernetes/bin
-        {{< /text >}}
+    {{< text bash >}}
+    $ helm install istio.io/istio-cni --name=istio-cni --namespace=istio-system --set cniBinDir=/home/kubernetes/bin
+    {{< /text >}}
 
 ## Sidecar injection compatibility
 

--- a/content/docs/setup/kubernetes/additional-setup/cni/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/cni/index.md
@@ -47,10 +47,11 @@ replaces the functionality provided by the `istio-init` container.
     1.  Refer to the [Hosted Kubernetes Usage](#hosted-kubernetes-usage) section for any non-default
         settings required.
 
-1.  Update Helm's local package cache per the instructions in the [Istio Installation with Helm procedure](/docs/setup/kubernetes/install/helm/).
+1.  Update Helm's local package cache with the instructions found in the [Istio Installation with Helm procedure](/docs/setup/kubernetes/install/helm/). 
+    To install using the `helm template`, fetch the `istio-cni` template in addition
+    to the other Istio templates you fetched when following [option 1 of the Istio Helm installation procedure](/docs/setup/kubernetes/install/helm/#option-1-install-with-helm-via-helm-template).
 
-    1.  If installing via `helm template` fetch the `istio-cni` template in addition to the other Istio
-        templates fetched per the [Istio Helm installation procedure](/docs/setup/kubernetes/install/helm/#option-1-install-with-helm-via-helm-template)
+
 
         {{< text bash >}}
         $ helm fetch istio.io/istio-cni --untar --untardir $HOME/istio-fetch
@@ -64,13 +65,13 @@ replaces the functionality provided by the `istio-init` container.
 
 1.  Install Istio CNI.
 
-    1.  Option 1.  Render and apply the Istio CNI Helm template.
+    - Option 1.  Render and apply the Istio CNI Helm template.
 
         {{< text bash >}}
         $ helm template $HOME/istio-fetch/istio-cni --name=istio-cni --namespace=istio-system | kubectl apply -f -
         {{< /text >}}
 
-    1.  Option 2.  Install via Helm and Tiller via `helm install`.
+    - Option 2.  Install via Helm and Tiller via `helm install`.
 
         {{< text bash >}}
         $ helm install istio.io/istio-cni --name=istio-cni --namespace=istio-system
@@ -151,9 +152,9 @@ of many common Kubernetes environments.
     *  Note for existing clusters this redeploys the nodes.
 
 1.  Install Istio CNI via Helm including this option
-    `--set cniBinDir=/home/kubernetes/bin`
+    `--set cniBinDir=/home/kubernetes/bin`. For example, the following `helm install`
+    command sets the `cniBinDir` value for GKE setups:
 
-    1.  For example, the following `helm install` command sets the `cniBinDir` value for GKE setups:
 
         {{< text bash >}}
         $ helm install istio.io/istio-cni --name=istio-cni --namespace=istio-system --set cniBinDir=/home/kubernetes/bin

--- a/content/docs/setup/kubernetes/additional-setup/cni/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/cni/index.md
@@ -47,6 +47,39 @@ replaces the functionality provided by the `istio-init` container.
     1.  Refer to the [Hosted Kubernetes Usage](#hosted-kubernetes-usage) section for any non-default
         settings required.
 
+1.  Update Helm's local package cache per the instructions in the [Istio Installation with Helm procedure](/docs/setup/kubernetes/install/helm/).
+
+    1.  If installing via `helm template` fetch the `istio-cni` template in addition to the other Istio
+        templates fetched per the [Istio Helm installation procedure](/docs/setup/kubernetes/install/helm/#option-1-install-with-helm-via-helm-template)
+
+        {{< text bash >}}
+        $ helm fetch istio.io/istio-cni --untar --untardir $HOME/istio-fetch
+        {{< /text >}}
+
+1.  Create a namespace for the Istio control-plane components:
+
+    {{< text bash >}}
+    $ kubectl create namespace istio-system
+    {{< /text >}}
+
+1.  Install Istio CNI.
+
+    1.  Option 1.  Render and apply the Istio CNI Helm template.
+
+        {{< text bash >}}
+        $ helm template $HOME/istio-fetch/istio-cni --name=istio-cni --namespace=istio-system | kubectl apply -f -
+        {{< /text >}}
+
+    1.  Option 2.  Install via Helm and Tiller via `helm install`.
+
+        {{< text bash >}}
+        $ helm install istio.io/istio-cni --name=istio-cni --namespace=istio-system
+        {{< /text >}}
+
+    {{< tip >}}
+    Refer to the full set of `istio-cni` Helm parameters in the chart's [`values.yaml`](https://github.com/istio/cni/blob/master/deployments/kubernetes/install/helm/istio-cni/values.yaml).
+    {{< /tip >}}
+
 1.  Add the `--set istio_cni.enabled=true` setting to the [Istio Installation with Helm procedure](/docs/setup/kubernetes/install/helm/) to include the installation of the Istio CNI plugin. For example:
 
     {{< text bash >}}
@@ -54,23 +87,33 @@ replaces the functionality provided by the `istio-init` container.
       --set istio_cni.enabled=true > $HOME/istio.yaml
     {{< /text >}}
 
-    {{< tip >}}
-    Refer to the full set of `istio-cni` Helm parameters in the chart's [`values.yaml`](https://github.com/istio/cni/blob/master/deployments/kubernetes/install/helm/istio-cni/values.yaml).
-    {{< /tip >}}
-
 ### Example: excluding specific Kubernetes namespaces
 
 The following example configures the Istio CNI plugin to ignore pods in the namespaces `istio-system`,
 `foo_ns`, and `bar_ns`.
 
-1.  Create an Istio manifest with the Istio CNI plugin enabled and override the default
-    configuration of the `istio-cni` Helm chart's `logLevel` and `excludeNamespaces` parameters:
+1.  Create an `istio-system` namespace for the Istio control-plane components.
+
+    {{< text bash >}}
+    $ kubectl create namespace istio-system
+    {{< /text >}}
+
+1.  Create and apply Istio CNI manifest.  Override the default configuration of the `istio-cni` Helm
+    chart's `logLevel` and `excludeNamespaces` parameters:
+
+    {{< text bash >}}
+    $ helm template $HOME/istio-fetch/istio-cni --name=istio-cni --namespace=istio-system \
+    --set istio-cni.logLevel=info \
+    --set istio-cni.excludeNamespaces={"istio-system,foo_ns,bar_ns"} > $HOME/istio-cni.yaml
+    $ kubectl apply -f $HOME/istio-cni.yaml
+    {{< /text >}}
+
+1.  Create and apply Istio manifest with the Istio CNI plugin enabled:
 
     {{< text bash >}}
     $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
-    --set istio_cni.enabled=true \
-    --set istio-cni.logLevel=info \
-    --set istio-cni.excludeNamespaces={"istio-system,foo_ns,bar_ns"} > $HOME/istio.yaml
+    --set istio_cni.enabled=true > $HOME/istio.yaml
+    $ kubectl apply -f $HOME/istio.yaml
     {{< /text >}}
 
 ### Helm chart parameters
@@ -107,8 +150,8 @@ of many common Kubernetes environments.
     enable [network-policy](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy) in your cluster.
     *  Note for existing clusters this redeploys the nodes.
 
-1.  Install Istio via Helm including these options
-    `--set istio_cni.enabled=true --set istio-cni.cniBinDir=/home/kubernetes/bin`
+1.  Install Istio CNI via Helm including these options
+    `--set cniBinDir=/home/kubernetes/bin`
 
 ## Sidecar injection compatibility
 

--- a/content/docs/setup/kubernetes/additional-setup/cni/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/cni/index.md
@@ -103,8 +103,8 @@ The following example configures the Istio CNI plugin to ignore pods in the name
 
     {{< text bash >}}
     $ helm template $HOME/istio-fetch/istio-cni --name=istio-cni --namespace=istio-system \
-    --set istio-cni.logLevel=info \
-    --set istio-cni.excludeNamespaces={"istio-system,foo_ns,bar_ns"} > $HOME/istio-cni.yaml
+    --set logLevel=info \
+    --set excludeNamespaces={"istio-system,foo_ns,bar_ns"} > $HOME/istio-cni.yaml
     $ kubectl apply -f $HOME/istio-cni.yaml
     {{< /text >}}
 
@@ -150,8 +150,14 @@ of many common Kubernetes environments.
     enable [network-policy](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy) in your cluster.
     *  Note for existing clusters this redeploys the nodes.
 
-1.  Install Istio CNI via Helm including these options
+1.  Install Istio CNI via Helm including this option
     `--set cniBinDir=/home/kubernetes/bin`
+
+    1.  For example, the following `helm install` command sets the `cniBinDir` value for GKE setups:
+
+        {{< text bash >}}
+        $ helm install istio.io/istio-cni --name=istio-cni --namespace=istio-system --set cniBinDir=/home/kubernetes/bin
+        {{< /text >}}
 
 ## Sidecar injection compatibility
 


### PR DESCRIPTION
There is now a 2 step procedure to install Istio CNI and Istio separately, rather than the prior single/coupled helm install.