### PR TITLE
Fortio binary moved; breaks examples

### DIFF
--- a/content/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -100,7 +100,7 @@ Pass in `-curl` to indicate that you just want to make one call:
 
     {{< text bash >}}
     $ FORTIO_POD=$(kubectl get pod | grep fortio | awk '{ print $1 }')
-    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/local/bin/fortio -- load -curl  http://httpbin:8000/get
+    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/bin/fortio -- load -curl  http://httpbin:8000/get
     HTTP/1.1 200 OK
     server: envoy
     date: Tue, 16 Jan 2018 23:47:00 GMT
@@ -140,7 +140,7 @@ one connection and request concurrently, you should see some failures when the
 (`-n 20`):
 
     {{< text bash >}}
-    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/local/bin/fortio -- load -c 2 -qps 0 -n 20 -loglevel Warning http://httpbin:8000/get
+    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/bin/fortio -- load -c 2 -qps 0 -n 20 -loglevel Warning http://httpbin:8000/get
     Fortio 0.6.2 running at 0 queries per second, 2->2 procs, for 5s: http://httpbin:8000/get
     Starting at max qps with 2 thread(s) [gomax 2] for exactly 20 calls (10 per thread + 0)
     23:51:10 W http.go:617> Parsed non ok code 503 (HTTP/1.1 503)
@@ -179,7 +179,7 @@ one connection and request concurrently, you should see some failures when the
 1. Bring the number of concurrent connections up to 3:
 
     {{< text bash >}}
-    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/local/bin/fortio -- load -c 3 -qps 0 -n 30 -loglevel Warning http://httpbin:8000/get
+    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/bin/fortio -- load -c 3 -qps 0 -n 30 -loglevel Warning http://httpbin:8000/get
     Fortio 0.6.2 running at 0 queries per second, 2->2 procs, for 5s: http://httpbin:8000/get
     Starting at max qps with 3 thread(s) [gomax 2] for exactly 30 calls (10 per thread + 0)
     23:51:51 W http.go:617> Parsed non ok code 503 (HTTP/1.1 503)

--- a/content_zh/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content_zh/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -101,7 +101,7 @@ keywords: [traffic-management,circuit-breaking]
 
     {{< text bash >}}
     $ FORTIO_POD=$(kubectl get pod | grep fortio | awk '{ print $1 }')
-    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/local/bin/fortio -- load -curl  http://httpbin:8000/get
+    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/bin/fortio -- load -curl  http://httpbin:8000/get
     HTTP/1.1 200 OK
     server: envoy
     date: Tue, 16 Jan 2018 23:47:00 GMT
@@ -137,7 +137,7 @@ keywords: [traffic-management,circuit-breaking]
 1. 接下来尝试一下两个并发连接（`-c 2`），发送 20 请求（`-n 20`）：
 
     {{< text bash >}}
-    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/local/bin/fortio -- load -c 2 -qps 0 -n 20 -loglevel Warning http://httpbin:8000/get
+    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/bin/fortio -- load -c 2 -qps 0 -n 20 -loglevel Warning http://httpbin:8000/get
     Fortio 0.6.2 running at 0 queries per second, 2->2 procs, for 5s: http://httpbin:8000/get
     Starting at max qps with 2 thread(s) [gomax 2] for exactly 20 calls (10 per thread + 0)
     23:51:10 W http.go:617> Parsed non ok code 503 (HTTP/1.1 503)
@@ -175,7 +175,7 @@ keywords: [traffic-management,circuit-breaking]
 1. 接下来把并发连接数量提高到 3：
 
     {{< text bash >}}
-    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/local/bin/fortio -- load -c 3 -qps 0 -n 30 -loglevel Warning http://httpbin:8000/get
+    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/bin/fortio -- load -c 3 -qps 0 -n 30 -loglevel Warning http://httpbin:8000/get
     Fortio 0.6.2 running at 0 queries per second, 2->2 procs, for 5s: http://httpbin:8000/get
     Starting at max qps with 3 thread(s) [gomax 2] for exactly 30 calls (10 per thread + 0)
     23:51:51 W http.go:617> Parsed non ok code 503 (HTTP/1.1 503)


### PR DESCRIPTION
For https://github.com/istio/istio.io/issues/3561

The `fortio` binary is now in _/usr/bin_, not _/usr/local/bin_.