### PR TITLE
Add a warning about using sudo for a TCP sample

### DIFF
--- a/content/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
+++ b/content/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
@@ -86,6 +86,10 @@ the [Bookinfo](/docs/examples/bookinfo/#determining-the-ingress-ip-and-port) doc
     one Mon Nov 12 23:25:19 UTC 2018
     {{< /text >}}
 
+    {{< tip >}}
+    You may need to prefix the `docker` command with `sudo` depending on your Docker installation.
+    {{< /tip >}}
+
     You should notice that all the timestamps have a prefix of _one_, which means that all traffic
 was routed to the `v1` version of the `tcp-echo` service.
 
@@ -143,6 +147,10 @@ was routed to the `v1` version of the `tcp-echo` service.
     one Mon Nov 12 23:39:05 UTC 2018
     one Mon Nov 12 23:39:07 UTC 2018
     {{< /text >}}
+
+    {{< tip >}}
+    You may need to prefix the `docker` command with `sudo` depending on your Docker installation.
+    {{< /tip >}}
 
     You should now notice that about 20% of the timestamps have a prefix of _two_, which means that
 80% of the TCP traffic was routed to the `v1` version of the `tcp-echo` service, while 20% was

--- a/content/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
+++ b/content/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
@@ -86,9 +86,9 @@ the [Bookinfo](/docs/examples/bookinfo/#determining-the-ingress-ip-and-port) doc
     one Mon Nov 12 23:25:19 UTC 2018
     {{< /text >}}
 
-    {{< tip >}}
-    You may need to prefix the `docker` command with `sudo` depending on your Docker installation.
-    {{< /tip >}}
+    {{< warning >}}
+    The `docker` command may require using `sudo` depending on your Docker installation.
+    {{< /warning >}}
 
     You should notice that all the timestamps have a prefix of _one_, which means that all traffic
 was routed to the `v1` version of the `tcp-echo` service.
@@ -148,9 +148,9 @@ was routed to the `v1` version of the `tcp-echo` service.
     one Mon Nov 12 23:39:07 UTC 2018
     {{< /text >}}
 
-    {{< tip >}}
-    You may need to prefix the `docker` command with `sudo` depending on your Docker installation.
-    {{< /tip >}}
+    {{< warning >}}
+    The `docker` command may require using `sudo` depending on your Docker installation.
+    {{< /warning >}}
 
     You should now notice that about 20% of the timestamps have a prefix of _two_, which means that
 80% of the TCP traffic was routed to the `v1` version of the `tcp-echo` service, while 20% was


### PR DESCRIPTION
This adds a warning about using `sudo` while running the TCP Traffic Shifting sample on certain platforms. Fixes #3579.