### PR TITLE
Tweak the installation pages.

### DIFF
--- a/layouts/shortcodes/idea.html
+++ b/layouts/shortcodes/idea.html
@@ -4,6 +4,6 @@
     </div>
     <div class="content">
         {{- $trimmed := trim .Inner " \n" -}}
-        {{- $trimmed | safeHTML -}}
+        {{- $trimmed | markdownify | safeHTML -}}
     </div>
 </aside>

--- a/layouts/shortcodes/quote.html
+++ b/layouts/shortcodes/quote.html
@@ -4,6 +4,6 @@
     </div>
     <div class="content">
         {{- $trimmed := trim .Inner " \n" -}}
-        {{- $trimmed | safeHTML -}}
+        {{- $trimmed | markdownify | safeHTML -}}
     </div>
 </aside>

--- a/layouts/shortcodes/tip.html
+++ b/layouts/shortcodes/tip.html
@@ -4,6 +4,6 @@
     </div>
     <div class="content">
         {{- $trimmed := trim .Inner " \n" -}}
-        {{- $trimmed | safeHTML -}}
+        {{- $trimmed | markdownify | safeHTML -}}
     </div>
 </aside>

--- a/layouts/shortcodes/warning.html
+++ b/layouts/shortcodes/warning.html
@@ -4,6 +4,6 @@
     </div>
     <div class="content">
         {{- $trimmed := trim .Inner " \n" -}}
-        {{- $trimmed | safeHTML -}}
+        {{- $trimmed | markdownify | safeHTML -}}
     </div>
 </aside>


### PR DESCRIPTION
- Move requirements up to be the first thing people see. This matches
the order presented in the landing page.

- Shuffle the order in the sidebar a bit to correspond to the order
the material is presented in the landing page.

- Clean up some of the wording on the k8s landing page.

- Use shorter names for the platforms in the platform-specific
instructions within the sidebar.

Fixes #2762 
Fixes #3590 
