### PR TITLE
Tweak the installation pages.

### DIFF
--- a/content/about/contribute/creating-and-editing-pages/index.md
+++ b/content/about/contribute/creating-and-editing-pages/index.md
@@ -117,6 +117,7 @@ The available front matter fields are:
 |Field              | Description
 |-------------------|------------
 |`title`            | The short title of the page
+|`linktitle`        | An alternate, typically shorter, title for the page which is used in the side bar to reference the page
 |`subtitle`         | An optional subtitle which gets displayed below the main title
 |`description`      | A one-line description of what the page is about
 |`icon`             | An optional path to an image file which gets displayed next to the main title

--- a/content/docs/examples/endpoints/index.md
+++ b/content/docs/examples/endpoints/index.md
@@ -111,7 +111,7 @@ This solution uses Istio proxy for TCP bypassing. The traffic is secured through
     {{< /text >}}
 
 1.  Update the mesh service deployment. See further readings on port naming rules in
-[Requirements for Pods and Services](/docs/setup/kubernetes/additional-setup/requirements/).
+[Requirements for Pods and Services](/docs/setup/kubernetes/requirements/).
 
 1.  You can verify access to the Endpoints service through secure Ingress:
 

--- a/content/docs/setup/kubernetes/_index.md
+++ b/content/docs/setup/kubernetes/_index.md
@@ -18,18 +18,15 @@ Istio {{< istio_version >}} has been tested with these Kubernetes releases: {{< 
 ## Getting started
 
 Istio offers multiple installation flows depending on your Kubernetes platform.
-
 However, the basic flow is the same regardless of platform:
 
-1. [Review the pod requirements](/docs/setup/kubernetes/additional-setup/requirements/)
+1. [Review the pod requirements](/docs/setup/kubernetes/requirements/)
 1. [Prepare your platform for Istio](/docs/setup/kubernetes/platform-setup/)
+1. [Download the Istio release](/docs/setup/kubernetes/download-release/)
 1. [Install Istio on your platform](/docs/setup/kubernetes/)
 
-Some platforms additionally require you [download the latest Istio release](/docs/setup/kubernetes/download-release/)
-manually.
-
-Whether or not you intend to use Istio on production, it is critical when
-deciding which installation to perform.
+Whether or not you intend to use Istio in production is an important consideration when
+deciding which installation flow to follow.
 
 ## Evaluating Istio
 

--- a/content/docs/setup/kubernetes/additional-setup/cni/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/cni/index.md
@@ -23,7 +23,7 @@ networking functionality but without requiring Istio users to enable elevated
 Kubernetes RBAC permissions.
 
 The Istio CNI plugin performs the Istio mesh pod traffic redirection in the Kubernetes pod lifecycle's network
-setup phase, thereby removing the [`NET_ADMIN` capability requirement](/docs/setup/kubernetes/additional-setup/requirements//)
+setup phase, thereby removing the [`NET_ADMIN` capability requirement](/docs/setup/kubernetes/requirements//)
 for users deploying pods into the Istio mesh.  The [Istio CNI plugin](https://github.com/istio/cni)
 replaces the functionality provided by the `istio-init` container.
 

--- a/content/docs/setup/kubernetes/download-release/index.md
+++ b/content/docs/setup/kubernetes/download-release/index.md
@@ -1,7 +1,7 @@
 ---
 title: Downloading the Release
 description: Download the Istio release and prepare for installation.
-weight: 1
+weight: 15
 aliases:
     - /docs/setup/kubernetes/download-release/
 keywords: [kubernetes]

--- a/content/docs/setup/kubernetes/install/_index.md
+++ b/content/docs/setup/kubernetes/install/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Installation Flows
 description: Choose the flows that best suit your needs and platform.
-weight: 3
+weight: 20
 icon: setup
 ---
 

--- a/content/docs/setup/kubernetes/install/helm/index.md
+++ b/content/docs/setup/kubernetes/install/helm/index.md
@@ -36,7 +36,7 @@ installation key and value pairs.
 
 1. Perform any necessary [platform-specific setup](/docs/setup/kubernetes/platform-setup/).
 
-1. Check the [Requirements for Pods and Services](/docs/setup/kubernetes/additional-setup/requirements//) on Pods and Services.
+1. Check the [Requirements for Pods and Services](/docs/setup/kubernetes/requirements/) on Pods and Services.
 
 1. [Install a Helm client with a version higher than 2.10](https://github.com/helm/helm/blob/master/docs/install.md).
 

--- a/content/docs/setup/kubernetes/install/kubernetes/index.md
+++ b/content/docs/setup/kubernetes/install/kubernetes/index.md
@@ -38,7 +38,7 @@ This permits customization of Istio to operator specific requirements.
     Istio {{< istio_version >}} has been tested with these Kubernetes releases: {{< supported_kubernetes_versions >}}.
     {{< /tip >}}
 
-1. Check the [Requirements for Pods and Services](/docs/setup/kubernetes/additional-setup/requirements//).
+1. Check the [Requirements for Pods and Services](/docs/setup/kubernetes/requirements/).
 
 ## Installation steps
 

--- a/content/docs/setup/kubernetes/install/platform/alicloud/index.md
+++ b/content/docs/setup/kubernetes/install/platform/alicloud/index.md
@@ -1,5 +1,6 @@
 ---
 title: Install Istio on the Alibaba Cloud Kubernetes Container Service
+linktitle: Alibaba Cloud
 description: Instructions to install Istio using the Alibaba Cloud Kubernetes Container Service.
 weight: 60
 keywords: [kubernetes,alibabacloud,aliyun]

--- a/content/docs/setup/kubernetes/install/platform/gke/index.md
+++ b/content/docs/setup/kubernetes/install/platform/gke/index.md
@@ -1,5 +1,6 @@
 ---
 title: Install Istio on the Google Kubernetes Engine
+linktitle: Google Kubernetes Engine
 description: Instructions to install Istio using the Google Kubernetes Engine (GKE).
 weight: 65
 keywords: [kubernetes,gke,google]

--- a/content/docs/setup/kubernetes/install/platform/ibm/index.md
+++ b/content/docs/setup/kubernetes/install/platform/ibm/index.md
@@ -1,5 +1,6 @@
 ---
 title: Install Istio using the IBM Cloud
+linktitle: IBM Cloud
 description: Instructions to install Istio using IBM Cloud Public or IBM Cloud Private.
 weight: 70
 keywords: [kubernetes,ibm,icp]

--- a/content/docs/setup/kubernetes/platform-setup/_index.md
+++ b/content/docs/setup/kubernetes/platform-setup/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Platform Setup
 description: How to prepare various Kubernetes platforms before installing Istio.
-weight: 2
+weight: 10
 type: section-index
 keywords: [platform-setup]
 ---

--- a/content/docs/setup/kubernetes/requirements/index.md
+++ b/content/docs/setup/kubernetes/requirements/index.md
@@ -1,9 +1,7 @@
 ---
 title: Requirements for Pods and Services
 description:  Describes the requirements for Kubernetes pods and services to run Istio.
-weight: 50
-aliases:
-    - /docs/setup/kubernetes/additional-setup/requirements//
+weight: 5
 keywords: [kubernetes,sidecar,sidecar-injection]
 ---
 

--- a/content/docs/setup/kubernetes/upgrade/index.md
+++ b/content/docs/setup/kubernetes/upgrade/index.md
@@ -1,7 +1,7 @@
 ---
 title: Upgrading
 description: Upgrade the Istio control plane and data plane independently.
-weight: 5
+weight: 25
 aliases:
     - /docs/setup/kubernetes/upgrading-istio/
 keywords: [kubernetes,upgrading]

--- a/content/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/docs/tasks/traffic-management/request-routing/index.md
@@ -206,7 +206,7 @@ to the request by the `productpage` service.
 
 Note that Kubernetes services, like the Bookinfo ones used in this task, must
 adhere to certain restrictions to take advantage of Istio's L7 routing features.
-Refer to the [Requirements for Pods and Services](/docs/setup/kubernetes/additional-setup/requirements/) for details.
+Refer to the [Requirements for Pods and Services](/docs/setup/kubernetes/requirements/) for details.
 
 In the [traffic shifting](/docs/tasks/traffic-management/traffic-shifting) task, you
 will follow the same basic pattern you learned here to configure route rules to

--- a/content/help/ops/traffic-management/troubleshooting/index.md
+++ b/content/help/ops/traffic-management/troubleshooting/index.md
@@ -49,7 +49,7 @@ but similar version routing rules have no effect on your own application, it may
 your Kubernetes services need to be changed slightly.
 Kubernetes services must adhere to certain restrictions in order to take advantage of
 Istio's L7 routing features.
-Refer to the [Requirements for Pods and Services](/docs/setup/kubernetes/additional-setup/requirements/)
+Refer to the [Requirements for Pods and Services](/docs/setup/kubernetes/requirements/)
 for details.
 
 Another potential issue is that the route rules may simply be slow to take effect.


### PR DESCRIPTION
- Move requirements up to be the first thing people see. This matches
the order presented in the landing page.

- Shuffle the order in the sidebar a bit to correspond to the order
the material is presented in the landing page.

- Clean up some of the wording on the k8s landing page.

- Shorten the platform names used in the sidebar nav so they fit better.
This matches the names used in the Platform Setup section.