### PR TITLE
Highlight apply default destination rules for bookinfo.

### DIFF
--- a/content/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/docs/tasks/traffic-management/request-routing/index.md
@@ -15,7 +15,7 @@ microservice.
 * Setup Istio by following the instructions in the
 [Installation guide](/docs/setup/).
 
-* Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
+* Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application, make sure you have the [default destination rules applied](/docs/examples/bookinfo/#apply-default-destination-rules).
 
 * Review the [Traffic Management](/docs/concepts/traffic-management) concepts doc. Before attempting this task, you should be familiar with important terms such as *destination rule*, *virtual service*, and *subset*.
 

--- a/content_zh/docs/tasks/traffic-management/request-routing/index.md
+++ b/content_zh/docs/tasks/traffic-management/request-routing/index.md
@@ -11,7 +11,7 @@ keywords: [traffic-management,routing]
 
 * 按照[安装指南](/zh/docs/setup/)中的说明安装 Istio。
 
-* 部署 [Bookinfo](/zh/docs/examples/bookinfo/) 示例应用程序。
+* 部署 [Bookinfo](/zh/docs/examples/bookinfo/) 示例应用程序，必须保证事先[部署默认目标规则](/zh/docs/examples/bookinfo/#apply-default-destination-rules)。
 
 * 查看[流量管理](/zh/docs/concepts/traffic-management)的概念文档。在尝试此任务之前，您应该熟悉一些重要的术语，例如 *destination rule* 、*virtual service* 和 *subset* 。
 


### PR DESCRIPTION
Some people often forget to apply default destination rules for bookinfo
wheh running this example, it is better to highlight it here.