### PR TITLE
Fix incorrect indentation of `redirect` in `HTTPRedirect` docs

### DIFF
--- a/content/docs/reference/config/networking/v1alpha3/virtual-service/index.html
+++ b/content/docs/reference/config/networking/v1alpha3/virtual-service/index.html
@@ -737,9 +737,9 @@ spec:
   - match:
     - uri:
         exact: /v1/getProductRatings
-  redirect:
-    uri: /v1/bookRatings
-    authority: newratings.default.svc.cluster.local
+    redirect:
+      uri: /v1/bookRatings
+      authority: newratings.default.svc.cluster.local
   ...
 </code></pre>
 


### PR DESCRIPTION
```diff
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
metadata:
  name: ratings-route
spec:
  hosts:
  - ratings.prod.svc.cluster.local
  http:
  - match:
    - uri:
        exact: /v1/getProductRatings
-  redirect:
-    uri: /v1/bookRatings
-    authority: newratings.default.svc.cluster.local
+    redirect:
+      uri: /v1/bookRatings
+      authority: newratings.default.svc.cluster.local
  ...

```


I believe there is a typo in the docs
https://istio.io/docs/reference/config/istio.networking.v1alpha3/#HTTPRedirect