### PR TITLE
Remove IKS free clusters from documentation

### DIFF
--- a/content/docs/setup/kubernetes/install/platform/ibm/index.md
+++ b/content/docs/setup/kubernetes/install/platform/ibm/index.md
@@ -72,8 +72,7 @@ Make sure to use the `kubectl` CLI version that matches the Kubernetes version o
 1. Install the Helm chart to your cluster:
 
     {{< tip >}}
-    The Istio `demo` profile (`install/kubernetes/helm/istio/values-istio-demo.yaml`) is specified in the following command to support the IBM Cloud Kubernetes Service free cluster, which only contains a single worker providing fewer resources than needed.
-    If using a paid cluster of sufficient size, you can remove the `--values` parameter which will use the default Istio configuration values instead.
+    The Istio `demo` profile (`install/kubernetes/helm/istio/values-istio-demo.yaml`) is specified in the following command to support smaller machine-typed IBM Cloud Kubernetes Service clusters. If using a cluster of sufficient size, you can remove the `--values` parameter which will use the default Istio configuration values instead. See Istio's built-in [configuration profiles](/docs/setup/kubernetes/additional-setup/config-profiles/) for a description of the available profiles.
     {{< /tip >}}
 
     {{< text bash >}}

--- a/content/docs/setup/kubernetes/prepare/platform-setup/ibm/index.md
+++ b/content/docs/setup/kubernetes/prepare/platform-setup/ibm/index.md
@@ -22,7 +22,7 @@ To install the managed Istio add-on in IBM Cloud Public, see the [IBM Cloud Kube
 
 1. [Install the IBM Cloud CLI, the IBM Cloud Kubernetes Service plug-in, and the Kubernetes CLI](https://cloud.ibm.com/docs/containers?topic=containers-cs_cli_install).
 
-1. Create a billable Kubernetes cluster. Replace `<cluster-name>` with the name of the cluster you want to use in the following instructions.
+1. Create a standard Kubernetes cluster. Replace `<cluster-name>` with the name of the cluster you want to use in the following instructions.
 
     {{< tip >}}
     To see available zones, run `ibmcloud ks zones`. Zones are isolated from each other, which ensures no shared single point of failure. IBM Cloud Kubernetes Service [Regions and zones](https://cloud.ibm.com/docs/containers?topic=containers-regions-and-zones) describes regions, zones, and how to specify the region and zone for your new cluster.

--- a/content/docs/setup/kubernetes/prepare/platform-setup/ibm/index.md
+++ b/content/docs/setup/kubernetes/prepare/platform-setup/ibm/index.md
@@ -20,27 +20,27 @@ To install the managed Istio add-on in IBM Cloud Public, see the [IBM Cloud Kube
 
 ## IBM Cloud Public
 
-Replace `<cluster-name>` with the name of the cluster you want to use in the following instructions.
+1. [Install the IBM Cloud CLI, the IBM Cloud Kubernetes Service plug-in, and the Kubernetes CLI](https://cloud.ibm.com/docs/containers?topic=containers-cs_cli_install).
 
-1. Create a new lite or paid Kubernetes cluster.
+1. Create a billable Kubernetes cluster. Replace `<cluster-name>` with the name of the cluster you want to use in the following instructions.
 
-    Lite cluster:
+    {{< tip >}}
+    To see available zones, run 'ibmcloud ks zone-ls'.
+    {{< /tip >}}
+
+    {{< tip >}}
+    The command below does not contain the `--private-vlan value` and `--public-vlan value` options. To see available VLANs, run 'ibmcloud ks vlan-ls --zone <zone name>'. If you do not have a private and public VLAN yet, they will be automatically created for you. If you already have VLANs, they need to be specified using the `--private-vlan value` and `--public-vlan value` options.
+    {{< /tip >}}
 
     {{< text bash >}}
-    $ ibmcloud cs cluster-create --name <cluster-name>
-    {{< /text >}}
-
-    Paid cluster:
-
-    {{< text bash >}}
-    $ ibmcloud cs cluster-create --location <location> --machine-type u2c.2x4 \
+    $ ibmcloud ks cluster-create --zone <name> --machine-type b2c.4x16 \
       --name <cluster-name>
     {{< /text >}}
 
 1. Retrieve your credentials for `kubectl`.
 
     {{< text bash >}}
-    $(ibmcloud cs cluster-config <cluster-name> --export)
+    $(ibmcloud ks cluster-config <cluster-name> --export)
     {{< /text >}}
 
 ## IBM Cloud Private

--- a/content/docs/setup/kubernetes/prepare/platform-setup/ibm/index.md
+++ b/content/docs/setup/kubernetes/prepare/platform-setup/ibm/index.md
@@ -25,15 +25,15 @@ To install the managed Istio add-on in IBM Cloud Public, see the [IBM Cloud Kube
 1. Create a billable Kubernetes cluster. Replace `<cluster-name>` with the name of the cluster you want to use in the following instructions.
 
     {{< tip >}}
-    To see available zones, run 'ibmcloud ks zone-ls'.
+    To see available zones, run `ibmcloud ks zones`. Zones are isolated from each other, which ensures no shared single point of failure. IBM Cloud Kubernetes Service [Regions and zones](https://cloud.ibm.com/docs/containers?topic=containers-regions-and-zones) describes regions, zones, and how to specify the region and zone for your new cluster.
     {{< /tip >}}
 
     {{< tip >}}
-    The command below does not contain the `--private-vlan value` and `--public-vlan value` options. To see available VLANs, run 'ibmcloud ks vlan-ls --zone <zone name>'. If you do not have a private and public VLAN yet, they will be automatically created for you. If you already have VLANs, they need to be specified using the `--private-vlan value` and `--public-vlan value` options.
+    The command below does not contain the `--private-vlan value` and `--public-vlan value` options. To see available VLANs, run `ibmcloud ks vlan-ls --zone <zone-name>`. If you do not have a private and public VLAN yet, they will be automatically created for you. If you already have VLANs, they need to be specified using the `--private-vlan value` and `--public-vlan value` options.
     {{< /tip >}}
 
     {{< text bash >}}
-    $ ibmcloud ks cluster-create --zone <name> --machine-type b2c.4x16 \
+    $ ibmcloud ks cluster-create --zone <zone-name> --machine-type b2c.4x16 \
       --name <cluster-name>
     {{< /text >}}
 

--- a/content/docs/tasks/traffic-management/ingress/index.md
+++ b/content/docs/tasks/traffic-management/ingress/index.md
@@ -88,13 +88,6 @@ Setting the ingress IP depends on the cluster provider:
     $ gcloud compute firewall-rules create allow-gateway-https --allow tcp:$SECURE_INGRESS_PORT
     {{< /text >}}
 
-1.  _IBM Cloud Kubernetes Service Free Tier:_
-
-    {{< text bash >}}
-    $ bx cs workers <cluster-name or id>
-    $ export INGRESS_HOST=<public IP of one of the worker nodes>
-    {{< /text >}}
-
 1.  _Minikube:_
 
     {{< text bash >}}


### PR DESCRIPTION
Since IKS free clusters no longer support Istio default to demo profiles, remove them from the documentation.