### PR TITLE
Add webhook information for OpenShift

### DIFF
--- a/content/docs/setup/kubernetes/prepare/platform-setup/openshift/index.md
+++ b/content/docs/setup/kubernetes/prepare/platform-setup/openshift/index.md
@@ -39,3 +39,31 @@ constraints as part of sidecar injection:
 {{< text bash >}}
 $ oc adm policy add-scc-to-user privileged -z default -n <target-namespace>
 {{< /text >}}
+    
+## Automatic Injection
+Webhook and certificate signing requests support must be enabled for auto injection to work. To do so, you must modify the master configuration file for the cluster. 
+
+On the master node in the directory containing the master configuration file (likely /etc/origin/master/master-config.yaml), create a file named master-config.patch with the following contents:
+
+{{< text yaml >}}
+admissionConfig:
+  pluginConfig:
+    MutatingAdmissionWebhook:
+      configuration:
+        apiVersion: apiserver.config.k8s.io/v1alpha1
+        kubeConfigFile: /dev/null
+        kind: WebhookAdmission
+    ValidatingAdmissionWebhook:
+      configuration:
+        apiVersion: apiserver.config.k8s.io/v1alpha1
+        kubeConfigFile: /dev/null
+        kind: WebhookAdmission
+{{< /text >}}
+In the same directory, execute:
+
+{{< text bash >}}
+$ cp -p master-config.yaml master-config.yaml.prepatch
+$ oc ex config patch master-config.yaml.prepatch -p "$(cat master-config.patch)" > master-config.yaml
+$ master-restart api
+$ master-restart controllers
+{{< /text >}}

--- a/content/docs/setup/kubernetes/prepare/platform-setup/openshift/index.md
+++ b/content/docs/setup/kubernetes/prepare/platform-setup/openshift/index.md
@@ -39,11 +39,16 @@ constraints as part of sidecar injection:
 {{< text bash >}}
 $ oc adm policy add-scc-to-user privileged -z default -n <target-namespace>
 {{< /text >}}
-    
-## Automatic Injection
-Webhook and certificate signing requests support must be enabled for auto injection to work. To do so, you must modify the master configuration file for the cluster. 
 
-On the master node in the directory containing the master configuration file (likely /etc/origin/master/master-config.yaml), create a file named master-config.patch with the following contents:
+## Automatic Injection
+
+Webhook and certificate signing requests support must be enabled for [automatic injection](/docs/setup/kubernetes/additional-setup/sidecar-injection/#automatic-sidecar-injection) to work. Modify the master configuration file on the master node for the cluster as follows.
+
+{{< tip >}}
+By default, the master configuration file can be found in /etc/origin/master/master-config.yaml.
+{{< /tip >}}
+
+In the same directory as the master configuration file, create a file named master-config.patch with the following contents:
 
 {{< text yaml >}}
 admissionConfig:
@@ -59,6 +64,7 @@ admissionConfig:
         kubeConfigFile: /dev/null
         kind: WebhookAdmission
 {{< /text >}}
+
 In the same directory, execute:
 
 {{< text bash >}}


### PR DESCRIPTION
OpenShift requires enabling webhooks in the master-config.yaml in order to use automatic injection. 