### PR TITLE
zh: correct a Chinese translation error

### DIFF
--- a/content_zh/docs/setup/kubernetes/additional-setup/sidecar-injection/index.md
+++ b/content_zh/docs/setup/kubernetes/additional-setup/sidecar-injection/index.md
@@ -139,7 +139,7 @@ sleep-776b7bcdcd-gmvnr   1/1       Running       0          2s
 
 #### 理解原理
 
-被 Kubernetes 调用 Webhook 时，[admissionregistration.k8s.io/v1beta1#MutatingWebhookConfiguration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#mutatingwebhookconfiguration-v1beta1-admissionregistration-k8s-io) 会进行配置。Istio 提供的缺省配置，会在带有 `istio-injection=enabled` 标签的命名空间中选择 Pod。使用 `kubectl edit mutatingwebhookconfiguration istio-sidecar-injector` 命令可以编辑目标命名空间的范围。
+[admissionregistration.k8s.io/v1beta1#MutatingWebhookConfiguration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#mutatingwebhookconfiguration-v1beta1-admissionregistration-k8s-io) 配置了 Webhook 何时会被 Kubernetes 调用。Istio 提供的缺省配置，会在带有 `istio-injection=enabled` 标签的命名空间中选择 Pod。使用 `kubectl edit mutatingwebhookconfiguration istio-sidecar-injector` 命令可以编辑目标命名空间的范围。
 
 {{< warning >}}
 修改 `mutatingwebhookconfiguration` 之后，应该重新启动已经被注入 Sidecar 的 Pod。


### PR DESCRIPTION
If I understand correctly, the translation for this state is not correct and should be re-translated:

> admissionregistration.k8s.io/v1beta1#MutatingWebhookConfiguration configures when the webhook is invoked by Kubernetes.