### PR TITLE
Specify an explicit download version # in various pages.

### DIFF
--- a/content/docs/setup/consul/quick-start/index.md
+++ b/content/docs/setup/consul/quick-start/index.md
@@ -19,7 +19,7 @@ Quick Start instructions to install and configure Istio networking in a Docker C
     run the following command to download and extract the latest release automatically:
 
     {{< text bash >}}
-    $ curl -L https://git.io/getLatestIstio | sh -
+    $ curl -L https://git.io/getLatestIstio | ISTIO_VERSION={{< istio_full_version >}} sh -
     {{< /text >}}
 
 1.  Extract the installation file and change the directory to the file location. The

--- a/content/docs/setup/kubernetes/download/index.md
+++ b/content/docs/setup/kubernetes/download/index.md
@@ -19,7 +19,7 @@ services from all other namespaces.
     extract the latest release automatically:
 
     {{< text bash >}}
-    $ curl -L https://git.io/getLatestIstio | sh -
+    $ curl -L https://git.io/getLatestIstio | ISTIO_VERSION={{< istio_full_version >}} sh -
     {{< /text >}}
 
 1.  Move to the Istio package directory. For example, if the package is

--- a/content_zh/docs/setup/consul/quick-start/index.md
+++ b/content_zh/docs/setup/consul/quick-start/index.md
@@ -17,7 +17,7 @@ keywords: [consul]
 1.  在 [Istio release](https://github.com/istio/istio/releases) 页面下载与你操作系统相对应的安装文件。如果你使用了 macOS 或者 Linux 系统，你还可以运行以下命令自动下载并解压最新版本的安装文件。
 
     {{< text bash >}}
-    $ curl -L https://git.io/getLatestIstio | sh -
+    $ curl -L https://git.io/getLatestIstio | ISTIO_VERSION={{< istio_full_version >}} sh -
     {{< /text >}}
 
 1.  解压下载好的文件并切换到文件所在的目录。安装文件目录中包含以下内容：

--- a/content_zh/docs/setup/kubernetes/download/index.md
+++ b/content_zh/docs/setup/kubernetes/download/index.md
@@ -12,7 +12,7 @@ Istio 会被安装到自己的 `istio-system` 命名空间，并且能够对所�
 1. 进入 [Istio release](https://github.com/istio/istio/releases) 页面，下载对应目标操作系统的安装文件。在 macOS 或者 Linux 系统中，还可以运行下面的命令，进行下载和自动解压缩：
 
     {{< text bash >}}
-    $ curl -L https://git.io/getLatestIstio | sh -
+    $ curl -L https://git.io/getLatestIstio | ISTIO_VERSION={{< istio_full_version >}} sh -
     {{< /text >}}
 
 1. 进入 Istio 包目录。例如，假设这个包是 `istio-{{< istio_full_version >}}.0`：


### PR DESCRIPTION
Fixes #3325.

I tried replacing the short name from getLatestIstio to downloadIstio, but git.io won't let you give two names to the same URLs, and there's no way to delete the old name. So I kept the old name and only added the ISTIO_VERSION portion.

The page will always point to the right Istio version for the doc set, just like the DOWNLOAD button on the home page and a few other places.