### PR TITLE
Add doc on policy check enablement and clean-up P&T release notes

### DIFF
--- a/content/about/feature-stages/index.md
+++ b/content/about/feature-stages/index.md
@@ -91,7 +91,8 @@ Below is our list of existing features and their current phases. This informatio
 | [Kubernetes: Envoy Installation and Traffic Interception](/docs/setup/kubernetes/)        | Stable
 | [Kubernetes: Istio Control Plane Installation](/docs/setup/kubernetes/) | Stable
 | [Attribute Expression Language](/docs/reference/config/policy-and-telemetry/expression-language/)        | Stable
-| [Mixer Adapter Authoring Model](/blog/2017/adapter-model/)        | Stable
+| [Mixer In-Process Adapter Authoring Model](/blog/2017/adapter-model/)        | Deprecated
+| Mixer Out-of-Process Adapter Authoring Model | Beta
 | [Helm](/docs/setup/kubernetes/install/helm/) | Beta
 | [Multicluster Mesh over VPN](/docs/setup/kubernetes/install/multicluster/) | Alpha
 | [Kubernetes: Istio Control Plane Upgrade](/docs/setup/kubernetes/) | Beta

--- a/content/about/notes/1.1/index.md
+++ b/content/about/notes/1.1/index.md
@@ -115,7 +115,8 @@ a richer visualization experience. See the [Kiali task](/docs/tasks/telemetry/ki
 - **Control Headers and Routing**. Added the option to create adapters to influence
 an incoming request's headers and routing.
 
-- **Out of Process Adapters**. The out-of-process adapter functionality is now ready for production use.
+- **Out of Process Adapters**. The out-of-process adapter functionality is now ready for production use. As a result, the in-process
+adapter model is being deprecated in this release. All new adapter development should use the out-of-process model moving forward.
 
 - **Tracing Improvements**. There have been many improvements in our overall tracing story:
 

--- a/content/about/notes/1.1/index.md
+++ b/content/about/notes/1.1/index.md
@@ -99,7 +99,7 @@ TBD: LINK
 ## Policies and telemetry
 
 - **Policy Checks Off By Default**. Changed policy checks to be turned off by default which improves performance for most customer scenarios.
-TBD: LINK
+[Enabling Policy Enforcement](/docs/tasks/policy-enforcement/enabling-policy/) details how to turn on Istio policy checks, if needed.
 
 - **Kiali**. Replaced the [Service Graph addon](https://github.com/istio/istio/issues/9066) with [Kiali](https://www.kiali.io) to provide
 a richer visualization experience. See the [Kiali task](/docs/tasks/telemetry/kiali/) for more details.
@@ -115,8 +115,7 @@ a richer visualization experience. See the [Kiali task](/docs/tasks/telemetry/ki
 - **Control Headers and Routing**. Added the option to create adapters to influence
 an incoming request's headers and routing.
 
-- **Out of Process Adapters**. The out-of-process adapter functionality is now ready for production
-TBD: LINK
+- **Out of Process Adapters**. The out-of-process adapter functionality is now ready for production use.
 
 - **Tracing Improvements**. There have been many improvements in our overall tracing story:
 

--- a/content/docs/tasks/policy-enforcement/denial-and-list/index.md
+++ b/content/docs/tasks/policy-enforcement/denial-and-list/index.md
@@ -16,6 +16,11 @@ This task shows how to control access to a service using simple denials, attribu
 * Set up Istio on Kubernetes by following the instructions in the
   [Installation guide](/docs/setup/kubernetes/).
 
+    {{< warning >}}
+    Policy enforcement **must** be enabled in your cluster for this task. Follow the steps in
+    [Enabling Policy Enforcement](/docs/tasks/policy-enforcement/enabling-policy/) to ensure that policy enforcement is enabled.
+    {{< /warning >}}
+
 * Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
 
 * Initialize the application version routing to direct `reviews` service

--- a/content/docs/tasks/policy-enforcement/enabling-policy/index.md
+++ b/content/docs/tasks/policy-enforcement/enabling-policy/index.md
@@ -12,7 +12,7 @@ This task shows you how to enable Istio policy enforcement.
 In the default Istio installation profile, policy enforcement is disabled. To install Istio
 with policy enforcement on, use the `--set global.disablePolicyChecks=false` Helm install option.
 
-Alternatively, you may [install Istio using the demo profile](https://preliminary.istio.io/docs/setup/kubernetes/install/kubernetes/),
+Alternatively, you may [install Istio using the demo profile](/docs/setup/kubernetes/install/kubernetes/),
 which enables policy checks by default.
 
 ## For an existing Istio mesh

--- a/content/docs/tasks/policy-enforcement/enabling-policy/index.md
+++ b/content/docs/tasks/policy-enforcement/enabling-policy/index.md
@@ -1,0 +1,48 @@
+---
+title: Enabling Policy Enforcement
+description: This task shows you how to enable Istio policy enforcement.
+weight: 1
+keywords: [policies]
+---
+
+This task shows you how to enable Istio policy enforcement.
+
+## At install time
+
+In the default Istio installation profile, policy enforcement is disabled. To install Istio
+with policy enforcement on, use the `--set global.disablePolicyChecks=false` Helm install option.
+
+Alternatively, you may [install Istio using the demo profile](https://preliminary.istio.io/docs/setup/kubernetes/install/kubernetes/),
+which enables policy checks by default.
+
+## For an existing Istio mesh
+
+1. Check the status of policy enforcement for your mesh.
+
+    {{< text bash >}}
+    $ kubectl -n istio-system get cm istio -o jsonpath="{@.data.mesh}" | grep disablePolicyChecks
+    disablePolicyChecks: true
+    {{< /text >}}
+
+    If policy enforcement is enabled, no further action is needed.
+
+1. Edit the `istio` configmap to enable policy checks.
+
+    {{< text bash >}}
+    $ kubectl -n istio-system get cm istio -o jsonpath="{@.data.mesh}" | sed -e "s/disablePolicyChecks: true/disablePolicyChecks: false/" > /tmp/mesh.yaml
+    $ kubectl -n istio-system create cm istio -o yaml --dry-run --from-file=mesh=/tmp/mesh.yaml | kubectl replace -f -
+    configmap "istio" replaced
+    {{< /text >}}
+
+1. Delete the temporary file created to patch the `istio` configmap.
+
+    {{< text bash >}}
+    $ rm /tmp/mesh.yaml
+    {{< /text >}}
+
+1. Validate that policy enforcement is now enabled.
+
+    {{< text bash >}}
+    $ kubectl -n istio-system get cm istio -o jsonpath="{@.data.mesh}" | grep disablePolicyChecks
+    disablePolicyChecks: false
+    {{< /text >}}

--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -15,6 +15,11 @@ service.
 1. Setup Istio in a Kubernetes cluster by following the instructions in the
    [Installation Guide](/docs/setup/kubernetes/install/kubernetes/).
 
+    {{< warning >}}
+    Policy enforcement **must** be enabled in your cluster for this task. Follow the steps in
+    [Enabling Policy Enforcement](/docs/tasks/policy-enforcement/enabling-policy/) to ensure that policy enforcement is enabled.
+    {{< /warning >}}
+
 1. Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
 
     The Bookinfo sample deploys 3 versions of the `reviews` service:


### PR DESCRIPTION
Also, includes deprecation notice for in-proc adapters in release notes (#3670).

Fixes: #3671 