### PR TITLE
[PoC] Proposal: Add test coverage section to task docs

### DIFF
--- a/content/docs/tasks/policy-enforcement/denial-and-list/index.md
+++ b/content/docs/tasks/policy-enforcement/denial-and-list/index.md
@@ -289,3 +289,7 @@ subnet.
 * If you are not planning to explore any follow-on tasks, refer to the
   [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
   to shutdown the application.
+
+## Test coverage
+
+<iframe src="https://testgrid.k8s.io/istio-release#e2e-mixer-no_auth&include-filter-by-regex=Denials&embed-without-column-labels=" height="125" width="100%"></iframe>

--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -424,3 +424,7 @@ namespace.
 1. If you are not planning to explore any follow-on tasks, refer to the
   [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
   to shutdown the application.
+
+## Test coverage
+
+<iframe src="https://testgrid.k8s.io/istio-release#e2e-mixer-no_auth&include-filter-by-regex=Quota&embed-without-column-labels=" height="125" width="100%"></iframe>


### PR DESCRIPTION
In one of the Code Mauve discussions, it was mentioned that it would be nice to know which sections of the istio.io site were validated by tests -- and known to be working.

I've thrown together this PoC to further discussion as to what this might look like. My original line of thinking was that we could have some sort of test badge, based on individual test links in CI. Moving forward, we could require that all tasks have links to specific tests (and their statuses).

I've used the testgrid.k8s.io embed links to present coverage for the `Policies` tasks of rate limits and denials in this PR.

It looks like:

![image](https://user-images.githubusercontent.com/21148125/54461718-a8574180-472a-11e9-92a5-5801d043d5b6.png)

Hopefully, someone with better JS skills and/or understanding of Prow links could just extract the latest status from both the release branch and master.

Would be interested in thoughts on general approach, enhancements, etc.

/hold