### PR TITLE
Modify Envoy Access Log Task to use Helm Template 

### DIFF
--- a/content/docs/tasks/telemetry/logs/access-log/index.md
+++ b/content/docs/tasks/telemetry/logs/access-log/index.md
@@ -21,17 +21,14 @@ The standard output of Envoy's containers can then be printed by the `kubectl lo
 Edit the `istio` configuration map:
 
 {{< text bash >}}
-$ kubectl edit cm istio -n istio-system
+$ helm template install/kubernetes/helm/istio --namespace=istio-system -x templates/configmap.yaml --set global.proxy.accessLogFile="/dev/stdout" | kubectl replace -f -
+configmap "istio" replaced
 {{< /text >}}
 
-Set the value of `accessLogFile` to `"/dev/stdout"`.
-
-You can choose between JSON and text by setting `accessLogEncoding` to `JSON` or `TEXT`.
+You can also choose between JSON and text by setting `accessLogEncoding` to `JSON` or `TEXT`.
 
 You may also want to customize the
 [format](https://www.envoyproxy.io/docs/envoy/latest/configuration/access_log#format-rules) of the access log by editing `accessLogFormat`.
-
-Save the configuration map and exit the editing mode.
 
 {{< tip >}}
 All three of these parameters may also be configured via [helm values](/docs/reference/config/installation-options/):
@@ -99,5 +96,6 @@ $ kubectl delete -f @samples/httpbin/httpbin.yaml@
 Edit the `istio` configuration map and set `accessLogFile` to `""`.
 
 {{< text bash >}}
-$ kubectl edit cm istio -n istio-system
+$ helm template install/kubernetes/helm/istio --namespace=istio-system -x templates/configmap.yaml | kubectl replace -f -
+configmap "istio" replaced
 {{< /text >}}


### PR DESCRIPTION
Improves consistency of configmap editing across the site.