### PR TITLE
fix indent so dollar sign is not included in copy/paste

### DIFF
--- a/content/docs/setup/kubernetes/install/helm/index.md
+++ b/content/docs/setup/kubernetes/install/helm/index.md
@@ -315,6 +315,6 @@ The `istio-init` chart contains all raw CRDs in the `istio-init/files` directory
 You can simply delete the CRDs using `kubectl`.
 To permanently delete Istio's CRDs and the entire Istio configuration, run:
 
-    {{< text bash >}}
-    $ kubectl delete -f install/kubernetes/helm/istio-init/files
-    {{< /text >}}
+{{< text bash >}}
+$ kubectl delete -f install/kubernetes/helm/istio-init/files
+{{< /text >}}


### PR DESCRIPTION
`$` currently included in the copy/paste instructions in the cleanup section. 