### PR TITLE
fix generation of istio-egressgateway.yaml

### DIFF
--- a/content/docs/examples/advanced-gateways/egress-gateway-tls-origination/index.md
+++ b/content/docs/examples/advanced-gateways/egress-gateway-tls-origination/index.md
@@ -631,6 +631,7 @@ to hold the configuration of the NGINX server:
 
     {{< text bash >}}
     $ helm template install/kubernetes/helm/istio/ --name istio --namespace istio-system -x charts/gateways/templates/deployment.yaml --set gateways.istio-ingressgateway.enabled=false \
+    --set gateways.istio-egressgateway.enabled=true \
     --set gateways.istio-egressgateway.secretVolumes[0].name=egressgateway-certs \
     --set gateways.istio-egressgateway.secretVolumes[0].secretName=istio-egressgateway-certs \
     --set gateways.istio-egressgateway.secretVolumes[0].mountPath=/etc/istio/egressgateway-certs \


### PR DESCRIPTION
In the current documentation it does not generate a correct egress gateway deployment (istio-egressgateway.yaml) unless you add the following
```
--set gateways.istio-egressgateway.enabled=true
```