### PR TITLE
remove unused command that throw error

### DIFF
--- a/content/docs/tasks/security/auth-sds/index.md
+++ b/content/docs/tasks/security/auth-sds/index.md
@@ -54,7 +54,6 @@ This approach has the following benefits:
     {{< text bash >}}
     $ cat install/kubernetes/namespace.yaml > istio-auth-sds.yaml
     $ cat install/kubernetes/helm/istio-init/files/crd-* >> istio-auth-sds.yaml
-    $ helm dep update --skip-refresh install/kubernetes/helm/istio
     $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system --values @install/kubernetes/helm/istio/values-istio-sds-auth.yaml@ >> istio-auth-sds.yaml
     $ kubectl create -f istio-auth-sds.yaml
     {{< /text >}}

--- a/content/docs/tasks/security/vault-ca/index.md
+++ b/content/docs/tasks/security/vault-ca/index.md
@@ -32,7 +32,6 @@ requests to a testing Vault CA:
 
     {{< text bash >}}
     $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user="$(gcloud config get-value core/account)"
-    $ helm dep update --skip-refresh install/kubernetes/helm/istio
     $ cat install/kubernetes/namespace.yaml > istio-auth.yaml
     $ cat install/kubernetes/helm/istio-init/files/crd-* >> istio-auth.yaml
     $ helm template \


### PR DESCRIPTION
This command works when origin documentation PRs were checked in.

seems in latest 1.1 release, this command throw below error - 
```
Error: no repository definition for , , , , , , , , , , , , , . Please add them via 'helm repo add'
Note that repositories must be URLs or aliases. For example, to refer to the stable
repository, use "https://kubernetes-charts.storage.googleapis.com/" or "@stable" instead of
"stable". Don't forget to add the repo, too ('helm repo add').
```