### PR TITLE
Clarify and fix comma

### DIFF
--- a/content/docs/setup/kubernetes/install/multicluster/vpn/index.md
+++ b/content/docs/setup/kubernetes/install/multicluster/vpn/index.md
@@ -410,7 +410,7 @@ section provides a high level overview of these options:
 
 ### Update the DNS entries
 
-Upon any failure or restart of the local Istio control plane, `kube-dns` on the remote clusters can be
+Upon any failure or restart of the local Istio control plane, `kube-dns` on the remote clusters must be
 updated with the correct endpoint mappings for the Istio services.  There
 are a number of ways this can be done. The most obvious is to rerun the Helm
 install in the remote cluster after the Istio services on the control plane

--- a/content/docs/setup/kubernetes/install/multicluster/vpn/index.md
+++ b/content/docs/setup/kubernetes/install/multicluster/vpn/index.md
@@ -410,7 +410,7 @@ section provides a high level overview of these options:
 
 ### Update the DNS entries
 
-Upon any failure or pod, restart `kube-dns` on the remote clusters can be
+Upon any failure or restart of the local Istio control plane, `kube-dns` on the remote clusters can be
 updated with the correct endpoint mappings for the Istio services.  There
 are a number of ways this can be done. The most obvious is to rerun the Helm
 install in the remote cluster after the Istio services on the control plane


### PR DESCRIPTION
This sentence could use further clarification:
`Upon any failure or pod, restart kube-dns on the remote clusters can be updated with the correct endpoint mappings for the Istio services. `
https://istio.io/docs/setup/kubernetes/install/multicluster/vpn/