### PR TITLE
Fix sidecar.istio.io/inject usage in EFK example

### DIFF
--- a/content/docs/tasks/telemetry/logs/fluentd/index.md
+++ b/content/docs/tasks/telemetry/logs/fluentd/index.md
@@ -100,13 +100,13 @@ metadata:
   namespace: logging
   labels:
     app: elasticsearch
-  annotations:
-    sidecar.istio.io/inject: "false"
 spec:
   template:
     metadata:
       labels:
         app: elasticsearch
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1
@@ -163,13 +163,13 @@ metadata:
   namespace: logging
   labels:
     app: fluentd-es
-  annotations:
-    sidecar.istio.io/inject: "false"
 spec:
   template:
     metadata:
       labels:
         app: fluentd-es
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: fluentd-es
@@ -248,13 +248,13 @@ metadata:
   namespace: logging
   labels:
     app: kibana
-  annotations:
-    sidecar.istio.io/inject: "false"
 spec:
   template:
     metadata:
       labels:
         app: kibana
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: kibana


### PR DESCRIPTION
**sidecar.istio.io/inject** is not properly used in [example-fluentd-elasticsearch-kibana-stack](https://istio.io/docs/tasks/telemetry/logs/fluentd/#example-fluentd-elasticsearch-kibana-stack)

The annotation is used on deployment's metadata whereas is should be on the pod template spec's metadata (cf [docs](https://istio.io/docs/setup/kubernetes/additional-setup/sidecar-injection/#policy))