### PR TITLE
fix regex to get multiple lines in between snippet tags

### DIFF
--- a/src/ts/codeBlocks.ts
+++ b/src/ts/codeBlocks.ts
@@ -315,7 +315,7 @@ function handleCodeBlocks() {
                 })
                 .then(data => {
                     if (code.dataset.snippet) {
-                        const pattern = "\\n.*?\\$snippet " + code.dataset.snippet + "\\n(.+?)\\n.*?\\$endsnippet";
+                        const pattern = "\\#.*?\\$snippet " + code.dataset.snippet + "\\n(.*?)\\n\\#.+?\\$endsnippet";
                         const regex = new RegExp(pattern, "gms");
 
                         let buf = "";


### PR DESCRIPTION
The text_import feature, using URL, is ignoring multiline snippets, and it is taking only the first line. This commit fixes the regex to get all lines in between `# $snippet XXXX` and `# $endsnippet`.

This commit was tested with this example:
https://raw.githubusercontent.com/tvieira/istio/snippets/docs/snippets/fault-injection.txt

At least, all 3 snippets worked as expected.