### PR TITLE
Update index.md

### DIFF
--- a/content/docs/examples/bookinfo/index.md
+++ b/content/docs/examples/bookinfo/index.md
@@ -184,7 +184,7 @@ is used for this purpose.
     {{< /text >}}
 
     {{< tip >}}
-    If the Istio Pilot container terminates, re-run the command from the previous step.
+    If the Istio Pilot container terminates, re-run the command `docker-compose -f install/consul/istio.yaml up -d`.
     {{< /tip >}}
 
 1.  Set `GATEWAY_URL`:


### PR DESCRIPTION
When using consul, if `istio-pilot` terminates, we have to run `docker-compose -f install/consul/istio.yaml up -d`.  Re-run the previous step `docker-compose -f samples/bookinfo/platform/bookinfo.yaml up -d` will not restart `istio-pilot`