### PR TITLE
Fix grammar and invalid links in Skywalking adapter page

### DIFF
--- a/content/docs/reference/config/policy-and-telemetry/adapters/apache-skywalking/index.html
+++ b/content/docs/reference/config/policy-and-telemetry/adapters/apache-skywalking/index.html
@@ -10,17 +10,17 @@ provider: Apache SkyWalking
 contact_email: dev@skywalking.apache.org
 support_link:
 source_link: https://github.com/apache/incubator-skywalking
-latest_release_link: https://github.com/apache/incubator-skywalking/tree/v6.0.0-GA
+latest_release_link: https://skywalking.apache.org/downloads/
 helm_chart_link:
 istio_versions: "1.0.3, 1.0.4, 1.1.0, 1.1.1"
 supported_templates: metric
-logo_link: hhttps://github.com/apache/incubator-skywalking-website/blob/master/docs/.vuepress/public/assets/logo.svg
+logo_link: https://github.com/apache/incubator-skywalking-website/raw/master/docs/.vuepress/public/assets/logo.svg
 number_of_entries: 1
 ---
-<p>The SkyWalking uses <code>Istio bypass</code> adapter collects metrics and makes them available to
-<a href="https://skywalking.apache.org/">Apache SkyWalking</a>. In SkyWalking, we provide topology map and metric graph 
+<p>The SkyWalking adapter uses the <code>Istio bypass</code> adapter to collect metrics and make them available to
+<a href="https://skywalking.apache.org/">Apache SkyWalking</a>. SkyWalking provides a topology map and metrics graph 
 to visualize the whole mesh.</p>
 
 <p>This adapter supports the <a href="/docs/reference/config/policy-and-telemetry/templates/metric/">metric template</a>.</p>
 
-<p>Follow our <a href="https://github.com/apache/incubator-skywalking-kubernetes/tree/master/6/6.0.0-GA/istio">document</> to set Istio bypass adaptor</p>
+<p>Follow the <a href="https://github.com/apache/incubator-skywalking-kubernetes/tree/master/6/6.0.0-GA/istio">official Apache Skywalking documentation</a> for details on configuring the Istio bypass adapter.</p>


### PR DESCRIPTION
Fix grammar and invalid links in the Skywalking adapter page. This change has been made by running the `grab_reference_docs` to fetch the fixed version of the Skywalking docs.