### PR TITLE
Update the Egress MongoDB blog post

### DIFF
--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -217,7 +217,7 @@ instructions in this section. Alternatively, if you do want to direct your traff
     Also note that when the protocol `TCP` is specified, the configuration is not specific for MongoDB, but is the same
     for any other database with the protocol on top of TCP.
 
-    Note that the host of your MongoDB is not used in TCP routing, so you can use any host, for example `my-mongo-fake-host.com`. Notice the `STATIC` resolution and the endpoint with the IP of your MongoDB service. Once you define such an endpoint, you can access MongoDB services which do not have an FQDN hostname.
+    Note that the host of your MongoDB is not used in TCP routing, so you can use any host, for example `my-mongo-fake-host.com`. Notice the `STATIC` resolution and the endpoint with the IP of your MongoDB service. Once you define such an endpoint, you can access MongoDB services that do not have an FQDN hostname.
 
 1.  Refresh the web page of the application. Now the application should display the ratings without error:
 

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -455,7 +455,7 @@ enable Mixer policy enforcement based on that identity. By enabling mutual TLS y
 
     {{< text bash >}}
     $ kubectl logs -l istio=egressgateway -n istio-system
-    [2019-04-14T06:12:07.636Z] "- - -" 0 - "-" 1591 4393 94 - "-" "-" "-" "-" "169.50.214.187:<your MongoDB port>" outbound|<your MongoDB port>||<your MongoDB host> 172.30.146.119:59924 172.30.146.119:443 172.30.230.1:59206 <your MongoDB host>
+    [2019-04-14T06:12:07.636Z] "- - -" 0 - "-" 1591 4393 94 - "-" "-" "-" "-" "<Your MongoDB IP>:<your MongoDB port>" outbound|<your MongoDB port>||my-mongo.tcp.svc 172.30.146.119:59924 172.30.146.119:443 172.30.230.1:59206 -
     {{< /text >}}
 
 ### Cleanup of TCP egress traffic control

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -221,10 +221,10 @@ instructions in this section. Alternatively, if you do want to direct your traff
 
 1.  Refresh the web page of the application. Now the application should display the ratings without error:
 
-{{< image width="80%" link="./externalDBRatings.png" caption="Book Ratings Displayed Correctly" >}}
+    {{< image width="80%" link="./externalDBRatings.png" caption="Book Ratings Displayed Correctly" >}}
 
-Note that you see a one-star rating for both displayed reviews, as expected. You set the ratings to be one star to
-provide yourself with a visual clue that your external database is indeed being used.
+    Note that you see a one-star rating for both displayed reviews, as expected. You set the ratings to be one star to
+    provide yourself with a visual clue that your external database is indeed being used.
 
 #### Cleanup of the egress configuration for TCP without a gateway
 

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -283,7 +283,7 @@ connections from the MongoDB client to the egress gateway, by matching the IP of
     configured.
 
     {{< text bash >}}
-    $ helm template install/kubernetes/helm/istio/ --name istio-egressgateway --namespace istio-system -x charts/gateways/templates/service.yaml --set gateways.istio-ingressgateway.enabled=false --set gateways.istio-egressgateway.ports[0].port=80 --set gateways.istio-egressgateway.ports[0].name=http --set gateways.istio-egressgateway.ports[1].port=443 --set gateways.istio-egressgateway.ports[1].name=https --set gateways.istio-egressgateway.ports[2].port=$EGRESS_GATEWAY_MONGODB_PORT --set gateways.istio-egressgateway.ports[2].name=mongo | kubectl apply -f -
+    $ helm template install/kubernetes/helm/istio/ --name istio-egressgateway --namespace istio-system -x charts/gateways/templates/service.yaml --set gateways.istio-ingressgateway.enabled=false --set gateways.istio-egressgateway.enabled=true --set gateways.istio-egressgateway.ports[0].port=80 --set gateways.istio-egressgateway.ports[0].name=http --set gateways.istio-egressgateway.ports[1].port=443 --set gateways.istio-egressgateway.ports[1].name=https --set gateways.istio-egressgateway.ports[2].port=$EGRESS_GATEWAY_MONGODB_PORT --set gateways.istio-egressgateway.ports[2].name=mongo | kubectl apply -f -
     {{< /text >}}
 
 1.  Check that the `istio-egressgateway` service indeed has the selected port:

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -356,7 +356,7 @@ connections from the MongoDB client to the egress gateway, by matching the IP of
     EOF
     {{< /text >}}
 
-1.  Proceed to [Verify that TCP egress traffic is directed through the egress gateway](#verify-that-tcp-egress-traffic-is-directed-through-the-egress-gateway).
+1.  [Verify that egress traffic is directed through the egress gateway](#verify-that-egress-traffic-is-directed-through-the-egress-gateway).
 
 #### Mutual TLS between the sidecar proxies and the egress gateway
 
@@ -751,7 +751,7 @@ to be 443. The egress gateway accepts the MongoDB traffic on the port 443, match
 
     {{< /tabset >}}
 
-1. [Verify that the traffic is directed though the egress gateway](/blog/2018/egress-mongo/#verify-that-egress-traffic-is-directed-through-the-egress-gateway)
+1. [Verify that the traffic is directed though the egress gateway](#verify-that-egress-traffic-is-directed-through-the-egress-gateway)
 
 #### Cleanup directing TLS Egress traffic through an egress gateway
 

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -350,9 +350,9 @@ enable Mixer policy enforcement based on that identity. By enabling mutual TLS y
 1.  Delete the configuration from the previous section:
 
     {{< text bash >}}
-    $ kubectl delete gateway istio-egressgateway
-    $ kubectl delete virtualservice direct-mongo-through-egress-gateway
-    $ kubectl delete destinationrule egressgateway-for-mongo mongo
+    $ kubectl delete gateway istio-egressgateway --ignore-not-found=true
+    $ kubectl delete virtualservice direct-mongo-through-egress-gateway --ignore-not-found=true
+    $ kubectl delete destinationrule egressgateway-for-mongo mongo --ignore-not-found=true
     {{< /text >}}
 
 1.  Create an egress `Gateway` for your MongoDB service, and destination rules and a virtual service

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -217,7 +217,7 @@ instructions in this section. Alternatively, if you do want to direct your traff
     Also note that when the protocol `TCP` is specified, the configuration is not specific for MongoDB, but is the same
     for any other database with the protocol on top of TCP.
 
-    Note that the host of your MongoDB is not used in TCP routing, so you can use any host, for example `my-mongo.tcp.svc`. Notice the `STATIC` resolution and the endpoint with the IP of your MongoDB service. Once you define such an endpoint, you can access MongoDB services that do not have an FQDN hostname.
+    Note that the host of your MongoDB is not used in TCP routing, so you can use any host, for example `my-mongo.tcp.svc`. Notice the `STATIC` resolution and the endpoint with the IP of your MongoDB service. Once you define such an endpoint, you can access MongoDB services that do not have a domain name.
 
 1.  Refresh the web page of the application. Now the application should display the ratings without error:
 

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -494,7 +494,7 @@ In case you [do not need an egress gateway](/docs/examples/advanced-gateways/egr
 instructions in this section. If you want to direct your traffic through an egress gateway, proceed to
 [Direct TCP Egress traffic through an egress gateway](#direct-tcp-egress-traffic-through-an-egress-gateway).
 
-1.  Create a `ServiceEntry` and a `VirtualService` for the MongoDB service:
+1.  Create a `ServiceEntry` for the MongoDB service:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
@@ -510,26 +510,6 @@ instructions in this section. If you want to direct your traffic through an egre
         name: tls
         protocol: TLS
       resolution: DNS
-    ---
-    apiVersion: networking.istio.io/v1alpha3
-    kind: VirtualService
-    metadata:
-      name: mongo
-    spec:
-      hosts:
-      - $MONGODB_HOST
-      tls:
-      - match:
-        - port: $MONGODB_PORT
-          sni_hosts:
-          - $MONGODB_HOST
-        route:
-        - destination:
-            host: $MONGODB_HOST
-            port:
-              number: $MONGODB_PORT
-          weight: 100
-      location: MESH_EXTERNAL
     EOF
     {{< /text >}}
 
@@ -539,7 +519,6 @@ instructions in this section. If you want to direct your traffic through an egre
 
 {{< text bash >}}
 $ kubectl delete serviceentry mongo
-$ kubectl delete virtualservice mongo
 {{< /text >}}
 
 ### Direct TLS Egress traffic through an egress gateway

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -453,17 +453,19 @@ enable Mixer policy enforcement based on that identity. By enabling mutual TLS y
 
 1.  Proceed to the next section.
 
-#### Verify that TCP egress traffic is directed through the egress gateway
+#### Verify that egress traffic is directed through the egress gateway
 
 1.  Refresh the web page of the application again and verify that the ratings are still displayed correctly.
 
-1.  Check the statistics of the egress gateway's Envoy and see a counter that corresponds to your
+1.  [Enable Envoy’s access logging](/docs/tasks/telemetry/logs/access-log/#enable-envoy-s-access-logging)
+
+1.  Check the log of the egress gateway's Envoy and see a line that corresponds to your
     requests to the MongoDB service. If Istio is deployed in the `istio-system` namespace, the command to print the
-    counter is:
+    log is:
 
     {{< text bash >}}
-    $ kubectl exec -it $(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -c istio-proxy -n istio-system -- curl -s localhost:15000/stats | grep $MONGODB_PORT | grep ${MONGODB_HOST}.upstream_cx_total
-    cluster.outbound|<your MongoDB port>||<your MongoDB host>.upstream_cx_total: 1
+    $ kubectl logs -l istio=egressgateway -n istio-system
+    [2019-04-14T06:12:07.636Z] "- - -" 0 - "-" 1591 4393 94 - "-" "-" "-" "-" "169.50.214.187:<your MongoDB port>" outbound|<your MongoDB port>||<your MongoDB host> 172.30.146.119:59924 172.30.146.119:443 172.30.230.1:59206 <your MongoDB host>
     {{< /text >}}
 
 #### Cleanup directing TCP egress traffic through an egress gateway
@@ -749,16 +751,7 @@ to be 443. The egress gateway accepts the MongoDB traffic on the port 443, match
 
     {{< /tabset >}}
 
-1.  Refresh the web page of the application again and verify that the ratings are still displayed correctly.
-
-1.  Check the statistics of the egress gateway's Envoy and see a counter that corresponds to your
-    requests to the MongoDB service. If Istio is deployed in the `istio-system` namespace, the command to print the
-    counter is:
-
-    {{< text bash >}}
-    $ kubectl exec -it $(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -c istio-proxy -n istio-system -- curl -s localhost:15000/stats | grep $MONGODB_PORT | grep ${MONGODB_HOST}.upstream_cx_total
-    cluster.outbound|<your MongoDB port>||<your MongoDB host>.upstream_cx_total: 1
-    {{< /text >}}
+1. [Verify that the traffic is directed though the egress gateway](/blog/2018/egress-mongo/#verify-that-egress-traffic-is-directed-through-the-egress-gateway)
 
 #### Cleanup directing TLS Egress traffic through an egress gateway
 
@@ -1074,6 +1067,8 @@ to hold the configuration of the Nginx SNI proxy:
     {{< /text >}}
 
 1.  Refresh the web page of the application again and verify that the ratings are still displayed correctly.
+
+1.  [Enable Envoy’s access logging](/docs/tasks/telemetry/logs/access-log/#enable-envoy-s-access-logging)
 
 1.  Check the log of the egress gateway's Envoy proxy. If Istio is deployed in the `istio-system` namespace, the command
     to print the log is:

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -193,7 +193,7 @@ instructions in this section. Alternatively, if you do want to direct your traff
       name: mongo
     spec:
       hosts:
-      - my-mongo-fake-host.com
+      - my-mongo.tcp.svc
       addresses:
       - $MONGODB_IP/32
       ports:
@@ -217,7 +217,7 @@ instructions in this section. Alternatively, if you do want to direct your traff
     Also note that when the protocol `TCP` is specified, the configuration is not specific for MongoDB, but is the same
     for any other database with the protocol on top of TCP.
 
-    Note that the host of your MongoDB is not used in TCP routing, so you can use any host, for example `my-mongo-fake-host.com`. Notice the `STATIC` resolution and the endpoint with the IP of your MongoDB service. Once you define such an endpoint, you can access MongoDB services that do not have an FQDN hostname.
+    Note that the host of your MongoDB is not used in TCP routing, so you can use any host, for example `my-mongo.tcp.svc`. Notice the `STATIC` resolution and the endpoint with the IP of your MongoDB service. Once you define such an endpoint, you can access MongoDB services that do not have an FQDN hostname.
 
 1.  Refresh the web page of the application. Now the application should display the ratings without error:
 
@@ -251,7 +251,7 @@ connections from the MongoDB client to the egress gateway, by matching the IP of
       name: mongo
     spec:
       hosts:
-      - my-mongo-fake-host.com
+      - my-mongo.tcp.svc
       addresses:
       - $MONGODB_IP/32
       ports:
@@ -312,7 +312,7 @@ connections from the MongoDB client to the egress gateway, by matching the IP of
           name: tcp
           protocol: TCP
         hosts:
-        - my-mongo-fake-host.com
+        - my-mongo.tcp.svc
     ---
     apiVersion: networking.istio.io/v1alpha3
     kind: DestinationRule
@@ -328,7 +328,7 @@ connections from the MongoDB client to the egress gateway, by matching the IP of
     metadata:
       name: mongo
     spec:
-      host: my-mongo-fake-host.com
+      host: my-mongo.tcp.svc
     ---
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
@@ -336,7 +336,7 @@ connections from the MongoDB client to the egress gateway, by matching the IP of
       name: direct-mongo-through-egress-gateway
     spec:
       hosts:
-      - my-mongo-fake-host.com
+      - my-mongo.tcp.svc
       gateways:
       - mesh
       - istio-egressgateway
@@ -359,7 +359,7 @@ connections from the MongoDB client to the egress gateway, by matching the IP of
           port: $EGRESS_GATEWAY_MONGODB_PORT
         route:
         - destination:
-            host: my-mongo-fake-host.com
+            host: my-mongo.tcp.svc
             port:
               number: $MONGODB_PORT
           weight: 100
@@ -400,7 +400,7 @@ enable Mixer policy enforcement based on that identity. By enabling mutual TLS y
           name: tls
           protocol: TLS
         hosts:
-        - my-mongo-fake-host.com
+        - my-mongo.tcp.svc
         tls:
           mode: MUTUAL
           serverCertificate: /etc/certs/cert-chain.pem
@@ -423,14 +423,14 @@ enable Mixer policy enforcement based on that identity. By enabling mutual TLS y
               number: 443
             tls:
               mode: ISTIO_MUTUAL
-              sni: my-mongo-fake-host.com
+              sni: my-mongo.tcp.svc
     ---
     apiVersion: networking.istio.io/v1alpha3
     kind: DestinationRule
     metadata:
       name: mongo
     spec:
-      host: my-mongo-fake-host.com
+      host: my-mongo.tcp.svc
     ---
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
@@ -438,7 +438,7 @@ enable Mixer policy enforcement based on that identity. By enabling mutual TLS y
       name: direct-mongo-through-egress-gateway
     spec:
       hosts:
-      - my-mongo-fake-host.com
+      - my-mongo.tcp.svc
       gateways:
       - mesh
       - istio-egressgateway
@@ -461,7 +461,7 @@ enable Mixer policy enforcement based on that identity. By enabling mutual TLS y
           port: 443
         route:
         - destination:
-            host: my-mongo-fake-host.com
+            host: my-mongo.tcp.svc
             port:
               number: $MONGODB_PORT
           weight: 100

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -226,11 +226,8 @@ instructions in this section. Alternatively, if you do want to direct your traff
     Note that you see a one-star rating for both displayed reviews, as expected. You set the ratings to be one star to
     provide yourself with a visual clue that your external database is indeed being used.
 
-#### Cleanup of the egress configuration for TCP without a gateway
-
-{{< text bash >}}
-$ kubectl delete serviceentry mongo
-{{< /text >}}
+1.  If you want to direct the traffic through an egress gateway, proceed to the next section. Otherwise, perform
+    [cleanup](#cleanup-of-tcp-egress-traffic-control).
 
 ### Direct TCP Egress traffic through an egress gateway
 
@@ -241,31 +238,7 @@ connections from the MongoDB client to the egress gateway, by matching the IP of
 
 1.  [Deploy Istio egress gateway](/docs/examples/advanced-gateways/egress-gateway/#deploy-istio-egress-gateway).
 
-1.  Create a `ServiceEntry` for the MongoDB service in the same way as in the case without egress gateway.
-
-    {{< text bash >}}
-    $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
-    kind: ServiceEntry
-    metadata:
-      name: mongo
-    spec:
-      hosts:
-      - my-mongo.tcp.svc
-      addresses:
-      - $MONGODB_IP/32
-      ports:
-      - number: $MONGODB_PORT
-        name: tcp
-        protocol: TCP
-      location: MESH_EXTERNAL
-      resolution: STATIC
-      endpoints:
-      - address: $MONGODB_IP
-    EOF
-    {{< /text >}}
-
-1.  Refresh the web page of the application and verify that the ratings are displayed correctly.
+1.  If you did not perform the steps in [the previous section](#control-tcp-egress-traffic-without-a-gateway), perform them now.
 
 1.  Proceed to the following section.
 
@@ -485,13 +458,13 @@ enable Mixer policy enforcement based on that identity. By enabling mutual TLS y
     [2019-04-14T06:12:07.636Z] "- - -" 0 - "-" 1591 4393 94 - "-" "-" "-" "-" "169.50.214.187:<your MongoDB port>" outbound|<your MongoDB port>||<your MongoDB host> 172.30.146.119:59924 172.30.146.119:443 172.30.230.1:59206 <your MongoDB host>
     {{< /text >}}
 
-#### Cleanup directing TCP egress traffic through an egress gateway
+### Cleanup of TCP egress traffic control
 
 {{< text bash >}}
 $ kubectl delete serviceentry mongo
-$ kubectl delete gateway istio-egressgateway
-$ kubectl delete virtualservice direct-mongo-through-egress-gateway
-$ kubectl delete destinationrule egressgateway-for-mongo mongo
+$ kubectl delete gateway istio-egressgateway --ignore-not-found=true
+$ kubectl delete virtualservice direct-mongo-through-egress-gateway --ignore-not-found=true
+$ kubectl delete destinationrule egressgateway-for-mongo mongo --ignore-not-found=true
 {{< /text >}}
 
 ## Egress control for TLS

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -267,7 +267,7 @@ connections from the MongoDB client to the egress gateway, by matching the IP of
     istio-egressgateway   ClusterIP   172.21.202.204   <none>        80/TCP,443/TCP,7777/TCP   34d
     {{< /text >}}
 
-1.  Create an egress `Gateway` for your MongoDB service, and destination rules and virtual services to direct the
+1.  Create an egress `Gateway` for your MongoDB service, and destination rules and a virtual service to direct the
     traffic through the egress gateway and from the egress gateway to the external service.
 
     {{< text bash >}}
@@ -355,7 +355,7 @@ enable Mixer policy enforcement based on that identity. By enabling mutual TLS y
     $ kubectl delete destinationrule egressgateway-for-mongo mongo
     {{< /text >}}
 
-1.  Create an egress `Gateway` for your MongoDB service, and destination rules and virtual services
+1.  Create an egress `Gateway` for your MongoDB service, and destination rules and a virtual service
     to direct the traffic through the egress gateway and from the egress gateway to the external service.
 
     {{< text bash >}}

--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -241,7 +241,7 @@ connections from the MongoDB client to the egress gateway, by matching the IP of
 
 1.  [Deploy Istio egress gateway](/docs/examples/advanced-gateways/egress-gateway/#deploy-istio-egress-gateway).
 
-1.  Create a `ServiceEntry` for the MongoDB service in the same way as for the case without egress gateway.
+1.  Create a `ServiceEntry` for the MongoDB service in the same way as in the case without egress gateway.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF


### PR DESCRIPTION
1. replace checking Envoy's statistics with printing Envoy's logs to verify that the traffic flows through the egress gateway
1. add enabling Envoy's logging
1. use fake hostname in TCP routing + static endpoints, to enable routing to MongoDB services without an FQDN hostname, since now IPs are not allowed as hostnames.
1. add a flag to enable egress gateway since now it is disabled by default 