### PR TITLE
Update the deployment document for Citadel replica

### DIFF
--- a/content/docs/setup/kubernetes/upgrade/steps/index.md
+++ b/content/docs/setup/kubernetes/upgrade/steps/index.md
@@ -11,7 +11,7 @@ process may install new binaries and may change configuration and API schemas.
 The upgrade process may result in service downtime. To minimize downtime,
 please ensure your Istio control plane components and your applications are
 highly available with multiple replicas (as multi-replica Citadel is still
-under development, Citadel should be deployed with one replica). 
+under development, Citadel should be deployed with one replica).
 
 This flow assumes that the Istio components are installed and upgraded in the
 `istio-system` namespace.

--- a/content/docs/setup/kubernetes/upgrade/steps/index.md
+++ b/content/docs/setup/kubernetes/upgrade/steps/index.md
@@ -10,7 +10,8 @@ control plane and the sidecar proxies, to a new release of Istio. The upgrade
 process may install new binaries and may change configuration and API schemas.
 The upgrade process may result in service downtime. To minimize downtime,
 please ensure your Istio control plane components and your applications are
-highly available with multiple replicas.
+highly available with multiple replicas (as multi-replica Citadel is still
+under development, Citadel should be deployed with one replica). 
 
 This flow assumes that the Istio components are installed and upgraded in the
 `istio-system` namespace.


### PR DESCRIPTION
Update the deployment document for Citadel replica. Multi-replica Citadel is still under development; currently for secret-mount-based Citadel when multiple Citadel are deployed, they have race condition.
