### PR TITLE
apply ISTIO_MUTUAL to egress gateway in the general cases

### DIFF
--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -386,6 +386,14 @@ enable Mixer policy enforcement based on that identity. By enabling mutual TLS y
       name: egressgateway-for-mongo
     spec:
       host: istio-egressgateway.istio-system.svc.cluster.local
+      trafficPolicy:
+        loadBalancer:
+          simple: ROUND_ROBIN
+        portLevelSettings:
+        - port:
+            number: 443
+          tls:
+            mode: ISTIO_MUTUAL
       subsets:
       - name: mongo
         trafficPolicy:
@@ -597,6 +605,14 @@ to be 443. The egress gateway accepts the MongoDB traffic on the port 443, match
       name: egressgateway-for-mongo
     spec:
       host: istio-egressgateway.istio-system.svc.cluster.local
+      trafficPolicy:
+        loadBalancer:
+          simple: ROUND_ROBIN
+        portLevelSettings:
+        - port:
+            number: 443
+          tls:
+            mode: ISTIO_MUTUAL
       subsets:
       - name: mongo
         trafficPolicy:
@@ -944,6 +960,14 @@ to hold the configuration of the Nginx SNI proxy:
       name: mtls-for-egress-gateway
     spec:
       host: istio-egressgateway-with-sni-proxy.istio-system.svc.cluster.local
+      trafficPolicy:
+        loadBalancer:
+          simple: ROUND_ROBIN
+        portLevelSettings:
+        - port:
+            number: 443
+          tls:
+            mode: ISTIO_MUTUAL
       subsets:
         - name: mongo
           trafficPolicy:

--- a/content/docs/examples/advanced-gateways/egress-gateway-tls-origination/index.md
+++ b/content/docs/examples/advanced-gateways/egress-gateway-tls-origination/index.md
@@ -129,6 +129,14 @@ be done by the egress gateway, as opposed to by the sidecar in the previous exam
       name: egressgateway-for-cnn
     spec:
       host: istio-egressgateway.istio-system.svc.cluster.local
+      trafficPolicy:
+        loadBalancer:
+          simple: ROUND_ROBIN
+        portLevelSettings:
+        - port:
+            number: 80
+          tls:
+            mode: ISTIO_MUTUAL
       subsets:
       - name: cnn
         trafficPolicy:
@@ -697,6 +705,14 @@ to hold the configuration of the NGINX server:
       name: egressgateway-for-nginx
     spec:
       host: istio-egressgateway.istio-system.svc.cluster.local
+      trafficPolicy:
+        loadBalancer:
+          simple: ROUND_ROBIN
+        portLevelSettings:
+        - port:
+            number: 443
+          tls:
+            mode: ISTIO_MUTUAL
       subsets:
       - name: nginx
         trafficPolicy:

--- a/content/docs/examples/advanced-gateways/egress-gateway/index.md
+++ b/content/docs/examples/advanced-gateways/egress-gateway/index.md
@@ -140,6 +140,14 @@ First create a `ServiceEntry` to allow direct traffic to an external service.
       name: egressgateway-for-cnn
     spec:
       host: istio-egressgateway.istio-system.svc.cluster.local
+      trafficPolicy:
+        loadBalancer:
+          simple: ROUND_ROBIN
+        portLevelSettings:
+        - port:
+            number: 80
+          tls:
+            mode: ISTIO_MUTUAL
       subsets:
       - name: cnn
         trafficPolicy:

--- a/content/docs/examples/advanced-gateways/wildcard-egress-hosts/index.md
+++ b/content/docs/examples/advanced-gateways/wildcard-egress-hosts/index.md
@@ -453,6 +453,14 @@ The SNI proxy will forward the traffic to port `443`.
       name: egressgateway-for-wikipedia
     spec:
       host: istio-egressgateway-with-sni-proxy.istio-system.svc.cluster.local
+      trafficPolicy:
+        loadBalancer:
+          simple: ROUND_ROBIN
+        portLevelSettings:
+        - port:
+            number: 443
+          tls:
+            mode: ISTIO_MUTUAL
       subsets:
         - name: wikipedia
           trafficPolicy:


### PR DESCRIPTION
Apply ISTIO_MUTUAL in DestinationRules not only in the used subsets, but also in the general cases.
While only the subsets are used to communicate with the egress gateway
service, not applying ISTIO_MUTUAL in the general cases causes istiocl authn tls-check to produce conflict errors

fixes https://github.com/istio/istio.io/issues/4024