### PR TITLE
Site improvements

### DIFF
--- a/content/blog/2018/egress-monitoring-access-control/index.md
+++ b/content/blog/2018/egress-monitoring-access-control/index.md
@@ -80,7 +80,7 @@ _info_ log entry. To understand the Istio `logentries`, `rules`, and `handlers`,
 [Istio Adapter Model](/blog/2017/adapter-model/). A diagram with the involved entities and dependencies between them
 appears below:
 
-{{< image width="80%" ratio="68.27%"
+{{< image width="80%"
     link="egress-adapters-monitoring.svg"
     caption="Instances, rules and handlers for egress monitoring"
     >}}
@@ -359,7 +359,7 @@ static list of allowed URL paths, specified by the `overrides` field. For an ext
 diagram of the instances, rules and handlers appears below. Note that you reuse the same policy rule, `handle-cnn-access`
  both for logging and for access policy checks.
 
-{{< image width="80%" ratio="65.45%"
+{{< image width="80%"
     link="egress-adapters-monitoring-policy.svg"
     caption="Instances, rules and handlers for egress monitoring and access policies"
     >}}
@@ -548,7 +548,7 @@ check, the egress gateway performs TLS origination to the external destination (
 is encrypted again and sent encrypted to the external destination. The diagram below demonstrates the network flow of
 this approach. The HTTP protocol inside the gateway designates the protocol as seen by the gateway after decryption.
 
-{{< image width="80%" ratio="73.96%"
+{{< image width="80%"
 link="http-to-gateway.svg"
 caption="HTTP egress traffic through an egress gateway"
 >}}
@@ -562,7 +562,7 @@ In the HTTPS approach, the requests are encrypted end-to-end, from the applicati
 diagram below demonstrates the network flow of this approach. The HTTPS protocol inside the gateway designates the
 protocol as seen by the gateway.
 
-{{< image width="80%" ratio="73.96%"
+{{< image width="80%"
 link="https-to-gateway.svg"
 caption="HTTPS egress traffic through an egress gateway"
 >}}

--- a/content/blog/2019/data-plane-setup/index.md
+++ b/content/blog/2019/data-plane-setup/index.md
@@ -21,7 +21,6 @@ The control plane manages and configures the proxies to route traffic. Additiona
 {{< /quote >}}
 
 {{< image width="40%"
-    ratio="33%"
     link="./arch-2.svg"
     alt="The overall architecture of an Istio-based application."
     caption="Istio Architecture"

--- a/content/docs/concepts/multicluster-deployments/index.md
+++ b/content/docs/concepts/multicluster-deployments/index.md
@@ -59,7 +59,7 @@ you can configure a single logical service mesh that is composed from the partic
 This approach has no special networking requirements and is therefore generally considered
 the easiest approach to start with when there is no universal connectivity across clusters.
 
-{{< image width="80%" ratio="36.01%"
+{{< image width="80%"
     link="./multicluster-with-gateways.svg"
     caption="Istio mesh spanning multiple Kubernetes clusters using multiple Istio control planes and Gateway to reach remote pods"
     >}}
@@ -89,7 +89,7 @@ Envoy sidecars for all of the clusters.
 The following approach works best in environments where all of the participating clusters have VPN connectivity so
 every pod in the mesh is reachable from anywhere else using the same IP address.
 
-{{< image width="80%" ratio="36.01%"
+{{< image width="80%"
     link="./multicluster-with-vpn.svg"
     caption="Istio mesh spanning multiple Kubernetes clusters with direct network access to remote pods over VPN"
     >}}
@@ -112,7 +112,7 @@ as, for example, on managed Kubernetes platforms where the API servers run on a 
 to all tenant clusters.
 If this is not possible, a multiple control plane topology is probably a better alternative.
 
-{{< image width="80%" ratio="36.01%"
+{{< image width="80%"
     link="./multicluster-split-horizon-eds.svg"
     caption="Istio mesh spanning multiple Kubernetes clusters using single Istio control plane and Gateway to reach remote pods"
     >}}

--- a/content/docs/concepts/performance-and-scalability/index.md
+++ b/content/docs/concepts/performance-and-scalability/index.md
@@ -113,8 +113,8 @@ for the `http/1.1` protocol, with a 1 kB payload at 1000 requests per second usi
 In upcoming Istio releases we are moving `istio-policy` and `istio-telemetry` functionality into the proxy as `MixerV2`.
 This will decrease the amount data flowing through the system, which will in turn reduce the CPU usage and latency.
 
-{{< image width="90%" ratio="75%"
-    link="latency.svg?sanitize=true"
+{{< image width="90%"
+    link="latency.svg"
     alt="P90 latency vs client connections"
     caption="P90 latency vs client connections"
 >}}

--- a/content/docs/examples/multicluster/split-horizon-eds/index.md
+++ b/content/docs/examples/multicluster/split-horizon-eds/index.md
@@ -13,7 +13,7 @@ Split-horizon EDS enables Istio to route requests to different endpoints, depend
 
 By following the instructions in this example, you will setup a two cluster mesh as shown in the following diagram:
 
-  {{< image width="80%" ratio="36.01%"
+  {{< image width="80%"
   link="./diagram.svg"
   caption="Single Istio control plane topology spanning multiple Kubernetes clusters with Split-horizon EDS configured" >}}
 

--- a/content_zh/blog/2017/0.1-auth/index.md
+++ b/content_zh/blog/2017/0.1-auth/index.md
@@ -34,7 +34,7 @@ attribution: The Istio Team
 
 下图概述了 Kubernetes 上的 `Istio Auth` 服务认证体系结构。
 
-{{< image link="/blog/2017/0.1-auth/istio_auth_overview.svg" caption="`Istio Auth` 概览" >}}
+{{< image link="istio_auth_overview.svg" caption="`Istio Auth` 概览" >}}
 
 上图说明了三个关键的安全功能：
 
@@ -66,7 +66,7 @@ attribution: The Istio Team
 
 下图说明了 Kubernetes 上的端到端 `Istio Auth` 身份验证工作流程：
 
-{{< image link="/blog/2017/0.1-auth/istio_auth_workflow.svg" caption="`Istio Auth` 工作流程" >}}
+{{< image link="istio_auth_workflow.svg" caption="`Istio Auth` 工作流程" >}}
 
 `Istio Auth` 是更广泛的容器安全中的一部分。 Red Hat 是 Kubernetes 开发的合作伙伴，定义了 [10 层](https://www.redhat.com/en/resources/container-security-openshift-cloud-devops-whitepaper) 容器安全。 Istio 和 `Istio Auth` 解决了其中两个层：”网络隔离” 和 “API 和服务端点管理”。 随着集群联邦在 Kubernetes 和其他平台上的发展，我们的目的是让 Istio 对跨越多个联邦集群的服务间通信提供保护。
 

--- a/content_zh/blog/2018/egress-https/index.md
+++ b/content_zh/blog/2018/egress-https/index.md
@@ -56,7 +56,7 @@ $ kubectl apply -f @samples/bookinfo/platform/kube/bookinfo-details-v2.yaml@ --d
 现在，应用程序的更新架构如下所示：
 
 {{< image width="80%"
-    link="/blog/2018/egress-https/bookinfo-details-v2.svg"
+    link="bookinfo-details-v2.svg"
     caption="Bookinfo 的 details V2 应用程序"
     >}}
 
@@ -75,7 +75,7 @@ $ kubectl apply -f @samples/bookinfo/networking/virtual-service-details-v2.yaml@
 
 糟糕...页面显示 _Error fetching product details_，而不是书籍详细信息：
 
-{{< image width="80%" link="/blog/2018/egress-https/errorFetchingBookDetails.png" caption="获取产品详细信息的错误消息" >}}
+{{< image width="80%" link="errorFetchingBookDetails.png" caption="获取产品详细信息的错误消息" >}}
 
 好消息是我们的应用程序没有崩溃, 通过良好的微服务设计，我们没有让**故障扩散**。在我们的例子中，
 失败的 _details_ 微服务不会导致 `productpage` 微服务失败, 尽管 _details_ 微服务失败，
@@ -130,7 +130,7 @@ EOF
 
 现在访问应用程序的网页会显示书籍详细信息而不会出现错误：
 
-{{< image width="80%" link="/blog/2018/egress-https/externalBookDetails.png" caption="正确显示书籍详细信息" >}}
+{{< image width="80%" link="externalBookDetails.png" caption="正确显示书籍详细信息" >}}
 
 您可以查询您的 `ServiceEntry` ：
 
@@ -184,7 +184,7 @@ sidecar 代理的这种监督和策略执行是无法实现的。Istio 只能通
 这些请求被 sidecar Envoy 代理拦截 , sidecar 代理执行 TLS 发起，因此 pod 和外部服务之间的流量被加密。
 
 {{< image width="60%"
-    link="/blog/2018/egress-https/https_from_the_app.svg"
+    link="https_from_the_app.svg"
     caption="对外发起 HTTPS 流量的两种方式：微服务自行发起，或由 Sidecar 代理发起"
     >}}
 

--- a/content_zh/blog/2018/egress-monitoring-access-control/index.md
+++ b/content_zh/blog/2018/egress-monitoring-access-control/index.md
@@ -45,7 +45,7 @@ keywords: [egress,traffic-management,access-control,monitoring]
 
 配置 Istio 以记录对 _*.cnn.com_ 的访问。创建一个 `logentry` 和两个 [stdio](/docs/reference/config/policy-and-telemetry/adapters/stdio/) `handlers`，一个用于记录禁止访问(_error_ 日志级别)，另一个用于记录对 _*.cnn.com_ 的所有访问(_info_ 日志级别)。然后创建规则将 `logentry` 实例定向到 `handlers`。一个规则指导访问 _*.cnn.com/politics_ 为日志禁止访问处理程序,另一个规则指导日志条目的处理程序，输出每个访问 _*.cnn.com_ 作为 _info_ 的日志级别。要了解 Istio `logentries`、`rules` 和 `handlers`，请参见 [Istio 适配器模型](/zh/blog/2017/adapter-model/)。下图显示了涉及的实体和它们之间的依赖关系：
 
-{{< image width="80%" ratio="68.27%"
+{{< image width="80%"
     link="egress-adapters-monitoring.svg"
     caption="用于 egress 监视和访问策略的实例、规则和处理程序"
     >}}
@@ -288,7 +288,7 @@ keywords: [egress,traffic-management,access-control,monitoring]
 
  在该步骤中，您使用 Mixer [`Listchecker` 适配器](/docs/reference/config/policy-and-telemetry/adapters/list/)，它是一种白名单。您可以使用请求的 URL 路径定义一个 `listentry`，并使用一个 `listchecker` 由 `overrides` 字段指定的允许 URL 路径的静态列表检查 `listentry`。对于[外部标识和访问管理](https://en.wikipedia.org/wiki/Identity_management)系统，请使用 `providerurl` 字段。实例、规则和处理程序的更新图如下所示。注意，您重用相同的策略规则 `handle-cn-access` 来进行日志记录和访问策略检查。
 
-{{< image width="80%" ratio="65.45%"
+{{< image width="80%"
     link="egress-adapters-monitoring-policy.svg"
     caption="用于 egress 监视和访问策略的实例、规则和处理程序"
     >}}
@@ -456,7 +456,7 @@ keywords: [egress,traffic-management,access-control,monitoring]
 
 在 HTTP 方法中，请求在本地主机上不加密地发送，由 Istio sidecar 代理拦截并转发到 egress 网关。由于您将 Istio 配置为在 sidecar 代理和 egress 网关之间使用相互的 TLS，因此流量会使 pod 加密。egress 网关解密流量，检查 URL 路径、 HTTP 方法和报头，报告遥测数据并执行策略检查。如果请求没有被某些策略检查阻止，那么 egress 网关将执行 TLS 发起到外部目的地（在我们的示例中是 _cnn.com_ ），因此请求将再次加密并发送到外部目的地。下图演示了这种方法的流程。网关内的 HTTP 协议根据解密后网关看到的协议来指定协议。
 
-{{< image width="80%" ratio="73.96%"
+{{< image width="80%"
 link="http-to-gateway.svg"
 caption="HTTP egress 流量通过 egress 网关"
 >}}
@@ -465,7 +465,7 @@ caption="HTTP egress 流量通过 egress 网关"
 
 在 HTTPS 方法中，从应用程序到外部目的地的请求是端到端加密的。下图演示了这种方法的流程。网关中的 HTTPS 协议指定网关所看到的协议。
 
-{{< image width="80%" ratio="73.96%"
+{{< image width="80%"
 link="https-to-gateway.svg"
 caption="HTTPS egress 流量通过 egress 网关"
 >}}

--- a/content_zh/blog/2018/egress-tcp/index.md
+++ b/content_zh/blog/2018/egress-tcp/index.md
@@ -173,7 +173,7 @@ keywords: [traffic-management,egress,tcp]
 更新的架构如下所示，请注意，网格内的蓝色箭头标记根据我们添加的虚拟服务配置的流量，根据虚拟服务的定义，流量将发送到 _reviews v3_ 和 _ratings v2-mysql_ 。
 
 {{< image width="80%"
-    link="/blog/2018/egress-tcp/bookinfo-ratings-v2-mysql-external.svg"
+    link="bookinfo-ratings-v2-mysql-external.svg"
     caption="Bookinfo 应用程序，其评级为 v2-mysql，外部为 MySQL 数据库"
     >}}
 
@@ -185,7 +185,7 @@ keywords: [traffic-management,egress,tcp]
 
 你会发现问题，在每次审核下方都会显示消息 _"Ratings service is currently unavailable”_  而不是评级星标。
 
-{{< image width="80%" link="/blog/2018/egress-tcp/errorFetchingBookRating.png" caption="Ratings 服务的错误信息" >}}
+{{< image width="80%" link="errorFetchingBookRating.png" caption="Ratings 服务的错误信息" >}}
 
 与[使用外部Web服务](/zh/blog/2018/egress-https/)一样，你会体验到**优雅的服务降级**，这很好，虽然 _ratings_ 服务中有错误，但是应用程序并没有因此而崩溃，应用程序的网页正确显示了书籍信息，详细信息和评论，只是没有评级星。
 
@@ -240,7 +240,7 @@ keywords: [traffic-management,egress,tcp]
 
 有效！ 访问应用程序的网页会显示评级而不会出现错误：
 
-{{< image width="80%" link="/blog/2018/egress-tcp/externalMySQLRatings.png" caption="Book Ratings 显示正常" >}}
+{{< image width="80%" link="externalMySQLRatings.png" caption="Book Ratings 显示正常" >}}
 
 请注意，正如预期的那样，你会看到两个显示评论的一星评级。将评级更改为一颗星，为我们提供了一个视觉线索，确实使用了我们的外部数据库。
 

--- a/content_zh/blog/2018/export-logs-through-stackdriver/index.md
+++ b/content_zh/blog/2018/export-logs-through-stackdriver/index.md
@@ -18,7 +18,7 @@ attribution: Nupur Garg and Douglas Reid
 
 Istio 使用 `logentry` [`模板`](/docs/reference/config/policy-and-telemetry/templates/logentry)导出日志。这里指定了可用于分析的所有变量。它包含源服务、目标服务、`auth` 指标（即将实现......）等信息。以下是示意图：
 
-{{< image width="75%" link="/blog/2018/export-logs-through-stackdriver/istio-analytics-using-stackdriver.png" caption="导出日志到 Stackdriver 进行分析的图释" >}}
+{{< image width="75%" link="istio-analytics-using-stackdriver.png" caption="导出日志到 Stackdriver 进行分析的图释" >}}
 
 Istio 支持将日志导出到 Stackdriver，而 Stackdriver 又可以配置为将日志导出到喜欢的接收器，如 BigQuery、Pub/Sub 或 GCS。请按照以下步骤设置喜欢的接收器，首先导出日志，然后在 Istio 中使用 Stackdriver。
 

--- a/content_zh/blog/2018/v1alpha3-routing/index.md
+++ b/content_zh/blog/2018/v1alpha3-routing/index.md
@@ -28,7 +28,7 @@ keywords: [traffic-management]
 在一个典型的网格中，通常有一个或多个用于终结外部 TLS 链接，将流量引入网格的负载均衡器（我们称之为 gateway）。 然后流量通过边车网关（sidecar gateway）流经内部服务。 应用程序使用外部服务的情况也很常见（例如访问 Google Maps API），一些情况下，这些外部服务可能被直接调用；但在某些部署中，网格中所有访问外部服务的流量可能被要求强制通过专用的出口网关（Egress gateway）。 下图描绘了网关在网格中的使用情况。
 
 {{< image width="80%"
-    link="/blog/2018/v1alpha3-routing/gateways.svg"
+    link="gateways.svg"
     alt="Role of gateways in the mesh"
     caption="Istio服务网格中的网关"
     >}}
@@ -45,7 +45,7 @@ keywords: [traffic-management]
 下图描述了跨多个配置资源的控制流程。
 
 {{< image width="80%"
-    link="/blog/2018/v1alpha3-routing/virtualservices-destrules.svg"
+    link="virtualservices-destrules.svg"
     caption="不同v1alpha3元素之间的关系"
     >}}
 

--- a/content_zh/blog/2019/data-plane-setup/index.md
+++ b/content_zh/blog/2019/data-plane-setup/index.md
@@ -22,7 +22,6 @@ Istio 服务网格逻辑上分为数据平面和控制平面。
 {{< /quote >}}
 
 {{< image width="40%"
-    ratio="33%"
     link="./arch-2.svg"
     alt="基于 Istio 的应用的总体架构。"
     caption="Istio 架构"

--- a/content_zh/docs/concepts/multicluster-deployments/index.md
+++ b/content_zh/docs/concepts/multicluster-deployments/index.md
@@ -32,8 +32,7 @@ Istio 支持将一个应用程序的服务以多种拓扑分布，而不仅仅�
 在多控制平面配置中，每个集群具有相同的 Istio 控制平面安装方式，每个控制平面管理自己的 endpoint。
 使用 Istio gateway、公共根证书颁发机构（CA）和 service entry，您可以配置由参与集群组成的单个逻辑服务网格。这种方法没有特殊的网络要求，因此通常被认为是在集群之间没有通用连接时最简单的方法。
 
-{{< image width="80%" ratio="36.01%"
-    link="/docs/concepts/multicluster-deployments/multicluster-with-gateways.svg"
+{{< image width="80%" link="multicluster-with-gateways.svg"
     caption="Istio 网格跨越多个 Kubernetes 集群，使用多个 Istio 控制平面和 Gateway 到达远程 pod"
     >}}
 
@@ -45,8 +44,7 @@ Istio 支持将一个应用程序的服务以多种拓扑分布，而不仅仅�
 
 这种多集群配置使用运行在某个集群上的单个 Istio 控制平面。控制平面的 Pilot 管理本地和远程集群上的 service，并为所有集群配置 Envoy sidecar。这种方法在所有参与集群都具有 VPN 连接的环境中效果最佳，从其他任何地方都可以通过相同的 IP 地址访问网格中的每个 pod。
 
-{{< image width="80%" ratio="36.01%"
-    link="/docs/concepts/multicluster-deployments/multicluster-with-vpn.svg"
+{{< image width="80%" link="multicluster-with-vpn.svg"
     caption="Istio 网格跨越多个 Kubernetes 集群，通过 VPN 直接访问远程 pod"
     >}}
 
@@ -54,8 +52,7 @@ Istio 支持将一个应用程序的服务以多种拓扑分布，而不仅仅�
 
 如果设置具有全局 pod-to-pod 连接的环境很困难或不可能，您仍然可以使用 Istio 网关并和启用 Istio Pilot 的位置感知服务路由功能（也即`水平分割 EDS（Endpoint Discovery Service，终端发现服务）`）来配置单个控制平面拓扑。此方法仍需要从所有集群到 Kubernetes API server 的连接，例如在一个托管的 Kubernetes 平台上，其 API server 运行的网络可以被所有租户集群访问。如果无法做到这一点，那么多控制平面拓扑可能是更好的选择
 
-{{< image width="80%" ratio="36.01%"
-    link="/docs/concepts/multicluster-deployments/multicluster-split-horizon-eds.svg"
+{{< image width="80%" link="multicluster-split-horizon-eds.svg"
     caption="Istio 网格使用单个控制平面和 Gateway 跨越多个 Kubernetes 集群到达远程 pod"
     >}}
 

--- a/content_zh/docs/concepts/policies-and-telemetry/index.md
+++ b/content_zh/docs/concepts/policies-and-telemetry/index.md
@@ -13,7 +13,7 @@ Istio 提供统一抽象，使得 Istio 可以与一组开放式基础设施后�
 
 Mixer 是负责提供策略控制和遥测收集的 Istio 组件：
 
-{{< image width="75%" link="/docs/concepts/policies-and-telemetry/topology-without-cache.svg" caption="Mixer 拓扑" >}}
+{{< image width="75%" link="topology-without-cache.svg" caption="Mixer 拓扑" >}}
 
 在每次请求执行先决条件检查之前以及在每次报告遥测请求之后，Envoy sidecar 在逻辑上调用 Mixer。
 该 Sidecar 具有本地缓存​，从而可以在缓存中执行相对较大比例的前提条件检查。此外，sidecar 缓冲出站遥测，使其实际上不需要经常调用 Mixer。
@@ -33,7 +33,7 @@ Mixer 是高度模块化和可扩展的组件。它的一个关键功能就是�
 
 Mixer 处理不同基础设施后端的灵活性是通过使用通用插件模型实现的。每个插件都被称为 **Adapter**，Mixer 通过它们与不同的基础设施后端连接，这些后端可提供核心功能，例如日志、监控、配额、ACL 检查等。通过配置能够决定在运行时使用的确切的适配器套件，并且可以轻松扩展到新的或定制的基础设施后端。
 
-{{< image width="35%" link="/docs/concepts/policies-and-telemetry/adapters.svg"
+{{< image width="35%" link="adapters.svg"
     alt="显示 Mixer 及其适配器"
     caption="Mixer 及其适配器"
     >}}
@@ -50,7 +50,7 @@ Mixer 是一个高可用的组件，其设计有助于提高整体可用性并�
 
 网格中每个服务都会有对应的 Sidecar 代理在运行，因此在内存消耗方面，Sidecar 必须厉行节约，这就限制了本地缓存和缓冲的可能数量。然而，独立运行 的 Mixer 可以使用相当大的缓存和输出缓冲区。因此，Mixer 可用作 Sidecar 的高度扩展且高度可用的二级缓存。
 
-{{< image width="75%" link="/docs/concepts/policies-and-telemetry/topology-with-cache.svg"  caption="Mixer 拓扑" >}}
+{{< image width="75%" link="topology-with-cache.svg"  caption="Mixer 拓扑" >}}
 
 由于 Mixer 的预期可用性远高于大多数基础设施后端（通常这些可用性可能达到 99.9％）。Mixer 的本地缓存和缓冲不仅有助于减少延迟，而且即使在后端无响应时也能继续运行，从而有助于屏蔽基础设施后端故障。
 
@@ -74,7 +74,7 @@ destination.service: example
 
 Mixer 本质上是一个属性处理机。每个经过 Envoy sidecar 的请求都会调用 Mixer，为 Mixer 提供一组描述请求和请求周围环境的属性。基于 Envoy sidecar 的配置和给定的特定属性集，Mixer 会调用各种基础设施后端。
 
-{{< image width="60%" link="/docs/concepts/policies-and-telemetry/machine.svg" caption="属性机" >}}
+{{< image width="60%" link="machine.svg" caption="属性机" >}}
 
 ### 属性词汇
 

--- a/content_zh/docs/concepts/security/index.md
+++ b/content_zh/docs/concepts/security/index.md
@@ -15,7 +15,7 @@ Istio Security 尝试提供全面的安全解决方案来解决所有这些问�
 
 本页概述了如何使用 Istio 的安全功能来保护您的服务，无论您在何处运行它们。特别是 Istio 安全性可以缓解针对您的数据，端点，通信和平台的内部和外部威胁。
 
-{{< image width="80%" link="/docs/concepts/security/overview.svg"
+{{< image width="80%" link="overview.svg"
     alt="Istio 安全模型的组件构成。"
     caption="Istio 安全概述"
     >}}
@@ -45,7 +45,7 @@ Istio 中的安全性涉及多个组件：
 
 - **Mixer** 管理授权和审计
 
-{{< image width="80%" link="/docs/concepts/security/architecture.svg" caption="Istio 安全架构" >}}
+{{< image width="80%" link="architecture.svg" caption="Istio 安全架构" >}}
 
 在下面的部分中，我们将详细介绍 Istio 安全功能。
 
@@ -118,7 +118,7 @@ Istio 支持在 Kubernetes pod 和本地计算机上运行的服务。
 
 Istio 提供了在 Kubernetes 中使用节点代理进行证书和密钥分配的选项，如下图所示。请注意，本地计算机的标识提供流程是相同的，因此我们仅描述 Kubernetes 方案。
 
-{{< image width="80%" link="/docs/concepts/security/node_agent.svg" caption="PKI 与 Kubernetes 中的节点代理" >}}
+{{< image width="80%" link="node_agent.svg" caption="PKI 与 Kubernetes 中的节点代理" >}}
 
 流程如下：
 
@@ -202,7 +202,7 @@ Istio 双向 TLS 具有一个宽容模式（permissive mode），允许 service 
 
 发送请求的客户端服务负责遵循必要的身份验证机制。对于源身份验证（JWT），应用程序负责获取 JWT 凭据并将其附加到请求。对于双向 TLS，Istio 提供[目标规则](/zh/docs/concepts/traffic-management/#目标规则)。运维人员可以使用目标规则来指示客户端代理使用 TLS 与服务器端预期的证书进行初始连接。您可以在 [双向 TLS 认证](/zh/docs/concepts/security/#双向-tls-认证)中找到有关双向 TLS 如何在 Istio 中工作的更多信息。
 
-{{< image width="60%" link="/docs/concepts/security/auth.svg" caption="认证架构" >}}
+{{< image width="60%" link="auth.svg" caption="认证架构" >}}
 
 Istio 将两种类型的身份验证以及凭证中的其他声明（如果适用）输出到下一层：[授权](/zh/docs/concepts/security/#授权)。此外，运维人员可以指定将传输或原始身份验证中的哪个身份作为`委托人`使用。
 

--- a/content_zh/docs/concepts/traffic-management/index.md
+++ b/content_zh/docs/concepts/traffic-management/index.md
@@ -10,7 +10,7 @@ keywords: [traffic-management]
 使用 Istio 的流量管理模型，本质上是将流量与基础设施扩容解耦，让运维人员可以通过 Pilot 指定流量遵循什么规则，而不是指定哪些 pod/VM 应该接收流量——Pilot 和智能 Envoy 代理会帮我们搞定。因此，例如，您可以通过 Pilot 指定特定服务的 5％ 流量可以转到金丝雀版本，而不必考虑金丝雀部署的大小，或根据请求的内容将流量发送到特定版本。
 
 {{< image width="85%"
-    link="/docs/concepts/traffic-management/TrafficManagementOverview.svg"
+    link="TrafficManagementOverview.svg"
     caption=" Istio 流量管理"
     >}}
 
@@ -29,7 +29,7 @@ Istio 流量管理的核心组件是 [Pilot](#pilot-和-envoy)，它管理和配
 Pilot 负责管理通过 Istio 服务网格发布的 Envoy 实例的生命周期。
 
 {{< image width="60%"
-    link="/docs/concepts/traffic-management/PilotAdapters.svg"
+    link="PilotAdapters.svg"
     caption="Pilot 架构"
     >}}
 
@@ -48,7 +48,7 @@ Istio 引入了服务版本的概念，可以通过版本（`v1`、`v2`）或环
 ### 服务之间的通讯
 
 {{< image width="60%"
-    link="/docs/concepts/traffic-management/ServiceModel_Versions.svg"
+    link="ServiceModel_Versions.svg"
     alt="服务版本的处理。"
     caption="服务版本"
     >}}
@@ -66,7 +66,7 @@ Istio 不提供 DNS。应用程序可以尝试使用底层平台（`kube-dns`、
 Istio 假定进入和离开服务网络的所有流量都会通过 Envoy 代理进行传输。通过将 Envoy 代理部署在服务之前，运维人员可以针对面向用户的服务进行 A/B 测试、部署金丝雀服务等。类似地，通过使用 Envoy 将流量路由到外部 Web 服务（例如，访问 Maps API 或视频服务 API）的方式，运维人员可以为这些服务添加超时控制、重试、断路器等功能，同时还能从服务连接中获取各种细节指标。
 
 {{< image width="85%"
-    link="/docs/concepts/traffic-management/ServiceModel_RequestFlow.svg"
+    link="ServiceModel_RequestFlow.svg"
     alt="通过 Envoy 的 Ingress 和 Egress。"
     caption="请求流"
     >}}
@@ -80,7 +80,7 @@ Istio 假定存在服务注册表，以追踪应用程序中服务的 pod/VM。�
 Pilot 使用来自服务注册的信息，并提供与平台无关的服务发现接口。网格中的 Envoy 实例执行服务发现，并相应地动态更新其负载均衡池。
 
 {{< image width="55%"
-    link="/docs/concepts/traffic-management/LoadBalancing.svg"
+    link="LoadBalancing.svg"
     caption="发现与负载均衡">}}
 
 如上图所示，网格中的服务使用其 DNS 名称访问彼此。服务的所有 HTTP 流量都会通过 Envoy 自动重新路由。Envoy 在负载均衡池中的实例之间分发流量。虽然 Envoy 支持多种[复杂的负载均衡算法](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/load_balancing/load_balancing)，但 Istio 目前仅允许三种负载均衡模式：轮询、随机和带权重的最少请求。

--- a/content_zh/docs/concepts/what-is-istio/index.md
+++ b/content_zh/docs/concepts/what-is-istio/index.md
@@ -81,7 +81,7 @@ Istio 服务网格逻辑上分为**数据平面**和**控制平面**。
 下图显示了构成每个面板的不同组件：
 
 {{< image width="80%"
-    link="/docs/concepts/what-is-istio/arch.svg"
+    link="arch.svg"
     alt="基于 Istio 的应用程序架构概览"
     caption="Istio 架构"
     >}}

--- a/content_zh/docs/examples/bookinfo/index.md
+++ b/content_zh/docs/examples/bookinfo/index.md
@@ -22,7 +22,7 @@ Bookinfo 应用分为四个单独的微服务：
 下图展示了这个应用的端到端架构。
 
 {{< image width="80%"
-    link="/docs/examples/bookinfo/noistio.svg"
+    link="noistio.svg"
     caption="Istio 注入之前的 Bookinfo 应用"
     >}}
 
@@ -37,7 +37,7 @@ Bookinfo 是一个异构应用，几个微服务是由不同的语言编写的�
 要在 Istio 中运行这一应用，无需对应用自身做出任何改变。我们只要简单的在 Istio 环境中对服务进行配置和运行，具体一点说就是把 Envoy sidecar 注入到每个服务之中。这个过程所需的具体命令和配置方法由运行时环境决定，而部署结果较为一致，如下图所示：
 
 {{< image width="80%"
-    link="/docs/examples/bookinfo/withistio.svg"
+    link="withistio.svg"
     caption="Bookinfo 应用"
     >}}
 

--- a/content_zh/docs/examples/integrating-vms/index.md
+++ b/content_zh/docs/examples/integrating-vms/index.md
@@ -14,7 +14,7 @@ keywords: [vms]
 ## 概述
 
 {{< image width="80%"
-    link="/docs/examples/integrating-vms/mesh-expansion.svg"
+    link="mesh-expansion.svg"
     caption="网格扩展环境下的 Bookinfo 应用"
     >}}
 

--- a/content_zh/docs/examples/multicluster/split-horizon-eds/index.md
+++ b/content_zh/docs/examples/multicluster/split-horizon-eds/index.md
@@ -9,8 +9,8 @@ keywords: [kubernetes,multicluster]
 
 按照此示例中的说明，您将设置一个两集群网格，如下图所示：
 
-  {{< image width="80%" ratio="36.01%"
-  link="/docs/examples/multicluster/split-horizon-eds/diagram.svg"
+  {{< image width="80%"
+  link="diagram.svg"
   caption="单个 Istio 控制平面配置水平分割 EDS，跨越多个 Kubernetes 集群" >}}
 
  原始集群 `cluster1` 将运行完整的 Istio 控制平面组件，而 `cluster2` 集群仅运行 Istio Citadel、Sidecar Injector 和 Ingress gateway。不需要 VPN 连接，不同集群中的工作负载之间也无需直接网络访问。

--- a/content_zh/docs/setup/kubernetes/install/multicluster/gateways/index.md
+++ b/content_zh/docs/setup/kubernetes/install/multicluster/gateways/index.md
@@ -13,7 +13,7 @@ keywords: [kubernetes,multicluster,federation,gateway]
 跨集群通信发生在相应集群的 Istio Gateway 上。
 
 {{< image width="80%"
-    link="/docs/setup/kubernetes/install/multicluster/gateways/multicluster-with-gateways.svg"
+    link="multicluster-with-gateways.svg"
     caption="Istio 网格使用 Istio Gateway 跨越多个 Kubernetes 集群访问远程 Pod"
     >}}
 

--- a/content_zh/docs/setup/kubernetes/install/multicluster/vpn/index.md
+++ b/content_zh/docs/setup/kubernetes/install/multicluster/vpn/index.md
@@ -10,7 +10,7 @@ keywords: [kubernetes,multicluster,federation,vpn]
 在此配置中，运行远程配置的多个 Kubernetes 控制平面将连接到**单个** Istio 控制平面。一旦一个或多个远程 Kubernetes 集群连接到 Istio 控制平面，Envoy 就可以与单个控制平面通信并形成跨多个集群的服务网格。
 
 {{< image width="80%"
-    link="/docs/setup/kubernetes/install/multicluster/vpn/multicluster-with-vpn.svg"
+    link="multicluster-with-vpn.svg"
     caption="通过 VPN 直连远程 pod 的多 Kubernetes 集群 Istio 网格"
     >}}
 

--- a/content_zh/docs/setup/kubernetes/install/platform/alicloud/index.md
+++ b/content_zh/docs/setup/kubernetes/install/platform/alicloud/index.md
@@ -40,7 +40,7 @@ $ helm init --service-account tiller
 - 在左侧的导航栏中点击 **应用目录** 。
 - 在右侧区域选择 **ack-istio** 。
 
-{{< image link="/docs/setup/kubernetes/install/platform/alicloud/app-catalog-istio-1.0.0.png" caption="Istio" >}}
+{{< image link="app-catalog-istio-1.0.0.png" caption="Istio" >}}
 
 ### 使用参数自定义安装
 

--- a/content_zh/docs/setup/kubernetes/install/platform/gke/index.md
+++ b/content_zh/docs/setup/kubernetes/install/platform/gke/index.md
@@ -23,11 +23,11 @@ keywords: [kubernetes,gke,google]
 
 `projectNumber-compute@developer.gserviceaccount.com`，缺省情况下，它只包含 `Editor` 角色。对角色进行编辑，在“角色”下拉框中查找 `Kubernetes Engine` 分组，选择角色 `Kubernetes Engine Admin`。
 
-{{< image link="/docs/setup/kubernetes/install/platform/gke/dm_gcp_iam.png" caption="GKE-IAM Service" >}}
+{{< image link="dm_gcp_iam.png" caption="GKE-IAM Service" >}}
 
 加入 `Kubernetes Engine Admin` 角色：
 
-{{< image width="70%" link="/docs/setup/kubernetes/install/platform/gke/dm_gcp_iam_role.png" caption="GKE-IAM Role" >}}
+{{< image width="70%" link="dm_gcp_iam_role.png" caption="GKE-IAM Role" >}}
 
 ## 在 GKE 上设置 Istio
 

--- a/content_zh/docs/setup/kubernetes/install/platform/ibm/index.md
+++ b/content_zh/docs/setup/kubernetes/install/platform/ibm/index.md
@@ -139,27 +139,27 @@ keywords: [kubernetes,ibm,icp]
 - 点击搜索框右侧的 `Filter` 并选中 `ibm-charts` 复选框。
 - 点击左侧导航窗格的 `Operations`。
 
-{{< image link="/docs/setup/kubernetes/install/platform/ibm/istio-catalog-1.png" caption="IBM 私有云 - Istio 目录" >}}
+{{< image link="istio-catalog-1.png" caption="IBM 私有云 - Istio 目录" >}}
 
 - 点击右侧面板中的 `ibm-istio`。
 
-{{< image link="/docs/setup/kubernetes/install/platform/ibm/istio-catalog-2.png" caption="IBM 私有云 - Istio 目录" >}}
+{{< image link="istio-catalog-2.png" caption="IBM 私有云 - Istio 目录" >}}
 
 - （可选的）使用 `CHART VERSION` 的下拉功能修改 Istio 版本。
 - 点击 `Configure` 按钮。
 
-{{< image link="/docs/setup/kubernetes/install/platform/ibm/istio-installation-1.png" caption="IBM 私有云 - 安装 Istio" >}}
+{{< image link="istio-installation-1.png" caption="IBM 私有云 - 安装 Istio" >}}
 
 - 输入 Helm 部署实例的名称（例如：`istio-1.0.3`），并选择 `istio-system` 作为目标 namespace。
 - 同意许可条款。
 - （可选的）点击 `All parameters` 自定义安装参数。
 - 点击 `Install` 按钮。
 
-{{< image link="/docs/setup/kubernetes/install/platform/ibm/istio-installation-2.png" caption="IBM 私有云 - 安装 Istio" >}}
+{{< image link="istio-installation-2.png" caption="IBM 私有云 - 安装 Istio" >}}
 
 安装完成后，你可以在 **Helm Releases** 页通过搜索实例名找到它。
 
-{{< image link="/docs/setup/kubernetes/install/platform/ibm/istio-release.png" caption="IBM 私有云 - 安装 Istio" >}}
+{{< image link="istio-release.png" caption="IBM 私有云 - 安装 Istio" >}}
 
 ### 升级或回滚
 
@@ -169,9 +169,9 @@ keywords: [kubernetes,ibm,icp]
 - 通过实例名找到已安装的 Istio。
 - 点击 `Action` 然后选择 `upgrade` 或 `rollback`。
 
-{{< image link="/docs/setup/kubernetes/install/platform/ibm/istio-upgrade-1.png" caption="IBM 私有云 - Istio 升级或回滚" >}}
+{{< image link="istio-upgrade-1.png" caption="IBM 私有云 - Istio 升级或回滚" >}}
 
-{{< image link="/docs/setup/kubernetes/install/platform/ibm/istio-upgrade-2.png" caption="IBM 私有云 - Istio 升级或回滚" >}}
+{{< image link="istio-upgrade-2.png" caption="IBM 私有云 - Istio 升级或回滚" >}}
 
 ### 卸载
 
@@ -181,4 +181,4 @@ keywords: [kubernetes,ibm,icp]
 - 通过实例名找到已安装的 Istio。
 - 点击 `Action` 并选择 `delete`。
 
-{{< image link="/docs/setup/kubernetes/install/platform/ibm/istio-deletion.png" caption="IBM 私有云 - 卸载 Istio" >}}
+{{< image link="istio-deletion.png" caption="IBM 私有云 - 卸载 Istio" >}}

--- a/content_zh/docs/setup/kubernetes/prepare/platform-setup/alicloud/index.md
+++ b/content_zh/docs/setup/kubernetes/prepare/platform-setup/alicloud/index.md
@@ -36,4 +36,4 @@ keywords: [platform-setup,alibaba-cloud,aliyun,alicloud]
 
 下图显示了完成前面所有步骤的界面:
 
-{{< image link="/docs/setup/kubernetes/prepare/platform-setup/alicloud/csconsole.png" caption="Console" >}}
+{{< image link="csconsole.png" caption="Console" >}}

--- a/content_zh/docs/setup/kubernetes/prepare/platform-setup/docker/index.md
+++ b/content_zh/docs/setup/kubernetes/prepare/platform-setup/docker/index.md
@@ -8,7 +8,7 @@ keywords: [platform-setup,kubernetes,docker-for-desktop]
 
 如果你想在桌面版 Docker 内置的 Kubernetes 下运行 Istio，你可能需要在 Docker 首选项的 *Advanced* 面板下增加 Docker 的内存限制。Pilot 默认请求内存为 `2048Mi`，这是 Docker 的默认限制。
 
-{{< image width="60%"  link="/docs/setup/kubernetes/prepare/platform-setup/docker/dockerprefs.png" caption="Docker 首选项"  >}}
+{{< image width="60%" link="dockerprefs.png" caption="Docker 首选项"  >}}
 
 也可以通过传递 Helm 参数 `--set pilot.resources.requests.memory="512Mi"` 来减少 Pilot 的内存请求。否则 Pilot 可能因资源不足而无法启动。
 有关详细信息，请看[安装选项](/zh/docs/reference/config/installation-options)。

--- a/content_zh/docs/tasks/telemetry/distributed-tracing/lightstep/index.md
+++ b/content_zh/docs/tasks/telemetry/distributed-tracing/lightstep/index.md
@@ -89,11 +89,11 @@ keywords: [telemetry,tracing,lightstep]
 
 1. 点击 **Run**。您将看到一些和下面相似的东西：
 
-    {{< image link="/docs/tasks/telemetry/distributed-tracing/lightstep/istio-tracing-list-lightstep.png" caption="Explorer" >}}
+    {{< image link="istio-tracing-list-lightstep.png" caption="Explorer" >}}
 
 1. 单击延迟直方图下方的示例追踪表中的第一行，以查看与刷新 `/productpage` 时相对应的详细信息。页面看起来像这样：
 
-    {{< image link="/docs/tasks/telemetry/distributed-tracing/lightstep/istio-tracing-details-lightstep.png" caption="Detailed Trace View" >}}
+    {{< image link="istio-tracing-details-lightstep.png" caption="Detailed Trace View" >}}
 
 屏幕截图显示追踪由一组 span 组成。 每个 span 对应于执行 `/productpage` 时调用的 Bookinfo 服务。
 

--- a/content_zh/docs/tasks/telemetry/kiali/index.md
+++ b/content_zh/docs/tasks/telemetry/kiali/index.md
@@ -116,11 +116,11 @@ $ kubectl apply -f $HOME/istio.yaml
 
     **Overview** 页面中会显示网格里所有命名空间中的服务。例如下面的截图：
 
-    {{< image width="75%" link="/docs/tasks/telemetry/kiali/kiali-overview.png" caption="概览示例" >}}
+    {{< image width="75%" link="kiali-overview.png" caption="概览示例" >}}
 
 1. 要查看指定命名空间的服务图，可以点击 Bookinfo 命名空间卡片，会显示类似的页面：
 
-    {{< image width="75%" link="/docs/tasks/telemetry/kiali/kiali-graph.png" caption="服务图样例" >}}
+    {{< image width="75%" link="kiali-graph.png" caption="服务图样例" >}}
 
 1. 要查看指标的合计，可以在服务图上选择任何节点或者边缘，就会在右边的 Panel 上显示所选指标的详情。
 
@@ -128,25 +128,25 @@ $ kubectl apply -f $HOME/istio.yaml
 
     * **App** 类型会将同一应用的所有版本的数据聚合为单一的图形节点，下面的例子展示了一个 **reviews** 节点，其中包含三个版本的 Reviews 应用：
 
-        {{< image width="75%" link="/docs/tasks/telemetry/kiali/kiali-app.png" caption="应用图样例" >}}
+        {{< image width="75%" link="kiali-app.png" caption="应用图样例" >}}
 
     * **Versioned App** 类型会把一个 App 的每个版本都用一个节点来展示，但是一个应用的所有版本会被汇总在一起，下面的示例中显示了一个在分组框中的 **reviews** 服务，其中包含了三个节点，每个节点都代表 reviews 应用的一个版本：
 
-        {{< image width="75%" link="/docs/tasks/telemetry/kiali/kiali-versionedapp.png" caption="分版本应用图样例" >}}
+        {{< image width="75%" link="kiali-versionedapp.png" caption="分版本应用图样例" >}}
 
     * **Workload** 类型的图会将网格中的每个工作负载都呈现为一个节点。
 
         这种类型的图不需要读取工作负载的 `app` 和 `version` 标签。所以如果你的工作负载中没有这些标签，这种类型就是个合理选择了。
 
-        {{< image width="70%" link="/docs/tasks/telemetry/kiali/kiali-workload.png" caption="工作负载图样例"  >}}
+        {{< image width="70%" link="kiali-workload.png" caption="工作负载图样例"  >}}
 
     * **Service** 图类型为网格中的每个服务生成一个节点，但是会排除所有的应用和工作负载。
 
-        {{< image width="70%" link="/docs/tasks/telemetry/kiali/kiali-service-graph.png" caption="服务图样例" >}}
+        {{< image width="70%" link="kiali-service-graph.png" caption="服务图样例" >}}
 
 1. 要验证 Istio 配置的详情，可以点击左边菜单栏上的 **Applications**、**Workloads** 或者 **Services**。下面的截图展示了 Bookinfo 应用的信息：
 
-    {{< image width="80%" link="/docs/tasks/telemetry/kiali/kiali-services.png" caption="详情样例" >}}
+    {{< image width="80%" link="kiali-services.png" caption="详情样例" >}}
 
 ## 关于 Kiali 的 API
 

--- a/content_zh/docs/tasks/telemetry/metrics/querying-metrics/index.md
+++ b/content_zh/docs/tasks/telemetry/metrics/querying-metrics/index.md
@@ -53,7 +53,7 @@ keywords: [telemetry,metrics]
 
 结果将类似于：
 
-{{< image link="/docs/tasks/telemetry/metrics/querying-metrics/prometheus_query_result.png" caption="Prometheus 查询结果" >}}
+{{< image link="prometheus_query_result.png" caption="Prometheus 查询结果" >}}
 
 其他查询尝试：
 

--- a/content_zh/docs/tasks/telemetry/metrics/using-istio-dashboard/index.md
+++ b/content_zh/docs/tasks/telemetry/metrics/using-istio-dashboard/index.md
@@ -49,7 +49,7 @@ keywords: [telemetry,visualization]
 
     Istio 仪表盘看起来类似于：
 
-    {{< image link="/docs/tasks/telemetry/metrics/using-istio-dashboard/grafana-istio-dashboard.png" caption="Istio Dashboard" >}}
+    {{< image link="grafana-istio-dashboard.png" caption="Istio Dashboard" >}}
 
 1.  向网格发送流量。
 
@@ -67,7 +67,7 @@ keywords: [telemetry,visualization]
 
     再次查看 Istio 仪表盘，它应该显示出生成的流量，看起来类似于：
 
-    {{< image link="/docs/tasks/telemetry/metrics/using-istio-dashboard/dashboard-with-traffic.png" caption="Istio Dashboard With Traffic" >}}
+    {{< image link="dashboard-with-traffic.png" caption="Istio Dashboard With Traffic" >}}
 
     这提供了网格的全局视图以及网格中的服务和工作负载。
     您可以通过导航到特定仪表盘获得有关服务和工作负载的更多详细信息，如下所述。
@@ -78,7 +78,7 @@ keywords: [telemetry,visualization]
 
     Istio 服务仪表盘看起来类似于：
 
-    {{< image link="/docs/tasks/telemetry/metrics/using-istio-dashboard/istio-service-dashboard.png" caption="Istio Service Dashboard" >}}
+    {{< image link="istio-service-dashboard.png" caption="Istio Service Dashboard" >}}
 
     这提供了有关服务的指标的详细信息，进一步地提供了有关该服务的客户端工作负载（调用此服务的工作负载）和服务工作负载（提供此服务的工作负载）的详细信息。
 
@@ -88,7 +88,7 @@ keywords: [telemetry,visualization]
 
     Istio 工作负载仪表盘看起来类似于：
 
-    {{< image link="/docs/tasks/telemetry/metrics/using-istio-dashboard/istio-workload-dashboard.png" caption="Istio Workload Dashboard" >}}
+    {{< image link="istio-workload-dashboard.png" caption="Istio Workload Dashboard" >}}
 
     这会提供有关每个工作负载的指标的详细信息，进一步地提供有关该工作负载的入站工作负载（向此工作负载发送请求的工作负载）和出站服务（此工作负载发送请求的服务）的指标。
 

--- a/content_zh/help/ops/controlz/index.md
+++ b/content_zh/help/ops/controlz/index.md
@@ -16,7 +16,7 @@ Mixer、Pilot 和 Galley 都实现了 ControlZ 功能。这些组件启动时将
 
 下面是 ControlZ 界面的示例：
 
-{{< image width="80%" link="/help/ops/controlz/ctrlz.png" caption="ControlZ 用户界面" >}}
+{{< image width="80%" link="ctrlz.png" caption="ControlZ 用户界面" >}}
 
 当启动组件时，可以通过命令行参数 `--ctrlz_port` 和 `--ctrlz_address` 指定特定的地址和端口来控制 ControlZ 暴露的地址。
 

--- a/layouts/shortcodes/gloss.html
+++ b/layouts/shortcodes/gloss.html
@@ -7,7 +7,7 @@
     {{- $gloss_entry = .Get 0 -}}
 {{- end -}}
 
-{{- $glossary := .Site.GetPage "/help/glossary" -}}
+{{- $glossary := .Site.GetPage "section" "glossary" -}}
 {{- $words := $glossary.Resources.ByType "page" -}}
 {{- $dfn := "" -}}
 {{- $title := $term -}}

--- a/layouts/shortcodes/image.html
+++ b/layouts/shortcodes/image.html
@@ -61,11 +61,19 @@ omit this value and it will be computed automatically.
     {{- end -}}
 {{- end -}}
 
-{{- $path := printf "content/%s" $link }}
+{{- $path := "" }}
+{{- if eq .Page.Language.Lang "zh" -}}
+    {{- $path = printf "content_zh%s" $link }}
+    {{- if not (fileExists $path) -}}
+        {{- $path = printf "content%s" $link }}
+    {{- end -}}
+{{- else -}}
+    {{- $path = printf "content%s" $link }}
+{{- end -}}
 
 {{- if strings.HasSuffix $link ".svg" -}}
     {{- if not (fileExists $path) -}}
-        {{- errorf "Image '%s' was not found (%s)" $path .Position -}}
+       {{- errorf "Image '%s' was not found (%s)" $path .Position -}}
     {{- end -}}
 
     {{- $file := readFile $path -}}


### PR DESCRIPTION
- Remove unnecessary ratio= attributes used with the image shortcode

- Make it so the gloss shortcode doesn't depend on the location of the glossary
within the content tree.

- Make it so the image shortcode understands languages. It will now look in the current
language's content tree, and then callback to the English tree if not found.

- Leverage the above to simplify the Chinese content and remove many absolute references from the
Chinese content to the English content.