### PR TITLE
Site improvements

### DIFF
--- a/layouts/_default/faq.html
+++ b/layouts/_default/faq.html
@@ -9,11 +9,11 @@
     <hr/>
     <div class="directory" role="directory">
         <nav id="InlineTableOfContents">
-            <ul>
+            <ol>
                 {{ range $q := $sorted_questions }}
-                    <li><a href="#{{ $q.File.BaseFileName | urlize }}">{{ $q.Title }}</a></li>
+                    <li role="none" aria-label="{{ $q.Title }}"><a href="#{{ $q.File.BaseFileName | urlize }}">{{ $q.Title }}</a></li>
                 {{ end }}
-            </ul>
+            </ol>
         </nav>
     </div>
     <hr/>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -55,7 +55,7 @@
 
             {{ if $page.Scratch.Get "seeAlso" }}
                 {{ with $related }}
-                    <li><a href="#see-also">{{ i18n "see_also" }}</a></li>
+                    <li role="none" aria-label="{{ i18n "see_also" }}"><a href="#see-also">{{ i18n "see_also" }}</a></li>
                 {{ end }}
             {{ end }}
         </ol>


### PR DESCRIPTION
- Add missing ARIA annotations on the See Also entry in the right-hand TOC

- Add missing ARIA annotations on the FAQ pages, and switch from a UL to an OL
list for the questions in order to get rid of the bullets.