### PR TITLE
Corrects the default timeout for http requests

### DIFF
--- a/content/docs/concepts/traffic-management/index.md
+++ b/content/docs/concepts/traffic-management/index.md
@@ -477,7 +477,7 @@ spec:
 
 #### Timeouts and retries
 
-By default, the timeout for HTTP requests is 15 seconds,
+By default, the timeout for HTTP requests is disabled,
 but it can be overridden in a route rule as follows:
 
 {{< text yaml >}}

--- a/content/docs/tasks/traffic-management/request-timeouts/index.md
+++ b/content/docs/tasks/traffic-management/request-timeouts/index.md
@@ -26,7 +26,7 @@ This task shows you how to setup request timeouts in Envoy using Istio.
 ## Request timeouts
 
 A timeout for http requests can be specified using the *timeout* field of the [route rule](/docs/reference/config/networking/v1alpha3/virtual-service/#HTTPRoute).
-By default, the timeout is 15 seconds, but in this task you override the `reviews` service
+By default, the timeout is disabled, but in this task you override the `reviews` service
 timeout to 1 second.
 To see its effect, however, you also introduce an artificial 2 second delay in calls
 to the `ratings` service.
@@ -111,7 +111,7 @@ to the `ratings` service.
 ## Understanding what happened
 
 In this task, you used Istio to set the request timeout for calls to the `reviews`
-microservice to half a second instead of the default of 15 seconds.
+microservice to half a second. By default the request timeout is disabled.
 Since the `reviews` service subsequently calls the `ratings` service when handling requests,
 you used Istio to inject a 2 second delay in calls to `ratings` to cause the
 `reviews` service to take longer than half a second to complete and consequently you could see the timeout in action.


### PR DESCRIPTION
By default this timeout is disabled. This change was made by
this PR:  https://github.com/istio/istio/pull/6042

Fixes #4085