### PR TITLE
improve code snippet style of MeshNetworks

### DIFF
--- a/content/docs/reference/config/istio.mesh.v1alpha1/index.html
+++ b/content/docs/reference/config/istio.mesh.v1alpha1/index.html
@@ -620,8 +620,8 @@ there are no services or ServiceEntries for the destination port</p>
 <p>MeshNetworks (config map) provides information about the set of networks
 inside a mesh and how to route to endpoints in each network. For example</p>
 
-<p>MeshNetworks(file/config map):
-networks:
+<p>MeshNetworks(file/config map):</p>
+<pre><code class="language-yaml">networks:
   network1:
   - endpoints:
     - fromRegistry: registry1 #must match secret name in Kubernetes
@@ -632,8 +632,8 @@ networks:
       locality: us-east-1a
     - address: 192.168.100.1
       port: 15443
-      locality: us-east-1a</p>
-
+      locality: us-east-1a
+</code></pre>
 <table class="message-fields">
 <thead>
 <tr>


### PR DESCRIPTION
currently, MeshNetworks  code snippet  is inline
![image](https://user-images.githubusercontent.com/463772/57305828-37258080-7114-11e9-9d38-53fd8db0fc87.png)

improved using `<code class="language-yaml">`
![image](https://user-images.githubusercontent.com/463772/57305969-84a1ed80-7114-11e9-82c5-92e89b29a144.png)
