### PR TITLE
re-add deleted step for docker with consul setup

### DIFF
--- a/content/docs/examples/bookinfo/index.md
+++ b/content/docs/examples/bookinfo/index.md
@@ -176,6 +176,7 @@ is used for this purpose.
 
     {{< text bash >}}
     $ docker-compose -f @samples/bookinfo/platform/consul/bookinfo.yaml@ up -d
+    $ docker-compose -f samples/bookinfo/platform/consul/bookinfo.sidecars.yaml up -d
     {{< /text >}}
 
 1.  Confirm that all docker containers are running:


### PR DESCRIPTION
removed in #3636

resolves https://discuss.istio.io/t/quickstart-for-booking-consul-docker-doesnt-have-step-for-deploying-sidecars/2194

cherry-pick:
https://github.com/istio/istio.io/pull/4106