### PR TITLE
Remove `kubectl create` tip in Authentication Policy task

### DIFF
--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -729,10 +729,6 @@ spec:
 EOF
 {{< /text >}}
 
-{{< tip >}}
-Use `kubectl create` if the `jwt-example` policy hasn't been submitted.
-{{< /tip >}}
-
 And add a destination rule:
 
 {{< text bash >}}

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -730,7 +730,7 @@ EOF
 {{< /text >}}
 
 {{< tip >}}
-Use `istio create` if the `jwt-example` policy hasn't been submitted.
+Use `kubectl create` if the `jwt-example` policy hasn't been submitted.
 {{< /tip >}}
 
 And add a destination rule:


### PR DESCRIPTION
The command should be `kubectl create`.