### PR TITLE
small update to policy check default

### DIFF
--- a/content/docs/concepts/policies-and-telemetry/index.md
+++ b/content/docs/concepts/policies-and-telemetry/index.md
@@ -44,7 +44,7 @@ At a high level, Mixer provides:
 Beyond these purely functional aspects, Mixer also has [reliability and scalability](#reliability-and-latency) benefits as outlined below.
 
 Policy enforcement and telemetry collection are entirely driven from configuration.
-Policy check is disabled by default, avoiding the need to go through the the Mixer policy component.
+Policy check is disabled by default, avoiding the need to go through the Mixer policy component.
 Refer to [Installation Options](/docs/reference/config/installation-options/) for more information.
 
 ## Adapters

--- a/content/docs/concepts/policies-and-telemetry/index.md
+++ b/content/docs/concepts/policies-and-telemetry/index.md
@@ -44,7 +44,7 @@ At a high level, Mixer provides:
 Beyond these purely functional aspects, Mixer also has [reliability and scalability](#reliability-and-latency) benefits as outlined below.
 
 Policy enforcement and telemetry collection are entirely driven from configuration.
-These features are completely disabled by default, avoiding the need to run the Mixer component.
+Policy check is disabled by default, avoiding the need to go through the the Mixer policy component.
 Refer to [Installation Options](/docs/reference/config/installation-options/) for more information.
 
 ## Adapters


### PR DESCRIPTION
One of our users pointed out this... I believe mixer policy or telemetry is enabled by default but policy check is disabled.

@geeknoid PTAL, thanks!