### PR TITLE
Announcement for upcoming 1.0 end of support

### DIFF
--- a/content/blog/2019/announcing-1.0-eol/index.md
+++ b/content/blog/2019/announcing-1.0-eol/index.md
@@ -1,13 +1,13 @@
 ---
 title: Support for Istio 1.0 ends on June 19th, 2019
-description: Upcoming Istio 1.0 EOL announcement.
-publishdate: 2019-05-20
+description: Upcoming Istio 1.0 end of life announcement.
+publishdate: 2019-05-23
 attribution: The Istio Team
 release: 1.0
 ---
 
 According to Istio's [support policy](/about/release-cadence/), LTS releases like 1.0 are supported for three months after the next LTS release.   Since [1.1 was released on March 19th](/about/notes/1.1/), support for 1.0 will end on June 19th, 2019.
 
-At that point we will stop back-porting fixes for security issues and critical bugs to 1.0, so we strongly encourage you to upgrade to 1.1 (currently 1.1.7).  If you don't do this you may put yourself in the position of having to do a major upgrade on a short timeframe to pick up a critical fix.
+At that point we will stop back-porting fixes for security issues and critical bugs to 1.0, so we encourage you to upgrade to the latest version of Istio ({{<istio_release_name>}}).  If you don't do this you may put yourself in the position of having to do a major upgrade on a short timeframe to pick up a critical fix.
 
 We care about you and your clusters, so please be kind to yourself and upgrade.

--- a/content/blog/2019/announcing-1.0-eol/index.md
+++ b/content/blog/2019/announcing-1.0-eol/index.md
@@ -8,6 +8,6 @@ release: 1.0
 
 According to Istio's [support policy](https://istio.io/about/release-cadence/), LTS releases like 1.0 are supported for three months after the next LTS release.   Since [1.1 was released on March 19th](https://istio.io/about/notes/1.1/), support for 1.0 will end on June 19th, 2019.
 
-At that point we will stop backporting fixes for security issues and critical bugs to 1.0, so we strongly encourage you to upgrade to 1.1 (currently 1.1.7).  If you don't do this you may put yourself in the position of having to do a major upgrade on a short timeframe to pick up a critical fix.   
+At that point we will stop back-porting fixes for security issues and critical bugs to 1.0, so we strongly encourage you to upgrade to 1.1 (currently 1.1.7).  If you don't do this you may put yourself in the position of having to do a major upgrade on a short timeframe to pick up a critical fix.
 
 We care about you and your clusters, so please be kind to yourself and upgrade.

--- a/content/blog/2019/announcing-1.0-eol/index.md
+++ b/content/blog/2019/announcing-1.0-eol/index.md
@@ -1,6 +1,6 @@
 ---
-title: Announcing end of support for Istio 1.0
-description: Istio 1.0 EOL announcement
+title: Support for Istio 1.0 ends on June 19th, 2019
+description: Upcoming Istio 1.0 EOL announcement
 publishdate: 2019-05-20
 attribution: The Istio Team
 release: 1.0

--- a/content/blog/2019/announcing-1.0-eol/index.md
+++ b/content/blog/2019/announcing-1.0-eol/index.md
@@ -1,0 +1,13 @@
+---
+title: Announcing end of support for Istio 1.0
+description: Istio 1.0 EOL announcement
+publishdate: 2019-05-20
+attribution: The Istio Team
+release: 1.0
+---
+
+According to Istio's [support policy](https://istio.io/about/release-cadence/), LTS releases like 1.0 are supported for three months after the next LTS release.   Since [1.1 was released on March 19th](https://istio.io/about/notes/1.1/), support for 1.0 will end on June 19th, 2019.
+
+At that point we will stop backporting fixes for security issues and critical bugs to 1.0, so we strongly encourage you to upgrade to 1.1 (currently 1.1.7).  If you don't do this you may put yourself in the position of having to do a major upgrade on a short timeframe to pick up a critical fix.   
+
+We care about you and your clusters, so please be kind to yourself and upgrade.

--- a/content/blog/2019/announcing-1.0-eol/index.md
+++ b/content/blog/2019/announcing-1.0-eol/index.md
@@ -6,7 +6,7 @@ attribution: The Istio Team
 release: 1.0
 ---
 
-According to Istio's [support policy](https://istio.io/about/release-cadence/), LTS releases like 1.0 are supported for three months after the next LTS release.   Since [1.1 was released on March 19th](https://istio.io/about/notes/1.1/), support for 1.0 will end on June 19th, 2019.
+According to Istio's [support policy](/about/release-cadence/), LTS releases like 1.0 are supported for three months after the next LTS release.   Since [1.1 was released on March 19th](/about/notes/1.1/), support for 1.0 will end on June 19th, 2019.
 
 At that point we will stop back-porting fixes for security issues and critical bugs to 1.0, so we strongly encourage you to upgrade to 1.1 (currently 1.1.7).  If you don't do this you may put yourself in the position of having to do a major upgrade on a short timeframe to pick up a critical fix.
 

--- a/content/blog/2019/announcing-1.0-eol/index.md
+++ b/content/blog/2019/announcing-1.0-eol/index.md
@@ -1,6 +1,6 @@
 ---
 title: Support for Istio 1.0 ends on June 19th, 2019
-description: Upcoming Istio 1.0 EOL announcement
+description: Upcoming Istio 1.0 EOL announcement.
 publishdate: 2019-05-20
 attribution: The Istio Team
 release: 1.0


### PR DESCRIPTION
Not sure if this will pass the linter.  I got this when I tried to lint locally:

```
$ make lint
Hugo Static Site Generator v0.55.5-A83256B9 linux/amd64 BuildDate: 2019-05-02T13:03:36Z
Building sites … WARN 2019/05/19 18:17:32 Page's .Dir is deprecated and will be removed in a future release. Use .File.Dir.
ERROR 2019/05/19 18:17:34 Page description doesn't end with a period: 'Upcoming Istio 1.0 EOL announcement'
WARN 2019/05/19 18:17:35 .File.Dir on zero object. Wrap it in if or with: {{ with .File }}{{ .Dir }}{{ end }}
Total in 6946 ms
Error: Error building site: logged 1 error(s)
Makefile:19: recipe for target 'gen' failed
make: *** [gen] Error 255
```