### PR TITLE
fix expression of clientSpan in Trace Span example

### DIFF
--- a/content/docs/reference/config/policy-and-telemetry/templates/tracespan/index.html
+++ b/content/docs/reference/config/policy-and-telemetry/templates/tracespan/index.html
@@ -24,7 +24,7 @@ spec:
   spanName: request.path | &quot;/&quot;
   startTime: request.time
   endTime: response.time
-  clientSpan: (context.reporter.kind | &quot;inbound&quot;) == &quot;inbound&quot;
+  clientSpan: (context.reporter.kind | &quot;inbound&quot;) == &quot;outbound&quot;
   rewriteClientSpanId: false
   spanTags:
     http.method: request.method | &quot;&quot;


### PR DESCRIPTION
currently, this is the expression about how to get clientSpan in `Trace Span` example
![image](https://user-images.githubusercontent.com/463772/58403414-36d63080-8095-11e9-8486-e347e2ebef94.png)

I think the right expression is :

when `context.reporter.kind` is inbound, the clientSpan should be **false**, so it's server side.
when `context.reporter.kind` is outbound, the clientSpan should be **true**, so it's client side.