### PR TITLE
Add ha-demo example to show how istio behaves for ha

### DIFF
--- a/content/docs/examples/ha-demo/index.md
+++ b/content/docs/examples/ha-demo/index.md
@@ -1,0 +1,99 @@
+---
+title: HA-Demo
+description: Deploys a sample application in a high available fashion to show that Istio features are high available as well.
+weight: 10
+aliases:
+    - /docs/samples/ha-demo.html
+    - /docs/guides/ha-demo/index.html
+---
+
+This example deploys a small sample application composed of two components used
+to demonstrate Istio features in a high available fashion. The service shows the latest news article.
+
+The HA-demo application consists of two components:
+
+* `news`. The `news` calls `article` to retrieve the actual news and returns it to the caller. The reason for introducing this service in front of `article` is to keep the client independent from the sidecar injection. So Istio can be updated without restarting the client.
+* `article`. The `article` returns different headlines, depending on the version.
+
+## Before you begin
+
+If you haven't already done so, setup Istio by following the instructions
+corresponding to your platform [installation guide for Kubernetes](/docs/setup/kubernetes).
+
+## Deploy the ha-demo
+
+### Deploying the application on Kubernetes
+
+{{< text bash >}}
+$ kubectl apply -f @samples/ha-demo/platform/kube/ha-demo.yaml@
+{{< /text >}}
+
+This creates two namespaces:
+
+* One for the client
+* One containing the ha-demo with sidecar injection enabled.
+
+### Update Virtual Service
+
+In order for the sidecar to re-route the traffic to different articles using Istio configuration object, we need to update the `Virtual Service` with the IP from the just generated Kubernetes service.
+
+{{< text bash >}}
+$ SERVICE_IP=$(kubectl get service -n ha-demo article -o=jsonpath='{.spec.clusterIP}') && echo $SERVICE_IP
+$ kubectl get -n ha-demo virtualservice latest-article  -o json | jq --arg ip "$SERVICE_IP" '.spec.tcp[0].match[0].destinationSubnets[0]=$ip' | kubectl apply -f -
+{{< /text >}}
+
+### Install client
+
+To test the service, we use `curl`. So any client using `curl` would do
+
+{{< text bash >}}
+$ kubectl apply -n client -f @samples/sleep/sleep.yaml@
+{{< /text >}}
+
+## Test ha-demo
+
+### Enable Continuous Update
+
+We continuously restart the deployments to show that the service can still be accessed without errors or hiccups.
+
+{{< text bash >}}
+$ ./@samples/ha-demo/restart-continuously.sh@ > /dev/null &
+{{< /text >}}
+
+You can monitor the pods being updated with
+
+{{< text bash >}}
+$ watch kubectl -n ha-demo get pods
+{{< /text >}}
+
+### Accessing the service from the client
+
+By curling the service, we can verify that although the restarts are ongoing, no request fails
+
+{{< text bash >}}
+$ POD_NAME=$(kubectl -n client get pods -l app=sleep -o=jsonpath='{.items[0].metadata.name}') && echo $POD_NAME
+$ while true; do kubectl exec -n client $POD_NAME -c sleep -- curl -s news.ha-demo.svc.cluster.local/article; done
+{{< /text >}}
+
+## Cleanup
+
+When you're finished experimenting with the Bookinfo sample, uninstall and clean
+it up using the following instructions corresponding to your Istio runtime environment.
+
+1. Stop background process restarting the pods
+  
+    {{< text bash >}}
+    $ ps | grep -v grep | grep "restart-continuously" | awk '{print $1}' | xargs kill
+    {{< /text >}}
+
+1.  Delete the created namespaces
+
+    {{< text bash >}}
+    $ kubectl delete namespaces client ha-demo
+    {{< /text >}}
+
+1.  Confirm clean cluster
+
+    {{< text bash >}}
+    $ kubectl get namespaces   #-- there should be nothing left created for this demo
+    {{< /text >}}

--- a/content/docs/examples/ha-demo/index.md
+++ b/content/docs/examples/ha-demo/index.md
@@ -17,7 +17,7 @@ The HA-demo application consists of two components:
 ## Before you begin
 
 If you haven't already done so, setup Istio for Kubernetes. E.g. [Installation with Helm
-](/docs/setup/kubernetes/helm-install/).
+](/docs/setup/kubernetes/install/helm/).
 
 ## Deploy the ha-demo
 

--- a/content/docs/examples/ha-demo/index.md
+++ b/content/docs/examples/ha-demo/index.md
@@ -7,8 +7,7 @@ aliases:
     - /docs/guides/ha-demo/index.html
 ---
 
-This example deploys a small sample application composed of two components used
-to demonstrate Istio features in a high available fashion. The service shows the latest news article.
+This example deploys a small sample application composed of two components to demonstrate Istio's high available capabilities. The service shows the latest news article.
 
 The HA-demo application consists of two components:
 
@@ -17,8 +16,8 @@ The HA-demo application consists of two components:
 
 ## Before you begin
 
-If you haven't already done so, setup Istio by following the instructions
-corresponding to your platform [installation guide for Kubernetes](/docs/setup/kubernetes).
+If you haven't already done so, setup Istio for Kubernetes. E.g. [Installation with Helm
+](/docs/setup/kubernetes/helm-install/).
 
 ## Deploy the ha-demo
 
@@ -32,6 +31,15 @@ This creates two namespaces:
 
 * One for the client
 * One containing the ha-demo with sidecar injection enabled.
+
+There should now be two pods with two containers (workload and sidecar) each running in the ha-demo namespace.
+
+{{< text bash >}}
+$ kubectl get pods -n ha-demo
+NAME                         READY   STATUS    RESTARTS   AGE
+article-v2-8875b7c5f-rkbqr   2/2     Running   0          21s
+news-64647f476f-fpxhb        2/2     Running   0          21s
+{{< /text >}}
 
 ### Update Virtual Service
 
@@ -68,7 +76,7 @@ $ watch kubectl -n ha-demo get pods
 
 ### Accessing the service from the client
 
-By curling the service, we can verify that although the restarts are ongoing, no request fails
+By calling the service, we can verify that although the restarts are ongoing, no request fails
 
 {{< text bash >}}
 $ POD_NAME=$(kubectl -n client get pods -l app=sleep -o=jsonpath='{.items[0].metadata.name}') && echo $POD_NAME
@@ -77,11 +85,11 @@ $ while true; do kubectl exec -n client $POD_NAME -c sleep -- curl -s news.ha-de
 
 ## Cleanup
 
-When you're finished experimenting with the Bookinfo sample, uninstall and clean
+When you're finished experimenting with the HA-Demo, uninstall and clean
 it up using the following instructions corresponding to your Istio runtime environment.
 
 1. Stop background process restarting the pods
-  
+
     {{< text bash >}}
     $ ps | grep -v grep | grep "restart-continuously" | awk '{print $1}' | xargs kill
     {{< /text >}}


### PR DESCRIPTION
New simple demo which shows that istio is highly available. This demo can later also be used to show that istio can be updated without downtime for the client.

Possible enhancements:
* We could route to several services (round robin)  instead of only one.