### PR TITLE
fix(ops): change the yaml used in "Probes Rewriting"

### DIFF
--- a/content/docs/ops/setup/app-health-check/index.md
+++ b/content/docs/ops/setup/app-health-check/index.md
@@ -169,8 +169,8 @@ The configuration changes above (by Helm or by the configuration map) effect all
 ##### Re-deploy the liveness health check app
 
 {{< text bash >}}
-$ kubectl delete -f <(istioctl kube-inject -f @samples/health-check/liveness-command.yaml@)
-$ kubectl apply -f <(istioctl kube-inject -f @samples/health-check/liveness-command.yaml@)
+$ kubectl delete -f <(istioctl kube-inject -f @samples/health-check/liveness-http-same-port.yaml@)
+$ kubectl apply -f <(istioctl kube-inject -f @samples/health-check/liveness-http-same-port.yaml@)
 {{< /text >}}
 
 {{< text bash >}}


### PR DESCRIPTION
The current pod used a curl health check, but in this part of the documentation, a http health check is required on the same port used by the proxy