### PR TITLE
fix(tracing docs): update to provide references to access task

### DIFF
--- a/content/docs/tasks/telemetry/distributed-tracing/jaeger/index.md
+++ b/content/docs/tasks/telemetry/distributed-tracing/jaeger/index.md
@@ -25,15 +25,15 @@ To learn how Istio handles tracing, visit this task's [overview](../overview/).
 
 ## Accessing the dashboard
 
-1.  To setup access to the tracing dashboard, use port forwarding:
+[Remotely Accessing Telemetry Addons](/docs/tasks/telemetry/gateways) details how to configure access to the Istio       addons through ingressgateways. Alternatively, to use a Kubernetes ingress, specify the Helm chart option `--set tracing.ingress.enabled=true` during install.
 
-    {{< text bash >}}
-    $ kubectl port-forward -n istio-system $(kubectl get pod -n istio-system -l app=jaeger -o jsonpath='{.items[0].metadata.name}') 16686:16686  &
-    {{< /text >}}
+For testing (and temporary access), you may also use port-forwarding. Use the following, assuming you've deployed Jaeger to the `istio-control` namespace:
 
-    Open your browser to [http://localhost:16686](http://localhost:16686).
+{{< text bash >}}
+$ kubectl -n istio-control port-forward $(kubectl -n istio-control get pod -l app=jaeger -o jsonpath='{.items[0].metadata.name}') 15032:16686
+{{< /text >}}
 
-1.  To use a Kubernetes ingress, specify the Helm chart option `--set tracing.ingress.enabled=true`.
+Open your browser to [http://localhost:15032](http://localhost:15032).
 
 ## Generating traces using the Bookinfo sample
 

--- a/content/docs/tasks/telemetry/distributed-tracing/jaeger/index.md
+++ b/content/docs/tasks/telemetry/distributed-tracing/jaeger/index.md
@@ -25,7 +25,7 @@ To learn how Istio handles tracing, visit this task's [overview](../overview/).
 
 ## Accessing the dashboard
 
-[Remotely Accessing Telemetry Addons](/docs/tasks/telemetry/gateways) details how to configure access to the Istio       addons through ingressgateways. Alternatively, to use a Kubernetes ingress, specify the Helm chart option `--set tracing.ingress.enabled=true` during install.
+[Remotely Accessing Telemetry Addons](/docs/tasks/telemetry/gateways) details how to configure access to the Istio       addons through a gateway. Alternatively, to use a Kubernetes ingress, specify the Helm chart option `--set tracing.ingress.enabled=true` during install.
 
 For testing (and temporary access), you may also use port-forwarding. Use the following, assuming you've deployed Jaeger to the `istio-control` namespace:
 

--- a/content/docs/tasks/telemetry/distributed-tracing/zipkin/index.md
+++ b/content/docs/tasks/telemetry/distributed-tracing/zipkin/index.md
@@ -27,7 +27,7 @@ To learn how Istio handles tracing, visit this task's [overview](../overview/).
 
 ## Accessing the dashboard
 
-[Remotely Accessing Telemetry Addons](/docs/tasks/telemetry/gateways) details how to configure access to the Istio       addons through ingressgateways. Alternatively, to use a Kubernetes ingress, specify the Helm chart option `--set tracing.ingress.enabled=true` during install.
+[Remotely Accessing Telemetry Addons](/docs/tasks/telemetry/gateways) details how to configure access to the Istio       addons through a gateway. Alternatively, to use a Kubernetes ingress, specify the Helm chart option `--set tracing.ingress.enabled=true` during install.
 
 For testing (and temporary access), you may also use port-forwarding. Use the following, assuming you've deployed Zipkin to the `istio-control` namespace:
 

--- a/content/docs/tasks/telemetry/distributed-tracing/zipkin/index.md
+++ b/content/docs/tasks/telemetry/distributed-tracing/zipkin/index.md
@@ -27,15 +27,15 @@ To learn how Istio handles tracing, visit this task's [overview](../overview/).
 
 ## Accessing the dashboard
 
-1.  To setup access to the tracing dashboard, use port forwarding:
+[Remotely Accessing Telemetry Addons](/docs/tasks/telemetry/gateways) details how to configure access to the Istio       addons through ingressgateways. Alternatively, to use a Kubernetes ingress, specify the Helm chart option `--set tracing.ingress.enabled=true` during install.
 
-    {{< text bash >}}
-    $ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=istio-ingressgateway -o jsonpath='{.items[0].metadata.name}') 15032:15032 &
-    {{< /text >}}
+For testing (and temporary access), you may also use port-forwarding. Use the following, assuming you've deployed Zipkin to the `istio-control` namespace:
 
-    Open your browser to [http://localhost:15032](http://localhost:15032).
+{{< text bash >}}
+$ kubectl -n istio-control port-forward $(kubectl -n istio-control get pod -l app=zipkin -o jsonpath='{.items[0].metadata.name}') 15032:9411
+{{< /text >}}
 
-1.  To use a Kubernetes ingress, specify the Helm chart option `--set tracing.ingress.enabled=true`.
+Open your browser to [http://localhost:15032](http://localhost:15032).
 
 ## Generating traces using the Bookinfo sample
 


### PR DESCRIPTION
Address an issue around access the tracing services by linking to the `Remote Access` task and updating the `port-forward` command.

Fixes https://github.com/istio/istio/issues/13055.