### PR TITLE
Document the Helm whitespace problem

### DIFF
--- a/content/docs/setup/kubernetes/install/helm/index.md
+++ b/content/docs/setup/kubernetes/install/helm/index.md
@@ -56,11 +56,10 @@ Change directory to the root of the release and then
 choose one of the following two **mutually exclusive** options:
 
 {{< warning >}}
-Istio's installation uses [Helm Package Manager](https://helm.sh) extensively for rendering of manifests.
-Helm has an issue when extra white space in the command line is not properly disposed resulting in a
-`helm template` or `helm nstall` operation that produces an incorrect manifest.
-
-[Helm Issue 5863](https://github.com/helm/helm/issues/5863) contains details of this problem.
+Istio's installation uses [Helm Package Manager](https://helm.sh) extensively for rendering Istio
+manifests. [Helm Issue 5863](https://github.com/helm/helm/issues/5863) contains details of a problem where
+extra white space in the command line is not properly handled resulting in a `helm template`
+or `helm nstall` operation that produces an incorrect manifest.
 {{< /warning >}}
 
 1. To deploy Istio without using Tiller, follow the instructions for [option 1](/docs/setup/kubernetes/install/helm/#option-1-install-with-helm-via-helm-template).

--- a/content/docs/setup/kubernetes/install/helm/index.md
+++ b/content/docs/setup/kubernetes/install/helm/index.md
@@ -55,6 +55,14 @@ $ helm repo add istio.io https://storage.googleapis.com/istio-release/releases/{
 Change directory to the root of the release and then
 choose one of the following two **mutually exclusive** options:
 
+{{< warning >}}
+Istio's installation uses [Helm Package Manager](https://helm.sh) extensively for templating.  Helm
+has an issue extra white space in the command line is not properly eaten resulting in a `helm template`
+or `helmi nstall` operation that produces an incorrect manifest.
+
+See [Helm Issue 5863](https://github.com/helm/helm/issues/5863) for more details.
+{{< /warning >}}
+
 1. To deploy Istio without using Tiller, follow the instructions for [option 1](/docs/setup/kubernetes/install/helm/#option-1-install-with-helm-via-helm-template).
 1. To use [Helm's Tiller pod](https://helm.sh/) to manage your Istio release, follow the instructions for [option 2](/docs/setup/kubernetes/install/helm/#option-2-install-with-helm-and-tiller-via-helm-install).
 

--- a/content/docs/setup/kubernetes/install/helm/index.md
+++ b/content/docs/setup/kubernetes/install/helm/index.md
@@ -56,11 +56,11 @@ Change directory to the root of the release and then
 choose one of the following two **mutually exclusive** options:
 
 {{< warning >}}
-Istio's installation uses [Helm Package Manager](https://helm.sh) extensively for templating.  Helm
-has an issue extra white space in the command line is not properly eaten resulting in a `helm template`
-or `helmi nstall` operation that produces an incorrect manifest.
+Istio's installation uses [Helm Package Manager](https://helm.sh) extensively for rendering of manifests.
+Helm has an issue when extra white space in the command line is not properly disposed resulting in a
+`helm template` or `helm nstall` operation that produces an incorrect manifest.
 
-See [Helm Issue 5863](https://github.com/helm/helm/issues/5863) for more details.
+[Helm Issue 5863](https://github.com/helm/helm/issues/5863) contains details of this problem.
 {{< /warning >}}
 
 1. To deploy Istio without using Tiller, follow the instructions for [option 1](/docs/setup/kubernetes/install/helm/#option-1-install-with-helm-via-helm-template).


### PR DESCRIPTION
Document the helm whitespace command line problem.  We should consider
producing a list of known Helm problems as they relate to Istio - post
1.2 (with a quick backport to all of the branches including deprecated
Istio versions).  It will take some time to generate this list, but we
could replace this 1 warning with all of the various Helm issues we
see in production usage along with the upstream tracking bug.