### PR TITLE
Remove references to "PERMISSIVE" mode

### DIFF
--- a/content/docs/tasks/security/mtls-migration/index.md
+++ b/content/docs/tasks/security/mtls-migration/index.md
@@ -13,16 +13,13 @@ may be desirable to gradually migrate them to Istio. During the migration, some 
 sidecars while some do not. For a service with a sidecar, if you enable
 mutual TLS on the service, the connections from legacy clients (i.e., clients without
 Envoy) will lose communication since they do not have Envoy sidecars and client certificates.
-To solve this issue, Istio authentication policy provides a "PERMISSIVE" mode to solve
-this problem. Once "PERMISSIVE" mode is enabled, a service can take both HTTP
-and mutual TLS traffic.
 
 You can configure Istio services to send mutual
 TLS traffic to that service while connections from legacy services will not
 lose communication. Moreover, you can use the
 [Grafana dashboard](/docs/tasks/telemetry/using-istio-dashboard/) to check which services are
-still sending plain text traffic to the service in "PERMISSIVE" mode and choose to lock
-down once the migration is done.
+still sending plain text traffic to the service and choose to lock down once
+the migration is done.
 
 ## Before you begin
 


### PR DESCRIPTION
In c4b714ec99954882f8d0d56a5fca2ab922934913 (#3382), `PERMISSIVE` mode
references were removed from the documentation as it is no longer
required.

"PERMISSIVE" mode is not described elsewhere in the docs.

Remove references to this mode in the mainline documentation.