### PR TITLE
rbac: simplify and make authorization HTTP/TCP tasks consistent

### DIFF
--- a/content/docs/tasks/security/authz-http/index.md
+++ b/content/docs/tasks/security/authz-http/index.md
@@ -18,16 +18,16 @@ The activities in this task assume that you:
 
 * Read the [authorization concept](/docs/concepts/security/#authorization).
 
-* Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio **with the strict mutual TLS profile**.
+* Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio using the **strict mutual TLS profile**.
 
 * Deploy the [Bookinfo](/docs/examples/bookinfo#deploying-the-application) sample application.
 
 After deploying the Bookinfo application, go to the Bookinfo product page at `http://$GATEWAY_URL/productpage`. On
-the product page, you can see:
+the product page, you can see the following sections:
 
-* The **Book Details** section on the lower left of the page includes book type, number of
+* **Book Details** on the lower left side, which includes: book type, number of
   pages, publisher, etc.
-* The **Book Reviews** section on the lower right of the page.
+* **Book Reviews** on the lower right of the page.
 
 When you refresh the page, the app shows different versions of reviews in the product page.
 The app presents the reviews in a round robin style: red stars, black stars, or no stars.
@@ -65,7 +65,7 @@ Run the following command to create a namespace-level access control policy:
 $ kubectl apply -f @samples/bookinfo/platform/kube/rbac/namespace-policy.yaml@
 {{< /text >}}
 
-The policy does the following:
+Once applied, the policy has the following effects:
 
 *   Creates a `ServiceRole` `service-viewer` which allows read access to any service in the `default` namespace that has
 the `app` label
@@ -149,7 +149,7 @@ Run the following command:
 $ kubectl apply -f @samples/bookinfo/platform/kube/rbac/productpage-policy.yaml@
 {{< /text >}}
 
-The policy does the following:
+Once applied, the policy has the following effects:
 
 *   Creates a `ServiceRole` `productpage-viewer` which allows read access to the `productpage` service.
 
@@ -203,7 +203,7 @@ Run the following command:
 $ kubectl apply -f @samples/bookinfo/platform/kube/rbac/details-reviews-policy.yaml@
 {{< /text >}}
 
-The policy does the following:
+Once applied, the policy has the following effects:
 
 *   Creates a `ServiceRole` `details-reviews-viewer` which allows access to the `details` and `reviews` services.
 
@@ -258,7 +258,7 @@ Run the following command to create a policy that allows the `reviews` service t
 $ kubectl apply -f @samples/bookinfo/platform/kube/rbac/ratings-policy.yaml@
 {{< /text >}}
 
-The policy does the following:
+Once applied, the policy has the following effects:
 
 *   Creates a `ServiceRole` `ratings-viewer` which allows access to the `ratings` service.
 

--- a/content/docs/tasks/security/authz-http/index.md
+++ b/content/docs/tasks/security/authz-http/index.md
@@ -20,7 +20,7 @@ The activities in this task assume that you:
 
 * Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio using the **strict mutual TLS profile**.
 
-* Deploy the [Bookinfo](/docs/examples/bookinfo#deploying-the-application) sample application.
+* Deploy the [Bookinfo](/docs/examples/bookinfo/#deploying-the-application) sample application.
 
 After deploying the Bookinfo application, go to the Bookinfo product page at `http://$GATEWAY_URL/productpage`. On
 the product page, you can see the following sections:

--- a/content/docs/tasks/security/authz-http/index.md
+++ b/content/docs/tasks/security/authz-http/index.md
@@ -18,29 +18,19 @@ The activities in this task assume that you:
 
 * Read the [authorization concept](/docs/concepts/security/#authorization).
 
-* Follow the instructions in the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to
-install Istio **with mutual TLS enabled**.
+* Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio **with the strict mutual TLS profile**.
 
-* Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
+* Deploy the [Bookinfo](/docs/examples/bookinfo#deploying-the-application) sample application.
 
-* Create service accounts for the Bookinfo application. Run the following command to create service
-account `bookinfo-productpage` for `productpage` and service account `bookinfo-reviews` for `reviews`:
+After deploying the Bookinfo application, go to the Bookinfo product page at `http://$GATEWAY_URL/productpage`. On
+the product page, you can see:
 
-    {{< text bash >}}
-    $ kubectl apply -f <(istioctl kube-inject -f @samples/bookinfo/platform/kube/bookinfo-add-serviceaccount.yaml@)
-    {{< /text >}}
+* The **Book Details** section on the lower left of the page includes book type, number of
+  pages, publisher, etc.
+* The **Book Reviews** section on the lower right of the page.
 
-{{< tip >}}
-If you are using a namespace other than `default`, use `kubectl -n namespace ...` to specify the namespace.
-{{< /tip >}}
-
-* Point your browser at the Bookinfo `productpage` (`http://$GATEWAY_URL/productpage`). You should see:
-
-    * The "Book Details" section in the lower left part of the page, including type, pages, publisher, etc.
-    * The "Book Reviews" section in the lower right part of the page.
-
-    If you refresh the page several times, you should see different versions of reviews shown in the product page,
-    presented in a round robin style (red stars, black stars, no stars)
+When you refresh the page, the app shows different versions of reviews in the product page.
+The app presents the reviews in a round robin style: red stars, black stars, or no stars.
 
 ## Enabling Istio authorization
 
@@ -58,7 +48,7 @@ explicitly define access control policy to grant access to any service.
 There may be some delays due to caching and other propagation overhead.
 {{< /tip >}}
 
-## Namespace-level access control
+## Enforcing Namespace-level access control
 
 Using Istio authorization, you can easily setup namespace-level access control by specifying all (or a collection of) services
 in a namespace are accessible by services from another namespace.
@@ -139,7 +129,7 @@ Remove the following configuration before you proceed to the next task:
 $ kubectl delete -f @samples/bookinfo/platform/kube/rbac/namespace-policy.yaml@
 {{< /text >}}
 
-## Service-level access control
+## Enforcing Service-level access control
 
 This task shows you how to set up service-level access control using Istio authorization. Before you start, please make sure that:
 

--- a/content/docs/tasks/security/authz-permissive/index.md
+++ b/content/docs/tasks/security/authz-permissive/index.md
@@ -8,7 +8,7 @@ keywords: [security,access-control,rbac,authorization]
 The [authorization permissive mode](/docs/concepts/security/#authorization-permissive-mode) allows
 you to verify authorization policies before applying them in a production environment.
 
-The authorization permissive mode is an experimental feature in version 1.2. Its interface can change
+The authorization permissive mode is an experimental feature in version 1.1. Its interface can change
 in future releases. If you do not want to try out the permissive mode feature, you can directly
 [enable Istio authorization](/docs/tasks/security/authz-http#enabling-istio-authorization) to skip
 enabling the permissive mode.
@@ -27,16 +27,16 @@ To complete this task, you should first take the following actions:
 
 * Read the [authorization concept](/docs/concepts/security/#authorization).
 
-* Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio **with the strict mutual TLS profile**.
+* Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio using the **strict mutual TLS profile**.
 
 * Deploy the [Bookinfo](/docs/examples/bookinfo#deploying-the-application) sample application.
 
 After deploying the Bookinfo application, go to the Bookinfo product page at `http://$GATEWAY_URL/productpage`. On
-the product page, you can see:
+the product page, you can see the following sections:
 
-* The **Book Details** section on the lower left of the page includes book type, number of
+* **Book Details** on the lower left side, which includes: book type, number of
   pages, publisher, etc.
-* The **Book Reviews** section on the lower right of the page.
+* **Book Reviews** on the lower right of the page.
 
 When you refresh the page, the app shows different versions of reviews in the product page.
 The app presents the reviews in a round robin style: red stars, black stars, or no stars.

--- a/content/docs/tasks/security/authz-permissive/index.md
+++ b/content/docs/tasks/security/authz-permissive/index.md
@@ -29,7 +29,7 @@ To complete this task, you should first take the following actions:
 
 * Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio using the **strict mutual TLS profile**.
 
-* Deploy the [Bookinfo](/docs/examples/bookinfo#deploying-the-application) sample application.
+* Deploy the [Bookinfo](/docs/examples/bookinfo/#deploying-the-application) sample application.
 
 After deploying the Bookinfo application, go to the Bookinfo product page at `http://$GATEWAY_URL/productpage`. On
 the product page, you can see the following sections:

--- a/content/docs/tasks/security/authz-permissive/index.md
+++ b/content/docs/tasks/security/authz-permissive/index.md
@@ -8,7 +8,7 @@ keywords: [security,access-control,rbac,authorization]
 The [authorization permissive mode](/docs/concepts/security/#authorization-permissive-mode) allows
 you to verify authorization policies before applying them in a production environment.
 
-The authorization permissive mode is an experimental feature in version 1.1. Its interface can change
+The authorization permissive mode is an experimental feature in version 1.2. Its interface can change
 in future releases. If you do not want to try out the permissive mode feature, you can directly
 [enable Istio authorization](/docs/tasks/security/authz-http#enabling-istio-authorization) to skip
 enabling the permissive mode.
@@ -27,19 +27,21 @@ To complete this task, you should first take the following actions:
 
 * Read the [authorization concept](/docs/concepts/security/#authorization).
 
-* Follow the instructions in the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to
-install Istio **with mutual TLS enabled**.
+* Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio **with the strict mutual TLS profile**.
 
-* Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
+* Deploy the [Bookinfo](/docs/examples/bookinfo#deploying-the-application) sample application.
 
-* Create service accounts for the Bookinfo application. Run the following command to create service
-account `bookinfo-productpage` for `productpage` and service account `bookinfo-reviews` for `reviews`:
+After deploying the Bookinfo application, go to the Bookinfo product page at `http://$GATEWAY_URL/productpage`. On
+the product page, you can see:
 
-    {{< text bash >}}
-    $ kubectl apply -f <(istioctl kube-inject -f @samples/bookinfo/platform/kube/bookinfo-add-serviceaccount.yaml@)
-    {{< /text >}}
+* The **Book Details** section on the lower left of the page includes book type, number of
+  pages, publisher, etc.
+* The **Book Reviews** section on the lower right of the page.
 
-### Test enabling authorization globally
+When you refresh the page, the app shows different versions of reviews in the product page.
+The app presents the reviews in a round robin style: red stars, black stars, or no stars.
+
+## Test enabling authorization globally
 
 The following steps show you how to use authorization permissive mode to test whether it's safe to
 turn on authorization globally:
@@ -126,7 +128,7 @@ turn on authorization globally:
     as expected. To enable the authorization policy, follow the steps described in the
     [Enabling Istio authorization task](/docs/tasks/security/authz-http#enabling-istio-authorization).
 
-### Test adding authorization policy
+## Test adding authorization policy
 
 The following steps show how to test a new authorization policy with permissive mode when authorization
 has already been enabled.

--- a/content/docs/tasks/security/authz-tcp/index.md
+++ b/content/docs/tasks/security/authz-tcp/index.md
@@ -15,16 +15,16 @@ The activities in this task assume that you:
 
 * Read the [authorization concept](/docs/concepts/security/#authorization).
 
-* Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio **with the strict mutual TLS profile**.
+* Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio using the **strict mutual TLS profile**.
 
 * Deploy the [Bookinfo](/docs/examples/bookinfo#deploying-the-application) sample application.
 
 After deploying the Bookinfo application, go to the Bookinfo product page at `http://$GATEWAY_URL/productpage`. On
-the product page, you can see:
+the product page, you can see the following sections:
 
-* The **Book Details** section on the lower left of the page includes book type, number of
+* **Book Details** on the lower left side, which includes: book type, number of
   pages, publisher, etc.
-* The **Book Reviews** section on the lower right of the page.
+* **Book Reviews** on the lower right of the page.
 
 When you refresh the page, the app shows different versions of reviews in the product page.
 The app presents the reviews in a round robin style: red stars, black stars, or no stars.
@@ -123,9 +123,9 @@ Run the following command to apply the authorization policy:
 $ kubectl apply -f @samples/bookinfo/platform/kube/rbac/mongodb-policy.yaml@
 {{< /text >}}
 
-The step above does the following:
+Once applied, the policy has the following effects:
 
-* Creates a service role "mongodb-viewer" which allows access to the port 27017 of the MongoDB service.
+* Creates the following `mongodb-viewer` service role, which allows access to the MongoDB service on port 27017.
 
     {{< text yaml >}}
     apiVersion: "rbac.istio.io/v1alpha1"
@@ -141,7 +141,8 @@ The step above does the following:
           values: ["27017"]
     {{< /text >}}
 
-* Creates a service role binding `bind-mongodb-viewer` which assigns the `mongodb-viewer` role to `bookinfo-ratings-v2`.
+* Creates the following `bind-mongodb-viewer` service role binding, which assigns the `mongodb-viewer` role
+to the `bookinfo-ratings-v2` service.
 
     {{< text yaml >}}
     apiVersion: "rbac.istio.io/v1alpha1"
@@ -157,10 +158,10 @@ The step above does the following:
         name: "mongodb-viewer"
     {{< /text >}}
 
-Point your browser at the Bookinfo `productpage` (`http://$GATEWAY_URL/productpage`).  You should see:
+Point your browser at the Bookinfo `productpage` (`http://$GATEWAY_URL/productpage`). You should see the following sections:
 
-* The **Book Details** section on the lower left of the page includes book type, number of pages, publisher, etc.
-* The **Book Reviews** section on the lower right of the page includes red stars.
+* **Book Details** on the lower left side, which includes: book type, number of pages, publisher, etc.
+* **Book Reviews** on the lower right side, which includes: red stars.
 
 {{< tip >}}
 There may be some delays due to caching and other propagation overhead.

--- a/content/docs/tasks/security/authz-tcp/index.md
+++ b/content/docs/tasks/security/authz-tcp/index.md
@@ -17,7 +17,7 @@ The activities in this task assume that you:
 
 * Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio using the **strict mutual TLS profile**.
 
-* Deploy the [Bookinfo](/docs/examples/bookinfo#deploying-the-application) sample application.
+* Deploy the [Bookinfo](/docs/examples/bookinfo/#deploying-the-application) sample application.
 
 After deploying the Bookinfo application, go to the Bookinfo product page at `http://$GATEWAY_URL/productpage`. On
 the product page, you can see the following sections:

--- a/content/docs/tasks/security/authz-tcp/index.md
+++ b/content/docs/tasks/security/authz-tcp/index.md
@@ -15,24 +15,9 @@ The activities in this task assume that you:
 
 * Read the [authorization concept](/docs/concepts/security/#authorization).
 
-* Follow the instructions in the [quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio on
-  Kubernetes **with authentication enabled**.
+* Follow the [Kubernetes quick start](/docs/setup/kubernetes/install/kubernetes/) to install Istio **with the strict mutual TLS profile**.
 
-* Enable mutual TLS authentication when running the [installation steps](/docs/setup/kubernetes/install/kubernetes/#installation-steps).
-
-The commands used in this task assume the Bookinfo example application is deployed in the default
-namespace. To specify a namespace other than the default namespace, use the `-n` option in the command.
-
-## Installing and configuring a TCP service
-
-By default, the [Bookinfo](/docs/examples/bookinfo/) example application only includes HTTP services.
-To show how Istio handles the authorization of TCP services, we must update the application to use a
-TCP service. Follow this procedure to deploy the Bookinfo example app and update its `ratings` service
-to the `v2` version, which talks to a MongoDB backend using TCP.
-
-### Prerequisites
-
-Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
+* Deploy the [Bookinfo](/docs/examples/bookinfo#deploying-the-application) sample application.
 
 After deploying the Bookinfo application, go to the Bookinfo product page at `http://$GATEWAY_URL/productpage`. On
 the product page, you can see:
@@ -44,33 +29,28 @@ the product page, you can see:
 When you refresh the page, the app shows different versions of reviews in the product page.
 The app presents the reviews in a round robin style: red stars, black stars, or no stars.
 
-### Installing a service using a service account
+## Installing and configuring a TCP service
+
+By default, the [Bookinfo](/docs/examples/bookinfo/) example application only includes HTTP services.
+To show how Istio handles the authorization of TCP services, we must update the application to use a
+TCP service. Follow this procedure to deploy the Bookinfo example app and update its `ratings` service
+to the `v2` version, which talks to a MongoDB backend using TCP.
 
 1. Install `v2` of the `ratings` service with service account `bookinfo-ratings-v2`:
-
-    Istio cryptographically authenticates service accounts in the mesh. To give different services
-    different access privileges, we must create a `v2` version of the `ratings` service using the
-    `bookinfo-ratings-v2` service account. Other services use the `default` service account.
 
     * To create the service account and configure the new version of the service for a cluster
       **with** automatic sidecar injection enabled:
 
         {{< text bash >}}
-        $ kubectl apply -f @samples/bookinfo/platform/kube/rbac/ratings-v2-add-serviceaccount.yaml@
+        $ kubectl apply -f @samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml@
         {{< /text >}}
 
     * To create the service account and configure the new version of the service for a cluster
       **without** automatic sidecar injection enabled:
 
         {{< text bash >}}
-        $ kubectl apply -f <(istioctl kube-inject -f @samples/bookinfo/platform/kube/rbac/ratings-v2-add-serviceaccount.yaml@)
+        $ kubectl apply -f <(istioctl kube-inject -f @samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml@)
         {{< /text >}}
-
-### Configure the application to use the new version of the service
-
-The Bookinfo application can use multiple versions of each service. Istio requires you to define
-a service subset for each version. You must also define the load balancing policy for each subset.
-To define the subsets and their load balancing policies, you must create appropriate destination rules.
 
 1. Create the appropriate destination rules:
 
@@ -132,91 +112,59 @@ define access control policies to grant access to the MongoDB service.
 There may be some delays due to caching and other propagation overhead.
 {{< /tip >}}
 
-## Enforcing Service-level access control
+## Enforcing access control on TCP service
 
 Now let's set up service-level access control using Istio authorization to allow `v2` of `ratings`
 to access the MongoDB service.
 
-1. Run the following command to apply the authorization policy:
+Run the following command to apply the authorization policy:
 
-    {{< text bash >}}
-    $ kubectl apply -f @samples/bookinfo/platform/kube/rbac/mongodb-policy.yaml@
+{{< text bash >}}
+$ kubectl apply -f @samples/bookinfo/platform/kube/rbac/mongodb-policy.yaml@
+{{< /text >}}
+
+The step above does the following:
+
+* Creates a service role "mongodb-viewer" which allows access to the port 27017 of the MongoDB service.
+
+    {{< text yaml >}}
+    apiVersion: "rbac.istio.io/v1alpha1"
+    kind: ServiceRole
+    metadata:
+      name: mongodb-viewer
+      namespace: default
+    spec:
+      rules:
+      - services: ["mongodb.default.svc.cluster.local"]
+        constraints:
+        - key: "destination.port"
+          values: ["27017"]
     {{< /text >}}
 
-    The step above does the following:
+* Creates a service role binding `bind-mongodb-viewer` which assigns the `mongodb-viewer` role to `bookinfo-ratings-v2`.
 
-    * Creates a service role "mongodb-viewer" which allows access to the port 27017 of the MongoDB service.
-
-        {{< text yaml >}}
-        apiVersion: "rbac.istio.io/v1alpha1"
+    {{< text yaml >}}
+    apiVersion: "rbac.istio.io/v1alpha1"
+    kind: ServiceRoleBinding
+    metadata:
+      name: bind-mongodb-viewer
+      namespace: default
+    spec:
+      subjects:
+      - user: "cluster.local/ns/default/sa/bookinfo-ratings-v2"
+      roleRef:
         kind: ServiceRole
-        metadata:
-          name: mongodb-viewer
-          namespace: default
-        spec:
-          rules:
-          - services: ["mongodb.default.svc.cluster.local"]
-            constraints:
-            - key: "destination.port"
-              values: ["27017"]
-        {{< /text >}}
-
-    * Creates a service role binding `bind-mongodb-viewer` which assigns the "mongodb-viewer" role to "bookinfo-ratings-v2".
-
-        {{< text yaml >}}
-        apiVersion: "rbac.istio.io/v1alpha1"
-        kind: ServiceRoleBinding
-        metadata:
-          name: bind-mongodb-viewer
-          namespace: default
-        spec:
-          subjects:
-          - user: "cluster.local/ns/default/sa/bookinfo-ratings-v2"
-          roleRef:
-            kind: ServiceRole
-            name: "mongodb-viewer"
-        {{< /text >}}
-
-    Point your browser at the Bookinfo `productpage` (`http://$GATEWAY_URL/productpage`).  You should see:
-
-    * The **Book Details** section on the lower left of the page includes book type, number of pages, publisher, etc.
-    * The **Book Reviews** section on the lower right of the page includes red stars.
-
-    {{< tip >}}
-    There may be some delays due to caching and other propagation overhead.
-    {{< /tip >}}
-
-1. To confirm the MongoDB service can only be accessed by service account `bookinfo-ratings-v2`:
-
-    Run the following command to delete the `ratings` deployment with service account `bookinfo-ratings-v2`:
-
-    {{< text bash >}}
-    $ kubectl delete -f @samples/bookinfo/platform/kube/rbac/ratings-v2-add-serviceaccount.yaml@
+        name: "mongodb-viewer"
     {{< /text >}}
 
-    Run the following command to deploy the `ratings` deployment with service account `default`:
+Point your browser at the Bookinfo `productpage` (`http://$GATEWAY_URL/productpage`).  You should see:
 
-    * To deploy in a cluster **with** automatic sidecar injection enabled:
+* The **Book Details** section on the lower left of the page includes book type, number of pages, publisher, etc.
+* The **Book Reviews** section on the lower right of the page includes red stars.
 
-        {{< text bash >}}
-        $ kubectl apply -f @samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml@
-        {{< /text >}}
-
-    * To deploy in a cluster **without** automatic sidecar injection enabled:
-
-        {{< text bash >}}
-        $ kubectl apply -f <(istioctl kube-inject -f @samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml@)
-        {{< /text >}}
-
-    Point your browser at the Bookinfo `productpage` (`http://$GATEWAY_URL/productpage`).  You should see:
-
-    * The **Book Details** section on the lower left of the page includes book type, number of pages, publisher, etc.
-    * The **Book Reviews** section on the lower right of the page includes an error message **"Ratings
-      service is currently unavailable"**.
-
-    {{< tip >}}
-    There may be some delays due to caching and other propagation overhead.
-    {{< /tip >}}
+{{< tip >}}
+There may be some delays due to caching and other propagation overhead.
+{{< /tip >}}
 
 ## Cleanup
 


### PR DESCRIPTION
* Simplify the Bookinfo deployment, the service accounts could just be
added with the default Bookinfo deployment. (Depending on https://github.com/istio/istio/pull/14678 to be merged to 1.2)

* Make the `Before you begin` section more consistent for HTTP and TCP
tasks