### PR TITLE
fix locality-weighted load balancing sample.

### DIFF
--- a/content/docs/ops/traffic-management/locality-load-balancing/index.md
+++ b/content/docs/ops/traffic-management/locality-load-balancing/index.md
@@ -88,8 +88,9 @@ For example, if we want to keep 80% of traffic within our region, and send 20% o
 {{< text yaml >}}
 global:
   localityLbSetting:
-  - from: "us-central1/*"
-    to:
-      "us-central1/*": 80
-      "us-central2/*": 20
+    distribute:
+    - from: "us-central1/*"
+      to:
+        "us-central1/*": 80
+        "us-central2/*": 20
 {{< /text >}}


### PR DESCRIPTION
The locality-weighted load balancing sample is not valid, according to `LocalityLoadBalancerSetting` doc: https://preliminary.istio.io/docs/reference/config/istio.mesh.v1alpha1/#LocalityLoadBalancerSetting

The locality-weighted load balancing setting is supposed to be under `distribute`.