### PR TITLE
Add clarification on behaviour in absence of policy

### DIFF
--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -444,18 +444,8 @@ only one authentication policy per mesh and one authentication policy per
 namespace. Istio also requires mesh-wide and namespace-wide policies to have
 the specific name `default`.
 
-If a service has no matching policies, the service behaves as if the following
-`empty-policy` policy applies:
-
-{{< text yaml >}}
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
-metadata:
-  name: "empty-policy"
-spec:
-{{< /text >}}
-
-This policy disables both transport authentication and origin authentication.
+If a service has no matching policies, both transport authentication and
+origin authentication are disabled.
 
 #### Transport authentication
 

--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -444,6 +444,19 @@ only one authentication policy per mesh and one authentication policy per
 namespace. Istio also requires mesh-wide and namespace-wide policies to have
 the specific name `default`.
 
+If a service has no matching policies, the service behaves as if the following
+'empty' policy applies:
+
+{{< text yaml >}}
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "empty-policy"
+spec:
+{{< /text >}}
+
+This disables both transport authentication and origin authentication.
+
 #### Transport authentication
 
 The `peers:` section defines the authentication methods and associated

--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -445,7 +445,7 @@ namespace. Istio also requires mesh-wide and namespace-wide policies to have
 the specific name `default`.
 
 If a service has no matching policies, the service behaves as if the following
-'empty' policy applies:
+`empty-policy` policy applies:
 
 {{< text yaml >}}
 apiVersion: "authentication.istio.io/v1alpha1"
@@ -455,7 +455,7 @@ metadata:
 spec:
 {{< /text >}}
 
-This disables both transport authentication and origin authentication.
+This policy disables both transport authentication and origin authentication.
 
 #### Transport authentication
 


### PR DESCRIPTION
This closes #2542.

Seems like previous attempts to add clarification here were hampered by the specific wording around how the mesh could get into such a state, and introduced complications with Helm charts cf. https://github.com/istio/istio.io/pull/2547

I attempted to phrase this in the most neutral possible manner, and hopefully I actually got the behaviour right? Is this clear, or should we omit the example policy and just state that in the absence of a policy both transport and origin auth are disabled?