### PR TITLE
Add clarity to transport auth section, inc new mode param

### DIFF
--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -474,7 +474,7 @@ peers:
 
 The mutual TLS setting has an optional `mode` parameter that defines the
 strictness of the peer transport authentication. These modes are documented
-in the [Authentication Policy reference document](/docs/reference/config/istio.authentication.v1alpha1/#MutualTls).
+in the [Authentication Policy reference document](/docs/reference/config/istio.authentication.v1alpha1/#MutualTls-Mode).
 
 {{< tip >}}
 The default mutual TLS mode is `STRICT`. Therefore, `mode: STRICT` is equivalent

--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -490,9 +490,6 @@ When you do not specify a mutual TLS mode, peers cannot use transport
 authentication, and Istio rejects mutual TLS connections bound for the sidecar.
 At the application layer, services may still handle their own mutual TLS sessions.
 
-In the future, the mutual TLS setting may carry additional arguments to
-provide different mutual TLS implementations.
-
 #### Origin authentication
 
 The `origins:` section defines authentication methods and associated parameters

--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -477,8 +477,7 @@ strictness of the peer transport authentication. These modes are documented
 in the [Authentication Policy reference document](/docs/reference/config/istio.authentication.v1alpha1/#MutualTls-Mode).
 
 {{< tip >}}
-The default mutual TLS mode is `STRICT`. Therefore, `mode: STRICT` is equivalent
-to all of the following:
+The default mutual TLS mode is `STRICT`. Therefore, `mode: STRICT` is equivalent to all of the following:
 
 - `- mtls: {}`
 - `- mtls:`

--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -462,8 +462,7 @@ The `peers:` section defines the authentication methods and associated
 parameters supported for transport authentication in a policy. The section can
 list more than one method and only one method must be satisfied for the
 authentication to pass. However, as of the Istio 0.7 release, the only
-transport authentication method currently supported is mutual TLS. If you do not
-need transport authentication, skip this section entirely.
+transport authentication method currently supported is mutual TLS.
 
 The following example shows the `peers:` section enabling transport
 authentication using mutual TLS.
@@ -473,10 +472,24 @@ peers:
   - mtls: {}
 {{< /text >}}
 
-Currently, the mutual TLS setting doesn't require any parameters. Hence,
-`-mtls: {}`, `- mtls:` or `- mtls: null` declarations are treated the same. In
-the future, the mutual TLS setting may carry arguments to provide different
-mutual TLS implementations.
+The mutual TLS setting has an optional `mode` parameter that defines the
+strictness of the peer transport authentication:
+
+- `mode: STRICT` enforces that all peers must use mutual TLS. This declaration
+is identical to `-mtls: {}`, `- mtls:` or `- mtls: null`
+
+- `mode: PERMISSIVE` allows peers to use mututal TLS while still allowing
+peers to not use transport authentication. This mode is useful for transitioning
+existing workloads to peer authentication gradually, as it allows interoperation
+between mTLS and plaintext traffic.
+
+If this section is omitted completely, peers may not use transport
+authentication, and mutual TLS connections bound for the sidecar pod
+will be rejected. However clients are free to handle their own mutual
+TLS sessions at the application layer.
+
+In the future, the mutual TLS setting may carry additional arguments to
+provide different mutual TLS implementations.
 
 #### Origin authentication
 

--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -478,10 +478,10 @@ strictness of the peer transport authentication:
 - `mode: STRICT` enforces that all peers must use mutual TLS. This declaration
 is identical to `-mtls: {}`, `- mtls:` or `- mtls: null`
 
-- `mode: PERMISSIVE` allows peers to use mututal TLS while still allowing
+- `mode: PERMISSIVE` allows peers to use mutual TLS while still allowing
 peers to not use transport authentication. This mode is useful for transitioning
 existing workloads to peer authentication gradually, as it allows interoperation
-between mTLS and plaintext traffic.
+between mutual TLS and plaintext traffic.
 
 If this section is omitted completely, peers may not use transport
 authentication, and mutual TLS connections bound for the sidecar pod

--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -473,15 +473,18 @@ peers:
 {{< /text >}}
 
 The mutual TLS setting has an optional `mode` parameter that defines the
-strictness of the peer transport authentication:
+strictness of the peer transport authentication. These modes are documented
+in the [Authentication Policy reference document](/docs/reference/config/istio.authentication.v1alpha1/#MutualTls).
 
-- `mode: STRICT` enforces that all peers must use mutual TLS. This declaration
-is identical to `-mtls: {}`, `- mtls:` or `- mtls: null`
+{{< tip >}}
+The default mutual TLS mode is `STRICT`. Therefore, `mode: STRICT` is equivalent
+to all of the following:
 
-- `mode: PERMISSIVE` allows peers to use mutual TLS while still allowing
-peers to not use transport authentication. This mode is useful for transitioning
-existing workloads to peer authentication gradually, as it allows interoperation
-between mutual TLS and plaintext traffic.
+- `- mtls: {}`
+- `- mtls:`
+- `- mtls: null`
+
+{{< /tip >}}
 
 When you do not specify a mutual TLS mode, peers cannot use transport
 authentication, and Istio rejects mutual TLS connections bound for the sidecar.

--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -476,14 +476,11 @@ The mutual TLS setting has an optional `mode` parameter that defines the
 strictness of the peer transport authentication. These modes are documented
 in the [Authentication Policy reference document](/docs/reference/config/istio.authentication.v1alpha1/#MutualTls-Mode).
 
-{{< tip >}}
 The default mutual TLS mode is `STRICT`. Therefore, `mode: STRICT` is equivalent to all of the following:
 
 - `- mtls: {}`
 - `- mtls:`
 - `- mtls: null`
-
-{{< /tip >}}
 
 When you do not specify a mutual TLS mode, peers cannot use transport
 authentication, and Istio rejects mutual TLS connections bound for the sidecar.

--- a/content/docs/concepts/security/index.md
+++ b/content/docs/concepts/security/index.md
@@ -483,10 +483,9 @@ peers to not use transport authentication. This mode is useful for transitioning
 existing workloads to peer authentication gradually, as it allows interoperation
 between mutual TLS and plaintext traffic.
 
-If this section is omitted completely, peers may not use transport
-authentication, and mutual TLS connections bound for the sidecar pod
-will be rejected. However clients are free to handle their own mutual
-TLS sessions at the application layer.
+When you do not specify a mutual TLS mode, peers cannot use transport
+authentication, and Istio rejects mutual TLS connections bound for the sidecar.
+At the application layer, services may still handle their own mutual TLS sessions.
 
 In the future, the mutual TLS setting may carry additional arguments to
 provide different mutual TLS implementations.


### PR DESCRIPTION
Arguably the wording here before was incorrect, because the mtls
parameter does have an argument, the mode parameter. This documents
STRICT and PERMISSIVE modes, as well as discussing the equivalence
between STRICT mode and omission of the mode key. It also adds clarity
as to what happens when the section is omitted.