### PR TITLE
Title improvements

### DIFF
--- a/content/docs/ops/_index.md
+++ b/content/docs/ops/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Operations Guide
+title: Operations
 description: Hints, tips, tricks about running an Istio mesh.
 weight: 32
 aliases:

--- a/content/docs/setup/kubernetes/_index.md
+++ b/content/docs/setup/kubernetes/_index.md
@@ -1,5 +1,6 @@
 ---
-title: Kubernetes
+title: Installing on Kubernetes
+linktitle: Kubernetes
 description: Instructions for installing the Istio control plane on Kubernetes and adding virtual machines into the mesh.
 weight: 10
 aliases:


### PR DESCRIPTION
- Rename "Operations Guide" to "Operations" so it fits better in the sidebar.

- Rename the main kubernetes install page to "Installing on Kubernetes" rather than
just "Kubernetes" which was a bit odd when landing there. Links to the page in the
sidebar and elsewhere still say "Kubernetes" since these usually appear in context.