### PR TITLE
Update prep doc for IBM

### DIFF
--- a/content/docs/setup/kubernetes/platform-setup/ibm/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/ibm/index.md
@@ -45,7 +45,7 @@ You can install Istio in [IBM Cloud Public](#ibm-cloud-public) by using the [Man
 
 Instead of using Helm to install Istio, you can enable the managed Istio add-on in your cluster. Istio on IBM Cloud Kubernetes Service provides a seamless installation of Istio, automatic updates and lifecycle management of Istio control plane components, and integration with platform logging and monitoring tools. With one click, you can get all Istio core components, additional tracing, monitoring, and visualization, and the Bookinfo sample app up and running. Istio on IBM Cloud Kubernetes Service is offered as a managed add-on, so IBM Cloud automatically keeps all your Istio components up to date.
 
-To install the managed Istio add-on in IBM Cloud Public, see the [IBM Cloud Kubernetes Service documentation](https://cloud.ibm.com/docs/containers/cs_istio.html).
+To install the managed Istio add-on in IBM Cloud Public, see the [IBM Cloud Kubernetes Service documentation](https://cloud.ibm.com/docs/containers?topic=containers-istio).
 
 ## IBM Cloud Private
 

--- a/content/docs/setup/kubernetes/platform-setup/ibm/index.md
+++ b/content/docs/setup/kubernetes/platform-setup/ibm/index.md
@@ -10,13 +10,7 @@ keywords: [platform-setup,ibm,iks]
 
 Follow these instructions to prepare an IBM Cloud cluster for Istio.
 
-You can use the [Managed Istio add-on for IBM Cloud Kubernetes Service](#managed-istio-add-on) in IBM Cloud Public, use Helm to install Istio in [IBM Cloud Public](#ibm-cloud-public), or install Istio in [IBM Cloud Private](#ibm-cloud-private).
-
-## Managed Istio add-on
-
-Istio on IBM Cloud Kubernetes Service provides a seamless installation of Istio, automatic updates and lifecycle management of Istio control plane components, and integration with platform logging and monitoring tools. With one click, you can get all Istio core components, additional tracing, monitoring, and visualization, and the Bookinfo sample app up and running. Istio on IBM Cloud Kubernetes Service is offered as a managed add-on, so IBM Cloud automatically keeps all your Istio components up to date.
-
-To install the managed Istio add-on in IBM Cloud Public, see the [IBM Cloud Kubernetes Service documentation](https://cloud.ibm.com/docs/containers/cs_istio.html).
+You can install Istio in [IBM Cloud Public](#ibm-cloud-public) by using the [Managed Istio add-on for IBM Cloud Kubernetes Service](#managed-istio-add-on) or Helm, or install Istio in [IBM Cloud Private](#ibm-cloud-private) by using Helm.
 
 ## IBM Cloud Public
 
@@ -25,11 +19,11 @@ To install the managed Istio add-on in IBM Cloud Public, see the [IBM Cloud Kube
 1. Create a standard Kubernetes cluster. Replace `<cluster-name>` with the name of the cluster you want to use in the following instructions.
 
     {{< tip >}}
-    To see available zones, run `ibmcloud ks zones`. Zones are isolated from each other, which ensures no shared single point of failure. IBM Cloud Kubernetes Service [Regions and zones](https://cloud.ibm.com/docs/containers?topic=containers-regions-and-zones) describes regions, zones, and how to specify the region and zone for your new cluster.
+    To see available zones, run `ibmcloud ks zones`. Zones are isolated from each other, which ensures no shared single point of failure. IBM Cloud Kubernetes Service [Locations](https://cloud.ibm.com/docs/containers?topic=containers-regions-and-zones) describes available zones and how to specify the zone for your new cluster.
     {{< /tip >}}
 
     {{< tip >}}
-    The command below does not contain the `--private-vlan value` and `--public-vlan value` options. To see available VLANs, run `ibmcloud ks vlan-ls --zone <zone-name>`. If you do not have a private and public VLAN yet, they will be automatically created for you. If you already have VLANs, they need to be specified using the `--private-vlan value` and `--public-vlan value` options.
+    The command below does not contain the `--private-vlan value` and `--public-vlan value` options. To see available VLANs, run `ibmcloud ks vlans --zone <zone-name>`. If you do not have a private and public VLAN yet, they will be automatically created for you. If you already have VLANs, specify them by using the `--private-vlan value` and `--public-vlan value` options.
     {{< /tip >}}
 
     {{< text bash >}}
@@ -43,9 +37,15 @@ To install the managed Istio add-on in IBM Cloud Public, see the [IBM Cloud Kube
     $(ibmcloud ks cluster-config <cluster-name> --export)
     {{< /text >}}
 
-{{< warning >}}
-Make sure to use the `kubectl` CLI version that matches the Kubernetes version of your cluster.
-{{< /warning >}}
+    {{< warning >}}
+    Make sure to use the `kubectl` CLI version that matches the Kubernetes version of your cluster.
+    {{< /warning >}}
+
+### Managed Istio add-on
+
+Instead of using Helm to install Istio, you can enable the managed Istio add-on in your cluster. Istio on IBM Cloud Kubernetes Service provides a seamless installation of Istio, automatic updates and lifecycle management of Istio control plane components, and integration with platform logging and monitoring tools. With one click, you can get all Istio core components, additional tracing, monitoring, and visualization, and the Bookinfo sample app up and running. Istio on IBM Cloud Kubernetes Service is offered as a managed add-on, so IBM Cloud automatically keeps all your Istio components up to date.
+
+To install the managed Istio add-on in IBM Cloud Public, see the [IBM Cloud Kubernetes Service documentation](https://cloud.ibm.com/docs/containers/cs_istio.html).
 
 ## IBM Cloud Private
 


### PR DESCRIPTION
- Move Managed Istio add-on section into IBM Cloud Public section
- Update name of docs pages in the IKS doc set and remove region-specific text (regions are being deprecated; zones now only)
- Update cli command