### PR TITLE
Remove GDB documentation

### DIFF
--- a/content/docs/ops/component-debugging/index.md
+++ b/content/docs/ops/component-debugging/index.md
@@ -58,18 +58,6 @@ $ istioctl proxy-config endpoints <pod-name> [flags]
 
 See [Debugging Envoy and Pilot](/docs/ops/traffic-management/proxy-cmd/) for more advice on interpreting this information.
 
-## With GDB
-
-To debug Istio with `gdb`, you will need to run the debug images of Envoy / Mixer / Pilot. A recent `gdb` and the golang extensions (for Mixer/Pilot or other golang components) is required.
-
-1. `kubectl exec -it PODNAME -c [proxy | mixer | pilot]`
-
-1. Find process ID: ps ax
-
-1. gdb -p PID binary
-
-1. For go: info goroutines, goroutine x bt
-
 ## With Tcpdump
 
 Tcpdump doesn't work in the sidecar pod - the container doesn't run as root. However any other container in the same pod will see all the packets, since the


### PR DESCRIPTION
GDB is no longer shipped in the containers.  Whether it should be or not
is not relevant for 1.2 (its too late to add GDB to 1.2).  Remove
GDB from the documentaiton.  We don't really expect operators would
use GDB in production.  If GDB were reintroduced to the containers,
it may make sense to document GDB in the developer wiki.

Fixes: #4361