### PR TITLE
Fix doc 'istioctl apply' -> 'kubectl apply'

### DIFF
--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -105,7 +105,7 @@ The output shows:
 To illustrate the case when there are conflicts, add a service-specific destination rule for `httpbin` with incorrect TLS mode:
 
 {{< text bash >}}
-$ cat <<EOF | istioctl apply -f -
+$ cat <<EOF | kubectl apply -f -
 apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:


### PR DESCRIPTION
Example of code in documentation ask to execute the command `istioctl apply` but it has to be `kubectl apply`