### PR TITLE
fix the egress gateway example for multi cluster gateways

### DIFF
--- a/content/docs/tasks/multicluster/gateways/index.md
+++ b/content/docs/tasks/multicluster/gateways/index.md
@@ -144,9 +144,10 @@ use the following service entry for `httpbin.bar` instead of the one in the prev
 
 {{< tip >}}
 The egress gateway used in this configuration cannot also be used for other, non inter-cluster, egress traffic.
+{{< /tip >}}
+
 
 If `$CLUSTER2_GW_ADDR` is an IP address, use the `$CLUSTER2_GW_ADDR - IP address` option.  If `$CLUSTER2_GW_ADDR` is a hostname, use the `$CLUSTER2_GW_ADDR - hostname` option.
-{{< /tip >}}
 
 {{< tabset cookie-name="profile" >}}
 

--- a/content/docs/tasks/multicluster/gateways/index.md
+++ b/content/docs/tasks/multicluster/gateways/index.md
@@ -145,19 +145,21 @@ use the following service entry for `httpbin.bar` instead of the one in the prev
 {{< tip >}}
 The egress gateway used in this configuration cannot also be used for other, non inter-cluster, egress traffic.
 
-If $CLUSTER2_GW_ADDR is an IP address, use the `$CLUSTER2_GW_ADDR - IP address` option.  If $CLUSTER2_GW_ADDR is a hostname, use the `$CLUSTER2_GW_ADDR - hostname` option.
+If `$CLUSTER2_GW_ADDR` is an IP address, use the `$CLUSTER2_GW_ADDR - IP address` option.  If `$CLUSTER2_GW_ADDR` is a hostname, use the `$CLUSTER2_GW_ADDR - hostname` option.
 {{< /tip >}}
 
 {{< tabset cookie-name="profile" >}}
 
 {{< tab name="$CLUSTER2_GW_ADDR - IP address" cookie-value="option1" >}}
 * Export the `cluster1` egress gateway address:
+
 {{< text bash >}}
 $ export CLUSTER1_EGW_ADDR=$(kubectl get --context=$CTX_CLUSTER1 svc --selector=app=istio-egressgateway \
     -n istio-system -o yaml -o jsonpath='{.items[0].spec.clusterIP}')
 {{< /text >}}
 
 * Apply the httpbin-bar service entry:
+
 {{< text bash >}}
 $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
@@ -186,10 +188,12 @@ spec:
       http1: 15443
 EOF
 {{< /text >}}
+
 {{< /tab >}}
 
 {{< tab name="$CLUSTER2_GW_ADDR - hostname" cookie-value="option2" >}}
 If the `${CLUSTER2_GW_ADDR}` is a hostname, you can use `resolution: DNS` for the endpoint resolution: 
+
 {{< text bash >}}
 $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
@@ -217,7 +221,8 @@ spec:
     ports:
       http1: 15443
 EOF
-{{< /text >}}    
+{{< /text >}}
+
 {{< /tab >}}
 
 {{< /tabset >}}

--- a/content/docs/tasks/multicluster/gateways/index.md
+++ b/content/docs/tasks/multicluster/gateways/index.md
@@ -152,7 +152,7 @@ If $CLUSTER2_GW_ADDR is an IP address, use option 1.  If $CLUSTER2_GW_ADDR is a 
 {{< tab name="Option 1" cookie-value="option1" >}}
 * Export the `cluster1` egress gateway address:
 {{< text bash >}}
-export CLUSTER1_EGW_ADDR=$(kubectl get --context=$CTX_CLUSTER1 svc --selector=app=istio-egressgateway \
+$ export CLUSTER1_EGW_ADDR=$(kubectl get --context=$CTX_CLUSTER1 svc --selector=app=istio-egressgateway \
     -n istio-system -o yaml -o jsonpath='{.items[0].spec.clusterIP}')
 {{< /text >}}
 

--- a/content/docs/tasks/multicluster/gateways/index.md
+++ b/content/docs/tasks/multicluster/gateways/index.md
@@ -139,42 +139,79 @@ running in a second cluster.
 
 ## Send remote cluster traffic using egress gateway
 
-If you want to route traffic from `cluster1` via a dedicated
-egress gateway, instead of directly from the sidecars,
+If you want to route traffic from `cluster1` via a dedicated egress gateway, instead of directly from the sidecars,
 use the following service entry for `httpbin.bar` instead of the one in the previous section.
 
 {{< tip >}}
 The egress gateway used in this configuration cannot also be used for other, non inter-cluster, egress traffic.
 {{< /tip >}}
 
-{{< text bash >}}
-$ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
-kind: ServiceEntry
-metadata:
-  name: httpbin-bar
-spec:
-  hosts:
-  # must be of form name.namespace.global
-  - httpbin.bar.global
-  location: MESH_INTERNAL
-  ports:
-  - name: http1
-    number: 8000
-    protocol: http
-  resolution: DNS
-  addresses:
-  - 127.255.0.2
-  endpoints:
-  - address: ${CLUSTER2_GW_ADDR}
-    network: external
-    ports:
-      http1: 15443 # Do not change this port value
-  - address: istio-egressgateway.istio-system.svc.cluster.local
-    ports:
-      http1: 15443
-EOF
-{{< /text >}}
+1. Export the `cluster1` egress gateway address:
+    {{< text bash >}}
+    export CLUSTER1_EGW_ADDR=$(kubectl get --context=$CTX_CLUSTER1 svc --selector=app=istio-egressgateway \
+        -n istio-system -o yaml -o jsonpath='{.items[0].spec.clusterIP}')
+    {{< /text >}}
+
+1. Apply the httpbin-bar service entry:
+    {{< text bash >}}
+    $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
+    apiVersion: networking.istio.io/v1alpha3
+    kind: ServiceEntry
+    metadata:
+      name: httpbin-bar
+    spec:
+      hosts:
+      # must be of form name.namespace.global
+      - httpbin.bar.global
+      location: MESH_INTERNAL
+      ports:
+      - name: http1
+        number: 8000
+        protocol: http
+      resolution: STATIC
+      addresses:
+      - 127.255.0.2
+      endpoints:
+      - address: ${CLUSTER2_GW_ADDR}
+        network: external
+        ports:
+          http1: 15443 # Do not change this port value
+      - address: ${CLUSTER1_EGW_ADDR}
+        ports:
+          http1: 15443
+    EOF
+    {{< /text >}}
+    
+    If the `${CLUSTER2_GW_ADDR}` is a hostname, you can use `resolution: DNS` for the endpoint resolution: 
+    {{< text bash >}}
+    $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
+    apiVersion: networking.istio.io/v1alpha3
+    kind: ServiceEntry
+    metadata:
+      name: httpbin-bar
+    spec:
+      hosts:
+      # must be of form name.namespace.global
+      - httpbin.bar.global
+      location: MESH_INTERNAL
+      ports:
+      - name: http1
+        number: 8000
+        protocol: http
+      resolution: DNS
+      addresses:
+      - 127.255.0.2
+      endpoints:
+      - address: ${CLUSTER2_GW_ADDR}
+        network: external
+        ports:
+          http1: 15443 # Do not change this port value
+      - address: istio-egressgateway.istio-system.svc.cluster.local
+        ports:
+          http1: 15443
+    EOF
+    {{< /text >}}    
+    
 
 ## Version-aware routing to remote services
 

--- a/content/docs/tasks/multicluster/gateways/index.md
+++ b/content/docs/tasks/multicluster/gateways/index.md
@@ -144,12 +144,13 @@ use the following service entry for `httpbin.bar` instead of the one in the prev
 
 {{< tip >}}
 The egress gateway used in this configuration cannot also be used for other, non inter-cluster, egress traffic.
-If $CLUSTER2_GW_ADDR is an IP address, use option 1.  If $CLUSTER2_GW_ADDR is a host name, use option 2.
+
+If $CLUSTER2_GW_ADDR is an IP address, use the `$CLUSTER2_GW_ADDR - IP address` option.  If $CLUSTER2_GW_ADDR is a hostname, use the `$CLUSTER2_GW_ADDR - hostname` option.
 {{< /tip >}}
 
 {{< tabset cookie-name="profile" >}}
 
-{{< tab name="Option 1" cookie-value="option1" >}}
+{{< tab name="$CLUSTER2_GW_ADDR - IP address" cookie-value="option1" >}}
 * Export the `cluster1` egress gateway address:
 {{< text bash >}}
 $ export CLUSTER1_EGW_ADDR=$(kubectl get --context=$CTX_CLUSTER1 svc --selector=app=istio-egressgateway \
@@ -187,7 +188,7 @@ EOF
 {{< /text >}}
 {{< /tab >}}
 
-{{< tab name="Option 2" cookie-value="option2" >}}
+{{< tab name="$CLUSTER2_GW_ADDR - hostname" cookie-value="option2" >}}
 If the `${CLUSTER2_GW_ADDR}` is a hostname, you can use `resolution: DNS` for the endpoint resolution: 
 {{< text bash >}}
 $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF

--- a/content/docs/tasks/multicluster/gateways/index.md
+++ b/content/docs/tasks/multicluster/gateways/index.md
@@ -150,13 +150,13 @@ If $CLUSTER2_GW_ADDR is an IP address, use option 1.  If $CLUSTER2_GW_ADDR is a 
 {{< tabset cookie-name="profile" >}}
 
 {{< tab name="Option 1" cookie-value="option1" >}}
-1. Export the `cluster1` egress gateway address:
+* Export the `cluster1` egress gateway address:
 {{< text bash >}}
 export CLUSTER1_EGW_ADDR=$(kubectl get --context=$CTX_CLUSTER1 svc --selector=app=istio-egressgateway \
     -n istio-system -o yaml -o jsonpath='{.items[0].spec.clusterIP}')
 {{< /text >}}
 
-1. Apply the httpbin-bar service entry:
+* Apply the httpbin-bar service entry:
 {{< text bash >}}
 $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3
@@ -185,11 +185,9 @@ spec:
       http1: 15443
 EOF
 {{< /text >}}
-
 {{< /tab >}}
 
 {{< tab name="Option 2" cookie-value="option2" >}}
-
 If the `${CLUSTER2_GW_ADDR}` is a hostname, you can use `resolution: DNS` for the endpoint resolution: 
 {{< text bash >}}
 $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
@@ -219,7 +217,6 @@ spec:
       http1: 15443
 EOF
 {{< /text >}}    
-    
 {{< /tab >}}
 
 {{< /tabset >}}

--- a/content/docs/tasks/multicluster/gateways/index.md
+++ b/content/docs/tasks/multicluster/gateways/index.md
@@ -144,75 +144,84 @@ use the following service entry for `httpbin.bar` instead of the one in the prev
 
 {{< tip >}}
 The egress gateway used in this configuration cannot also be used for other, non inter-cluster, egress traffic.
+If $CLUSTER2_GW_ADDR is an IP address, use option 1.  If $CLUSTER2_GW_ADDR is a host name, use option 2.
 {{< /tip >}}
 
+{{< tabset cookie-name="profile" >}}
+
+{{< tab name="Option 1" cookie-value="option1" >}}
 1. Export the `cluster1` egress gateway address:
-    {{< text bash >}}
-    export CLUSTER1_EGW_ADDR=$(kubectl get --context=$CTX_CLUSTER1 svc --selector=app=istio-egressgateway \
-        -n istio-system -o yaml -o jsonpath='{.items[0].spec.clusterIP}')
-    {{< /text >}}
+{{< text bash >}}
+export CLUSTER1_EGW_ADDR=$(kubectl get --context=$CTX_CLUSTER1 svc --selector=app=istio-egressgateway \
+    -n istio-system -o yaml -o jsonpath='{.items[0].spec.clusterIP}')
+{{< /text >}}
 
 1. Apply the httpbin-bar service entry:
-    {{< text bash >}}
-    $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
-    kind: ServiceEntry
-    metadata:
-      name: httpbin-bar
-    spec:
-      hosts:
-      # must be of form name.namespace.global
-      - httpbin.bar.global
-      location: MESH_INTERNAL
-      ports:
-      - name: http1
-        number: 8000
-        protocol: http
-      resolution: STATIC
-      addresses:
-      - 127.255.0.2
-      endpoints:
-      - address: ${CLUSTER2_GW_ADDR}
-        network: external
-        ports:
-          http1: 15443 # Do not change this port value
-      - address: ${CLUSTER1_EGW_ADDR}
-        ports:
-          http1: 15443
-    EOF
-    {{< /text >}}
-    
-    If the `${CLUSTER2_GW_ADDR}` is a hostname, you can use `resolution: DNS` for the endpoint resolution: 
-    {{< text bash >}}
-    $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
-    kind: ServiceEntry
-    metadata:
-      name: httpbin-bar
-    spec:
-      hosts:
-      # must be of form name.namespace.global
-      - httpbin.bar.global
-      location: MESH_INTERNAL
-      ports:
-      - name: http1
-        number: 8000
-        protocol: http
-      resolution: DNS
-      addresses:
-      - 127.255.0.2
-      endpoints:
-      - address: ${CLUSTER2_GW_ADDR}
-        network: external
-        ports:
-          http1: 15443 # Do not change this port value
-      - address: istio-egressgateway.istio-system.svc.cluster.local
-        ports:
-          http1: 15443
-    EOF
-    {{< /text >}}    
-    
+{{< text bash >}}
+$ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: httpbin-bar
+spec:
+  hosts:
+  # must be of form name.namespace.global
+  - httpbin.bar.global
+  location: MESH_INTERNAL
+  ports:
+  - name: http1
+    number: 8000
+    protocol: http
+  resolution: STATIC
+  addresses:
+  - 127.255.0.2
+  endpoints:
+  - address: ${CLUSTER2_GW_ADDR}
+    network: external
+    ports:
+      http1: 15443 # Do not change this port value
+  - address: ${CLUSTER1_EGW_ADDR}
+    ports:
+      http1: 15443
+EOF
+{{< /text >}}
 
+{{< /tab >}}
+
+{{< tab name="Option 2" cookie-value="option2" >}}
+
+If the `${CLUSTER2_GW_ADDR}` is a hostname, you can use `resolution: DNS` for the endpoint resolution: 
+{{< text bash >}}
+$ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: httpbin-bar
+spec:
+  hosts:
+  # must be of form name.namespace.global
+  - httpbin.bar.global
+  location: MESH_INTERNAL
+  ports:
+  - name: http1
+    number: 8000
+    protocol: http
+  resolution: DNS
+  addresses:
+  - 127.255.0.2
+  endpoints:
+  - address: ${CLUSTER2_GW_ADDR}
+    network: external
+    ports:
+      http1: 15443 # Do not change this port value
+  - address: istio-egressgateway.istio-system.svc.cluster.local
+    ports:
+      http1: 15443
+EOF
+{{< /text >}}    
+    
+{{< /tab >}}
+    
 ## Version-aware routing to remote services
 
 If the remote service has multiple versions, you can add

--- a/content/docs/tasks/multicluster/gateways/index.md
+++ b/content/docs/tasks/multicluster/gateways/index.md
@@ -192,7 +192,7 @@ EOF
 {{< /tab >}}
 
 {{< tab name="$CLUSTER2_GW_ADDR - hostname" cookie-value="option2" >}}
-If the `${CLUSTER2_GW_ADDR}` is a hostname, you can use `resolution: DNS` for the endpoint resolution: 
+If the `${CLUSTER2_GW_ADDR}` is a hostname, you can use `resolution: DNS` for the endpoint resolution:
 
 {{< text bash >}}
 $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF

--- a/content/docs/tasks/multicluster/gateways/index.md
+++ b/content/docs/tasks/multicluster/gateways/index.md
@@ -221,7 +221,9 @@ EOF
 {{< /text >}}    
     
 {{< /tab >}}
-    
+
+{{< /tabset >}}
+
 ## Version-aware routing to remote services
 
 If the remote service has multiple versions, you can add

--- a/content/docs/tasks/multicluster/gateways/index.md
+++ b/content/docs/tasks/multicluster/gateways/index.md
@@ -146,7 +146,6 @@ use the following service entry for `httpbin.bar` instead of the one in the prev
 The egress gateway used in this configuration cannot also be used for other, non inter-cluster, egress traffic.
 {{< /tip >}}
 
-
 If `$CLUSTER2_GW_ADDR` is an IP address, use the `$CLUSTER2_GW_ADDR - IP address` option.  If `$CLUSTER2_GW_ADDR` is a hostname, use the `$CLUSTER2_GW_ADDR - hostname` option.
 
 {{< tabset cookie-name="profile" >}}


### PR DESCRIPTION
need to change static because one address was host the other was ip.

It is possible (non-default scenario when not following our example) that the cluster2_gw_addr is a hostname so added a note for that too.