### PR TITLE
revise doc

### DIFF
--- a/content/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -302,7 +302,7 @@ You can configure an ingress gateway for multiple hosts,
 `httpbin.example.com` and `helloworld-v1.example.com`, for example. The ingress gateway
 retrieves unique credentials corresponding to a specific `credentialName`.
 
-1.  Restore credentials for httpbin by deleting its secret and creating again.
+1.  To restore the credentials for `httpbin`, delete its secret and create it again.
 
     {{< text bash >}}
     $ kubectl -n istio-system delete secret httpbin-credential

--- a/content/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -302,6 +302,15 @@ You can configure an ingress gateway for multiple hosts,
 `httpbin.example.com` and `helloworld-v1.example.com`, for example. The ingress gateway
 retrieves unique credentials corresponding to a specific `credentialName`.
 
+1.  Restore credentials for httpbin by deleting its secret and creating again.
+
+    {{< text bash >}}
+    $ kubectl -n istio-system delete secret httpbin-credential
+    $ kubectl create -n istio-system secret generic httpbin-credential \
+    --from-file=key=httpbin.example.com/3_application/private/httpbin.example.com.key.pem \
+    --from-file=cert=httpbin.example.com/3_application/certs/httpbin.example.com.cert.pem
+    {{< /text >}}
+
 1.  Start the `helloworld-v1` sample
 
     {{< text bash >}}


### PR DESCRIPTION
In the Ingress SDS user guide, the first section introduces how to create a k8s secret to provide key/cert for httpbin gateway, and then replace the key/cert by deleting and creating a new k8s secret. The second section assumes the ingress gateway is using the original key/cert, not the new one. 

Add a missing step which restores the original key/cert for httpbin at the beginning of the second section.