### PR TITLE
Fix authn-policy task: add missing cleanup and a dependent lib

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -263,6 +263,7 @@ jason
 Jog
 json
 JSON-formatted
+jwcrypto
 JWT
 jwt.io
 JWTs

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -591,8 +591,10 @@ You also need the `key.pem` file:
 $ wget {{< github_file >}}/security/tools/jwt/samples/key.pem
 {{< /text >}}
 
-You may also need to download the [jwcrypto](https://pypi.org/project/jwcrypto) library,
-if it is not already present on your system.
+{{< tip >}}
+Download the [jwcrypto](https://pypi.org/project/jwcrypto) library,
+if you haven't installed it on your system.
+{{< /tip >}}
 
 For example, the command below creates a token that
 expires in 5 seconds. As you see, Istio authenticates requests using that token successfully at first but rejects them after 5 seconds:

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -591,6 +591,9 @@ You also need the `key.pem` file:
 $ wget {{< github_file >}}/security/tools/jwt/samples/key.pem
 {{< /text >}}
 
+You may also need to download the [jwcrypto](https://pypi.org/project/jwcrypto) library,
+if it is not already present on your system.
+
 For example, the command below creates a token that
 expires in 5 seconds. As you see, Istio authenticates requests using that token successfully at first but rejects them after 5 seconds:
 

--- a/content/docs/tasks/security/authn-policy/index.md
+++ b/content/docs/tasks/security/authn-policy/index.md
@@ -266,6 +266,7 @@ Remove global authentication policy and destination rules added in the session:
 $ kubectl delete meshpolicy default
 $ kubectl delete destinationrules httpbin-legacy -n legacy
 $ kubectl delete destinationrules api-server -n istio-system
+$ kubectl delete destinationrules default -n istio-system
 {{< /text >}}
 
 ## Enable mutual TLS per namespace or service


### PR DESCRIPTION
1. 
add missing cleanup step for authn policy task section 1
The "*.local" rule created in "Globally enabling Istio mutual TLS"
was not removed during the cleanup section, leading to unexpected
503s for users continuing on to the next section (enabling
per-namespace).

2. 
Note that jwcrypto needs to be present to run gen_jwt.py

Note that both of these are based on the live release & docs, so I'm guessing we probably want to backport this into the 1.1 branch? 