### PR TITLE
Clarify support for alpha features

### DIFF
--- a/content/about/feature-stages/index.md
+++ b/content/about/feature-stages/index.md
@@ -23,10 +23,11 @@ within the project, not to the project as a whole. Here is a high level descript
 
 |            | Alpha      | Beta         | Stable
 |-------------------|-------------------|-------------------|-------------------
-|   **Purpose**         | Demo-able, works end-to-end but has limitations     | Usable in production, not a toy anymore         | Dependable, production hardened
+|   **Purpose**         | Demo-able, works end-to-end but has limitations.  If you use it in production and encounter a serious issue we may not be able to fix it for you, so be sure that you can continue to function if you have to disable it | Usable in production, not a toy anymore | Dependable, production hardened
 |   **API**         | No guarantees on backward compatibility    | APIs are versioned         | Dependable, production-worthy. APIs are versioned, with automated version conversion for backward compatibility
 |  **Performance**         | Not quantified or guaranteed     | Not quantified or guaranteed         | Performance (latency/scale) is quantified, documented, with guarantees against regression
 |   **Deprecation Policy**        | None     | Weak - 3 months         | Dependable,  Firm. 1 year notice will be provided before changes
+| **Security** | Security vulnerabilities will be handled publicly as simple bug fixes | Security vulnerabilities will be handled according to our [security vulnerability policy](/about/security-vulnerabilities/) | Security vulnerabilities will be handled according to our [security vulnerability policy](/about/security-vulnerabilities/)
 
 ## Istio features
 


### PR DESCRIPTION
I'd like to make it clear that if you use alpha features in production...

1) You must be able to disable it and still work (we can't stabilize it for you in production)
2) Discovered security vulnerabilities will be handled publicly as simple bug fixes (we won't invoke our full blown security process because that's a lot of work)