### PR TITLE
Fix Hugo page generation issue.

### DIFF
--- a/content/docs/concepts/traffic-management/routing/destination-rules/index.md
+++ b/content/docs/concepts/traffic-management/routing/destination-rules/index.md
@@ -6,9 +6,10 @@ keywords: [traffic-management, destination-rule, service-subset, load-balancing]
 ---
 
 You specify the path for traffic with routing rules, and then you use
-[destination rules](/docs/reference/config/networking/v1alpha3/destination-rule/) to configure the set of policies that Envoy proxies apply
-to a request at a specific destination. Destination rules are applied after the
-routing rules are evaluated.
+[destination rules](/docs/reference/config/networking/v1alpha3/destination-rule/)
+to configure the set of policies that Envoy proxies apply to a request at a
+specific destination. Destination rules are applied after the routing rules are
+evaluated.
 
 Configurations you set in destination rules apply to traffic that you route
 through your platform's basic connectivity. You can use wildcard prefixes in a
@@ -23,7 +24,8 @@ service versions.
 You specify explicit routing rules to service subsets. This model allows you
 to:
 
-- Cleanly refer to a specific service version across different [virtual services](/docs/concepts/traffic-management/routing/virtual-services/).
+- Cleanly refer to a specific service version across different
+    [virtual services](/docs/concepts/traffic-management/routing/virtual-services/).
 
 - Simplify the stats that the Istio proxies emit.
 
@@ -60,18 +62,19 @@ spec:
 {{< /text >}}
 
 As shown above, you can specify multiple policies in a single destination rule.
-In this example, the default policy is defined above the `subsets` field. The
-`v2` specific policy is defined in the corresponding subset's field. The
-following diagram shows how the different configurations in the
-`my-destination-rule` destination rule and in the routing rules in `my-vtl-svc`
-virtual service would apply to the traffic to and from the `my-svc` service:
+In this example, the default policy is defined above the subsets field. The `v2`
+specific policy is defined in the corresponding subset's field. The following
+diagram shows how the different configurations in the `my-destination-rule`
+destination rule and in the routing rules in `my-vtl-svc` virtual service would
+apply to the traffic to and from the `my-svc` service:
 
 {{< image width="40%"
     link="./destination-rules-1.svg"
     caption="Configurable route examples defined in the destination rule"
     >}}
 
-Visit our [destination rules reference documentation](/docs/reference/config/networking/v1alpha3/destination-rule/) to review all the enabled keys and values.
+Visit our [destination rules reference documentation](/docs/reference/config/networking/v1alpha3/destination-rule/)
+to review all the enabled keys and values.
 
 ## Service subsets
 


### PR DESCRIPTION
Having back-ticks at the beginning of the lines was causing Hugo not to generate
the pages at build time at random. Moved the content with back-ticks away from the start of
the lines seems to fix the issue.

Signed-off-by: rcaballeromx <grca@google.com>