### PR TITLE
Minor cleanup of enabling-policy and rate-limiting for clarity

### DIFF
--- a/content/docs/tasks/policy-enforcement/enabling-policy/index.md
+++ b/content/docs/tasks/policy-enforcement/enabling-policy/index.md
@@ -24,7 +24,7 @@ which enables policy checks by default.
     disablePolicyChecks: true
     {{< /text >}}
 
-    If policy enforcement is enabled, no further action is needed.
+    If policy enforcement is enabled (`disablePolicyChecks` is false), no further action is needed.
 
 1. Edit the `istio` configmap to enable policy checks.
 

--- a/content/docs/tasks/policy-enforcement/rate-limiting/index.md
+++ b/content/docs/tasks/policy-enforcement/rate-limiting/index.md
@@ -170,10 +170,15 @@ In a realistic scenario you may use a `jwt` token for this purpose.
 
 You can update the `quota rule` by adding a match condition based on the `cookie`.
 
-{{< text yaml >}}
+{{< text bash >}}
 $ kubectl -n istio-system edit rules quota
+{{< /text >}}
+
+{{< text yaml >}}
 ...
+spec:
   match: match(request.headers["cookie"], "session=*") == false
+  actions:
 ...
 {{< /text >}}
 


### PR DESCRIPTION
1. In rate-limiting: clean up the command for editing rules to clarify the difference between the command and the line to add. Also add a bit of context to make it clear where it goes.
2. In enabling-policy: clarify a confusing double-negative situation. 