### PR TITLE
Document commands for running Kiali on OpenShift

### DIFF
--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -98,18 +98,16 @@ $ kubectl apply -f $HOME/istio.yaml
 
 Once you install Istio and Kiali, deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
 
-### Running On OpenShift
+### Running on OpenShift
 
-When Kiali runs on OpenShift it needs access to some OpenShift specific resources in order to function properly.
-
-The following commands need to be run after Kiali has been installed to allow this access:
+When Kiali runs on OpenShift it needs access to some OpenShift specific resources in order to function properly,
+which can be done using the following commands after Kiali has been installed:
 
 {{< text bash >}}
 $ oc patch clusterrole kiali -p '[{"op":"add", "path":"/rules/-", "value":{"apiGroups":["apps.openshift.io"], "resources":["deploymentconfigs"],"verbs": ["get", "list", "watch"]}}]' --type json
 $ oc patch clusterrole kiali -p '[{"op":"add", "path":"/rules/-", "value":{"apiGroups":["project.openshift.io"], "resources":["projects"],"verbs": ["get"]}}]' --type json
 $ oc patch clusterrole kiali -p '[{"op":"add", "path":"/rules/-", "value":{"apiGroups":["route.openshift.io"], "resources":["routes"],"verbs": ["get"]}}]' --type json
 {{< /text >}}
-
 
 ## Generating a service graph
 

--- a/content/docs/tasks/telemetry/kiali/index.md
+++ b/content/docs/tasks/telemetry/kiali/index.md
@@ -98,6 +98,19 @@ $ kubectl apply -f $HOME/istio.yaml
 
 Once you install Istio and Kiali, deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
 
+### Running On OpenShift
+
+When Kiali runs on OpenShift it needs access to some OpenShift specific resources in order to function properly.
+
+The following commands need to be run after Kiali has been installed to allow this access:
+
+{{< text bash >}}
+$ oc patch clusterrole kiali -p '[{"op":"add", "path":"/rules/-", "value":{"apiGroups":["apps.openshift.io"], "resources":["deploymentconfigs"],"verbs": ["get", "list", "watch"]}}]' --type json
+$ oc patch clusterrole kiali -p '[{"op":"add", "path":"/rules/-", "value":{"apiGroups":["project.openshift.io"], "resources":["projects"],"verbs": ["get"]}}]' --type json
+$ oc patch clusterrole kiali -p '[{"op":"add", "path":"/rules/-", "value":{"apiGroups":["route.openshift.io"], "resources":["routes"],"verbs": ["get"]}}]' --type json
+{{< /text >}}
+
+
 ## Generating a service graph
 
 1.  To verify the service is running in your cluster, run the following command:


### PR DESCRIPTION
Kiali installed on OpenShift using the Istio installers will cause Kiali to not function properly. This is due to Kiali missing permission to access some OpenShift specific resources.

This PR adds to the documentation what commands are needed in order to grant Kiali these permissions.