### PR TITLE
Clarify sds install profile

### DIFF
--- a/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
@@ -53,16 +53,15 @@ The components marked as **X** are installed within each profile:
 Some profiles have an authentication variant, with `-auth` appended to the name, which adds the following
 security features to the profile:
 
+{{< tip >}}
+Control plane security with SDS is planned for an upcoming release.
+{{< /tip >}}
+
 | | default | demo | minimal | sds-auth |
 | --- | --- | --- | --- | --- |
 | Control Plane Security | | X | | |
 | Strict Mutual TLS | | X | | X |
 | SDS | | | | X |
-
-{{< tip >}}
-Control plan security still requires the use of secret volume mounts, and is therefore
-incompatible with SDS.
-{{< /tip >}}
 
 To further customize Istio and install addons, you can add one or more `--set <key>=<value>` options in the `helm template` or `helm install` command that you use when installing Istio. The [Installation Options](/docs/reference/config/installation-options/) lists the complete set of supported installation key and value pairs.
 

--- a/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
@@ -57,11 +57,11 @@ security features to the profile:
 Control plane security with SDS is planned for an upcoming release.
 {{< /tip >}}
 
-| | default | demo | minimal | sds-auth |
-| --- | --- | --- | --- | --- |
-| Control Plane Security | | X | | |
-| Strict Mutual TLS | | X | | X |
-| SDS | | | | X |
+| Security feature | demo-auth | sds-auth |
+| --- | --- | --- |
+| Control Plane Security | X | |
+| Strict Mutual TLS | X | X |
+| SDS | | X |
 
 To further customize Istio and install addons, you can add one or more `--set <key>=<value>` options in the `helm template` or `helm install` command that you use when installing Istio. The [Installation Options](/docs/reference/config/installation-options/) lists the complete set of supported installation key and value pairs.
 

--- a/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
@@ -53,11 +53,16 @@ The components marked as **X** are installed within each profile:
 Some profiles have an authentication variant, with `-auth` appended to the name, which adds the following
 security features to the profile:
 
-| | default | demo | minimal | sds |
+| | default | demo | minimal | sds-auth |
 | --- | --- | --- | --- | --- |
 | Control Plane Security | | X | | |
 | Strict Mutual TLS | | X | | X |
 | SDS | | | | X |
+
+{{< tip >}}
+Control plan security still requires the use of secret volume mounts, and is therefore
+incompatible with SDS.
+{{< /tip >}}
 
 To further customize Istio and install addons, you can add one or more `--set <key>=<value>` options in the `helm template` or `helm install` command that you use when installing Istio. The [Installation Options](/docs/reference/config/installation-options/) lists the complete set of supported installation key and value pairs.
 

--- a/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
@@ -26,8 +26,8 @@ your specific needs. The following built-in configuration profiles are currently
 
 1. **minimal**: the minimal set of components necessary to use Istio's [traffic management](/docs/tasks/traffic-management/) features.
 
-1. **sds**: similar to the **default** profile, but also enables Istio's [SDS (secret discovery service)](/docs/tasks/security/auth-sds).
-    This profile comes only with authentication enabled.
+1. **sds-auth**: similar to the **default** profile, but also enables Istio's [SDS (secret discovery service)](/docs/tasks/security/auth-sds).
+    This profile comes with additional authentication features enabled by default (see table below).
 
 The components marked as **X** are installed within each profile:
 

--- a/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
@@ -27,7 +27,7 @@ your specific needs. The following built-in configuration profiles are currently
 1. **minimal**: the minimal set of components necessary to use Istio's [traffic management](/docs/tasks/traffic-management/) features.
 
 1. **sds-auth**: similar to the **default** profile, but also enables Istio's [SDS (secret discovery service)](/docs/tasks/security/auth-sds).
-    This profile comes with additional authentication features enabled by default (see table below).
+    This profile comes with additional authentication features enabled by default.
 
 The components marked as **X** are installed within each profile:
 


### PR DESCRIPTION
Closes #4416 

This adds clarity around the SDS install profile
* Clarifies that there is no non-auth variant by changing the name to `sds-auth`
* Adds clarity around additional auth features being enabled by default, instead of vague 'only comes with authentication'
* Adds tip around why control plane auth is disabled in the sds profile