### PR TITLE
Apply crds separately to avoid race

### DIFF
--- a/content/docs/tasks/multicluster/gke/index.md
+++ b/content/docs/tasks/multicluster/gke/index.md
@@ -112,8 +112,8 @@ the `default` namespace:
 
 {{< text bash >}}
 $ kubectl config use-context "gke_${proj}_${zone}_cluster-1"
-$ cat install/kubernetes/helm/istio-init/files/crd-* > $HOME/istio_master.yaml
-$ helm template install/kubernetes/helm/istio --name istio --namespace istio-system >> $HOME/istio_master.yaml
+$ kubectl apply -f install/kubernetes/helm/istio-init/files/crd/
+$ helm template install/kubernetes/helm/istio --name istio --namespace istio-system > $HOME/istio_master.yaml
 $ kubectl create ns istio-system
 $ kubectl apply -f $HOME/istio_master.yaml
 $ kubectl label namespace default istio-injection=enabled

--- a/content/docs/tasks/security/auth-sds/index.md
+++ b/content/docs/tasks/security/auth-sds/index.md
@@ -52,9 +52,9 @@ This approach has the following benefits:
   TLS enabled:
 
     {{< text bash >}}
-    $ cat install/kubernetes/namespace.yaml > istio-auth-sds.yaml
-    $ cat install/kubernetes/helm/istio-init/files/crd-* >> istio-auth-sds.yaml
-    $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system --values @install/kubernetes/helm/istio/values-istio-sds-auth.yaml@ >> istio-auth-sds.yaml
+    $ kubectl create namespace istio-system
+    $ kubectl apply -f install/kubernetes/helm/istio-init/files/crd/
+    $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system --values @install/kubernetes/helm/istio/values-istio-sds-auth.yaml@ > istio-auth-sds.yaml
     $ kubectl apply -f istio-auth-sds.yaml
     {{< /text >}}
 

--- a/content/docs/tasks/security/vault-ca/index.md
+++ b/content/docs/tasks/security/vault-ca/index.md
@@ -27,15 +27,15 @@ to Node Agent, which returns the signed certificate to the Istio proxy.
 
     {{< text bash >}}
     $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user="$(gcloud config get-value core/account)"
-    $ cat install/kubernetes/namespace.yaml > istio-auth.yaml
-    $ cat install/kubernetes/helm/istio-init/files/crd-* >> istio-auth.yaml
+    $ kubectl create namespace istio-system
+    $ kubectl apply -f install/kubernetes/helm/istio-init/files/crd/
     $ helm template \
         --name=istio \
         --namespace=istio-system \
         --set global.mtls.enabled=true \
         --values install/kubernetes/helm/istio/example-values/values-istio-example-sds-vault.yaml \
-        install/kubernetes/helm/istio >> istio-auth.yaml
-    $ kubectl create -f istio-auth.yaml
+        install/kubernetes/helm/istio > istio-auth.yaml
+    $ kubectl apply -f istio-auth.yaml
     {{< /text >}}
 
 The yaml file [`values-istio-example-sds-vault.yaml`]({{< github_file >}}/install/kubernetes/helm/istio/example-values/values-istio-example-sds-vault.yaml)


### PR DESCRIPTION
Closes #4421 

Cat-ing the crds into a single file along with the istio mainfests
leads to a race to install the crds. This applies the crds as a
separate step to avoid this.