### PR TITLE
Trying to restore SkyWalking back online.

### DIFF
--- a/content/docs/reference/config/policy-and-telemetry/adapters/apache-skywalking/index.html
+++ b/content/docs/reference/config/policy-and-telemetry/adapters/apache-skywalking/index.html
@@ -12,8 +12,8 @@ See the License for the specific language governing permissions and
 limitations under the License. -->
  
 ---
-WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL SOURCE IN THE https://github.com/apache/incubator-skywalking-data-collect-protocol REPO
-source_repo: https://github.com/apache/incubator-skywalking-data-collect-protocol
+WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL SOURCE IN THE https://github.com/apache/skywalking-data-collect-protocol REPO
+source_repo: https://github.com/apache/skywalking-data-collect-protocol
 title: Apache SkyWalking
 description: Adapter to deliver metrics to Apache SkyWalking.
 location: https://istio.io/docs/reference/config/policy-and-telemetry/adapters/apache-skywalking.html

--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -16,7 +16,7 @@ REPOS=(
     https://github.com/apigee/istio-mixer-adapter.git@master
     https://github.com/osswangxining/alicloud-istio-grpcadapter.git@master
     https://github.com/vmware/wavefront-adapter-for-istio.git@master
-    https://github.com/apache/incubator-skywalking-data-collect-protocol.git@master
+    https://github.com/apache/skywalking-data-collect-protocol.git@master
 )
 
 # The components to build and extract usage docs from.


### PR DESCRIPTION
Since SkyWalking graduated as Top Level Project in Apache, the `incubator-` prefix removed from all repos. 

This PR is trying to change the repo name and make it back online.

But from the changelogs, I am not sure whether it is the reason.