### PR TITLE
Restore eol final announcement.

### DIFF
--- a/content/blog/2019/announcing-1.0-eol-final/index.md
+++ b/content/blog/2019/announcing-1.0-eol-final/index.md
@@ -1,0 +1,10 @@
+---
+title: Support for Istio 1.0 has ended
+description: Istio 1.0 end of life announcement.
+publishdate: 2019-06-19
+attribution: The Istio Team
+---
+
+As [previously announced](/blog/2019/announcing-1.0-eol/), support for Istio 1.0 has now officially ended.
+
+We will no longer back-port fixes for security issues and critical bugs to 1.0, so we encourage you to upgrade to the latest version of Istio ({{<istio_release_name>}}) if you haven't already.


### PR DESCRIPTION
This is a revert of a revert.  We sent out the 1.0 EOL a day too early.  This restores the announcement.

It's already on master.

This reverts commit 53e82861b9348188ad0bff7d08264af360b9fbab.

