### PR TITLE
Mention istioctl authn tls-check only check conflict states between c…

### DIFF
--- a/content/docs/tasks/security/mutual-tls/index.md
+++ b/content/docs/tasks/security/mutual-tls/index.md
@@ -72,6 +72,11 @@ Please check [Istio identity](/docs/concepts/security/#istio-identity) for more 
 Use the `istioctl` tool to check if the mutual TLS settings are in effect. The `istioctl` command needs the client's pod because the destination rule depends on the client's namespace.
 You can also provide the destination service to filter the status to that service only.
 
+{{< tip >}}
+This tool only checks the consistency of the static TLS settings between destination rules and authentication policies. It doesn't take into account whether or not the
+corresponding workloads have sidecars or not. When they don't, the policy and destination rules are not enforced, so note that status `CONFLICT` doesn't always mean that traffic is broken.
+{{< /tip >}}
+
 The following commands identify the authentication policy for the `httpbin.default.svc.cluster.local` service and identify the destination rules for the service as seen from the same pod of the `sleep` app:
 
 {{< text bash >}}


### PR DESCRIPTION
…… (#4519)

* Mention istioctl authn tls-check only check conflict states between configurations

* Fix spelling

* Update content/docs/tasks/security/mutual-tls/index.md

Co-Authored-By: Frank Budinsky <frankb@ca.ibm.com>

* Update content/docs/tasks/security/mutual-tls/index.md

Co-Authored-By: Frank Budinsky <frankb@ca.ibm.com>

---
name: Pull Request
about: Add some features, do some cleanup, or fix some bugs.
---

Please provide a description for what this PR is for.

<description>

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastrcture
