### PR TITLE
Remove reference for name since it fails validation

### DIFF
--- a/content/docs/reference/config/networking/v1alpha3/destination-rule/index.html
+++ b/content/docs/reference/config/networking/v1alpha3/destination-rule/index.html
@@ -1047,14 +1047,8 @@ to fields omitted in port-level traffic policies.</p>
 <td><code>port</code></td>
 <td><code><a href="/docs/reference/config/networking/v1alpha3/virtual-service.html#PortSelector">PortSelector</a></code></td>
 <td>
-<p>Specifies the port name or number of a port on the destination service
+<p>Specifies the port number of a port on the destination service
 on which this policy is being applied.</p>
-
-<p>Names must comply with DNS label syntax (rfc1035) and therefore cannot
-collide with numbers. If there are multiple ports on a service with
-the same protocol the names should be of the form &lt;protocol-name&gt;-&lt;DNS
-label&gt;.</p>
-
 </td>
 </tr>
 <tr id="TrafficPolicy-PortTrafficPolicy-load_balancer">


### PR DESCRIPTION
Name is still documented in destination rules for the port, but the field is not documented in portSelector. Attempts to use the field hit (https://github.com/istio/istio/blob/870877a1e3d01f6a2c285f67ed1f709a9f993095/pilot/pkg/model/validation.go#L2257) "Port.name HTTP is no longer supported for destination". 

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
