### PR TITLE
Fix bash syntax, punctuation and spelling

### DIFF
--- a/content/faq/security/mysql-with-mtls.md
+++ b/content/faq/security/mysql-with-mtls.md
@@ -1,28 +1,28 @@
 ---
 title: MySQL Connectivity Troubleshooting
-description: Trouble shooting MySQL connectivity issue due to PERMISSIVE mode.
+description: Troubleshooting MySQL connectivity issue due to PERMISSIVE mode.
 weight: 95
 keywords: [mysql,mtls]
 ---
 
-You may find MySQL can't be connected after installing Istio. This is because of `PERMISSIVE` mode which is enabled in `istio-demo.yaml` by default, does not work with MySQL.
+You may find MySQL can't connect after installing Istio. This is because of `PERMISSIVE` mode which is enabled in `istio-demo.yaml` by default, does not work with MySQL.  You may see error messages such as "ERROR 2013 (HY000): Lost connection to MySQL server at 'reading initial communication packet', system error: 0".
 
 There have two options to solve the problem.
 
-1. Disable Mutual TLS
+1. Disable Mutual TLS.
 
     Choose this option if you don't want Istio mutual TLS. You achieve this by disabling mutual TLS on the MySQL
     service explicitly.
 
     {{< text syntax="bash" >}}
-    $ kubectl apply -f <<EOF
+    $ kubectl apply -f - <<EOF
     apiVersion: "authentication.istio.io/v1alpha1"
     kind: "Policy"
     metadata:
       name: mysql-nomtls-authn
     spec:
       targets:
-      - name: mysql-service
+      - name: YOUR-MYSQL-SERVICE     # The name of *your* K8s Service
     EOF
     {{< /text >}}
 
@@ -31,14 +31,14 @@ There have two options to solve the problem.
     If you want mutual TLS protection for MySQL, enable mutual TLS using a destination rule and an authentication policy.
 
     {{< text syntax="bash" >}}
-    $ kubectl apply -f <<EOF
+    $ kubectl apply -f - <<EOF
     apiVersion: "authentication.istio.io/v1alpha1"
     kind: "Policy"
     metadata:
       name: mysql-mtls-authn
     spec:
       targets:
-      - name: mysql-service
+      - name: YOUR-MYSQL-SERVICE     # The name of *your* K8s Service
       peers:
       - mtls:
           mode: STRICT
@@ -48,7 +48,7 @@ There have two options to solve the problem.
     metadata:
       name: mysql-mtls-dr
     spec:
-      host: "mysql-service"
+      host: YOUR-MYSQL-SERVICE     # The name of *your* K8s Service
       trafficPolicy:
         tls:
           mode: ISTIO_MUTUAL


### PR DESCRIPTION
Resolves https://github.com/istio/istio.io/issues/4564 by fixing bash syntax.  Also minor spelling and punctuation nits.