### PR TITLE
fix error in the jsonpath selector

### DIFF
--- a/content/docs/tasks/telemetry/logs/access-log/index.md
+++ b/content/docs/tasks/telemetry/logs/access-log/index.md
@@ -43,7 +43,7 @@ All three of these parameters may also be configured via [helm values](/docs/ref
 1.  Send a request from `sleep` to `httpbin`:
 
     {{< text bash >}}
-    $ kubectl exec -it $(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name}) -c sleep -- curl -v httpbin:8000/status/418
+    $ kubectl exec -it $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -c sleep -- curl -v httpbin:8000/status/418
     *   Trying 172.21.13.94...
     * TCP_NODELAY set
     * Connected to httpbin (172.21.13.94) port 8000 (#0)


### PR DESCRIPTION
error in `jsonpath={.items..metadata.name}` the json selector produces the pod's name value to be incorrect
the fix `jsonpath='{.items[0].metadata.name}'` produces the right pod's name