### PR TITLE
fix number err from `5`  to `2`

### DIFF
--- a/content_zh/boilerplates/verify-crds.md
+++ b/content_zh/boilerplates/verify-crds.md
@@ -1,10 +1,10 @@
-使用以下命令验证所有 `53` 个 Istio CRD 是否已提交到 Kubernetes api-server：
+使用以下命令验证所有 `23` 个 Istio CRD 是否已提交到 Kubernetes api-server：
 
 {{< warning >}}
-如果启用了 cert-manager，则 CRD 个数将为 `58` 个。
+如果启用了 cert-manager，则 CRD 个数将为 `28` 个。
 {{< /warning >}}
 
 {{< text bash >}}
 $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-53
+23
 {{< /text >}}

--- a/content_zh/docs/setup/kubernetes/install/helm/index.md
+++ b/content_zh/docs/setup/kubernetes/install/helm/index.md
@@ -52,15 +52,15 @@ icon: helm
     $ helm template install/kubernetes/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -
     {{< /text >}}
 
-1. 使用如下命令以确保全部 53 个 Istio CRD 被提交到 Kubernetes api-server：
+1. 使用如下命令以确保全部 23 个 Istio CRD 被提交到 Kubernetes api-server：
 
     {{< warning >}}
-    如果你启用了 cert-manager,那么 CRD 的数目为58个。
+    如果你启用了 cert-manager,那么 CRD 的数目为28个。
     {{< /warning >}}
 
     {{< text bash >}}
     $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-    53
+    23
     {{< /text >}}
 
 1. 选择一个 [配置文件](/docs/setup/kubernetes/additional-setup/config-profiles/)，接着部署与你选择的配置文件相对应的 Istio 的核心组件，我们建议在生成环境部署中使用 **default** 配置文件:

--- a/content_zh/docs/setup/kubernetes/install/helm/index.md
+++ b/content_zh/docs/setup/kubernetes/install/helm/index.md
@@ -54,7 +54,6 @@ icon: helm
 
 1. {{< boilerplate verify-crds >}}
 
-
 1. 选择一个 [配置文件](/docs/setup/kubernetes/additional-setup/config-profiles/)，接着部署与你选择的配置文件相对应的 Istio 的核心组件，我们建议在生成环境部署中使用 **default** 配置文件:
 
     {{< tip >}}
@@ -133,7 +132,6 @@ $ helm template install/kubernetes/helm/istio --name istio --namespace istio-sys
     {{< /text >}}
 
 1. {{< boilerplate verify-crds >}}
-
 
 1. 选择一个 [配置文件](/docs/setup/kubernetes/additional-setup/config-profiles/)，接着部署与你选择的配置文件相对应的 Istio 的核心组件，我们建议在生成环境部署中使用 **default** 配置文件:
 

--- a/content_zh/docs/setup/kubernetes/install/helm/index.md
+++ b/content_zh/docs/setup/kubernetes/install/helm/index.md
@@ -52,16 +52,8 @@ icon: helm
     $ helm template install/kubernetes/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -
     {{< /text >}}
 
-1. 使用如下命令以确保全部 23 个 Istio CRD 被提交到 Kubernetes api-server：
+1. {{< boilerplate verify-crds >}}
 
-    {{< warning >}}
-    如果你启用了 cert-manager,那么 CRD 的数目为28个。
-    {{< /warning >}}
-
-    {{< text bash >}}
-    $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-    23
-    {{< /text >}}
 
 1. 选择一个 [配置文件](/docs/setup/kubernetes/additional-setup/config-profiles/)，接着部署与你选择的配置文件相对应的 Istio 的核心组件，我们建议在生成环境部署中使用 **default** 配置文件:
 
@@ -140,16 +132,8 @@ $ helm template install/kubernetes/helm/istio --name istio --namespace istio-sys
     $ helm install install/kubernetes/helm/istio-init --name istio-init --namespace istio-system
     {{< /text >}}
 
-1. 使用如下命令以确保全部 53 个 Istio CRD 被提交到 Kubernetes api-server：
+1. {{< boilerplate verify-crds >}}
 
-    {{< warning >}}
-    如果你启用了 cert-manager,那么 CRD 的数目为58个。
-    {{< /warning >}}
-
-    {{< text bash >}}
-    $ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
-    53
-    {{< /text >}}
 
 1. 选择一个 [配置文件](/docs/setup/kubernetes/additional-setup/config-profiles/)，接着部署与你选择的配置文件相对应的 Istio 的核心组件，我们建议在生成环境部署中使用 **default** 配置文件:
 


### PR DESCRIPTION
Please provide a description for what this PR is for.
In English docs, something is below
```
$ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
23
```
and
```
If cert-manager is enabled, then the CRD count will be 28 instead.
```
these is something wrong with the number  `5` which shoud be `2` in Chinese docs, 
and I installed istio with helm,  the result is the same with  English docs, so I just fixed it.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
