### PR TITLE
use role instead of clusterrole in egress gateway deployment

### DIFF
--- a/content/blog/2018/egress-mongo/index.md
+++ b/content/blog/2018/egress-mongo/index.md
@@ -792,7 +792,7 @@ to hold the configuration of the Nginx SNI proxy:
 1.  The following command will generate `istio-egressgateway-with-sni-proxy.yaml` to edit and deploy.
 
     {{< text bash >}}
-    $ cat <<EOF | helm template install/kubernetes/helm/istio/ --name istio-egressgateway-with-sni-proxy --namespace istio-system -x charts/gateways/templates/deployment.yaml -x charts/gateways/templates/service.yaml -x charts/gateways/templates/serviceaccount.yaml -x charts/gateways/templates/autoscale.yaml -x charts/gateways/templates/clusterrole.yaml -x charts/gateways/templates/clusterrolebindings.yaml --set  global.mtls.enabled=true --set global.istioNamespace=istio-system -f - > ./istio-egressgateway-with-sni-proxy.yaml
+    $ cat <<EOF | helm template install/kubernetes/helm/istio/ --name istio-egressgateway-with-sni-proxy --namespace istio-system -x charts/gateways/templates/deployment.yaml -x charts/gateways/templates/service.yaml -x charts/gateways/templates/serviceaccount.yaml -x charts/gateways/templates/autoscale.yaml -x charts/gateways/templates/role.yaml -x charts/gateways/templates/rolebindings.yaml --set global.mtls.enabled=true --set global.istioNamespace=istio-system -f - > ./istio-egressgateway-with-sni-proxy.yaml
     gateways:
       enabled: true
       istio-ingressgateway:
@@ -839,8 +839,8 @@ to hold the configuration of the Nginx SNI proxy:
     {{< text bash >}}
     $ kubectl apply -f ./istio-egressgateway-with-sni-proxy.yaml
     serviceaccount "istio-egressgateway-with-sni-proxy-service-account" created
-    clusterrole "istio-egressgateway-with-sni-proxy-istio-system" created
-    clusterrolebinding "istio-egressgateway-with-sni-proxy-istio-system" created
+    role "istio-egressgateway-with-sni-proxy-istio-system" created
+    rolebinding "istio-egressgateway-with-sni-proxy-istio-system" created
     service "istio-egressgateway-with-sni-proxy" created
     deployment "istio-egressgateway-with-sni-proxy" created
     horizontalpodautoscaler "istio-egressgateway-with-sni-proxy" created

--- a/content/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -53,7 +53,7 @@ controlled way.
     $ helm template install/kubernetes/helm/istio --name istio-egressgateway --namespace istio-system \
         -x charts/gateways/templates/deployment.yaml -x charts/gateways/templates/service.yaml \
         -x charts/gateways/templates/serviceaccount.yaml -x charts/gateways/templates/autoscale.yaml \
-        -x charts/gateways/templates/clusterrole.yaml -x charts/gateways/templates/clusterrolebindings.yaml \
+        -x charts/gateways/templates/role.yaml -x charts/gateways/templates/rolebindings.yaml \
         --set global.istioNamespace=istio-system --set gateways.istio-ingressgateway.enabled=false \
         --set gateways.istio-egressgateway.enabled=true | kubectl apply -f -
     {{< /text >}}

--- a/content/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
+++ b/content/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
@@ -297,7 +297,7 @@ The SNI proxy will forward the traffic to port `443`.
 1.  The following command will generate `istio-egressgateway-with-sni-proxy.yaml` which you can optionally edit and then deploy.
 
     {{< text bash >}}
-    $ cat <<EOF | helm template install/kubernetes/helm/istio/ --name istio-egressgateway-with-sni-proxy --namespace istio-system -x charts/gateways/templates/deployment.yaml -x charts/gateways/templates/service.yaml -x charts/gateways/templates/serviceaccount.yaml -x charts/gateways/templates/autoscale.yaml -x charts/gateways/templates/clusterrole.yaml -x charts/gateways/templates/clusterrolebindings.yaml --set global.istioNamespace=istio-system -f - > ./istio-egressgateway-with-sni-proxy.yaml
+    $ cat <<EOF | helm template install/kubernetes/helm/istio/ --name istio-egressgateway-with-sni-proxy --namespace istio-system -x charts/gateways/templates/deployment.yaml -x charts/gateways/templates/service.yaml -x charts/gateways/templates/serviceaccount.yaml -x charts/gateways/templates/autoscale.yaml -x charts/gateways/templates/role.yaml -x charts/gateways/templates/rolebindings.yaml --set global.istioNamespace=istio-system -f - > ./istio-egressgateway-with-sni-proxy.yaml
     gateways:
       enabled: true
       istio-ingressgateway:
@@ -344,8 +344,8 @@ The SNI proxy will forward the traffic to port `443`.
     {{< text bash >}}
     $ kubectl apply -f ./istio-egressgateway-with-sni-proxy.yaml
     serviceaccount "istio-egressgateway-with-sni-proxy-service-account" created
-    clusterrole "istio-egressgateway-with-sni-proxy-istio-system" created
-    clusterrolebinding "istio-egressgateway-with-sni-proxy-istio-system" created
+    role "istio-egressgateway-with-sni-proxy-istio-system" created
+    rolebinding "istio-egressgateway-with-sni-proxy-istio-system" created
     service "istio-egressgateway-with-sni-proxy" created
     deployment "istio-egressgateway-with-sni-proxy" created
     horizontalpodautoscaler "istio-egressgateway-with-sni-proxy" created

--- a/content_zh/blog/2018/egress-mongo/index.md
+++ b/content_zh/blog/2018/egress-mongo/index.md
@@ -722,7 +722,7 @@ $ kubectl delete destinationrule egressgateway-for-mongo
 1. 下面的命令将产生用于编辑和部署的 `istio-egressgateway-with-sni-proxy.yaml` 文件。
 
     {{< text bash >}}
-    $ cat <<EOF | helm template install/kubernetes/helm/istio/ --name istio-egressgateway-with-sni-proxy --namespace istio-system -x charts/gateways/templates/deployment.yaml -x charts/gateways/templates/service.yaml -x charts/gateways/templates/serviceaccount.yaml -x charts/gateways/templates/autoscale.yaml -x charts/gateways/templates/clusterrole.yaml -x charts/gateways/templates/clusterrolebindings.yaml --set  global.mtls.enabled=true --set global.istioNamespace=istio-system -f - > ./istio-egressgateway-with-sni-proxy.yaml
+    $ cat <<EOF | helm template install/kubernetes/helm/istio/ --name istio-egressgateway-with-sni-proxy --namespace istio-system -x charts/gateways/templates/deployment.yaml -x charts/gateways/templates/service.yaml -x charts/gateways/templates/serviceaccount.yaml -x charts/gateways/templates/autoscale.yaml -x charts/gateways/templates/role.yaml -x charts/gateways/templates/rolebindings.yaml --set  global.mtls.enabled=true --set global.istioNamespace=istio-system -f - > ./istio-egressgateway-with-sni-proxy.yaml
     gateways:
       enabled: true
       istio-ingressgateway:
@@ -767,8 +767,8 @@ $ kubectl delete destinationrule egressgateway-for-mongo
     {{< text bash >}}
     $ kubectl apply -f ./istio-egressgateway-with-sni-proxy.yaml
     serviceaccount "istio-egressgateway-with-sni-proxy-service-account" created
-    clusterrole "istio-egressgateway-with-sni-proxy-istio-system" created
-    clusterrolebinding "istio-egressgateway-with-sni-proxy-istio-system" created
+    role "istio-egressgateway-with-sni-proxy-istio-system" created
+    rolebinding "istio-egressgateway-with-sni-proxy-istio-system" created
     service "istio-egressgateway-with-sni-proxy" created
     deployment "istio-egressgateway-with-sni-proxy" created
     horizontalpodautoscaler "istio-egressgateway-with-sni-proxy" created

--- a/content_zh/docs/tasks/traffic-management/edge-traffic/wildcard-egress-hosts/index.md
+++ b/content_zh/docs/tasks/traffic-management/edge-traffic/wildcard-egress-hosts/index.md
@@ -285,7 +285,7 @@ SNI 代理会将流量转发到 `443` 端口。
 1. 以下命令将生成 `istio-egressgateway-with-sni-proxy.yaml` 文件，您可以选择性编辑并部署。
 
     {{< text bash >}}
-    $ cat <<EOF | helm template install/kubernetes/helm/istio/ --name istio-egressgateway-with-sni-proxy --namespace istio-system -x charts/gateways/templates/deployment.yaml -x charts/gateways/templates/service.yaml -x charts/gateways/templates/serviceaccount.yaml -x charts/gateways/templates/autoscale.yaml -x charts/gateways/templates/clusterrole.yaml -x charts/gateways/templates/clusterrolebindings.yaml --set global.istioNamespace=istio-system -f - > ./istio-egressgateway-with-sni-proxy.yaml
+    $ cat <<EOF | helm template install/kubernetes/helm/istio/ --name istio-egressgateway-with-sni-proxy --namespace istio-system -x charts/gateways/templates/deployment.yaml -x charts/gateways/templates/service.yaml -x charts/gateways/templates/serviceaccount.yaml -x charts/gateways/templates/autoscale.yaml -x charts/gateways/templates/role.yaml -x charts/gateways/templates/rolebindings.yaml --set global.istioNamespace=istio-system -f - > ./istio-egressgateway-with-sni-proxy.yaml
     gateways:
       enabled: true
       istio-ingressgateway:
@@ -332,8 +332,8 @@ SNI 代理会将流量转发到 `443` 端口。
     {{< text bash >}}
     $ kubectl apply -f ./istio-egressgateway-with-sni-proxy.yaml
     serviceaccount "istio-egressgateway-with-sni-proxy-service-account" created
-    clusterrole "istio-egressgateway-with-sni-proxy-istio-system" created
-    clusterrolebinding "istio-egressgateway-with-sni-proxy-istio-system" created
+    role "istio-egressgateway-with-sni-proxy-istio-system" created
+    rolebinding "istio-egressgateway-with-sni-proxy-istio-system" created
     service "istio-egressgateway-with-sni-proxy" created
     deployment "istio-egressgateway-with-sni-proxy" created
     horizontalpodautoscaler "istio-egressgateway-with-sni-proxy" created


### PR DESCRIPTION
charts/gateways/templates/clusterrole.yaml -> charts/gateways/templates/role.yaml
charts/gateways/templates/clusterrolebinding.yaml -> charts/gateways/templates/rolebinding.yaml

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
