### PR TITLE
Turn  on mergify strict mode and add missing alias (#4666)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,7 +11,7 @@ pull_request_rules:
     actions:
       merge:
         method: squash
-        strict: false
+        strict: true
 
   - name: Automatically cherry pick a PR from master to the release branch if the right label is set
     conditions:

--- a/content/docs/ops/_index.md
+++ b/content/docs/ops/_index.md
@@ -7,5 +7,6 @@ aliases:
     - /troubleshooting/index.html
     - /help/troubleshooting/index.html
     - /help/ops
+    - /help
 icon: guide
 ---


### PR DESCRIPTION
* Turn on mergify strict mode.

* Added missing alias for legacy bookmarks.

(cherry picked from commit c43550249a050689f9a3995453b974f02a028f0a)
