### PR TITLE
Fix install CRD steps on various pages

### DIFF
--- a/content/docs/examples/multicluster/gke/index.md
+++ b/content/docs/examples/multicluster/gke/index.md
@@ -112,7 +112,7 @@ the `default` namespace:
 
 {{< text bash >}}
 $ kubectl config use-context "gke_${proj}_${zone}_cluster-1"
-$ kubectl apply -f install/kubernetes/helm/istio-init/files/crd/
+$ helm template install/kubernetes/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system > $HOME/istio_master.yaml
 $ kubectl create ns istio-system
 $ kubectl apply -f $HOME/istio_master.yaml

--- a/content/docs/examples/multicluster/gke/index.md
+++ b/content/docs/examples/multicluster/gke/index.md
@@ -112,9 +112,9 @@ the `default` namespace:
 
 {{< text bash >}}
 $ kubectl config use-context "gke_${proj}_${zone}_cluster-1"
-$ helm template install/kubernetes/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system > $HOME/istio_master.yaml
 $ kubectl create ns istio-system
+$ helm template install/kubernetes/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -
 $ kubectl apply -f $HOME/istio_master.yaml
 $ kubectl label namespace default istio-injection=enabled
 {{< /text >}}

--- a/content/docs/setup/kubernetes/install/multicluster/gateways/index.md
+++ b/content/docs/setup/kubernetes/install/multicluster/gateways/index.md
@@ -99,11 +99,13 @@ Cross-cluster communication occurs over Istio gateways of the respective cluster
             --from-file=@samples/certs/cert-chain.pem@
         {{< /text >}}
 
-    * Install Istio's CRDs:
+    * Install all the Istio
+    [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)
+    (CRDs) using `kubectl apply`, and wait a few seconds for the CRDs to be committed in the Kubernetes API-server:
 
-        {{< text bash >}}
-        $ kubectl apply -f install/kubernetes/helm/istio-init/files/crd/
-        {{< /text >}}
+    {{< text bash >}}
+    $ helm template install/kubernetes/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -
+    {{< /text >}}
 
     * {{< boilerplate verify-crds >}}
 

--- a/content/docs/tasks/security/vault-ca/index.md
+++ b/content/docs/tasks/security/vault-ca/index.md
@@ -28,7 +28,7 @@ to Node Agent, which returns the signed certificate to the Istio proxy.
     {{< text bash >}}
     $ kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user="$(gcloud config get-value core/account)"
     $ kubectl create namespace istio-system
-    $ kubectl apply -f install/kubernetes/helm/istio-init/files/crd/
+    $ helm template install/kubernetes/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -
     $ helm template \
         --name=istio \
         --namespace=istio-system \


### PR DESCRIPTION
Please provide a description for what this PR is for.

While working through the gateway multicluster example earlier today, I failed on an instruction:

```
kubectl apply -f install/kubernetes/helm/istio-init/files/crd/                                                                                           
error: the path "install/kubernetes/helm/istio-init/files/crd/" does not exist
```

I'm not sure if this is a underlying _kubectl_ change which causes the error or maybe there was process change that didn't happen across all pages.

I updated the step using the instructions from the kubernetes/helm/install page which worked on my system.

Info:
```
kubectl version
Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.1", GitCommit:"4485c6f18cee9a5d3c3b4e523bd27972b1b53892", GitTreeState:"clean", BuildDate:"2019-07-18T14:25:20Z", GoVersion:"go1.12.7", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"14", GitVersion:"v1.14.4+IKS", GitCommit:"8d1fc7dac0503d725342e28fdfd0f3710b58ccde", GitTreeState:"clean", BuildDate:"2019-07-11T13:18:41Z", GoVersion:"go1.12.5", Compiler:"gc", Platform:"linux/amd64"}
```

I noted that the same instruction was on 2 other pages, so made the changes there as well.