### PR TITLE
Add distroless as a core feature for 1.3.

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -158,6 +158,7 @@ Devirtualization
 devops
 discuss.istio.io
 distro
+Distroless
 Divya
 DNS
 docker-compose's

--- a/content/about/feature-stages/index.md
+++ b/content/about/feature-stages/index.md
@@ -107,6 +107,7 @@ The 'Authorization (RBAC)' runtime is considered Beta.  However, its API is stil
 | [Out of Process Mixer Adapters (gRPC Adapters)](https://github.com/istio/istio/wiki/Mixer-Out-Of-Process-Adapter-Dev-Guide) | Beta
 | [Istio CNI plugin](/docs/setup/kubernetes/additional-setup/cni/) | Alpha
 | IPv6 support for Kubernetes | Alpha
+| Distroless base images for Istio | Alpha
 
 {{< idea >}}
 Please get in touch by joining our [community](/about/community/) if there are features you'd like to see in our future releases!


### PR DESCRIPTION
Distroless is ready for Alpha. The images are built, pushed, and have been
running in CI for some time including presubmit testing.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
