### PR TITLE
Fix service name typo in documentation

### DIFF
--- a/content/docs/concepts/traffic-management/index.md
+++ b/content/docs/concepts/traffic-management/index.md
@@ -1334,7 +1334,7 @@ spec:
 
 You can use delay and abort faults together. The following configuration
 introduces a delay of 5 seconds for all requests from the `v2` subset of the
-`ratings` service to the `v1` subset of the `ratings` service and an abort for
+`reviews` service to the `v1` subset of the `ratings` service and an abort for
 10% of them:
 
 {{< text yaml >}}


### PR DESCRIPTION
The following configuration introduces a delay of 5 seconds for all requests from the `v2` subset of the
`reviews` service to the `v1` subset of the `ratings` service and an abort for 10% of them:

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
