### PR TITLE
Fix kubectl used instead of istioctl

### DIFF
--- a/content/blog/2018/soft-multitenancy/index.md
+++ b/content/blog/2018/soft-multitenancy/index.md
@@ -215,13 +215,13 @@ For example, the following command would be required to add a route rule to the 
 namespace:
 
 {{< text bash >}}
-$ kubectl –i istio-system1 apply -n ns-1 -f route_rule_v2.yaml
+$ istioctl -i istio-system1 apply -n ns-1 -f route_rule_v2.yaml
 {{< /text >}}
 
 And can be displayed using the command:
 
 {{< text bash >}}
-$ kubectl -i istio-system1 -n ns-1 get routerule
+$ istioctl -i istio-system1 -n ns-1 get routerule
 NAME                  KIND                                  NAMESPACE
 details-Default       RouteRule.v1alpha2.config.istio.io    ns-1
 productpage-default   RouteRule.v1alpha2.config.istio.io    ns-1


### PR DESCRIPTION
There is no support for the flag '-i' in vanilla kubectl, istioctl introduces this feature.


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
