### PR TITLE
Point /charts/ at GCS directly instead of gcsweb.

### DIFF
--- a/layouts/index.redir
+++ b/layouts/index.redir
@@ -19,7 +19,7 @@ https://istio.netlify.com/* https://istio.io/:splat 301!
 /  /zh   302  Language=zh
 
 # Redirect for the helm charts
-/charts/ https://gcsweb.istio.io/gcs/istio-release/releases/{{ .Site.Data.args.full_version }}/charts/ 301
+/charts/ https://storage.googleapis.com/istio-release/releases/{{ .Site.Data.args.full_version }}/charts/ 301
 
 # Redirects for all aliases
 {{- range $p := .Site.Pages -}}


### PR DESCRIPTION
gcsweb has not been considered a critical service and has no uptime or reliability guarantees, which can lead to surprising user-visible outages (e.g. istio/istio#15699).

This has the downside that users cannot see a file browser, but the upside of likely substantially better reliability, which may well be more important if people are expecting to be able to install from here.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure