### PR TITLE
Rename multiple control planes multi cluster pattern

### DIFF
--- a/content/blog/2019/announcing-1.1/index.md
+++ b/content/blog/2019/announcing-1.1/index.md
@@ -44,7 +44,7 @@ sweet YAML, reducing the chance of configuration errors. Galley will also be
 instrumental in [multicluster setups](/docs/setup/kubernetes/install/multicluster/),
 gathering service discovery information from each Kubernetes cluster. We are
 also supporting additional multicluster topologies including [shared control plane](/docs/concepts/multicluster-deployments/#shared-control-plane-topology)
-and [dedicated control plane](/docs/concepts/multicluster-deployments/#dedicated-control-plane-topology)
+and [dedicated control plane](/docs/concepts/multicluster-deployments/#dedicated-control-plane-topology) topologies
 without requiring a flat network.
 
 There is lots more -- see the [release notes](/about/notes/1.1/) for complete

--- a/content/blog/2019/announcing-1.1/index.md
+++ b/content/blog/2019/announcing-1.1/index.md
@@ -43,8 +43,8 @@ policy. We introduced a new component called
 sweet YAML, reducing the chance of configuration errors. Galley will also be
 instrumental in [multicluster setups](/docs/setup/kubernetes/install/multicluster/),
 gathering service discovery information from each Kubernetes cluster. We are
-also supporting additional multicluster topologies including [single control plane](/docs/concepts/multicluster-deployments/#shared-control-plane-topology)
-and [multiple synchronized control planes](/docs/concepts/multicluster-deployments/#multiple-control-plane-topology)
+also supporting additional multicluster topologies including [shared control plane](/docs/concepts/multicluster-deployments/#shared-control-plane-topology)
+and [dedicated control plane](/docs/concepts/multicluster-deployments/#dedicated-control-plane-topology)
 without requiring a flat network.
 
 There is lots more -- see the [release notes](/about/notes/1.1/) for complete

--- a/content/blog/2019/multicluster-version-routing/index.md
+++ b/content/blog/2019/multicluster-version-routing/index.md
@@ -454,7 +454,7 @@ only see reviews without ratings (`v1`).
 
 In this article, we've seen how to use Istio route rules to distribute the versions of a service
 across clusters in a multicluster service mesh with a
-[multiple control plane topology](/docs/concepts/multicluster-deployments/#multiple-control-plane-topology).
+[dedicated control plane topology](/docs/concepts/multicluster-deployments/#dedicated-control-plane-topology).
 In this example, we manually configured the `.global` service entry and destination rules needed to provide
 connectivity to one remote service, `reviews`. In general, however, if we wanted to enable any service
 to run either locally or remotely, we would need to create `.global` resources for every service.

--- a/content/blog/2019/multicluster-version-routing/index.md
+++ b/content/blog/2019/multicluster-version-routing/index.md
@@ -20,13 +20,13 @@ in more than one cluster, i.e., in a
 [multicluster service mesh](/docs/concepts/multicluster-deployments/#multicluster-service-mesh).
 The simplest way to setup a multicluster mesh, because it has no special networking requirements,
 is using a
-[multiple control plane topology](/docs/concepts/multicluster-deployments/#multiple-control-plane-topology).
+[dedicated control plane topology](/docs/concepts/multicluster-deployments/#dedicated-control-plane-topology).
 In this configuration, each Kubernetes cluster contributing to the mesh has its own control plane,
 but each control plane is synchronized and running under a single administrative control.
 
 In this article we'll look at how one of the features of Istio,
 [traffic management](/docs/concepts/traffic-management/), works in a multicluster mesh with
-a multiple control plane topology.
+a dedicated control plane topology.
 We'll show how to configure Istio route rules to call remote services in a multicluster service mesh
 by deploying the [Bookinfo sample]({{<github_tree>}}/samples/bookinfo) with version `v1` of the `reviews` service
 running in one cluster, versions `v2` and `v3` running in a second cluster.
@@ -36,7 +36,7 @@ running in one cluster, versions `v2` and `v3` running in a second cluster.
 To start, you'll need two Kubernetes clusters, both running a slightly customized configuration of Istio.
 
 * Set up a multicluster environment with two Istio clusters by following the
-    [multiple control planes with gateways](/docs/setup/kubernetes/install/multicluster/gateways/) instructions.
+    [dedicated control planes](/docs/setup/kubernetes/install/multicluster/gateways/) instructions.
 
 * The `kubectl` command is used to access both clusters with the `--context` flag.
     Use the following command to list your contexts:

--- a/content/docs/concepts/multicluster-deployments/index.md
+++ b/content/docs/concepts/multicluster-deployments/index.md
@@ -50,9 +50,9 @@ two clusters might share a control plane while a third has its own.
 Which approach to use and how to configure it depends on the requirements of the application
 and on the features and limitations of the underlying cloud deployment platform.
 
-### Multiple control plane topology
+### Dedicated control plane topology
 
-In a multiple control plane topology, each cluster has an identical Istio control plane
+In a dedicated control plane topology, each cluster has an identical Istio control plane
 installation and each control plane manages its own endpoints.
 Using Istio gateways, a common root Certificate Authority (CA), and service entries,
 you can configure a single logical service mesh that is composed from the participating clusters.
@@ -80,7 +80,7 @@ configuration. You configure service discovery of `foo.ns.global` by creating an
 [service entry](/docs/concepts/traffic-management/#service-entries).
 
 To configure this type of multicluster topology, visit our
-[multiple control planes instructions](/docs/setup/kubernetes/install/multicluster/gateways/).
+[dedicated control planes instructions](/docs/setup/kubernetes/install/multicluster/gateways/).
 
 ### Shared control plane topology
 
@@ -115,7 +115,7 @@ it may still be possible to configure a shared control plane topology using Isti
 by enabling Istio Pilot's location-aware service routing feature.
 
 This topology requires connectivity to Kubernetes API servers from all of the clusters. If this is
-not possible, a multiple control plane topology is probably a better alternative.
+not possible, a dedicated control plane topology is probably a better alternative.
 
 {{< image width="80%"
     link="./multicluster-split-horizon-eds.svg"

--- a/content/docs/concepts/multicluster-deployments/index.md
+++ b/content/docs/concepts/multicluster-deployments/index.md
@@ -84,8 +84,8 @@ To configure this type of multicluster topology, visit our
 
 ### Shared control plane topology
 
-This multicluster configuration uses a single Istio control plane running on one of the clusters.
-The control plane's Pilot manages services on the local and remote clusters and configures the
+This multicluster configuration uses one or several Istio control planes running on some of the clusters.
+The control planes' Pilots manage services on the local and remote clusters and configure the
 Envoy sidecars for all of the clusters.
 
 #### Single-network shared control plane
@@ -99,9 +99,9 @@ same IP address.
     caption="Istio mesh spanning multiple Kubernetes clusters with direct network access to remote pods over VPN"
 >}}
 
-In this topology, the Istio control plane is deployed on one of the clusters while all other
-clusters run a simpler remote Istio configuration which connects them to the single Istio control plane
-that manages all of the Envoy's as a single mesh. The IP addresses on the various clusters must not
+In this topology, the Istio control plane is deployed on some of the clusters while all other
+clusters run a simpler remote Istio configuration which connects them to the remote Istio control planes
+that manage all of the Envoy's as a single mesh. The IP addresses on the various clusters must not
 overlap and DNS resolution for services on remote clusters is not automatic. Users need to replicate
 the services on every participating cluster.
 

--- a/content/docs/concepts/multicluster-deployments/index.md
+++ b/content/docs/concepts/multicluster-deployments/index.md
@@ -114,9 +114,8 @@ If setting up an environment with universal pod-to-pod connectivity is difficult
 it may still be possible to configure a shared control plane topology using Istio gateways and
 by enabling Istio Pilot's location-aware service routing feature.
 
-This topology requires connectivity to Kubernetes API servers from all of the clusters with
-Istio control planes. If this is not possible, a dedicated control plane topology is probably a
-better alternative.
+This topology requires connectivity to Kubernetes API servers from all of the clusters. If this is
+not possible, a dedicated control plane topology is probably a better alternative.
 
 {{< image width="80%"
     link="./multicluster-split-horizon-eds.svg"

--- a/content/docs/concepts/multicluster-deployments/index.md
+++ b/content/docs/concepts/multicluster-deployments/index.md
@@ -114,8 +114,9 @@ If setting up an environment with universal pod-to-pod connectivity is difficult
 it may still be possible to configure a shared control plane topology using Istio gateways and
 by enabling Istio Pilot's location-aware service routing feature.
 
-This topology requires connectivity to Kubernetes API servers from all of the clusters. If this is
-not possible, a dedicated control plane topology is probably a better alternative.
+This topology requires connectivity to Kubernetes API servers from all of the clusters with
+Istio control planes. If this is not possible, a dedicated control plane topology is probably a
+better alternative.
 
 {{< image width="80%"
     link="./multicluster-split-horizon-eds.svg"

--- a/content/docs/concepts/multicluster-deployments/index.md
+++ b/content/docs/concepts/multicluster-deployments/index.md
@@ -88,7 +88,7 @@ This multicluster configuration uses one or several Istio control planes running
 The control planes' Pilots manage services on the local and remote clusters and configure the
 Envoy sidecars for all of the clusters.
 
-#### Single-network shared control plane
+#### Single-network shared control plane topology
 
 The following topology works best in environments where all of the participating clusters
 have VPN or similar connectivity so every pod in the mesh is reachable from anywhere else using the
@@ -108,7 +108,7 @@ the services on every participating cluster.
 To configure this type of multicluster topology, visit our
 [single-network shared control plane instructions](/docs/setup/kubernetes/install/multicluster/shared-vpn/).
 
-#### Multi-network shared control plane
+#### Multi-network shared control plane topology
 
 If setting up an environment with universal pod-to-pod connectivity is difficult or impossible,
 it may still be possible to configure a shared control plane topology using Istio gateways and

--- a/content/docs/concepts/multicluster-deployments/index.md
+++ b/content/docs/concepts/multicluster-deployments/index.md
@@ -84,8 +84,8 @@ To configure this type of multicluster topology, visit our
 
 ### Shared control plane topology
 
-This multicluster configuration uses one or several Istio control planes running on some of the clusters.
-The control planes' Pilots manage services on the local and remote clusters and configure the
+This multicluster configuration uses a single Istio control plane running on one of the clusters.
+The control plane's Pilot manages services on the local and remote clusters and configures the
 Envoy sidecars for all of the clusters.
 
 #### Single-network shared control plane topology
@@ -99,9 +99,9 @@ same IP address.
     caption="Istio mesh spanning multiple Kubernetes clusters with direct network access to remote pods over VPN"
 >}}
 
-In this topology, the Istio control plane is deployed on some of the clusters while all other
-clusters run a simpler remote Istio configuration which connects them to the remote Istio control planes
-that manage all of the Envoy's as a single mesh. The IP addresses on the various clusters must not
+In this topology, the Istio control plane is deployed on one of the clusters while all other
+clusters run a simpler remote Istio configuration which connects them to the single Istio control plane
+that manages all of the Envoy's as a single mesh. The IP addresses on the various clusters must not
 overlap and DNS resolution for services on remote clusters is not automatic. Users need to replicate
 the services on every participating cluster.
 

--- a/content/docs/examples/multicluster/gke/index.md
+++ b/content/docs/examples/multicluster/gke/index.md
@@ -8,8 +8,8 @@ aliases:
 ---
 
 This example shows how to configure a multicluster mesh with a
-[single-network shared control plane](/docs/concepts/multicluster-deployments/#single-network-shared-control-plane)
-topology over 2 [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) clusters.
+[single-network shared control plane topology](/docs/concepts/multicluster-deployments/#single-network-shared-control-plane-topology)
+over 2 [Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine/) clusters.
 
 ## Before you begin
 

--- a/content/docs/examples/multicluster/icp/index.md
+++ b/content/docs/examples/multicluster/icp/index.md
@@ -10,8 +10,7 @@ aliases:
 This example demonstrates how to setup network connectivity between two
 [IBM Cloud Private](https://www.ibm.com/cloud/private) clusters
 and then compose them into a multicluster mesh using a
-[single-network shared control plane](/docs/concepts/multicluster-deployments/#single-network-shared-control-plane)
-topology.
+[single-network shared control plane topology](/docs/concepts/multicluster-deployments/#single-network-shared-control-plane-topology).
 
 ## Create the IBM Cloud Private Clusters
 

--- a/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
+++ b/content/docs/setup/kubernetes/additional-setup/config-profiles/index.md
@@ -74,7 +74,7 @@ Istio provides two additional built-in configuration profiles that are used excl
     multicluster mesh with a [shared control plane topology](/docs/concepts/multicluster-deployments/#shared-control-plane-topology).
 
 1. **multicluster-gateways**: used for configuring all of the clusters of a
-    multicluster mesh with a [multiple control plane topology](/docs/concepts/multicluster-deployments/#multiple-control-plane-topology).
+    multicluster mesh with a [dedicated control plane topology](/docs/concepts/multicluster-deployments/#dedicated-control-plane-topology).
 
 The **remote** profile is configured using the values file `values-istio-remote.yaml`. This profile installs only two
 Istio core components:

--- a/content/docs/setup/kubernetes/install/multicluster/gateways/index.md
+++ b/content/docs/setup/kubernetes/install/multicluster/gateways/index.md
@@ -6,7 +6,7 @@ aliases:
   - /docs/setup/kubernetes/multicluster-install/gateways/
   - /docs/examples/multicluster/gateways/
   - /docs/tasks/multicluster/gateways/
-keywords: [kubernetes,multicluster,federation,gateway]
+keywords: [kubernetes,multicluster,gateway]
 ---
 
 Follow this guide to install an Istio

--- a/content/docs/setup/kubernetes/install/multicluster/gateways/index.md
+++ b/content/docs/setup/kubernetes/install/multicluster/gateways/index.md
@@ -1,5 +1,5 @@
 ---
-title: Multiple control planes
+title: Dedicated control planes
 description: Install an Istio mesh across multiple Kubernetes clusters with individually deployed control planes.
 weight: 2
 aliases:

--- a/content/docs/setup/kubernetes/install/multicluster/shared-gateways/index.md
+++ b/content/docs/setup/kubernetes/install/multicluster/shared-gateways/index.md
@@ -14,7 +14,7 @@ with gateways to connect network-isolated clusters.
 Istio's location-aware service routing feature is used to route requests to different endpoints,
 depending on the location of the request source.
 
-By following the instructions in this guide, you will setup a two cluster mesh as shown in the following diagram:
+By following the instructions in this guide, you will setup a two-cluster mesh as shown in the following diagram:
 
   {{< image width="80%"
   link="./diagram.svg"

--- a/content/docs/setup/kubernetes/install/multicluster/shared-vpn/index.md
+++ b/content/docs/setup/kubernetes/install/multicluster/shared-vpn/index.md
@@ -13,9 +13,11 @@ where the Kubernetes cluster services and the applications in each cluster
 have the capability to expose their internal Kubernetes network to other
 clusters.
 
-In this configuration, one or several Istio control planes watch Kubernetes API servers in multiple remote clusters.
-Envoys in clusters without Istio control plane communicate with Istio control planes deployed outside of their cluster
-and form a single mesh across multiple clusters.
+In this configuration, multiple Kubernetes control planes running
+a remote configuration connect to a **single** Istio control plane.
+Once one or more remote Kubernetes clusters are connected to the
+Istio control plane, Envoy can then communicate with the **single**
+control plane and form a mesh network across multiple clusters.
 
 {{< image width="80%" link="./multicluster-with-vpn.svg" caption="Istio mesh spanning multiple Kubernetes clusters with direct network access to remote pods over VPN" >}}
 

--- a/content/docs/setup/kubernetes/install/multicluster/shared-vpn/index.md
+++ b/content/docs/setup/kubernetes/install/multicluster/shared-vpn/index.md
@@ -13,11 +13,9 @@ where the Kubernetes cluster services and the applications in each cluster
 have the capability to expose their internal Kubernetes network to other
 clusters.
 
-In this configuration, multiple Kubernetes control planes running
-a remote configuration connect to a **single** Istio control plane.
-Once one or more remote Kubernetes clusters are connected to the
-Istio control plane, Envoy can then communicate with the **single**
-control plane and form a mesh network across multiple clusters.
+In this configuration, one or several Istio control planes watch Kubernetes API servers in multiple remote clusters.
+Envoys in clusters without Istio control plane communicate with Istio control planes deployed outside of their cluster
+and form a single mesh across multiple clusters.
 
 {{< image width="80%" link="./multicluster-with-vpn.svg" caption="Istio mesh spanning multiple Kubernetes clusters with direct network access to remote pods over VPN" >}}
 

--- a/content_zh/docs/setup/kubernetes/additional-setup/config-profiles/index.md
+++ b/content_zh/docs/setup/kubernetes/additional-setup/config-profiles/index.md
@@ -60,7 +60,7 @@ Istio 提供了两种附加的内置配置，专门用于搭建[多集群服务�
 
 1. **remote**：用于搭建[单控制平面拓扑](/docs/concepts/multicluster-deployments/#shared-control-plane-topology)的多集群网格。
 
-1. **multicluster-gateways**：用来搭建[多控制平面拓扑](/docs/concepts/multicluster-deployments/#multiple-control-plane-topology)的多集群网络。
+1. **multicluster-gateways**：用来搭建[多控制平面拓扑](/docs/concepts/multicluster-deployments/#dedicated-control-plane-topology)的多集群网络。
 
 **remote** 配置对应的配置文件是 `values-istio-remote.yaml`。这个配置仅安装两个核心组件：
 

--- a/content_zh/docs/tasks/multicluster/gateways/index.md
+++ b/content_zh/docs/tasks/multicluster/gateways/index.md
@@ -7,7 +7,7 @@ aliases:
   - /zh/docs/examples/multicluster/gateways/
 ---
 
-这个示例展示了如何在[多控制平面拓扑](/docs/concepts/multicluster-deployments/#multiple-control-plane-topology)的多集群网格中
+这个示例展示了如何在[多控制平面拓扑](/docs/concepts/multicluster-deployments/#dedicated-control-plane-topology)的多集群网格中
 配置和调用远程服务。为了演示跨集群访问，会在一个集群中使用 [Sleep 服务]({{<github_tree>}}/samples/sleep)调用另一个集群中的 [httpbin 服务]({{<github_tree>}}/samples/httpbin)。
 
 ## 开始之前 {#before-you-begin}


### PR DESCRIPTION
Following the discussion at https://docs.google.com/document/d/1ZwZ4KrE2pvcrdE1FVLke6ZMIAfC3y8_SYTzk6K2U9aQ/edit?ts=5d38f558#, remove multiple vs single control plane distinction, use dedicated vs shared control planes instead.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X ] Installation
[X ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure