### PR TITLE
Fix broken link in blog related to Traffic Mirroring

### DIFF
--- a/content/blog/2018/traffic-mirroring/index.md
+++ b/content/blog/2018/traffic-mirroring/index.md
@@ -40,4 +40,4 @@ A few things to note here:
 * You'll need to have the 0-weighted route to hint to Istio to create the proper Envoy cluster under the covers; [this should be ironed out in future releases](https://github.com/istio/istio/issues/3270).
 
 Learn more about mirroring by visiting the [Mirroring Task](/docs/tasks/traffic-management/mirroring/) and see a more
-[comprehensive treatment of this scenario on my blog](https://blog.christianposta.com/microservices/traffic-shadowing-with-istio-reduce-the-risk-of-code-release/).
+[comprehensive treatment of this scenario on my blog](https://dzone.com/articles/traffic-shadowing-with-istio-reducing-the-risk-of).

--- a/content_zh/blog/2018/traffic-mirroring/index.md
+++ b/content_zh/blog/2018/traffic-mirroring/index.md
@@ -40,4 +40,4 @@ spec:
 * 必须创建一个权重为 0 的路由，让 Istio 据此通知 Envoy 创建对应的集群定义; [这应该在未来的版本中解决](https://github.com/istio/istio/issues/3270)。
 
 访问[镜像任务](/zh/docs/tasks/traffic-management/mirroring/)了解有关镜像的更多信息，并查看更多信息
-[在我的博客上综合处理这种情况](https://blog.christianposta.com/microservices/traffic-shadowing-with-istio-reduce-the-risk-of-code-release/).
+[在我的博客上综合处理这种情况](https://dzone.com/articles/traffic-shadowing-with-istio-reducing-the-risk-of).


### PR DESCRIPTION
This was causing linter to fail.

Fixes Bug: #4726


[ ] Configuration Infrastructure
[ X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
