### PR TITLE
Fix broken link in Quick Start Evaluation Install

### DIFF
--- a/content/docs/setup/kubernetes/install/kubernetes/index.md
+++ b/content/docs/setup/kubernetes/install/kubernetes/index.md
@@ -54,7 +54,7 @@ requirements.
 {{< tabset cookie-name="profile" >}}
 
 {{< tab name="permissive mutual TLS" cookie-value="permissive" >}}
-When using the [permissive mutual TLS mode]((/docs/concepts/security/#permissive-mode), all services accept both plaintext and
+When using the [permissive mutual TLS mode](/docs/concepts/security/#permissive-mode), all services accept both plaintext and
 mutual TLS traffic. Clients send plaintext traffic unless configured for
 [mutual TLS migration](/docs/tasks/security/mtls-migration/).
 


### PR DESCRIPTION
The link to permissive mutual TLS concept in this task is broken because of
an extra opening parenthesis.

Fixes Bug: #4739

[ ] Configuration Infrastructure
[ X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
