### PR TITLE
Add docs for updated Citadel namespace targeting mechanism

### DIFF
--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -212,49 +212,51 @@ and enforces different access control rules to the services.
 
 ### How Citadel determines whether to create Service Account secrets
 
-When a Citadel instance notices that a `ServiceAccount` was created in a namespace, it needs to decide whether it should generate an `istio.io/key-and-cert` secret for that `ServiceAccount`. In order to make that decision, there are three relevant values (note: there can be multiple Citadel instances deployed in a single cluster, and the following targeting rules are applied to each instance):
+When a Citadel instance notices that a `ServiceAccount` is created in a namespace, it must decide whether it should generate an `istio.io/key-and-cert` secret for that `ServiceAccount`. In order to make that decision, Citadel considers three inputs (note: there can be multiple Citadel instances deployed in a single cluster, and the following targeting rules are applied to each instance):
 
-1. `ca.istio.io/env` namespace label: *string valued* label which should be pointed at the namespace of the desired Citadel instance
+1. `ca.istio.io/env` namespace label: *string valued* label containing the namespace of the desired Citadel instance
 
 1. `ca.istio.io/override` namespace label: *boolean valued* label which overrides all other configurations and forces all Citadel instances either to target or ignore a namespace
 
-1. [`enableNamespacesByDefault` security configuration](/docs/reference/config/installation-options/#security-options): default behavior if no labels are found on the `ServiceAccount's` namespace
+1. [`enableNamespacesByDefault` security configuration](/docs/reference/config/installation-options/#security-options): default behavior if no labels are found on the `ServiceAccount`'s namespace
 
 From these three values, the decision process mirrors that of the [`Sidecar Injection Webhook`](/docs/ops/setup/injection-concepts/). The detailed behavior is that:
 
-- If `ca.istio.io/override` exists and is valid, then follow what it tells us (generate key/cert secrets for workloads if `true`, don't if `false`)
+- If `ca.istio.io/override` exists and is `true`, generate key/cert secrets for workloads.
 
-- If not, then check `ca.istio.io/env: "ns-foo"`. The Citadel instance in namespace `ns-foo` will be responsible for generating key/cert secrets for workloads
+- Otherwise, if `ca.istio.io/override` exists and is `false`, don't generate key/cert secrets for workloads.
 
-- If `ca.istio.io/env` is nonexistent or invalid, follow the `enableNamespacesByDefault` helm flag
+- Otherwise, if a `ca.istio.io/env: "ns-foo"` label is defined in the service account's namespace, the Citadel instance in namespace `ns-foo` will be used for generating key/cert secrets for workloads in the `ServiceAccount`'s namespace.
 
-- If `enableNamespacesByDefault` is `true`, the Citadel instance will create secrets for unlabeled namespaces, otherwise it will not
+- Otherwise, follow the `enableNamespacesByDefault` Helm flag. If it is `true`, the default Citadel instance will be used for generating key/cert secrets for workloads in the `ServiceAccount`'s namespace.
+
+- Otherwise, no secrets are created for the `ServiceAccount`'s namespace.
 
 This logic is captured in the truth table below:
 
 | `ca.istio.io/override` value | `ca.istio.io/env` match | `enableNamespacesByDefault` configuration | Workload secret created |
 |------------------------------|-------------------------|-------------------------------------------|-------------------------|
-|true|yes|true|yes|
-|true|yes|false|yes|
-|true|no|true|yes|
-|true|no|false|yes|
-|true|`unset`|true|yes|
-|true|`unset`|false|yes|
-|false|yes|true|no|
-|false|yes|false|no|
-|false|no|true|no|
-|false|no|false|no|
-|false|`unset`|true|no|
-|false|`unset`|false|no|
-|`unset`|yes|true|yes|
-|`unset`|yes|false|yes|
-|`unset`|no|true|no|
-|`unset`|no|false|no|
-|`unset`|`unset`|true|yes|
-|`unset`|`unset`|false|no|
+|`true`|yes|`true`|yes|
+|`true`|yes|`false`|yes|
+|`true`|no|`true`|yes|
+|`true`|no|`false`|yes|
+|`true`|unset|`true`|yes|
+|`true`|unset|`false`|yes|
+|`false`|yes|`true`|no|
+|`false`|yes|`false`|no|
+|`false`|no|`true`|no|
+|`false`|no|`false`|no|
+|`false`|unset|`true`|no|
+|`false`|unset|`false`|no|
+|unset|yes|`true`|yes|
+|unset|yes|`false`|yes|
+|unset|no|`true`|no|
+|unset|no|`false`|no|
+|unset|unset|`true`|yes|
+|unset|unset|`false`|no|
 
 {{< idea >}}
-When a namespace transitions from `disabled` to `enabled`, Citadel will retroactively generate secrets for all `ServiceAccounts` in that namespace. When transitioning from `enabled` to `disabled`, however, Citadel will not delete the namespace's generated secrets until certificate renewal
+When a namespace transitions from _disabled_ to _enabled_, Citadel will retroactively generate secrets for all `ServiceAccounts` in that namespace. When transitioning from _enabled_ to _disabled_, however, Citadel will not delete the namespace's generated secrets until the root certificate is renewed.
 {{< /idea >}}
 
 ## Authentication

--- a/content/en/docs/reference/config/installation-options/index.md
+++ b/content/en/docs/reference/config/installation-options/index.md
@@ -472,6 +472,7 @@ To customize Istio install using Helm, use the `--set <key>=<value>` option in H
 | `security.replicaCount` | `1` |  |
 | `security.rollingMaxSurge` | `100%` |  |
 | `security.rollingMaxUnavailable` | `25%` |  |
+| `security.enableNamespacesByDefault` | `true` | `determines whether namespaces without the ca.istio.io/env and ca.istio.io/override labels should be targeted by the Citadel instance for secret creation` |
 | `security.image` | `citadel` |  |
 | `security.selfSigned` | `true` | `indicate if self-signed CA is used.` |
 | `security.createMeshPolicy` | `true` |  |

--- a/content/en/docs/tasks/security/ca-namespace-targeting/index.md
+++ b/content/en/docs/tasks/security/ca-namespace-targeting/index.md
@@ -1,0 +1,112 @@
+---
+title: Configure Citadel Service Account Secret Generation
+description: Configure which namespaces Citadel should generate service account secrets for.
+weight: 80
+---
+
+For various reasons, a cluster operator might decide not to generate `Service Account` secrets for some subset of namespaces, or to make `Service Account` secret generation opt-in per namespace. This task describes how an operator can configure their cluster for these situations. Full documentation of the Citadel namespace targeting mechanism can be found [here](/docs/concepts/security/#how-citadel-determines-whether-to-create-service-account-secrets).
+
+## Before you begin
+
+To complete this task, you should first take the following actions:
+
+* Read the [security concept](/docs/concepts/security/#how-citadel-determines-whether-to-create-service-account-secrets).
+
+* Follow the [Kubernetes quick start](/docs/setup/install/kubernetes/) to install Istio using the **strict mutual TLS profile**.
+
+### Deactivating Service Account secret generation for a single namespace
+
+For this example, let's create a new sample namespace `foo`
+
+{{< text bash >}}
+$ kubectl create ns foo
+{{< /text >}}
+
+Since service account secrets are created as the default behavior, Citadel should have generated a key/cert secret for the default service account in the `foo` namespace. Let's verify this with
+
+{{< text bash >}}
+$ kubectl get secrets -n foo | grep istio.io
+NAME                    TYPE                           DATA      AGE
+istio.default           istio.io/key-and-cert          3         13s
+{{< /text >}}
+
+Suppose we'd like to prevent Citadel from creating `ServiceAccount` secrets in target namespace `foo`. This can be done through labeling the namespace with
+
+{{< text bash >}}
+$ kubectl label ns foo ca.istio.io/override=false
+{{< /text >}}
+
+Now, if we create a new `ServiceAccount` in this namespace with
+
+{{< text bash >}}
+$ kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sample-service-account
+  namespace: foo
+EOF
+{{< /text >}}
+
+and then check the namespace secrets again
+
+{{< text bash >}}
+$ kubectl get secrets -n foo | grep istio.io
+NAME                    TYPE                           DATA      AGE
+istio.default           istio.io/key-and-cert          3         11m
+{{< /text >}}
+
+We can observe that no new `istio.io/key-and-cert` secret was generated for the `sample-service-account` service account.
+
+### Opt-in Service Account secret generation
+
+Let's suppose that as an operator, we would like to make `ServiceAcount` secret generation opt-in (i.e. don't generate secrets unless otherwise specified). In this case we should set the following in our helm chart configuration
+
+{{< text yaml >}}
+...
+security:
+    enableNamespacesByDefault: false
+...
+{{< /text >}}
+
+Once this mesh configuration is applied, create a namespace `foo`, and check the secrets present in that namespace
+
+{{< text bash >}}
+$ kubectl create ns foo
+$ kubectl get secrets -n foo | grep istio.io
+{{< /text >}}
+
+There should be no output from `kubectl get secrets -n foo`, as we configured the cluster not to generate `istio.io/key-and-cert` secrets by default. Now, to override this value on the `foo` namespace, label it with
+
+{{< text bash >}}
+$ kubectl label ns foo ca.istio.io/override=true
+{{< /text >}}
+
+and then create a new service account in the `foo` namespace with
+
+{{< text bash >}}
+$ kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sample-service-account
+  namespace: foo
+EOF
+{{< /text >}}
+
+Now, let's examine the secrets in the `foo` namespace again
+
+{{< text bash >}}
+$ kubectl get secrets -n foo | grep istio.io
+NAME                                 TYPE                                  DATA   AGE
+istio.default                        istio.io/key-and-cert                 3      47s
+istio.sample-service-account         istio.io/key-and-cert                 3      6s
+{{< /text >}}
+
+Notice that despite only having created the `sample-service-account` service account after activating the namespace, there is an `istio.io/key-and-cert` secret for the `default` namespace as well. This is due to the retroactive secret generation feature, which will create secrets for all service accounts in a namespace once it transitions from `inactive` to `active`.
+
+## Cleanup
+
+{{< text bash >}}
+$ kubectl delete ns foo
+{{< /text >}}

--- a/content/en/docs/tasks/security/ca-namespace-targeting/index.md
+++ b/content/en/docs/tasks/security/ca-namespace-targeting/index.md
@@ -4,7 +4,7 @@ description: Configure which namespaces Citadel should generate service account 
 weight: 80
 ---
 
-For various reasons, a cluster operator might decide not to generate `Service Account` secrets for some subset of namespaces, or to make `Service Account` secret generation opt-in per namespace. This task describes how an operator can configure their cluster for these situations. Full documentation of the Citadel namespace targeting mechanism can be found [here](/docs/concepts/security/#how-citadel-determines-whether-to-create-service-account-secrets).
+A cluster operator might decide not to generate `ServiceAccount` secrets for some subset of namespaces, or to make `ServiceAccount` secret generation opt-in per namespace. This task describes how an operator can configure their cluster for these situations. Full documentation of the Citadel namespace targeting mechanism can be found [here](/docs/concepts/security/#how-citadel-determines-whether-to-create-service-account-secrets).
 
 ## Before you begin
 
@@ -16,13 +16,13 @@ To complete this task, you should first take the following actions:
 
 ### Deactivating Service Account secret generation for a single namespace
 
-For this example, let's create a new sample namespace `foo`
+To create a new sample namespace `foo`, run:
 
 {{< text bash >}}
 $ kubectl create ns foo
 {{< /text >}}
 
-Since service account secrets are created as the default behavior, Citadel should have generated a key/cert secret for the default service account in the `foo` namespace. Let's verify this with
+Service account secrets are created following the default behavior. To verify that Citadel has generated a key/cert secret for the default service account in the `foo` namespace, run (note that this may take up to 1 minute):
 
 {{< text bash >}}
 $ kubectl get secrets -n foo | grep istio.io
@@ -30,13 +30,13 @@ NAME                    TYPE                           DATA      AGE
 istio.default           istio.io/key-and-cert          3         13s
 {{< /text >}}
 
-Suppose we'd like to prevent Citadel from creating `ServiceAccount` secrets in target namespace `foo`. This can be done through labeling the namespace with
+To label the namespace to prevent Citadel from creating `ServiceAccount` secrets in target namespace `foo`, run:
 
 {{< text bash >}}
 $ kubectl label ns foo ca.istio.io/override=false
 {{< /text >}}
 
-Now, if we create a new `ServiceAccount` in this namespace with
+To create a new `ServiceAccount` in this namespace, run:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -48,7 +48,7 @@ metadata:
 EOF
 {{< /text >}}
 
-and then check the namespace secrets again
+To check the namespace's secrets again, run:
 
 {{< text bash >}}
 $ kubectl get secrets -n foo | grep istio.io
@@ -56,11 +56,11 @@ NAME                    TYPE                           DATA      AGE
 istio.default           istio.io/key-and-cert          3         11m
 {{< /text >}}
 
-We can observe that no new `istio.io/key-and-cert` secret was generated for the `sample-service-account` service account.
+You can observe that no new `istio.io/key-and-cert` secret was generated for the `sample-service-account` service account.
 
 ### Opt-in Service Account secret generation
 
-Let's suppose that as an operator, we would like to make `ServiceAcount` secret generation opt-in (i.e. don't generate secrets unless otherwise specified). In this case we should set the following in our helm chart configuration
+To make `ServiceAcount` secret generation opt-in (i.e. to disable generating secrets unless otherwise specified)., set the `enableNamespacesByDefault` Helm value to `false`:
 
 {{< text yaml >}}
 ...
@@ -69,20 +69,20 @@ security:
 ...
 {{< /text >}}
 
-Once this mesh configuration is applied, create a namespace `foo`, and check the secrets present in that namespace
+Once this mesh configuration is applied, to create a namespace `foo` and check the secrets present in that namespace, run:
 
 {{< text bash >}}
 $ kubectl create ns foo
 $ kubectl get secrets -n foo | grep istio.io
 {{< /text >}}
 
-There should be no output from `kubectl get secrets -n foo`, as we configured the cluster not to generate `istio.io/key-and-cert` secrets by default. Now, to override this value on the `foo` namespace, label it with
+You can observe that no secrets have been created. To override this value for the `foo` namespace, add a `ca.istio.io/override=true` label in that namespace:
 
 {{< text bash >}}
 $ kubectl label ns foo ca.istio.io/override=true
 {{< /text >}}
 
-and then create a new service account in the `foo` namespace with
+To create a new service account in the `foo` namespace, run:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -94,7 +94,7 @@ metadata:
 EOF
 {{< /text >}}
 
-Now, let's examine the secrets in the `foo` namespace again
+To check the secrets in the `foo` namespace again, run:
 
 {{< text bash >}}
 $ kubectl get secrets -n foo | grep istio.io
@@ -103,9 +103,11 @@ istio.default                        istio.io/key-and-cert                 3    
 istio.sample-service-account         istio.io/key-and-cert                 3      6s
 {{< /text >}}
 
-Notice that despite only having created the `sample-service-account` service account after activating the namespace, there is an `istio.io/key-and-cert` secret for the `default` namespace as well. This is due to the retroactive secret generation feature, which will create secrets for all service accounts in a namespace once it transitions from `inactive` to `active`.
+You can observe that an `istio.io/key-and-cert` secret has been created for the `default` service account in addition to the `sample-service-account`. This is due to the retroactive secret generation feature, which will create secrets for all service accounts in a namespace once it transitions from inactive to active.
 
 ## Cleanup
+
+To delete the `foo` test namespace and all its resources, run:
 
 {{< text bash >}}
 $ kubectl delete ns foo


### PR DESCRIPTION
[https://github.com/istio/istio/pull/15503](https://github.com/istio/istio/pull/15503) will change the way that Citadel decides which namespaces it should create `ServiceAccount` secrets for, and once merged, will need to be documented.

This PR documents the new `security.enableNamespacesByDefault` flag in the `Installation Options` page, and adds a section to the `Keys and Certificates` page surrounding this new selection mechanism, along with a few brief usage examples. Please let me know if this section would be better split up / moved elsewhere in the docs 

/cc @incfly 

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
