### PR TITLE
Istio 1.2.2 1.2.1 annoucements cherrypick to master

### DIFF
--- a/content/about/notes/1.2.1/index.md
+++ b/content/about/notes/1.2.1/index.md
@@ -1,0 +1,10 @@
+---
+title: Istio 1.2.1
+publishdate: 2019-06-27
+icon: notes
+release: 1.2.1
+---
+
+This release includes several bug fixes and improvements.  This release note describes what's different between Istio 1.2 and Istio 1.2.1.
+
+{{< relnote >}}

--- a/content/about/notes/1.2.2/index.md
+++ b/content/about/notes/1.2.2/index.md
@@ -1,0 +1,10 @@
+---
+title: Istio 1.2.2
+publishdate: 2019-06-28
+icon: notes
+release: 1.2.2
+---
+
+This release includes bug fixes.  This release note describes what's different between Istio 1.2.1 and Istio 1.2.2.
+
+{{< relnote >}}

--- a/content/blog/2019/announcing-1.2.1/index.md
+++ b/content/blog/2019/announcing-1.2.1/index.md
@@ -1,0 +1,11 @@
+---
+title: Announcing Istio 1.2.1
+description: Istio 1.2.1 patch release.
+publishdate: 2019-06-27
+attribution: The Istio Team
+release: 1.2.1
+---
+
+We're pleased to announce the availability of Istio 1.2.1. Please see below for what's changed.
+
+{{< relnote >}}

--- a/content/blog/2019/announcing-1.2.2/index.md
+++ b/content/blog/2019/announcing-1.2.2/index.md
@@ -1,0 +1,11 @@
+---
+title: Announcing Istio 1.2.2
+description: Istio 1.2.2 patch release.
+publishdate: 2019-06-28
+attribution: The Istio Team
+release: 1.2.2
+---
+
+We're pleased to announce the availability of Istio 1.2.2. Please see below for what's changed.
+
+{{< relnote >}}

--- a/content/boilerplates/notes/1.2.1.md
+++ b/content/boilerplates/notes/1.2.1.md
@@ -1,0 +1,13 @@
+## Bug fixes
+
+- Fix duplicate CRD being generated in the install ([Issue 14976](https://github.com/istio/istio/issues/14976))
+- Fix Mixer unable to start when Galley is disabled ([Issue 14841](https://github.com/istio/istio/issues/14841))
+- Fix environment variable shadowing (NAMESPACE is used for listened namespaces and overwrites Citadel storage namespace (istio-system))
+- Fix cause of 'TLS error: Secret is not supplied by SDS' errors during upgrade ([Issue 15020](https://github.com/istio/istio/issues/15020))
+
+## Minor enhancements
+
+- Allow users to disable Istio default retries by setting retries to 0 ([Issue 14900](https://github.com/istio/istio/issues/14900))
+- Introduction of a Redis filter (this feature is guarded with the environment feature flag `PILOT_ENABLE_REDIS_FILTER`, disabled by default)
+- Add HTTP/1.0 support to gateway configuration generation ([Issue 13085](https://github.com/istio/istio/issues/13085))
+- Add [toleration](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) for Istio components ([Pull Request 15081](https://github.com/istio/istio/pull/15081))

--- a/content/boilerplates/notes/1.2.2.md
+++ b/content/boilerplates/notes/1.2.2.md
@@ -1,0 +1,4 @@
+## Bug fixes
+
+- Fix crash in Istio's JWT Envoy filter caused by malformed JWT ([Issue 15084](https://github.com/istio/istio/issues/15084))
+- Fix incorrect overwrite of x-forwarded-proto header ([Issue 15124](https://github.com/istio/istio/issues/15124))


### PR DESCRIPTION
Please provide a description for what this PR is for.

The goal of this PR is to fix a divergence introduced by the addition of security release blog announcements on the release/1.2 branch without being commited on master first.

This PR cherry-picks the changes that landed directly to the branch. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
