### PR TITLE
Add release notes for Istio 1.2.3

### DIFF
--- a/content/about/notes/1.2.3/index.md
+++ b/content/about/notes/1.2.3/index.md
@@ -1,0 +1,10 @@
+---
+title: Istio 1.2.3
+publishdate: 2019-08-02
+icon: notes
+release: 1.2.3
+---
+
+This release includes bug fixes.  This release note describes what's different between Istio 1.2.2 and Istio 1.2.3.
+
+{{< relnote >}}

--- a/content/blog/2019/announcing-1.2.3/index.md
+++ b/content/blog/2019/announcing-1.2.3/index.md
@@ -1,0 +1,11 @@
+---
+title: Announcing Istio 1.2.3
+description: Istio 1.2.3 patch release.
+publishdate: 2019-08-02
+attribution: The Istio Team
+release: 1.2.3
+---
+
+We're pleased to announce the availability of Istio 1.2.3. Please see below for what's changed.
+
+{{< relnote >}}

--- a/content/blog/2019/cve-2019-12995/index.md
+++ b/content/blog/2019/cve-2019-12995/index.md
@@ -37,6 +37,7 @@ Overall CVSS score: 7.5 [AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:F/RL:O/RC:C](http
 ## Vulnerability impact and Detection
 
 Envoy is vulnerable if the following two conditions are satisfied:
+
 * A JWT authentication policy is applied to it.
 * The JWT issuer (specified by `jwksUri`) uses the RSA algorithm for signature verification
 
@@ -51,6 +52,7 @@ If JWT policy is applied to the sidecar only, please keep in mind it might still
 A vulnerable Envoy will crash on an HTTP request with a malformed JWT token. When Envoy crashes, all existing connections will be disconnected immediately. The `pilot-agent` will restart the crashed Envoy automatically and it may take a few seconds to a few minutes for the restart. pilot-agent will stop restarting Envoy after it crashed more than ten times. In this case, Kubernetes will redeploy the pod, including the workload behind Envoy.
 
 To detect if there is any JWT authentication policy applied in your cluster, run the following command which print either of the following output:
+
 * Found JWT in authentication policy, **YOU ARE AFFECTED**
 * Did NOT find JWT in authentication policy, *YOU ARE NOT AFFECTED*
 

--- a/content/boilerplates/notes/1.2.3.md
+++ b/content/boilerplates/notes/1.2.3.md
@@ -7,5 +7,8 @@
 - Fix HPA and CPU settings for demo profile ([Issue 15338](https://github.com/istio/istio/issues/15338))
 - Relax Keep-Alive enforcement policy to avoid dropping connections under load ([Issue 15088](https://github.com/istio/istio/issues/15088))
 - When SDS is not used, skip Kubernetes JWT authentication to mitigate the risk of compromised (untrustworthy) JWTs being used.
+
+## Tests upgrade
+
 - Update base image version for Bookinfo reviews sample app ([Issue 15477](https://github.com/istio/istio/issues/15477))
 - Bookinfo samples image qualification ([Issue 14237](https://github.com/istio/istio/issues/14237))

--- a/content/boilerplates/notes/1.2.3.md
+++ b/content/boilerplates/notes/1.2.3.md
@@ -1,7 +1,7 @@
 ## Bug fixes
 
 - Fix a bug where the sidecar could infinitely forward requests to itself when pod defines a port undefined for service ([Issue 14443](https://github.com/istio/istio/issues/14443)) and ([Issue 14242](https://github.com/istio/istio/issues/14242))
-- Fix a bug where Stackdriver adapter shutsdown after telemetry is started.
+- Fix a bug where Stackdriver adapter shuts down after telemetry is started.
 - Fix Redis connectivity issues.
 - Fix case-sensitivity in regex-based HTTP URI matching for Virtual Service ([Issue 14983](https://github.com/istio/istio/issues/14983))
 - Fix HPA and CPU settings for demo profile ([Issue 15338](https://github.com/istio/istio/issues/15338))

--- a/content/boilerplates/notes/1.2.3.md
+++ b/content/boilerplates/notes/1.2.3.md
@@ -1,6 +1,6 @@
 ## Bug fixes
 
-- Fix infinite loops self-requests when pod defines a port undefined for service ([Issue 14443](https://github.com/istio/istio/issues/14443)) and ([Issue 14242](https://github.com/istio/istio/issues/14242))
+- Fix a bug where the sidecar could infinitely forward requests to itself when pod defines a port undefined for service ([Issue 14443](https://github.com/istio/istio/issues/14443)) and ([Issue 14242](https://github.com/istio/istio/issues/14242))
 - Fix a bug where Stackdriver adapter shutsdown after telemetry is started.
 - Fix Redis connectivity issues.
 - Fix case-sensitivity in regex-based HTTP URI matching for Virtual Service ([Issue 14983](https://github.com/istio/istio/issues/14983))

--- a/content/boilerplates/notes/1.2.3.md
+++ b/content/boilerplates/notes/1.2.3.md
@@ -1,0 +1,13 @@
+## Bug fixes
+
+- Fix infinite loops self-requests when pod defines a port undefined for service ([Issue 14443](https://github.com/istio/istio/issues/14443)) and ([Issue 14242](https://github.com/istio/istio/issues/14242))
+- Fix a bug where Stackdriver adapter is getting shutdown after telemetry is started.
+- Fix Redis Connectivity Issues.
+- Fix case-sensitivity in regex-based HTTP URI matching for Virtual Service ([Issue 14983](https://github.com/istio/istio/issues/14983))
+- Fix HPA and CPU settings for demo profile ([Issue 15338](https://github.com/istio/istio/issues/15338))
+- Relax Keep-Alive enforcement policy to avoid dropping connections under load ([Issue 15088](https://github.com/istio/istio/issues/15088))
+- When SDS is not used, skip Kubernetes JWT authentication to mitigate the risk of compromised (untrustworthy) JWTs being used.
+
+## Tests upgrade
+- Update base image version for Bookinfo reviews sample app ([Issue 15477](https://github.com/istio/istio/issues/15477))
+- Bookinfo samples image qualification ([Issue 14237](https://github.com/istio/istio/issues/14237))

--- a/content/boilerplates/notes/1.2.3.md
+++ b/content/boilerplates/notes/1.2.3.md
@@ -2,7 +2,7 @@
 
 - Fix infinite loops self-requests when pod defines a port undefined for service ([Issue 14443](https://github.com/istio/istio/issues/14443)) and ([Issue 14242](https://github.com/istio/istio/issues/14242))
 - Fix a bug where Stackdriver adapter is getting shutdown after telemetry is started.
-- Fix Redis Connectivity Issues.
+- Fix Redis connectivity issues.
 - Fix case-sensitivity in regex-based HTTP URI matching for Virtual Service ([Issue 14983](https://github.com/istio/istio/issues/14983))
 - Fix HPA and CPU settings for demo profile ([Issue 15338](https://github.com/istio/istio/issues/15338))
 - Relax Keep-Alive enforcement policy to avoid dropping connections under load ([Issue 15088](https://github.com/istio/istio/issues/15088))

--- a/content/boilerplates/notes/1.2.3.md
+++ b/content/boilerplates/notes/1.2.3.md
@@ -7,7 +7,5 @@
 - Fix HPA and CPU settings for demo profile ([Issue 15338](https://github.com/istio/istio/issues/15338))
 - Relax Keep-Alive enforcement policy to avoid dropping connections under load ([Issue 15088](https://github.com/istio/istio/issues/15088))
 - When SDS is not used, skip Kubernetes JWT authentication to mitigate the risk of compromised (untrustworthy) JWTs being used.
-
-## Tests upgrade
 - Update base image version for Bookinfo reviews sample app ([Issue 15477](https://github.com/istio/istio/issues/15477))
 - Bookinfo samples image qualification ([Issue 14237](https://github.com/istio/istio/issues/14237))

--- a/content/boilerplates/notes/1.2.3.md
+++ b/content/boilerplates/notes/1.2.3.md
@@ -1,7 +1,7 @@
 ## Bug fixes
 
 - Fix infinite loops self-requests when pod defines a port undefined for service ([Issue 14443](https://github.com/istio/istio/issues/14443)) and ([Issue 14242](https://github.com/istio/istio/issues/14242))
-- Fix a bug where Stackdriver adapter is getting shutdown after telemetry is started.
+- Fix a bug where Stackdriver adapter shutsdown after telemetry is started.
 - Fix Redis connectivity issues.
 - Fix case-sensitivity in regex-based HTTP URI matching for Virtual Service ([Issue 14983](https://github.com/istio/istio/issues/14983))
 - Fix HPA and CPU settings for demo profile ([Issue 15338](https://github.com/istio/istio/issues/15338))


### PR DESCRIPTION
- Also introduce a cosmetic style fix on cve-2019-12995 that was missing
  proper new line before 2 lists.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
