### PR TITLE
Change the service name in the description to match the example 

### DIFF
--- a/content/en/docs/concepts/traffic-management/index.md
+++ b/content/en/docs/concepts/traffic-management/index.md
@@ -1334,7 +1334,7 @@ spec:
 
 You can use delay and abort faults together. The following configuration
 introduces a delay of 5 seconds for all requests from the `v2` subset of the
-`ratings` service to the `v1` subset of the `ratings` service and an abort for
+`reviews` service to the `v1` subset of the `ratings` service and an abort for
 10% of them:
 
 {{< text yaml >}}


### PR DESCRIPTION
Signed-off-by: Nancy Avinger <navinger@google.com>

Change the service name in the description to match the example. This way the doc repo maintainers can close out PR #4661, which was languishing because the submitter didn't sign the PR.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
