### PR TITLE
$FORTIO_POD and tls.mode: disable

### DIFF
--- a/content/en/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/en/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -41,6 +41,8 @@ when calling the `httpbin` service:
     spec:
       host: httpbin
       trafficPolicy:
+        tls:
+          mode: DISABLE      
         connectionPool:
           tcp:
             maxConnections: 1
@@ -99,7 +101,7 @@ governed by Istio:
 Pass in `-curl` to indicate that you just want to make one call:
 
     {{< text bash >}}
-    $ FORTIO_POD=$(kubectl get pod | grep fortio | awk '{ print $1 }')
+    $ FORTIO_POD=$(kubectl -n httpbin get pod -l app=fortio -o jsonpath='{.items[0].metadata.name}')
     $ kubectl exec -it $FORTIO_POD  -c fortio /usr/bin/fortio -- load -curl  http://httpbin:8000/get
     HTTP/1.1 200 OK
     server: envoy


### PR DESCRIPTION
Replace 
`kubectl -n httpbin get pod | grep fortio | awk '{ print $1 }'`
with 
`kubectl -n httpbin get pod -l app=fortio -o jsonpath='{.items[0].metadata.name}`

provide the tls.mode statement

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
