### PR TITLE
Rename example YAML manifests to match intent

### DIFF
--- a/content/en/docs/tasks/security/mtls-migration/index.md
+++ b/content/en/docs/tasks/security/mtls-migration/index.md
@@ -117,7 +117,7 @@ $ cat <<EOF | kubectl apply -n foo -f -
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:
-  name: "example-httpbin-permissive"
+  name: "example-httpbin-strict"
   namespace: foo
 spec:
   targets:

--- a/content/zh/docs/tasks/security/mtls-migration/index.md
+++ b/content/zh/docs/tasks/security/mtls-migration/index.md
@@ -115,7 +115,7 @@ $ cat <<EOF | istioctl create -n foo -f -
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:
-  name: "example-httpbin-permissive"
+  name: "example-httpbin-strict"
   namespace: foo
 spec:
   targets:


### PR DESCRIPTION
Resolves the documentation component of https://github.com/istio/istio.io/issues/4760

Also related: https://github.com/istio/istio/blob/master/pkg/test/istio.io/tasks/security/mtls-migration/httpbin-foo-mtls-only.sh .  This file should also be changed.