### PR TITLE
Modify build_site.sh to work with new build-tools image

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -1,7 +1,7 @@
 ISTIO_SERVE_DOMAIN ?= localhost
 export ISTIO_SERVE_DOMAIN
 
-img := gcr.io/istio-testing/website-tools:2019-07-25
+img := gcr.io/istio-testing/build-tools:2019-08-15
 uid := $(shell id -u)
 docker := docker run -e INTERNAL_ONLY=true -t -i --sig-proxy=true --rm --user $(uid) -v /etc/passwd:/etc/passwd:ro -v $(shell pwd):/site -w /site $(img)
 

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -35,8 +35,17 @@ serve: build
 	@docker run -t -i --sig-proxy=true --rm --user $(uid) -v /etc/passwd:/etc/passwd:ro -v $(shell pwd):/site -w /site -p 1313:1313 $(img) hugo serve --baseURL "http://${ISTIO_SERVE_DOMAIN}:1313/" --bind 0.0.0.0 --disableFastRender
 
 install:
-	@npm install -g sass sass-lint typescript tslint @babel/cli @babel/core svgstore-cli
-	@npm install babel-preset-minify --save-dev
+	@npm init -y
+	@npm install -g \
+	    sass \
+	    sass-lint \
+	    typescript \
+	    tslint \
+	    markdown-spellcheck \
+	    svgstore-cli \
+	    svgo
+	@npm install --save-dev @babel/core @babel/cli @babel/preset-env
+	@npm install --save @babel/polyfill
 
 netlify: install
 	@scripts/build_site.sh

--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -6,6 +6,8 @@ mkdir -p generated/css generated/js generated/img tmp/js
 npx sass src/sass/_all.scss all.css -s compressed --no-source-map
 mv all.css* generated/css
 npx tsc
-npx babel tmp/js/constants.js tmp/js/utils.js tmp/js/kbdnav.js tmp/js/themes.js tmp/js/menu.js tmp/js/header.js tmp/js/sidebar.js tmp/js/tabset.js tmp/js/prism.js tmp/js/codeBlocks.js tmp/js/links.js tmp/js/scroll.js tmp/js/overlays.js tmp/js/lang.js tmp/js/callToAction.js --out-file generated/js/all.min.js --source-maps --minified --no-comments --presets minify
-npx babel tmp/js/themes_init.js --out-file generated/js/themes_init.min.js --source-maps --minified --no-comments --presets minify
+
+npx babel-cli --source-maps --minified --no-comments tmp/js/constants.js tmp/js/utils.js tmp/js/kbdnav.js tmp/js/themes.js tmp/js/menu.js tmp/js/header.js tmp/js/sidebar.js tmp/js/tabset.js tmp/js/prism.js tmp/js/codeBlocks.js tmp/js/links.js tmp/js/scroll.js tmp/js/overlays.js tmp/js/lang.js tmp/js/callToAction.js --out-file generated/js/all.min.js
+
+npx babel-cli --source-maps --minified --no-comments --out-file tmp/js/themes_init.js generated/js/themes_init.min.js
 npx svgstore -o generated/img/icons.svg src/icons/**/*.svg

--- a/scripts/build_site.sh
+++ b/scripts/build_site.sh
@@ -9,5 +9,5 @@ npx tsc
 
 npx babel-cli --source-maps --minified --no-comments tmp/js/constants.js tmp/js/utils.js tmp/js/kbdnav.js tmp/js/themes.js tmp/js/menu.js tmp/js/header.js tmp/js/sidebar.js tmp/js/tabset.js tmp/js/prism.js tmp/js/codeBlocks.js tmp/js/links.js tmp/js/scroll.js tmp/js/overlays.js tmp/js/lang.js tmp/js/callToAction.js --out-file generated/js/all.min.js
 
-npx babel-cli --source-maps --minified --no-comments --out-file tmp/js/themes_init.js generated/js/themes_init.min.js
+npx babel-cli --source-maps --minified --no-comments tmp/js/themes_init.js --out-file generated/js/themes_init.min.js
 npx svgstore -o generated/img/icons.svg src/icons/**/*.svg


### PR DESCRIPTION
babel-cli must be used instead of babel.  babel=version6,
babel-cli=version7.  I don't know the details, but make serve
seems to work well enough.

I had to drop a minifier rule. We can reintroduce this rule.

The babel-cli required a reordering of command line args.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
