### PR TITLE
Update docs for CoreDNS newer than 1.3.2

### DIFF
--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -145,8 +145,8 @@ Create one of the following ConfigMaps, or update an existing one, in each
 cluster that will be calling services in remote clusters
 (every cluster in the general case):
 
-For clusters that use `kube-dns`:
-
+{{< tabset cookie-name="platform" >}}
+{{< tab name="KubeDNS" cookie-value="kube-dns" >}}
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
 apiVersion: v1
@@ -159,9 +159,9 @@ data:
     {"global": ["$(kubectl get svc -n istio-system istiocoredns -o jsonpath={.spec.clusterIP})"]}
 EOF
 {{< /text >}}
+{{< /tab >}}
 
-For clusters that use CoreDNS (< 1.4.0):
-
+{{< tab name="CoreDNS (< 1.4.0)" cookie-value="coredns-prev-1.4.0" >}}
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
 apiVersion: v1
@@ -193,9 +193,9 @@ data:
     }
 EOF
 {{< /text >}}
+{{< /tab >}}
 
-For clusters that use CoreDNS (> 1.4.0):
-
+{{< tab name="CoreDNS (>= 1.4.0)" cookie-value="coredns-after-1.4.0" >}}
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
 apiVersion: v1
@@ -227,6 +227,8 @@ data:
     }
 EOF
 {{< /text >}}
+{{< /tab >}}
+{{< /tabset >}}
 
 ## Configure application services
 

--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -147,6 +147,7 @@ cluster that will be calling services in remote clusters
 
 {{< tabset cookie-name="platform" >}}
 {{< tab name="KubeDNS" cookie-value="kube-dns" >}}
+
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
 apiVersion: v1
@@ -159,9 +160,11 @@ data:
     {"global": ["$(kubectl get svc -n istio-system istiocoredns -o jsonpath={.spec.clusterIP})"]}
 EOF
 {{< /text >}}
+
 {{< /tab >}}
 
 {{< tab name="CoreDNS (< 1.4.0)" cookie-value="coredns-prev-1.4.0" >}}
+
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
 apiVersion: v1
@@ -193,9 +196,11 @@ data:
     }
 EOF
 {{< /text >}}
+
 {{< /tab >}}
 
 {{< tab name="CoreDNS (>= 1.4.0)" cookie-value="coredns-after-1.4.0" >}}
+
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
 apiVersion: v1
@@ -227,6 +232,7 @@ data:
     }
 EOF
 {{< /text >}}
+
 {{< /tab >}}
 {{< /tabset >}}
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR provides documentation for CoreDNS users that use a more recent version of CoreDNS (> 1.3.2). Since the `proxy` command was deprecated the resulting `ConfigMap` for `CoreDNS` looks a little bit different.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
