### PR TITLE
[Cherrypick from release 1.2] @duderino/jblatt 1.2.4 and 1.1.13 [Original PR #4785]

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -108,6 +108,7 @@ bring-your-own-identity
 Brooks
 bt
 Budinsky
+c.f.
 callouts
 Callouts
 camelCase
@@ -145,10 +146,15 @@ CSRs
 Ctrl
 Customizable
 CVE
-CVEs
-D3.js
+CVE-2019-14993
+CVE-2019-9512
+CVE-2019-9513
+CVE-2019-9514
+CVE-2019-9515
+CVE-2019-9518
 Datadog
 datapath
+CVEs
 dataset
 datastore
 Datawire
@@ -270,6 +276,8 @@ IPv4
 IPv6
 Istio
 istio.io
+ISTIO-SECURITY-2019-004
+ISTIO-SECURITY-2019-003
 istio.io.
 Istiofied
 IstioMesh
@@ -529,6 +537,7 @@ unmanaged
 unnormalized
 unsampled
 untrusted
+URIs
 uptime
 url
 user

--- a/content/about/notes/1.1.13/index.md
+++ b/content/about/notes/1.1.13/index.md
@@ -1,0 +1,10 @@
+---
+title: Istio 1.1.13
+publishdate: 2019-08-13
+icon: notes
+release: 1.1.13
+---
+
+This release includes an important security update.  This release note describes what's different between Istio 1.1.12 and Istio 1.1.13.
+
+{{< relnote >}}

--- a/content/about/notes/1.2.4/index.md
+++ b/content/about/notes/1.2.4/index.md
@@ -1,0 +1,10 @@
+---
+title: Istio 1.2.4
+publishdate: 2019-08-13
+icon: notes
+release: 1.2.4
+---
+
+This release includes an important security update.  This release note describes what's different between Istio 1.2.3 and Istio 1.2.4.
+
+{{< relnote >}}

--- a/content/blog/2019/announcing-1.1.13/index.md
+++ b/content/blog/2019/announcing-1.1.13/index.md
@@ -1,0 +1,11 @@
+---
+title: Announcing Istio 1.1.13
+description: Istio 1.1.13 patch release.
+publishdate: 2019-08-13
+attribution: The Istio Team
+release: 1.1.13
+---
+
+We're pleased to announce the availability of Istio 1.1.13. Please see below for what's changed.
+
+{{< relnote >}}

--- a/content/blog/2019/announcing-1.2.4/index.md
+++ b/content/blog/2019/announcing-1.2.4/index.md
@@ -1,0 +1,11 @@
+---
+title: Announcing Istio 1.2.4
+description: Istio 1.2.4 patch release.
+publishdate: 2019-08-13
+attribution: The Istio Team
+release: 1.2.4
+---
+
+We're pleased to announce the availability of Istio 1.2.4. Please see below for what's changed.
+
+{{< relnote >}}

--- a/content/blog/2019/istio-security-003-004/index.md
+++ b/content/blog/2019/istio-security-003-004/index.md
@@ -1,0 +1,100 @@
+---
+title: Security Update - ISTIO-SECURITY-003 and ISTIO-SECURITY-004
+description: Security vulnerability disclosure for multiple CVEs.
+publishdate: 2019-08-13
+attribution: The Istio Team
+keywords: [CVE]
+---
+
+Today we are releasing two new versions of Istio. Istio [1.1.13](/about/notes/1.1.13/) and [1.2.4](/about/notes/1.2.4/) address vulnerabilities that can be used to mount a Denial of Service (DoS) attack against services using Istio.
+
+__ISTIO-SECURITY-2019-003__: An Envoy user reported publicly an issue (c.f. [Envoy Issue 7728](https://github.com/envoyproxy/envoy/issues/7728)) about regular expressions (or regex) matching that crashes Envoy with very large URIs.
+  * __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
+
+__ISTIO-SECURITY-2019-004__: Envoy, and subsequently Istio are vulnerable to a series of trivial HTTP/2-based DoS attacks:
+  * __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+  * __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
+  * __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
+  * __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using SETTINGS frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+  * __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
+  * See [this security bulletin](https://github.com/Netflix/security-bulletins/blob/master/advisories/third-party/2019-002.md) for more information
+
+Those HTTP/2-based vulnerabilities were reported externally and affect multiple proxy implementations.
+
+## Affected Istio releases
+
+The following Istio releases are vulnerable:
+
+* 1.1, 1.1.1, 1.1.2, 1.1.3, 1.1.4, 1.1.5, 1.1.6, 1.1.7, 1.1.8, 1.1.9, 1.1.10, 1.1.11, 1.1.12
+* 1.2, 1.2.1, 1.2.2, 1.2.3
+
+All versions prior to 1.1 are no longer supported and are considered vulnerable.
+
+## Impact score
+
+* Overall CVSS score for __ISTIO-SECURITY-2019-003__: 7.5 [CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H)
+* Overall CVSS score for __ISTIO-SECURITY-2019-004__: 7.5 [CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H](https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H)
+
+## Vulnerability impact and detection
+
+__ISTIO-SECURITY-2019-003__: To detect if there is any regular expressions used in Istio APIs in your cluster, run the following command which prints either of the following output:
+  * YOU ARE AFFECTED: found regex used in `AuthenticationPolicy` or `VirtualService`
+  * YOU ARE NOT AFFECTED: did not find regex usage
+
+```bash
+cat <<'EOF' | bash -
+set -e
+set -u
+set -o pipefail
+
+red=`tput setaf 1`
+green=`tput setaf 2`
+reset=`tput sgr0`
+
+echo "Checking regex usage in Istio API ..."
+
+AFFECTED=()
+
+JWT_REGEX=()
+JWT_REGEX+=($(kubectl get Policy --all-namespaces -o jsonpath='{..regex}'))
+JWT_REGEX+=($(kubectl get MeshPolicy --all-namespaces -o jsonpath='{..regex}'))
+if [ "${#JWT_REGEX[@]}" != 0 ]; then
+  AFFECTED+=("AuthenticationPolicy")
+fi
+
+VS_REGEX=()
+VS_REGEX+=($(kubectl get VirtualService --all-namespaces -o jsonpath='{..regex}'))
+if [ "${#VS_REGEX[@]}" != 0 ]; then
+  AFFECTED+=("VirtualService")
+fi
+
+HTTPAPI_REGEX=()
+HTTPAPI_REGEX+=($(kubectl get HTTPAPISpec --all-namespaces -o jsonpath='{..regex}'))
+if [ "${#HTTPAPI_REGEX[@]}" != 0 ]; then
+  AFFECTED+=("HTTPAPISpec")
+fi
+
+QUOTA_REGEX=()
+QUOTA_REGEX+=($(kubectl get QuotaSpec --all-namespaces -o jsonpath='{..regex}'))
+if [ "${#QUOTA_REGEX[@]}" != 0 ]; then
+  AFFECTED+=("QuotaSpec")
+fi
+
+if [ "${#AFFECTED[@]}" != 0 ]; then
+  echo "${red}YOU ARE AFFECTED: found regex used in ${AFFECTED[@]}${reset}"
+  exit 1
+fi
+
+echo "${green}YOU ARE NOT AFFECTED: did not find regex usage${reset}"
+EOF
+```
+
+__ISTIO-SECURITY-2019-004__: If Istio terminates externally originated HTTP then it is vulnerable.   If Istio is instead fronted by an intermediary that terminates HTTP (e.g., a HTTP load balancer), then that intermediary would protect Istio, assuming the intermediary is not itself vulnerable to the same HTTP/2 exploits.
+
+## Mitigations
+
+For both vulnerabilities:
+  * For Istio 1.1.x deployments: update to a minimum version of Istio 1.1.13
+  * For Istio 1.2.x deployments: update to a minimum version of Istio 1.2.4
+
+We’d like to remind our community to follow the [vulnerability reporting process](/about/security-vulnerabilities/) to report any bug that can result in a security vulnerability.

--- a/content/boilerplates/notes/1.1.13.md
+++ b/content/boilerplates/notes/1.1.13.md
@@ -1,0 +1,16 @@
+## Security update
+
+This release contains fixes for the security vulnerabilities described in [our August 13th, 2019 blog post](/blog/2019/istio-security-003-004/).  Specifically:
+
+__ISTIO-SECURITY-2019-003__: An Envoy user reported publicly an issue (c.f. [Envoy Issue 7728](https://github.com/envoyproxy/envoy/issues/7728)) about regular expressions matching that crashes Envoy with very large URIs.
+  * __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
+
+__ISTIO-SECURITY-2019-004__: Envoy, and subsequently Istio are vulnerable to a series of trivial HTTP/2-based DoS attacks:
+  * __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+  * __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
+  * __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
+  * __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using `SETTINGS` frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+  * __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
+  * See [this security bulletin](https://github.com/Netflix/security-bulletins/blob/master/advisories/third-party/2019-002.md) for more information
+
+Nothing else is included in this release except for the above security fixes.

--- a/content/boilerplates/notes/1.2.4.md
+++ b/content/boilerplates/notes/1.2.4.md
@@ -1,0 +1,16 @@
+## Security update
+
+This release contains fixes for the security vulnerabilities described in [our August 13th, 2019 blog post](/blog/2019/istio-security-003-004/).  Specifically:
+
+__ISTIO-SECURITY-2019-003__: An Envoy user reported publicly an issue (c.f. [Envoy Issue 7728](https://github.com/envoyproxy/envoy/issues/7728)) about regular expressions matching that crashes Envoy with very large URIs.
+  * __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
+
+__ISTIO-SECURITY-2019-004__: Envoy, and subsequently Istio are vulnerable to a series of trivial HTTP/2-based DoS attacks:
+  * __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+  * __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
+  * __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
+  * __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using `SETTINGS` frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+  * __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
+  * See [this security bulletin](https://github.com/Netflix/security-bulletins/blob/master/advisories/third-party/2019-002.md) for more information
+
+Nothing else is included in this release except for the above security fixes.


### PR DESCRIPTION
Because of the way security embargo works, these commits landed directly in release branch instead of following the process of `master branch->cherry pick to release branch` path.

Original description:
* Fixed the linting errors I was able to.
* Add 1.1.13 and 1.2.4 release notes.

And fix some linter errors in oaktowner's blog post.

* Minor fixes
* code review fixes.
* If istio terminates any http since it will autodetect and use http/2 if
supplied.
* Apply suggestions from code review

Applying geeknoid's suggestions

Co-Authored-By: Martin Taillefer <geeknoid@users.noreply.github.com>

* It's queuing not queueing.
* Rename cve announcement path to istio-security path.
* Add note that these are minimal patches that fix only the security bugs.
* Add CVE for regex vulnerabilities in the mixer filter.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
