### PR TITLE
Fix 1.1.14 and 1.2.5 notes

### DIFF
--- a/content/en/boilerplates/notes/1.1.14.md
+++ b/content/en/boilerplates/notes/1.1.14.md
@@ -7,4 +7,4 @@ You can find the gRPC vulnerability fix description on their mailing list (c.f.
 
 ## Bug fix
 
-- Fix an Envoy bug that breaks `java.net.http.HttpClient` and other clients that attempt to upgrade from `HTTP/1.1` to `HTTP/2` using the `Upgrade: h2c` header.  ([Issue 16391](https://github.com/istio/istio/issues/16391)).
+- Fix an Envoy bug that breaks `java.net.http.HttpClient` and other clients that attempt to upgrade from `HTTP/1.1` to `HTTP/2` using the `Upgrade: h2c` header ([Issue 16391](https://github.com/istio/istio/issues/16391)).

--- a/content/en/boilerplates/notes/1.2.5.md
+++ b/content/en/boilerplates/notes/1.2.5.md
@@ -7,5 +7,5 @@ You can find the gRPC vulnerability fix description on their mailing list (c.f.
 
 ## Bug fixes
 
-- Fix an Envoy bug that breaks `java.net.http.HttpClient` and other clients that attempt to upgrade from `HTTP/1.1` to `HTTP/2` using the `Upgrade: h2c` header.  ([Issue 16391](https://github.com/istio/istio/issues/16391)).
+- Fix an Envoy bug that breaks `java.net.http.HttpClient` and other clients that attempt to upgrade from `HTTP/1.1` to `HTTP/2` using the `Upgrade: h2c` header ([Issue 16391](https://github.com/istio/istio/issues/16391)).
 - Fix a goroutine leak on send timeout ([Issue 15876](https://github.com/istio/istio/issues/15876)).


### PR DESCRIPTION
The current release notes say that the http2 upgrade bug was made necessary by the HTTP/2 vulnerability fixes, but really they have always been in Envoy.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
