### PR TITLE
Fix 1.1.14 and 1.2.5 notes (#4837)

### DIFF
--- a/content/boilerplates/notes/1.1.14.md
+++ b/content/boilerplates/notes/1.1.14.md
@@ -7,4 +7,4 @@ You can find the gRPC vulnerability fix description on their mailing list (c.f.
 
 ## Bug fix
 
-This release fixes a bug which was introduced during the security vulnerability fix of 1.1.13: 503 HTTP errors were returned on HTTP requests attempting to upgrade to HTTP2.
+- Fix an Envoy bug that breaks `java.net.http.HttpClient` and other clients that attempt to upgrade from `HTTP/1.1` to `HTTP/2` using the `Upgrade: h2c` header ([Issue 16391](https://github.com/istio/istio/issues/16391)).

--- a/content/boilerplates/notes/1.2.5.md
+++ b/content/boilerplates/notes/1.2.5.md
@@ -7,5 +7,5 @@ You can find the gRPC vulnerability fix description on their mailing list (c.f.
 
 ## Bug fixes
 
-- This release fixes a bug which was introduced during the security vulnerability fix of 1.2.4: 503 HTTP errors were returned on HTTP requests attempting to upgrade to HTTP2.
-- Fix a goroutine leak on send timeout ([Issue 15876](https://github.com/istio/istio/issues/15876))
+- Fix an Envoy bug that breaks `java.net.http.HttpClient` and other clients that attempt to upgrade from `HTTP/1.1` to `HTTP/2` using the `Upgrade: h2c` header ([Issue 16391](https://github.com/istio/istio/issues/16391)).
+- Fix a goroutine leak on send timeout ([Issue 15876](https://github.com/istio/istio/issues/15876)).


### PR DESCRIPTION
* Fix release notes - h2c upgrade issue was not introduced by the http/2
cve fixes.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
