### PR TITLE
Fix wrong default policy being stated in injection troubleshooting guide

### DIFF
--- a/content/en/docs/ops/troubleshooting/injection/index.md
+++ b/content/en/docs/ops/troubleshooting/injection/index.md
@@ -96,7 +96,7 @@ of injected sidecar when it was.
 
     Allowed policy values are `disabled` and `enabled`. The default policy
     only applies if the webhook’s `namespaceSelector` matches the target
-    namespace. Unrecognized policy values default to `disabled`.
+    namespace. Unrecognized policy causes injection to be disabled completely.
 
 1. Check the per-pod override annotation
 


### PR DESCRIPTION
When policy is set to an unrecognized value, the sidecar injector
defaults to [not injecting the pod, regardless of any other factors](https://github.com/istio/istio/blob/master/pkg/kube/inject/inject.go#L478)

This is different to the behvaior of `policy: disabled`, so the docs
should make that clear.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure
