### PR TITLE
[release-1.3] Fix auto-completion link to point to the pertinent content

### DIFF
--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -104,5 +104,5 @@ services from all other namespaces.
     $ export PATH=$PWD/bin:$PATH
     {{< /text >}}
 
-1. You can enable the [auto-completion option](/docs/ops/troubleshooting/istioctl) when working with a bash or ZSH console.
+1. You can enable the [auto-completion option](/docs/ops/troubleshooting/istioctl#enabling-auto-completion) when working with a bash or ZSH console.
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR fixes the link to enabling auto completion such that it links to the anchor in the page rather than the page in general. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
