### PR TITLE
[release-1.3] Add missing ports in installation

### DIFF
--- a/content/en/docs/setup/additional-setup/requirements/index.md
+++ b/content/en/docs/setup/additional-setup/requirements/index.md
@@ -75,13 +75,18 @@ The following ports and protocols are used by Istio. Ensure that there are no TC
 | 8060 | HTTP | Citadel | GRPC server |
 | 9090 | HTTP |  Prometheus | Prometheus |
 | 9091 | HTTP | Mixer | Policy/Telemetry |
-| 9093 | HTTP | Citadel | |
+| 9901 | GRPC | Galley| Mesh Configuration Protocol |
 | 15000 | TCP | Envoy | Envoy admin port (commands/diagnostics) |
 | 15001 | TCP | Envoy | Envoy |
 | 15004 | HTTP | Mixer, Pilot | Policy/Telemetry - `mTLS` |
 | 15010 | HTTP | Pilot | Pilot service - XDS pilot - discovery |
 | 15011 | TCP | Pilot | Pilot service - `mTLS` - Proxy - discovery |
-| 15014 | HTTP | Citadel, Mixer, Pilot | Control plane monitoring |
-| 15030 | TCP | Prometheus | Prometheus |
+| 15014 | HTTP | Citadel, Galley, Mixer, Pilot, Sidecar Injector | Control plane monitoring |
+| 15020 | HTTP | Ingress Gateway | Pilot health checks |
+| 15029 | HTTP | Kiali | Kiali User Interface |
+| 15030 | HTTP | Prometheus | Prometheus User Interface |
+| 15031 | HTTP | Grafana | Grafana User Interface |
+| 15032 | HTTP | Tracing | Tracing User Interface |
+| 15443 | TLS | Ingress and Egress Gateways | SNI |
 | 15090 | HTTP | Mixer | Proxy |
 | 42422 | TCP | Mixer | Telemetry - Prometheus |

--- a/content/en/docs/setup/install/kubernetes/index.md
+++ b/content/en/docs/setup/install/kubernetes/index.md
@@ -96,23 +96,23 @@ $ kubectl apply -f install/kubernetes/istio-demo-auth.yaml
 
     {{< text bash >}}
     $ kubectl get svc -n istio-system
-    NAME                     TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                                                                                                                   AGE
-    grafana                  ClusterIP      172.21.211.123   <none>          3000/TCP                                                                                                                  2m
-    istio-citadel            ClusterIP      172.21.177.222   <none>          8060/TCP,9093/TCP                                                                                                         2m
-    istio-egressgateway      ClusterIP      172.21.113.24    <none>          80/TCP,443/TCP                                                                                                            2m
-    istio-galley             ClusterIP      172.21.132.247   <none>          443/TCP,9093/TCP                                                                                                          2m
-    istio-ingressgateway     LoadBalancer   172.21.144.254   52.116.22.242   80:31380/TCP,443:31390/TCP,31400:31400/TCP,15011:32081/TCP,8060:31695/TCP,853:31235/TCP,15030:32717/TCP,15031:32054/TCP   2m
-    istio-pilot              ClusterIP      172.21.105.205   <none>          15010/TCP,15011/TCP,8080/TCP,9093/TCP                                                                                     2m
-    istio-policy             ClusterIP      172.21.14.236    <none>          9091/TCP,15004/TCP,9093/TCP                                                                                               2m
-    istio-sidecar-injector   ClusterIP      172.21.155.47    <none>          443/TCP                                                                                                                   2m
-    istio-telemetry          ClusterIP      172.21.196.79    <none>          9091/TCP,15004/TCP,9093/TCP,42422/TCP                                                                                     2m
-    jaeger-agent             ClusterIP      None             <none>          5775/UDP,6831/UDP,6832/UDP                                                                                                2m
-    jaeger-collector         ClusterIP      172.21.135.51    <none>          14267/TCP,14268/TCP                                                                                                       2m
-    jaeger-query             ClusterIP      172.21.26.187    <none>          16686/TCP                                                                                                                 2m
-    kiali                    ClusterIP      172.21.155.201   <none>          20001/TCP                                                                                                                 2m
-    prometheus               ClusterIP      172.21.63.159    <none>          9090/TCP                                                                                                                  2m
-    tracing                  ClusterIP      172.21.2.245     <none>          80/TCP                                                                                                                    2m
-    zipkin                   ClusterIP      172.21.182.245   <none>          9411/TCP                                                                                                                  2m
+    NAME                     TYPE           CLUSTER-IP       EXTERNAL-IP     PORT(S)                                                                                                                                      AGE
+    grafana                  ClusterIP      172.21.211.123   <none>          3000/TCP                                                                                                                                     2m
+    istio-citadel            ClusterIP      172.21.177.222   <none>          8060/TCP,15014/TCP                                                                                                                           2m
+    istio-egressgateway      ClusterIP      172.21.113.24    <none>          80/TCP,443/TCP,15443/TCP                                                                                                                     2m
+    istio-galley             ClusterIP      172.21.132.247   <none>          443/TCP,15014/TCP,9901/TCP                                                                                                                   2m
+    istio-ingressgateway     LoadBalancer   172.21.144.254   52.116.22.242   15020:31831/TCP,80:31380/TCP,443:31390/TCP,31400:31400/TCP,15029:30318/TCP,15030:32645/TCP,15031:31933/TCP,15032:31188/TCP,15443:30838/TCP   2m
+    istio-pilot              ClusterIP      172.21.105.205   <none>          15010/TCP,15011/TCP,8080/TCP,15014/TCP                                                                                                       2m
+    istio-policy             ClusterIP      172.21.14.236    <none>          9091/TCP,15004/TCP,15014/TCP                                                                                                                 2m
+    istio-sidecar-injector   ClusterIP      172.21.155.47    <none>          443/TCP,15014/TCP                                                                                                                            2m
+    istio-telemetry          ClusterIP      172.21.196.79    <none>          9091/TCP,15004/TCP,15014/TCP,42422/TCP                                                                                                       2m
+    jaeger-agent             ClusterIP      None             <none>          5775/UDP,6831/UDP,6832/UDP                                                                                                                   2m
+    jaeger-collector         ClusterIP      172.21.135.51    <none>          14267/TCP,14268/TCP                                                                                                                          2m
+    jaeger-query             ClusterIP      172.21.26.187    <none>          16686/TCP                                                                                                                                    2m
+    kiali                    ClusterIP      172.21.155.201   <none>          20001/TCP                                                                                                                                    2m
+    prometheus               ClusterIP      172.21.63.159    <none>          9090/TCP                                                                                                                                     2m
+    tracing                  ClusterIP      172.21.2.245     <none>          80/TCP                                                                                                                                       2m
+    zipkin                   ClusterIP      172.21.182.245   <none>          9411/TCP                                                                                                                                     2m
     {{< /text >}}
 
     {{< tip >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Noticed that quite a few of the ports were off in the `kubectl get svc` output. This PR fixes it. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
