### PR TITLE
Remove old note about Istio 1.1

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -61,15 +61,6 @@ service entry defined within the mesh.
 without controlling access to external services.
 You can then decide to [configure access to external services](#controlled-access-to-external-services) later.
 
-{{< warning >}}
-In versions prior to Istio 1.1.4, `ALLOW_ANY` only worked on ports with no HTTP services or
-service entries defined within the mesh.
-External hosts using the same port as any internal HTTP service
-fell back to a blocking-by-default behavior.
-Because some ports, such as port 80, have HTTP services inside Istio by default,
-prior to Istio 1.1.4 you couldn't call external services on any of those ports either.
-{{< /warning >}}
-
 1. To see this approach in action you need to ensure that your Istio installation is configured
     with the `global.outboundTrafficPolicy.mode` option set to `ALLOW_ANY`. Unless you explicitly
     set it to `REGISTRY_ONLY` mode when you installed Istio, it is probably enabled by default.


### PR DESCRIPTION
In 1.3 documentation I don't think we need a warning about 1.1 anymore

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
