### PR TITLE
remove containerPort requirements.

### DIFF
--- a/content/en/docs/setup/additional-setup/requirements/index.md
+++ b/content/en/docs/setup/additional-setup/requirements/index.md
@@ -35,10 +35,6 @@ cluster must satisfy the following requirements:
     plain TCP traffic unless the port [explicitly](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
     uses `Protocol: UDP` to signify a UDP port.
 
-- **Pod ports**: Pods must include an explicit list of the ports each
-  container listens on. Use a `containerPort` configuration in the container
-  specification for each port. Any unlisted ports bypass the Istio proxy.
-
 - **Service association**: A pod must belong to at least one Kubernetes
   service even if the pod does NOT expose any port.
   If a pod belongs to multiple [Kubernetes services](https://kubernetes.io/docs/concepts/services-networking/service/),


### PR DESCRIPTION
Please provide a description for what this PR is for.

remove `containerPort`requirement for pod, since we now default capture all the inbound ports after this PR: https://github.com/istio/istio/pull/16414

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ X ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
