### PR TITLE
Fix path in scripts/tablegen.py to reflect content reorg

### DIFF
--- a/scripts/tablegen.py
+++ b/scripts/tablegen.py
@@ -40,7 +40,7 @@ ISTIO_CONFIG_DIR = "istio/install/kubernetes/helm/istio"
 YAML_CONFIG_DIR = ISTIO_CONFIG_DIR + "/charts"
 VALUES_YAML = "values.yaml"
 ISTIO_IO_DIR = os.path.abspath(__file__ + "/../../")
-CONFIG_INDEX_DIR = "content/docs/reference/config/installation-options/index.md"
+CONFIG_INDEX_DIR = "content/en/docs/reference/config/installation-options/index.md"
 
 def endOfTheList(context, lineNum, lastLineNum, totalNum):
     flag = 0


### PR DESCRIPTION
Hard coded path in the `scripts/tablegen.py` are outdated after the `/en` content reorg.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
