### PR TITLE
Update text and links to refer to AKS-engine

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -63,7 +63,7 @@ accounts.my
 ack-istio
 ACLs
 Acmeair
-ACS-Engine
+AKS-Engine
 addon
 addons
 admissionregistration

--- a/content/en/docs/setup/platform-setup/azure/index.md
+++ b/content/en/docs/setup/platform-setup/azure/index.md
@@ -11,7 +11,7 @@ keywords: [platform-setup,azure]
 
 Follow these instructions to prepare an Azure cluster for Istio.
 
-You can deploy a Kubernetes cluster to Azure via [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/) or [ACS-Engine](https://github.com/azure/acs-engine) which fully supports Istio.
+You can deploy a Kubernetes cluster to Azure via [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/) or [AKS-Engine](https://github.com/azure/aks-engine) which fully supports Istio.
 
 ## AKS
 
@@ -52,21 +52,21 @@ For the `az` cli option, complete `az login` authentication OR use cloud shell, 
     $ az aks get-credentials --resource-group myResourceGroup --name myAKSCluster
     {{< /text >}}
 
-## ACS-Engine
+## AKS-Engine
 
-1. [Follow the instructions](https://github.com/Azure/acs-engine/blob/master/docs/acsengine.md#install) to get and install the `acs-engine` binary.
+1. [Follow the instructions](https://github.com/Azure/aks-engine/blob/master/docs/tutorials/quickstart.md#install-aks-engine) to get and install the `aks-engine` binary.
 
-1. Download the `acs-engine` API model definition that supports deploying Istio:
+1. Download the `aks-engine` API model definition that supports deploying Istio:
 
     {{< text bash >}}
-    $ wget https://raw.githubusercontent.com/Azure/acs-engine/master/examples/service-mesh/istio.json
+    $ wget https://raw.githubusercontent.com/Azure/aks-engine/master/examples/service-mesh/istio.json
     {{< /text >}}
 
-    Note: It is possible to use other api model definitions which will work with Istio.  The MutatingAdmissionWebhook and ValidatingAdmissionWebhook admission control flags and RBAC are enabled by default. See [acs-engine api model default values](https://github.com/Azure/acs-engine/blob/master/docs/clusterdefinition.md) for further information.
+    Note: It is possible to use other api model definitions which will work with Istio. The MutatingAdmissionWebhook and ValidatingAdmissionWebhook admission control flags and RBAC are enabled by default. See [aks-engine api model default values](https://github.com/Azure/aks-engine/blob/master/docs/topics/clusterdefinitions.md) for further information.
 
 1. Deploy your cluster using the `istio.json` template. You can find references
    to the parameters in the
-   [official docs](https://github.com/Azure/acs-engine/blob/master/docs/kubernetes/deploy.md#step-3-edit-your-cluster-definition).
+   [official docs](https://github.com/Azure/aks-engine/blob/master/docs/tutorials/deploy.md#step-3-edit-your-cluster-definition).
 
     | Parameter                             | Expected value             |
     |---------------------------------------|----------------------------|
@@ -75,7 +75,7 @@ For the `az` cli option, complete `az login` authentication OR use cloud shell, 
     | `location`                            | Cluster Location           |
 
     {{< text bash >}}
-    $ acs-engine deploy --subscription-id <subscription_id> \
+    $ aks-engine deploy --subscription-id <subscription_id> \
       --dns-prefix <dns_prefix> --location <location> --auto-suffix \
       --api-model istio.json
     {{< /text >}}
@@ -84,7 +84,7 @@ For the `az` cli option, complete `az login` authentication OR use cloud shell, 
     After a few minutes, you can find your cluster on your Azure subscription
     in a resource group called `<dns_prefix>-<id>`. Assuming `dns_prefix` has
     the value `myclustername`, a valid resource group with a unique cluster
-    ID is `mycluster-5adfba82`. The `acs-engine` generates your `kubeconfig`
+    ID is `mycluster-5adfba82`. The `aks-engine` generates your `kubeconfig`
     file in the `_output` folder.
     {{< /tip >}}
 

--- a/content/zh/docs/setup/kubernetes/prepare/platform-setup/azure/index.md
+++ b/content/zh/docs/setup/kubernetes/prepare/platform-setup/azure/index.md
@@ -8,7 +8,7 @@ keywords: [platform-setup,azure]
 
 依照本指南对 Azure 集群进行配置以便安装运行 Istio。
 
-可以使用 [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/) 或者 [ACS-Engine](https://github.com/azure/acs-engine) 部署 Kubernetes 集群，两种方式都完全能够支持 Istio 的安装和运行。
+可以使用 [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/) 或者 [AKS-Engine](https://github.com/azure/aks-engine) 部署 Kubernetes 集群，两种方式都完全能够支持 Istio 的安装和运行。
 
 ## AKS
 
@@ -49,19 +49,19 @@ keywords: [platform-setup,azure]
     $ az aks get-credentials --resource-group myResourceGroup --name myAKSCluster
     {{< /text >}}
 
-## ACS-Engine
+## AKS-Engine
 
-1. 按照下面的[介绍](https://github.com/Azure/acs-engine/blob/master/docs/acsengine.md#install)，下载和安装 `acs-engine` 的二进制包。
+1. 按照下面的[介绍](https://github.com/Azure/aks-engine/blob/master/docs/tutorials/quickstart.md#install-aks-engine)，下载和安装 `aks-engine` 的二进制包。
 
-1. 下载支持 Istio 的 `acs-engine` API 模型定义文件：
+1. 下载支持 Istio 的 `aks-engine` API 模型定义文件：
 
     {{< text bash >}}
-    $ wget https://raw.githubusercontent.com/Azure/acs-engine/master/examples/service-mesh/istio.json
+    $ wget https://raw.githubusercontent.com/Azure/aks-engine/master/examples/service-mesh/istio.json
     {{< /text >}}
 
-    注意：使用其他的 API 模型定义也是可以支持 Istio 的。MutatingAdmissionWebhook 以及 ValidatingAdmissionWebhook 两个准入控制标志以及 RBAC 在 1.9 或更新版本的集群中都是缺省开启的。请参看 [acs-engine API 模型的缺省值](https://github.com/Azure/acs-engine/blob/master/docs/clusterdefinition.md)获取更多相关信息。
+    注意：使用其他的 API 模型定义也是可以支持 Istio 的。MutatingAdmissionWebhook 以及 ValidatingAdmissionWebhook 两个准入控制标志以及 RBAC 在 1.9 或更新版本的集群中都是缺省开启的。请参看 [aks-engine API 模型的缺省值](https://github.com/Azure/aks-engine/blob/master/docs/topics/clusterdefinitions.md)获取更多相关信息。
 
-1. 使用 `istio.json` 模板定义集群。其中的参数可以在[官方文档](https://github.com/Azure/acs-engine/blob/master/docs/kubernetes/deploy.md#step-3-edit-your-cluster-definition)中找到。
+1. 使用 `istio.json` 模板定义集群。其中的参数可以在[官方文档](https://github.com/Azure/aks-engine/blob/master/docs/tutorials/deploy.md#step-3-edit-your-cluster-definition)中找到。
 
     | 参数                                   | 说明               |
     |---------------------------------------|---------------------------|
@@ -70,13 +70,13 @@ keywords: [platform-setup,azure]
     | `location`                            | 集群位置           |
 
     {{< text bash >}}
-    $ acs-engine deploy --subscription-id <subscription_id> \
+    $ aks-engine deploy --subscription-id <subscription_id> \
       --dns-prefix <dns_prefix> --location <location> --auto-suffix \
       --api-model istio.json
     {{< /text >}}
 
     {{< tip >}}
-    几分钟之后，就可以在 Azure 订阅中发现一个资源组，命名方式是 `<dns_prefix>-<id>`。假设 `dns-prefix` 取值为 `myclustername`，会在后面加入一个随机 ID 后缀，生成资源组名，例如 `mycluster-5adfba82`。`acs-engine` 会生成 `kubeconfig` 文件，放置到 `_output` 文件夹中。
+    几分钟之后，就可以在 Azure 订阅中发现一个资源组，命名方式是 `<dns_prefix>-<id>`。假设 `dns-prefix` 取值为 `myclustername`，会在后面加入一个随机 ID 后缀，生成资源组名，例如 `mycluster-5adfba82`。`aks-engine` 会生成 `kubeconfig` 文件，放置到 `_output` 文件夹中。
     {{< /tip >}}
 
 1. 使用 `<dns_prefix>-<id>` 集群 ID，把 `kubeconfig` 从 `_output` 文件夹中复制出来：


### PR DESCRIPTION
Please provide a description for what this PR is for.

Azure's acs-engine has been superseded by aks-engine- see: https://github.com/Azure/acs-engine

This PR replaces references to acs-engine with aks-engine and updates links accordingly.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure
