### PR TITLE
refine NetworkEndpoints fromRegistry field description

### DIFF
--- a/content/en/docs/reference/config/istio.mesh.v1alpha1/index.html
+++ b/content/en/docs/reference/config/istio.mesh.v1alpha1/index.html
@@ -968,8 +968,8 @@ ranges for endpoints from different networks must not overlap.</p>
 <td><code>string (oneof)</code></td>
 <td>
 <p>Add all endpoints from the specified registry into this network.
-The names of the registries should correspond to the secret name
-that was used to configure the registry (Kubernetes multicluster) or
+The names of the registries should correspond to the kubeconfig file name
+inside the secret that was used to configure the registry (Kubernetes multicluster) or
 supplied by MCP server.</p>
 
 </td>


### PR DESCRIPTION
Description in [Network.NetworkEndpoints field fromRegistry](https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#Network-NetworkEndpoints) is misleading by guiding to use a Kubernetes secret name rather than a kubeconfig filename used as a data key inside the secret.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
