### PR TITLE
[release-1.3] Fixed injection and validation operations guides

### DIFF
--- a/content/en/docs/ops/setup/injection-concepts/index.md
+++ b/content/en/docs/ops/setup/injection-concepts/index.md
@@ -31,15 +31,11 @@ the three configuration items. The security rules above cannot be overridden.
 
 | `namespaceSelector` match | default `policy` | Pod override annotation `sidecar.istio.io/inject` | Sidecar injected? |
 |---------------------------|------------------|---------------------------------------------------|-----------|
-| yes                       | enabled          | true                                              | yes       |
+| yes                       | enabled          | true (default)                                    | yes       |
 | yes                       | enabled          | false                                             | no        |
-| yes                       | enabled          |                                                   | yes       |
 | yes                       | disabled         | true                                              | yes       |
-| yes                       | disabled         | false                                             | no        |
-| yes                       | disabled         |                                                   | no        |
+| yes                       | disabled         | false (default)                                   | no        |
 | no                        | enabled          | true                                              | no        |
 | no                        | enabled          | false                                             | no        |
-| no                        | enabled          |                                                   | no        |
 | no                        | disabled         | true                                              | no        |
 | no                        | disabled         | false                                             | no        |
-| no                        | disabled         |                                                   | no        |

--- a/content/en/docs/ops/setup/injection-concepts/index.md
+++ b/content/en/docs/ops/setup/injection-concepts/index.md
@@ -38,4 +38,4 @@ the three configuration items. The security rules above cannot be overridden.
 | no                        | enabled          | true                                              | no        |
 | no                        | enabled          | false                                             | no        |
 | no                        | disabled         | true                                              | no        |
-| no                        | disabled         | false                                             | no        |
+ | no                        | disabled         | false (default)                                   | no        |

--- a/content/en/docs/ops/setup/injection-concepts/index.md
+++ b/content/en/docs/ops/setup/injection-concepts/index.md
@@ -38,4 +38,4 @@ the three configuration items. The security rules above cannot be overridden.
 | no                        | enabled          | true (default)                                    | no        |
 | no                        | enabled          | false                                             | no        |
 | no                        | disabled         | true                                              | no        |
- | no                        | disabled         | false (default)                                   | no        |
+| no                        | disabled         | false (default)                                   | no        |

--- a/content/en/docs/ops/setup/injection-concepts/index.md
+++ b/content/en/docs/ops/setup/injection-concepts/index.md
@@ -35,7 +35,7 @@ the three configuration items. The security rules above cannot be overridden.
 | yes                       | enabled          | false                                             | no        |
 | yes                       | disabled         | true                                              | yes       |
 | yes                       | disabled         | false (default)                                   | no        |
-| no                        | enabled          | true                                              | no        |
+ | no                        | enabled          | true (default)                                    | no        |
 | no                        | enabled          | false                                             | no        |
 | no                        | disabled         | true                                              | no        |
  | no                        | disabled         | false (default)                                   | no        |

--- a/content/en/docs/ops/setup/injection-concepts/index.md
+++ b/content/en/docs/ops/setup/injection-concepts/index.md
@@ -35,7 +35,7 @@ the three configuration items. The security rules above cannot be overridden.
 | yes                       | enabled          | false                                             | no        |
 | yes                       | disabled         | true                                              | yes       |
 | yes                       | disabled         | false (default)                                   | no        |
- | no                        | enabled          | true (default)                                    | no        |
+| no                        | enabled          | true (default)                                    | no        |
 | no                        | enabled          | false                                             | no        |
 | no                        | disabled         | true                                              | no        |
  | no                        | disabled         | false (default)                                   | no        |

--- a/content/en/docs/ops/setup/validation/index.md
+++ b/content/en/docs/ops/setup/validation/index.md
@@ -6,10 +6,10 @@ aliases:
     - /help/ops/setup/validation   
 ---
 
-Galley’s configuration validation ensures user authored Istio
+Galley's configuration validation ensures user authored Istio
 configuration is syntactically and semantically valid. It uses a
 Kubernetes `ValidatingWebhook`. The `istio-galley`
-`ValidationWebhookConfiguration` has two webhooks.
+`ValidatingWebhookConfiguration` has two webhooks.
 
 * `pilot.validation.istio.io` - Served on path `/admitpilot` and is
 responsible for validating configuration consumed by Pilot


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR fixes the phrase ValidationWebhookConfiguration in the configuration operations guide to match the actual name of ValidatingWebhookConfiguration and clarifies the injection options table. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
