### PR TITLE
Fix Envoy stats examples in egress docs

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
@@ -208,8 +208,8 @@ the set of domains.
     counter is:
 
     {{< text bash >}}
-    $ kubectl exec -it $(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -c istio-proxy -n istio-system -- curl -s localhost:15000/stats | grep www.wikipedia.org.upstream_cx_total
-    cluster.outbound|443||www.wikipedia.org.upstream_cx_total: 2
+    $ kubectl exec -it $(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}') -c istio-proxy -n istio-system -- curl -s localhost:15000/clusters | grep '^outbound|443||www.wikipedia.org.*cx_total:'
+    outbound|443||www.wikipedia.org::208.80.154.224:443::cx_total::2
     {{< /text >}}
 
 #### Cleanup wildcard configuration for a single hosting server


### PR DESCRIPTION
Envoy's `/stats` seem to have changed. Cluster stats are available from `/clusters`.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[x] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
