### PR TITLE
Update ingress-sds

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -539,6 +539,20 @@ $ kubectl create -n istio-system secret generic httpbin-credential  \
 
     {{< /text >}}
 
+1. Instead of creating a single secret `httpbin-credential` that holds all the credentials, you can 
+   also create two separate secret, with `httpbin-credential` that holds server key and server
+   certificate, and `httpbin-credential-cacert` that holds the client CA certificate. The second
+   secret should contain `-cacert` suffix.
+
+    {{< text bash >}}
+    $ kubectl -n istio-system delete secret httpbin-credential
+    $ kubectl create -n istio-system secret generic httpbin-credential  \
+    --from-file=key=httpbin.example.com/3_application/private/httpbin.example.com.key.pem \
+    --from-file=cert=httpbin.example.com/3_application/certs/httpbin.example.com.cert.pem
+    $ kubectl create -n istio-system secret generic httpbin-credential-cacert  \
+    --from-file=cacert=httpbin.example.com/2_intermediate/certs/ca-chain.cert.pem
+    {{< /text >}}
+
 ## Troubleshooting
 
 *   Inspect the values of the `INGRESS_HOST` and `SECURE_INGRESS_PORT` environment

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -544,7 +544,6 @@ $ kubectl create -n istio-system secret generic httpbin-credential  \
    
    - `httpbin-credential` holds the server's key and certificate
    -`httpbin-credential-cacert` holds the client's CA certificate and must have the `-cacert` suffix   
-   the client CA certificate, and it should contain `-cacert` suffix.
 
     {{< text bash >}}
     $ kubectl -n istio-system delete secret httpbin-credential

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -540,7 +540,10 @@ $ kubectl create -n istio-system secret generic httpbin-credential  \
     {{< /text >}}
 
 1. Instead of creating a `httpbin-credential` secret to hold all the credentials, you can
-   also create two separate secrets, `httpbin-credential` and `httpbin-credential-cacert`.
+   create two separate secrets: 
+   
+   - `httpbin-credential` holds the server's key and certificate
+   -`httpbin-credential-cacert` holds the client's CA certificate and must have the `-cacert` suffix   
    `httpbin-credential` holds server key and server certificate. `httpbin-credential-cacert` holds
    the client CA certificate, and it should contain `-cacert` suffix.
 

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -545,6 +545,8 @@ $ kubectl create -n istio-system secret generic httpbin-credential  \
    - `httpbin-credential` holds the server's key and certificate
    -`httpbin-credential-cacert` holds the client's CA certificate and must have the `-cacert` suffix   
 
+Create the two separate secrets with the following commands:
+
     {{< text bash >}}
     $ kubectl -n istio-system delete secret httpbin-credential
     $ kubectl create -n istio-system secret generic httpbin-credential  \

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -539,7 +539,7 @@ $ kubectl create -n istio-system secret generic httpbin-credential  \
 
     {{< /text >}}
 
-1. Instead of creating a single secret `httpbin-credential` that holds all the credentials, you can
+1. Instead of creating a `httpbin-credential` secret to hold all the credentials, you can
    also create two separate secrets, `httpbin-credential` and `httpbin-credential-cacert`.
    `httpbin-credential` holds server key and server certificate. `httpbin-credential-cacert` holds
    the client CA certificate, and it should contain `-cacert` suffix.

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -540,9 +540,9 @@ $ kubectl create -n istio-system secret generic httpbin-credential  \
     {{< /text >}}
 
 1. Instead of creating a single secret `httpbin-credential` that holds all the credentials, you can 
-   also create two separate secret, with `httpbin-credential` that holds server key and server
-   certificate, and `httpbin-credential-cacert` that holds the client CA certificate. The second
-   secret should contain `-cacert` suffix.
+   also create two separate secrets, `httpbin-credential` and `httpbin-credential-cacert`.
+   `httpbin-credential` holds server key and server certificate. `httpbin-credential-cacert` holds
+   the client CA certificate, and it should contain `-cacert` suffix.
 
     {{< text bash >}}
     $ kubectl -n istio-system delete secret httpbin-credential

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -544,7 +544,6 @@ $ kubectl create -n istio-system secret generic httpbin-credential  \
    
    - `httpbin-credential` holds the server's key and certificate
    -`httpbin-credential-cacert` holds the client's CA certificate and must have the `-cacert` suffix   
-   `httpbin-credential` holds server key and server certificate. `httpbin-credential-cacert` holds
    the client CA certificate, and it should contain `-cacert` suffix.
 
     {{< text bash >}}

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -540,10 +540,10 @@ $ kubectl create -n istio-system secret generic httpbin-credential  \
     {{< /text >}}
 
 1. Instead of creating a `httpbin-credential` secret to hold all the credentials, you can
-   create two separate secrets: 
-   
-   - `httpbin-credential` holds the server's key and certificate
-   -`httpbin-credential-cacert` holds the client's CA certificate and must have the `-cacert` suffix   
+   create two separate secrets:
+
+   -`httpbin-credential` holds the server's key and certificate
+   -`httpbin-credential-cacert` holds the client's CA certificate and must have the `-cacert` suffix
 
 Create the two separate secrets with the following commands:
 

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -539,7 +539,7 @@ $ kubectl create -n istio-system secret generic httpbin-credential  \
 
     {{< /text >}}
 
-1. Instead of creating a single secret `httpbin-credential` that holds all the credentials, you can 
+1. Instead of creating a single secret `httpbin-credential` that holds all the credentials, you can
    also create two separate secrets, `httpbin-credential` and `httpbin-credential-cacert`.
    `httpbin-credential` holds server key and server certificate. `httpbin-credential-cacert` holds
    the client CA certificate, and it should contain `-cacert` suffix.


### PR DESCRIPTION
Please provide a description for what this PR is for.
Ingress SDS now supports creating two separate Kubernetes secrets to configure mTLS ingress gateway. One secret holds server key and server certificate, and the other secret holds client CA certificate. The second secret should have suffix "-cacert".

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
