### PR TITLE
Fixed vertical positioning of glossary entries.

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -59,7 +59,3 @@ update_ref_docs:
 	@scripts/grab_reference_docs.sh
 
 include common/Makefile.common.mk
-
-foo:
-	mdl --help
-

--- a/src/sass/misc/_glossary.scss
+++ b/src/sass/misc/_glossary.scss
@@ -12,9 +12,9 @@
     .entries {
         .letter {
             @media screen {
-                &:target::before {
-                    height: calc(#{$headerHeight} - 1rem);
-                    margin-top: calc(0 - calc(#{$headerHeight} - 1rem));
+                dt:target::before {
+                    height: calc(#{$headerHeight} + 4.2rem);
+                    margin-top: calc(-#{$headerHeight} - 4.2rem);
                 }
             }
         }


### PR DESCRIPTION
- When hardlinking to a specific glossary entry, the page would
get positioned incorrectly, hiding the actual entry.

Fixes #4885 