### PR TITLE
remove force flag for istio init chart upgrade.

### DIFF
--- a/content/en/docs/setup/upgrade/steps/index.md
+++ b/content/en/docs/setup/upgrade/steps/index.md
@@ -150,7 +150,7 @@ the preferred upgrade option is to let Helm take care of the upgrade.
 1. Upgrade the `istio-init` chart to update all the Istio [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions) (CRDs).
 
     {{< text bash >}}
-    $ helm upgrade --install --force istio-init install/kubernetes/helm/istio-init --namespace istio-system
+    $ helm upgrade --install istio-init install/kubernetes/helm/istio-init --namespace istio-system
     {{< /text >}}
 
 1. {{< boilerplate verify-crds >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.

We have add suffix for CRD creation job, so we don't need the `--force` flag for the istio-init chart upgrade.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
