### PR TITLE
Remove warning about obscure edge case in install

### DIFF
--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -57,13 +57,6 @@ $ helm repo add istio.io https://storage.googleapis.com/istio-release/releases/{
 Change directory to the root of the release and then
 choose one of the following two **mutually exclusive** options:
 
-{{< warning >}}
-Istio's installation uses [Helm Package Manager](https://helm.sh) extensively for rendering Istio
-manifests. [Helm Issue 5863](https://github.com/helm/helm/issues/5863) contains details of a problem where
-extra white space in the command line is not properly handled resulting in a `helm template`
-or `helm install` operation that produces an incorrect manifest.
-{{< /warning >}}
-
 1. To deploy Istio without using Tiller, follow the instructions for [option 1](/docs/setup/install/helm/#option-1-install-with-helm-via-helm-template).
 1. To use [Helm's Tiller pod](https://helm.sh/) to manage your Istio release, follow the instructions for [option 2](/docs/setup/install/helm/#option-2-install-with-helm-and-tiller-via-helm-install).
 


### PR DESCRIPTION
I don't think we need to document every obscure edge case, especially in the very first page a user will look at. If the user follows our docs, this will never happen. If they *don't* follow the docs, they still will probably never hit this.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
