### PR TITLE
Simplify CRD verification step

### DIFF
--- a/content/en/boilerplates/verify-crds.md
+++ b/content/en/boilerplates/verify-crds.md
@@ -1,10 +1,6 @@
 Verify that all `23` Istio CRDs were committed to the Kubernetes api-server using the following command:
 
-{{< warning >}}
-If cert-manager is enabled, then the CRD count will be `28` instead.
-{{< /warning >}}
-
 {{< text bash >}}
-$ kubectl get crds | grep 'istio.io\|certmanager.k8s.io' | wc -l
+$ kubectl get crds | grep 'istio.io' | wc -l
 23
 {{< /text >}}


### PR DESCRIPTION
I don't think there is a need to insert this edge case about certmanager
here. Lets just look for Istio CRDs, which we know will always be 23,
and not confuse 99% of users for an advanced feature.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
