### PR TITLE
Remove port name requirement

### DIFF
--- a/content/en/docs/ops/traffic-management/protocol-selection/index.md
+++ b/content/en/docs/ops/traffic-management/protocol-selection/index.md
@@ -1,0 +1,51 @@
+---
+title: Protocol Selection
+description: Information on how to specify protocols.
+weight: 98
+keywords: [protocol,protocol sniffing,protocol selection,protocol detection]
+aliases:
+    - /help/ops/traffic-management/protocol-selection
+    - /help/ops/protocol-selection
+    - /help/tasks/traffic-management/protocol-selection
+---
+
+Istio supports proxying all TCP traffic by default, but in order to provide additional capabilities, such as routing and rich metrics, the protocol must be determined. This can be done automatically or explicitly specified.
+
+## Automatic Protocol Selection
+
+By default, Istio will automatically detect HTTP and HTTP/2 traffic. If the protocol cannot automatically be determined, traffic will be treated as plain TCP traffic.
+
+This feature can be turned off by providing the Helm value `--set pilot.enableProtocolSniffing=false`.
+
+## Manual Protocol Selection
+
+Other protocols must be specified manually by naming the Service port to the protocol. The port name should match either `protocol` or `protocol-suffix`.
+
+The following protocols are supported:
+
+  - `grpc`
+  - `http`
+  - `http2`
+  - `https`
+  - `mongo`
+  - `mysql`\*
+  - `redis`\*
+  - `tcp`
+  - `tls`
+  - `udp`
+
+\* These protocols are disabled by default to avoid accidentally enabling experimental features. To enable them, Pilot [environment variables](docs/reference/commands/pilot-discovery/#envvars) must be configured
+
+Below is an example of a Service that defines a `mysql` port and an `http` port:
+
+```yaml
+kind: Service
+metadata:
+  name: myservice
+spec:
+  ports:
+  - number: 3306
+    name: mysql
+  - number: 80
+    name: http-web
+```

--- a/content/en/docs/ops/traffic-management/protocol-selection/index.md
+++ b/content/en/docs/ops/traffic-management/protocol-selection/index.md
@@ -23,18 +23,18 @@ Other protocols must be specified manually by naming the Service port to the pro
 
 The following protocols are supported:
 
-  - `grpc`
-  - `http`
-  - `http2`
-  - `https`
-  - `mongo`
-  - `mysql`\*
-  - `redis`\*
-  - `tcp`
-  - `tls`
-  - `udp`
+- `grpc`
+- `http`
+- `http2`
+- `https`
+- `mongo`
+- `mysql`\*
+- `redis`\*
+- `tcp`
+- `tls`
+- `udp`
 
-\* These protocols are disabled by default to avoid accidentally enabling experimental features. To enable them, Pilot [environment variables](docs/reference/commands/pilot-discovery/#envvars) must be configured
+\* These protocols are disabled by default to avoid accidentally enabling experimental features. To enable them, Pilot [environment variables](/docs/reference/commands/pilot-discovery/#envvars) must be configured
 
 Below is an example of a Service that defines a `mysql` port and an `http` port:
 

--- a/content/en/docs/setup/additional-setup/requirements/index.md
+++ b/content/en/docs/setup/additional-setup/requirements/index.md
@@ -13,28 +13,6 @@ keywords: [kubernetes,sidecar,sidecar-injection]
 To be a part of an Istio service mesh, pods and services in a Kubernetes
 cluster must satisfy the following requirements:
 
-- **Named service ports**: Service ports must be named. The port name key/value
-  pairs must have the following syntax: `name: <protocol>[-<suffix>]`. To take
-  advantage of Istio's routing features, replace `<protocol>` with one of the
-  following values:
-
-    - `grpc`
-    - `http`
-    - `http2`
-    - `https`
-    - `mongo`
-    - `mysql`
-    - `redis`
-    - `tcp`
-    - `tls`
-    - `udp`
-
-    For example, `name: http2-foo` or  `name: http` are valid port names, but
-    `name: http2foo` is not. If the port name does not begin with a recognized
-    prefix or if the port is unnamed, traffic on the port is treated as
-    plain TCP traffic unless the port [explicitly](https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service)
-    uses `Protocol: UDP` to signify a UDP port.
-
 - **Service association**: A pod must belong to at least one Kubernetes
   service even if the pod does NOT expose any port.
   If a pod belongs to multiple [Kubernetes services](https://kubernetes.io/docs/concepts/services-networking/service/),

--- a/content/en/faq/traffic-management/naming-port-convention.md
+++ b/content/en/faq/traffic-management/naming-port-convention.md
@@ -1,11 +1,8 @@
 ---
-title: What is the naming convention for port name inside my application deployment file?
+title: What protocols does Istio support?
 weight: 50
 ---
 
-Named ports: Service ports must be named.
+Currently, Istio supports TCP based protocols. In additional to this, Istio provides additional functionality, such as routing and metrics, from other protocols such as `http` and `mysql`. Currently, UDP traffic is not supported.
 
-The port names must be of the form `protocol`-`suffix` with `grpc`, `http`, `http2`, `https`, `mongo`, `redis`, `tcp`, `tls` or `udp` as the `protocol` in order to take advantage of Istio’s routing features.
-
-For example, `name: http2-foo` or `name: http` are valid port names, but `name: http2foo` is not. If the port name does not begin with a recognized prefix or if the port is unnamed, traffic on the port will be treated as plain TCP traffic (unless the port explicitly uses Protocol: UDP to signify a UDP port).
-
+For a list of all protocols, and information on how to configure protocols, view the [Protocol Selection](/docs/ops/traffic-management/protocol-selection/) documentation.


### PR DESCRIPTION
We now do protocol sniffing.

Note - this is definitely not safe to merge. We still need docs explaining protocol sniffing, and how to select a port type explicitly (required for things other than tcp/http, and more performant if you know its tcp/http). Not sure the path forward for this

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
