### PR TITLE
Exclude istio/operator from having partner banner displayed

### DIFF
--- a/content/en/docs/reference/config/istio.operator.v1alpha12.pb/index.html
+++ b/content/en/docs/reference/config/istio.operator.v1alpha12.pb/index.html
@@ -4,7 +4,7 @@ source_repo: https://github.com/istio/operator
 title: Operator Installation
 description: Configuration for Istio control plane installation through the Operator.
 location: https://istio.io/docs/reference/config/istio.operator.v1alpha12.pb.html
-layout: partner-component
+layout: protoc-gen-docs
 generator: protoc-gen-docs
 number_of_entries: 52
 ---

--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -82,7 +82,7 @@ locate_file() {
 
     LEN=${#WORK_DIR}
 
-    if [[ "${REPO_URL}" != "https://github.com/istio/istio.git" && "${REPO_URL}" != "https://github.com/istio/api.git" ]]; then
+    if [[ "${REPO_URL}" != "https://github.com/istio/istio.git" && "${REPO_URL}" != "https://github.com/istio/api.git" && "${REPO_URL}" != "https://github.com/istio/operator.git" ]]; then
         sed -i -e 's/layout: protoc-gen-docs/layout: partner-component/g' "${ROOTDIR}/content/en/docs${PP}/${FN}/index.html"
     fi
 


### PR DESCRIPTION
This PR adds istio/operator to the list of repos that are excluded from having a "partner" banner displayed at the top of the rendered HTML.