### PR TITLE
Remove sudo call from minikube setup docs

### DIFF
--- a/content/en/docs/setup/platform-setup/minikube/index.md
+++ b/content/en/docs/setup/platform-setup/minikube/index.md
@@ -78,7 +78,7 @@ Refer to the [`api-server` reference docs](https://kubernetes.io/docs/reference/
     terminal to output diagnostic information about the network:
 
     {{< text bash >}}
-    $ sudo minikube tunnel
+    $ minikube tunnel
     {{< /text >}}
 
     {{< warning >}}
@@ -86,7 +86,7 @@ Refer to the [`api-server` reference docs](https://kubernetes.io/docs/reference/
     cleanup:
 
     {{< text bash >}}
-    $ sudo minikube tunnel --cleanup
+    $ minikube tunnel --cleanup
     {{< /text >}}
 
     {{< /warning >}}


### PR DESCRIPTION
sudo use with minikube is not generally advisable or necessary.
Fixes #4845.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
