### PR TITLE
Improve Tabs CSS

### DIFF
--- a/src/sass/misc/_tabset.scss
+++ b/src/sass/misc/_tabset.scss
@@ -21,8 +21,8 @@
             background-color: $tabsetUnselectedTabBackgroundColor;
 
             span {
-                color: $tabsetUnselectedTabTextColor;
-                font-size: 80%;
+                color: var(--textColor);
+                font-size: 90%;
             }
 
             &:hover, &:focus {
@@ -35,13 +35,9 @@
                 background-color: $tabsetSelectedTabBackgroundColor;
                 cursor: default;
                 box-shadow: none;
-                font-weight: bold;
+                font-weight: 600;
                 border-bottom: solid 2px $tabsetSelectedTabBackgroundColor;
-                border-top: solid 2px var(--mainBrandColor);
-
-                span {
-                    color: $tabsetSelectedTabTextColor;
-                }
+                border-top: solid 2px var(--secondBrandColor);
             }
         }
     }

--- a/src/sass/misc/_tabset.scss
+++ b/src/sass/misc/_tabset.scss
@@ -11,11 +11,9 @@
             display: inline-block;
             margin: 0 3px;
             border: 1px solid $tabsetBorderColor;
-            border-bottom: 0;
             border-top-left-radius: $border-radius;
             border-top-right-radius: $border-radius;
             padding: 0 1rem;
-            transform: skewX(-20deg);
             transform-origin: left bottom;
             cursor: pointer;
             outline: 0;
@@ -23,7 +21,6 @@
             background-color: $tabsetUnselectedTabBackgroundColor;
 
             span {
-                transform: skewX(6deg);
                 color: $tabsetUnselectedTabTextColor;
                 font-size: 80%;
             }
@@ -38,8 +35,9 @@
                 background-color: $tabsetSelectedTabBackgroundColor;
                 cursor: default;
                 box-shadow: none;
-                border-bottom: solid 2px $mainBrandColor;
-
+                font-weight: bold;
+                border-bottom: solid 2px $tabsetSelectedTabBackgroundColor;
+                border-top: solid 2px var(--mainBrandColor);
                 span {
                     color: $tabsetSelectedTabTextColor;
                 }
@@ -48,7 +46,6 @@
     }
 
     .tab-content {
-        border: 1px solid $tabsetBorderColor;
         border-radius: $border-radius;
         padding: 1rem;
         box-shadow: 3px 3px 8px $tabsetShadowColor;

--- a/src/sass/misc/_tabset.scss
+++ b/src/sass/misc/_tabset.scss
@@ -38,7 +38,7 @@
                 font-weight: bold;
                 border-bottom: solid 2px $tabsetSelectedTabBackgroundColor;
                 border-top: solid 2px var(--mainBrandColor);
-                
+
                 span {
                     color: $tabsetSelectedTabTextColor;
                 }

--- a/src/sass/misc/_tabset.scss
+++ b/src/sass/misc/_tabset.scss
@@ -38,6 +38,7 @@
                 font-weight: bold;
                 border-bottom: solid 2px $tabsetSelectedTabBackgroundColor;
                 border-top: solid 2px var(--mainBrandColor);
+                
                 span {
                     color: $tabsetSelectedTabTextColor;
                 }

--- a/src/sass/themes/_dark-theme.scss
+++ b/src/sass/themes/_dark-theme.scss
@@ -47,9 +47,9 @@
     --tabsetBorderColor: #777777;
     --tabsetShadowColor: #777777;
     --tabsetUnselectedTabTextColor: #e9ffaa;
-    --tabsetUnselectedTabBackgroundColor: #{$not-so-dark-gray};
+    --tabsetUnselectedTabBackgroundColor: #{$dark-gray};
     --tabsetSelectedTabTextColor: #a7a7a7;
-    --tabsetSelectedTabBackgroundColor: #{$dark-gray};
+    --tabsetSelectedTabBackgroundColor: #{$not-so-dark-gray};
 
     --sidebarRightChevron: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 407.436 407.436'%3E%3Cpath fill='white' d='M112.814 0L91.566 21.178l181.946 182.54-181.946 182.54 21.248 21.178 203.055-203.718z'/%3E%3C/svg%3E");
     --sidebarRightChevronHover: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 407.436 407.436'%3E%3Cpath fill='orange' d='M112.814 0L91.566 21.178l181.946 182.54-181.946 182.54 21.248 21.178 203.055-203.718z'/%3E%3C/svg%3E");

--- a/src/sass/themes/_dark-theme.scss
+++ b/src/sass/themes/_dark-theme.scss
@@ -46,9 +46,7 @@
 
     --tabsetBorderColor: #777777;
     --tabsetShadowColor: #777777;
-    --tabsetUnselectedTabTextColor: #e9ffaa;
     --tabsetUnselectedTabBackgroundColor: #{$dark-gray};
-    --tabsetSelectedTabTextColor: #a7a7a7;
     --tabsetSelectedTabBackgroundColor: #{$not-so-dark-gray};
 
     --sidebarRightChevron: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 407.436 407.436'%3E%3Cpath fill='white' d='M112.814 0L91.566 21.178l181.946 182.54-181.946 182.54 21.248 21.178 203.055-203.718z'/%3E%3C/svg%3E");

--- a/src/sass/themes/_light-theme.scss
+++ b/src/sass/themes/_light-theme.scss
@@ -45,9 +45,7 @@ html {
 
     --tabsetBorderColor: #f2f2f2;
     --tabsetShadowColor: #a7a7a7;
-    --tabsetUnselectedTabTextColor: #306bcc;
     --tabsetUnselectedTabBackgroundColor: #f2f2f2;
-    --tabsetSelectedTabTextColor: var(--textColor);
     --tabsetSelectedTabBackgroundColor: #ffffff;
 
     --sidebarRightChevron: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 407.436 407.436'%3E%3Cpath fill='black' d='M112.814 0L91.566 21.178l181.946 182.54-181.946 182.54 21.248 21.178 203.055-203.718z'/%3E%3C/svg%3E");

--- a/src/sass/themes/_light-theme.scss
+++ b/src/sass/themes/_light-theme.scss
@@ -46,9 +46,9 @@ html {
     --tabsetBorderColor: #f2f2f2;
     --tabsetShadowColor: #a7a7a7;
     --tabsetUnselectedTabTextColor: #306bcc;
-    --tabsetUnselectedTabBackgroundColor: #ffffff;
+    --tabsetUnselectedTabBackgroundColor: #f2f2f2;
     --tabsetSelectedTabTextColor: var(--textColor);
-    --tabsetSelectedTabBackgroundColor: #eeeeff;
+    --tabsetSelectedTabBackgroundColor: #ffffff;
 
     --sidebarRightChevron: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 407.436 407.436'%3E%3Cpath fill='black' d='M112.814 0L91.566 21.178l181.946 182.54-181.946 182.54 21.248 21.178 203.055-203.718z'/%3E%3C/svg%3E");
     --sidebarRightChevronHover: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 407.436 407.436'%3E%3Cpath fill='orange' d='M112.814 0L91.566 21.178l181.946 182.54-181.946 182.54 21.248 21.178 203.055-203.718z'/%3E%3C/svg%3E");

--- a/src/sass/themes/_vars.scss
+++ b/src/sass/themes/_vars.scss
@@ -45,9 +45,7 @@ $dropdownCheckHover: var(--dropdownCheckHover);
 
 $tabsetBorderColor: var(--tabsetBorderColor);
 $tabsetShadowColor: var(--tabsetShadowColor);
-$tabsetUnselectedTabTextColor: var(--tabsetUnselectedTabTextColor);
 $tabsetUnselectedTabBackgroundColor: var(--tabsetUnselectedTabBackgroundColor);
-$tabsetSelectedTabTextColor: var(--tabsetSelectedTabTextColor);
 $tabsetSelectedTabBackgroundColor: var(--tabsetSelectedTabBackgroundColor);
 
 $sidebarRightChevron: var(--sidebarRightChevron);


### PR DESCRIPTION
Users were not able to easily identify which tab was selected. With the help of a couple of UX designers, we found a way to make it clear and follow modern standards.
<img width="260" alt="image" src="https://user-images.githubusercontent.com/5502967/64817944-8f600980-d570-11e9-9daa-e108873b4aa3.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/5502967/64817964-9b4bcb80-d570-11e9-9183-dd13b8398912.png">



And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
