### PR TITLE
Remove "etc" from service version glossary term

### DIFF
--- a/content/en/docs/reference/glossary/service-version.md
+++ b/content/en/docs/reference/glossary/service-version.md
@@ -2,4 +2,4 @@
 title: Service Version
 ---
 Distinct variants of a [service](#service), typically backed by different versions of a [workload](#workload) binary.
-Common scenarios where multiple service versions may be used include A/B testing, canary rollouts, etc.
+Common scenarios where multiple service versions may be used include A/B testing and canary rollouts.


### PR DESCRIPTION
The etc does not add to the statement being made. Fixes #4899.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
