### PR TITLE
typo: "diconnected" in page description

### DIFF
--- a/content/en/docs/setup/install/multicluster/shared-gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/shared-gateways/index.md
@@ -1,6 +1,6 @@
 ---
 title: Shared control plane (multi-network)
-description: Install an Istio mesh across multiple Kubernetes clusters using a shared control plane for diconnected cluster networks.
+description: Install an Istio mesh across multiple Kubernetes clusters using a shared control plane for disconnected cluster networks.
 weight: 85
 keywords: [kubernetes,multi-cluster]
 aliases:


### PR DESCRIPTION
I don't know how this got past `make lint`.