### PR TITLE
fix(release notes): remove Mixer adapter deprecation notice

### DIFF
--- a/content/en/boilerplates/notes/1.3.md
+++ b/content/en/boilerplates/notes/1.3.md
@@ -46,7 +46,6 @@
 - **Improved** the mesh dashboard to provide monitoring of Istio's configuration state.
 - **Improved** the Pilot dashboard to expose additional key metrics to more clearly identify errors.
 - **Removed** deprecated `Adapter` and `Template` custom resource definitions (CRDs).
-- **Deprecated** Mixer adapters. Please begin the transition of all extensions to the new extension model. Legacy Mixer integration support continues only for Istio 1.3 and 1.4.
 - **Deprecated** the HTTP API spec used to produce API attributes. We will remove support for producing API attributes in Istio 1.4.
 
 ## Policy


### PR DESCRIPTION
Per TOC suggestion, @smawson, @mandarjog, and @douglas-reid had a conversation about the inclusion of the adapter deprecation notice. The plan for communication was to work on a multi-part blog describing the roadmap (and implementation details) for future of extensibility in Istio and to remove the deprecation notice from the 1.3 release notes.

This PR removes the deprecation notice from the 1.3 release notes.

The multi-part blog will follow.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ X ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
