### PR TITLE
dark-mode-css-bug

### DIFF
--- a/src/sass/themes/_light-theme-syntax.scss
+++ b/src/sass/themes/_light-theme-syntax.scss
@@ -45,7 +45,6 @@
 .language-css .token.string,
 .style .token.string {
     color: #9a6e3a;
-    background: hsla(0, 0%, 100%, .5);
 }
 
 .token.atrule,


### PR DESCRIPTION
Some characters ( <, | ) appear highlighted in dark mode:
<img width="530" alt="image" src="https://user-images.githubusercontent.com/5502967/65255435-e4999f00-dacb-11e9-9e62-9435fc8c8ba1.png">

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
