### PR TITLE
HTML-Proofer links lint errors

### DIFF
--- a/content/en/docs/setup/platform-setup/gardener/index.md
+++ b/content/en/docs/setup/platform-setup/gardener/index.md
@@ -43,7 +43,7 @@ project. To learn more about this open source project, read the
 
 You can create your cluster using `kubectl` cli by providing a cluster
 specification yaml file. You can find an example for GCP
-[here](https://github.com/gardener/gardener/blob/master/example/90-shoot-gcp.yaml).
+[here](https://github.com/gardener/gardener/blob/master/example/90-shoot.yaml).
 Make sure the namespace matches that of your project. Then just apply the
 prepared so-called "shoot" cluster CRD with `kubectl`:
 

--- a/content/zh/docs/reference/config/policy-and-telemetry/adapters/cloudmonitor/index.md
+++ b/content/zh/docs/reference/config/policy-and-telemetry/adapters/cloudmonitor/index.md
@@ -4,7 +4,7 @@ description: CloudMonitor 适配器使 Istio 可以向 AliCloud CloudMonitor 提
 weight: 70
 ---
 
-`cloudmonitor` 适配器让 Istio 可以向 [AliCloud CloudMonitor](https://cloudmonitor.console.aliyun.com/) 提供指标数据。
+`cloudmonitor` 适配器让 Istio 可以向 [AliCloud CloudMonitor](https://www.alibabacloud.com/product/cloud-monitor) 提供指标数据。
 
 The handler configuration must contain the same metrics as the instance configuration. The metrics specified in both instance and handler configurations will be sent to CloudMonitor.
 


### PR DESCRIPTION

```
- ./public/docs/reference/config/policy-and-telemetry/adapters/cloudmonitor/index.html
  *  External link https://cloudmonitor.console.aliyun.com/ failed: got a time out (response code 302)
- ./public/docs/setup/platform-setup/gardener/index.html
  *  External link https://github.com/gardener/gardener/blob/master/example/90-shoot-gcp.yaml failed: 404 No error
htmlproofer 3.9.2 | Error:  HTML-Proofer found 2 failures!
LINTING FAILED
```

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
