### PR TITLE
Adding Tip not to enable global sds

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
@@ -37,7 +37,7 @@ If you're editing the values.yml file, don't enable
 sds:
   enabled: false
 {{< /text >}}
-This will enable `mtls` between pods.
+This will enable `mtls` between pods which will cause pods to become unhealthy, if you don't have `mtls` configured.
 {{< /tip >}}
 
 ## Configuring DNS name and gateway

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
@@ -33,7 +33,7 @@ By default `istio-ingressgateway` will be exposed as a `LoadBalancer` service ty
 
 {{< tip >}}
 If you're editing the values.yml file, don't enable
-{{< text bash >}}
+{{< text yaml >}}
 sds:
   enabled: false
 {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
@@ -37,7 +37,7 @@ If you're editing the values.yml file, don't enable
 sds:
   enabled: false
 {{< /text >}}
-This will enable `mtls` between pods which will cause pods to become unhealthy, if you don't have `mtls` configured.
+This will enable mutual TLS between pods which will cause pods to become unhealthy if you don't have mutual TLS configured.
 {{< /tip >}}
 
 ## Configuring DNS name and gateway

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
@@ -32,11 +32,11 @@ By default `istio-ingressgateway` will be exposed as a `LoadBalancer` service ty
 {{< /tip >}}
 
 {{< tip >}}
-If you're editing the values.yml file, don't enable
+If you're editing the `values.yml` file, don't enable
 {{<text_hack yaml>}}
 sds:
   enabled: false
-{{</text_hack>}}
+{{</text>}}
 This will enable mutual TLS between pods which will cause pods to become unhealthy if you don't have mutual TLS configured.
 {{< /tip >}}
 

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
@@ -31,6 +31,15 @@ $ helm template $HOME/istio-fetch/istio \
 By default `istio-ingressgateway` will be exposed as a `LoadBalancer` service type. You may want to change that by setting the `gateways.istio-ingressgateway.type` installation option to `NodePort` if this is more applicable to your Kubernetes environment.
 {{< /tip >}}
 
+{{< tip >}}
+If you're editing the values.yml file, don't enable
+{{< text bash >}}
+sds:
+  enabled: false
+{{< /text >}}
+This will enable `mtls` between pods.
+{{< /tip >}}
+
 ## Configuring DNS name and gateway
 
 Take a note of the external IP address of the `istio-ingressgateway` service:

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
@@ -33,10 +33,10 @@ By default `istio-ingressgateway` will be exposed as a `LoadBalancer` service ty
 
 {{< tip >}}
 If you're editing the values.yml file, don't enable
-{{< text yaml >}}
+{{<text_hack yaml>}}
 sds:
   enabled: false
-{{< /text >}}
+{{</text_hack>}}
 This will enable mutual TLS between pods which will cause pods to become unhealthy if you don't have mutual TLS configured.
 {{< /tip >}}
 


### PR DESCRIPTION
While deploying certmanager, if somebody enables sds in values.yml rather than passing it via cli, their pods never become healthy as it'll enable mtls.

[ ] Configuration Infrastructure
[ x ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
