### PR TITLE
Egress TLS origination port 443 must be HTTPS

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -151,8 +151,8 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
         name: http-port
         protocol: HTTP
       - number: 443
-        name: http-port-for-tls-origination
-        protocol: HTTP
+        name: https-port-for-tls-origination
+        protocol: HTTPS
       resolution: DNS
     ---
     apiVersion: networking.istio.io/v1alpha3

--- a/content/zh/docs/tasks/traffic-management/edge-traffic/egress-tls-origination/index.md
+++ b/content/zh/docs/tasks/traffic-management/edge-traffic/egress-tls-origination/index.md
@@ -120,8 +120,8 @@ $ kubectl delete serviceentry cnn
         name: http-port
         protocol: HTTP
       - number: 443
-        name: http-port-for-tls-origination
-        protocol: HTTP
+        name: https-port-for-tls-origination
+        protocol: HTTPS
       resolution: DNS
     ---
     apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
Documentation for egress TLS origination results in broken routing. This PR fixes the documentation in accordance with https://github.com/istio/istio/issues/16458

Fixes: https://github.com/istio/istio/issues/17314
Fixes: https://github.com/istio/istio/issues/17358

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
