### PR TITLE
Replace multicast address with class E

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -345,7 +345,7 @@ misordered
 Mitigations
 MongoDB
 mongodb
-multicast
+Multicast
 Multicloud
 multicloud
 Multicluster

--- a/content/en/blog/2019/multicluster-version-routing/index.md
+++ b/content/en/blog/2019/multicluster-version-routing/index.md
@@ -299,7 +299,7 @@ spec:
     protocol: http
   resolution: DNS
   addresses:
-  - 224.0.0.3
+  - 240.0.0.3
   endpoints:
   - address: ${CLUSTER2_GW_ADDR}
     labels:
@@ -326,9 +326,9 @@ spec:
 EOF
 {{< /text >}}
 
-The address `224.0.0.3` of the service entry can be any arbitrary unallocated IP.
+The address `240.0.0.3` of the service entry can be any arbitrary unallocated IP.
 Note that loopback range `127.0.0.0/8` should not be used, as it will influence outbound traffic.
-Using an IP from the multicast range 224.0.0.0/4 is a good choice.
+Using an IP from the class E addresses range 240.0.0.0/4 is a good choice.
 Check out the
 [gateway-connected multicluster example](/docs/setup/install/multicluster/gateways/#configure-the-example-services)
 for more details.

--- a/content/en/blog/2019/multicluster-version-routing/index.md
+++ b/content/en/blog/2019/multicluster-version-routing/index.md
@@ -327,7 +327,6 @@ EOF
 {{< /text >}}
 
 The address `240.0.0.3` of the service entry can be any arbitrary unallocated IP.
-Note that loopback range `127.0.0.0/8` should not be used, as it will influence outbound traffic.
 Using an IP from the class E addresses range 240.0.0.0/4 is a good choice.
 Check out the
 [gateway-connected multicluster example](/docs/setup/install/multicluster/gateways/#configure-the-example-services)

--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -269,7 +269,7 @@ running in a second cluster. Before you begin:
     appropriate remote service.
 
     {{< warning >}}
-    Multicast addresses(224.0.0.0 ~ 239.255.255.255) should not be used as there is no route to them by default.
+    Multicast addresses (224.0.0.0 ~ 239.255.255.255) should not be used because there is no route to them by default.
     Loopback addresses (127.0.0.0/8) should also not be used because traffic sent to them may be redirected to the sidecar inbound listener.
     {{< /warning >}}
 

--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -264,13 +264,14 @@ running in a second cluster. Before you begin:
     {{< /tip >}}
 
     If the global services have actual VIPs, you can use those, but otherwise we suggest
-    using IPs from the class E addresses range `240.0.0.0/4` that are preserved.
-    These IPs are not loopback addresses and are non-routable outside of a pod.    
+    using IPs from the class E addresses range `240.0.0.0/4`, because they are preserved.
     Application traffic for these IPs will be captured by the sidecar and routed to the
     appropriate remote service.
-    
-    **Note** Multicast addresses(224.0.0.0 ~ 239.255.255.255) should not be used as there is no route to them by default.
 
+    {{< warning >}}
+    Multicast addresses(224.0.0.0 ~ 239.255.255.255) should not be used as there is no route to them by default.
+    Loopback addresses range `127.0.0.0/8` should also not be used, as the traffic sent to lo may be redirected to inbound listener.
+    {{< /warning >}}
 
     {{< text bash >}}
     $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF

--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -264,7 +264,7 @@ running in a second cluster. Before you begin:
     {{< /tip >}}
 
     If the global services have actual VIPs, you can use those, but otherwise we suggest
-    using IPs from the class E addresses range `240.0.0.0/4`, because they are preserved.
+    using IPs from the class E addresses range `240.0.0.0/4`.
     Application traffic for these IPs will be captured by the sidecar and routed to the
     appropriate remote service.
 

--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -264,10 +264,13 @@ running in a second cluster. Before you begin:
     {{< /tip >}}
 
     If the global services have actual VIPs, you can use those, but otherwise we suggest
-    using IPs from the multicast range `224.0.0.0/4` that are not already allocated.
-    These IPs are not loopback addresses and are non-routable outside of a pod.
+    using IPs from the class E addresses range `240.0.0.0/4` that are preserved.
+    These IPs are not loopback addresses and are non-routable outside of a pod.    
     Application traffic for these IPs will be captured by the sidecar and routed to the
     appropriate remote service.
+    
+    **Note** Multicast addresses(224.0.0.0 ~ 239.255.255.255) should not be used as there is no route to them by default.
+
 
     {{< text bash >}}
     $ kubectl apply --context=$CTX_CLUSTER1 -n foo -f - <<EOF
@@ -292,7 +295,7 @@ running in a second cluster. Before you begin:
       # must be unique for each remote service, within a given cluster.
       # This address need not be routable. Traffic for this IP will be captured
       # by the sidecar and routed appropriately.
-      - 224.0.0.2
+      - 240.0.0.2
       endpoints:
       # This is the routable address of the ingress gateway in cluster2 that
       # sits in front of sleep.foo service. Traffic from the sidecar will be
@@ -363,7 +366,7 @@ spec:
     protocol: http
   resolution: STATIC
   addresses:
-  - 224.0.0.2
+  - 240.0.0.2
   endpoints:
   - address: ${CLUSTER2_GW_ADDR}
     network: external
@@ -397,7 +400,7 @@ spec:
     protocol: http
   resolution: DNS
   addresses:
-  - 224.0.0.2
+  - 240.0.0.2
   endpoints:
   - address: ${CLUSTER2_GW_ADDR}
     network: external
@@ -457,7 +460,7 @@ spec:
   addresses:
   # the IP address to which httpbin.bar.global will resolve to
   # must be unique for each service.
-  - 224.0.0.2
+  - 240.0.0.2
   endpoints:
   - address: ${CLUSTER2_GW_ADDR}
     labels:

--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -270,7 +270,7 @@ running in a second cluster. Before you begin:
 
     {{< warning >}}
     Multicast addresses(224.0.0.0 ~ 239.255.255.255) should not be used as there is no route to them by default.
-    Loopback addresses range `127.0.0.0/8` should also not be used, as the traffic sent to lo may be redirected to inbound listener.
+    Loopback addresses (127.0.0.0/8) should also not be used because traffic sent to them may be redirected to the sidecar inbound listener.
     {{< /warning >}}
 
     {{< text bash >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fix https://github.com/istio/istio.io/pull/5036#issuecomment-534887702
By default there is no route to multicast address, it will meet network unreachable error.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
