### PR TITLE
Fix probe rewrite configuration command

### DIFF
--- a/content/en/docs/ops/app-health-check/index.md
+++ b/content/en/docs/ops/app-health-check/index.md
@@ -106,7 +106,7 @@ You have two ways to enable Istio to rewrite the liveness HTTP probes.
 **Alternatively**, update the configuration map of Istio sidecar injection:
 
 {{< text bash >}}
-$ kubectl get cm istio-sidecar-injector -n istio-system -o yaml | sed -e "s/ rewriteAppHTTPProbe: false/ rewriteAppHTTPProbe: true/" | kubectl apply -f -
+$ kubectl get cm istio-sidecar-injector -n istio-system -o yaml | sed -e 's/"rewriteAppHTTPProbe":false/"rewriteAppHTTPProbe":true/' | kubectl apply -f -
 {{< /text >}}
 
 The above installation option and configuration map, each instruct the sidecar injection process to automatically


### PR DESCRIPTION
The latest version of Istio has configuration in the `"rewriteAppHTTPProbe":false` format, which is different from the previous `rewriteAppHTTPProbe: true` format. This PR updates the `sed` command to reflect that change.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure