### PR TITLE
Added note for trying out WebAssembly sandbox

### DIFF
--- a/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
+++ b/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
@@ -40,7 +40,8 @@ To generate service-level metrics directly in the Envoy proxies, follow these st
 
     or
 
-    Enable metadata exchange filter with WebAssembly sandbox using the following command:
+    If you have Istio 1.3.1, you can enable metadata exchange filter with WebAssembly sandbox using the
+    following command:
 
     {{< text bash >}}
     $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/release-1.3/extensions/stats/testdata/istio/metadata-exchange_with_wasm_filter.yaml

--- a/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
+++ b/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
@@ -40,7 +40,7 @@ To generate service-level metrics directly in the Envoy proxies, follow these st
 
     or
 
-    If you have Istio 1.3.1, you can enable metadata exchange filter with WebAssembly sandbox using the
+    If you have Istio 1.3.x, you can enable metadata exchange filter with WebAssembly sandbox using the
     following command:
 
     {{< text bash >}}

--- a/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
+++ b/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
@@ -37,11 +37,11 @@ To generate service-level metrics directly in the Envoy proxies, follow these st
     {{< text bash >}}
     $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/master/extensions/stats/testdata/istio/metadata-exchange_filter.yaml
     {{< /text >}}
-    
+
     or
-    
+
     Enable metadata exchange filter with WebAssembly sandbox using the following command:
-    
+
     {{< text bash >}}
     $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/master/extensions/stats/testdata/istio/metadata-exchange_with_wasm_filter.yaml
     {{< /text >}}

--- a/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
+++ b/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
@@ -38,14 +38,15 @@ To generate service-level metrics directly in the Envoy proxies, follow these st
     $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/master/extensions/stats/testdata/istio/metadata-exchange_filter.yaml
     {{< /text >}}
 
-    or
-
-    If you have Istio 1.3.x, you can enable metadata exchange filter with WebAssembly sandbox using the
+    {{< tip >}}
+    Alternatively, if you have Istio 1.3.x, you can enable metadata exchange filter with WebAssembly sandbox using the
     following command:
 
     {{< text bash >}}
     $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/release-1.3/extensions/stats/testdata/istio/metadata-exchange_with_wasm_filter.yaml
     {{< /text >}}
+
+    {{< /tip >}}
 
 1. To actually generate the service-level metrics, you must apply the custom stats filter.
 

--- a/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
+++ b/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
@@ -37,6 +37,14 @@ To generate service-level metrics directly in the Envoy proxies, follow these st
     {{< text bash >}}
     $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/master/extensions/stats/testdata/istio/metadata-exchange_filter.yaml
     {{< /text >}}
+    
+    or
+    
+    Enable metadata exchange filter with WebAssembly sandbox using the following command:
+    
+    {{< text bash >}}
+    $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/master/extensions/stats/testdata/istio/metadata-exchange_with_wasm_filter.yaml
+    {{< /text >}}
 
 1. To actually generate the service-level metrics, you must apply the custom stats filter.
 

--- a/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
+++ b/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
@@ -43,7 +43,7 @@ To generate service-level metrics directly in the Envoy proxies, follow these st
     Enable metadata exchange filter with WebAssembly sandbox using the following command:
 
     {{< text bash >}}
-    $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/master/extensions/stats/testdata/istio/metadata-exchange_with_wasm_filter.yaml
+    $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/release-1.3/extensions/stats/testdata/istio/metadata-exchange_with_wasm_filter.yaml
     {{< /text >}}
 
 1. To actually generate the service-level metrics, you must apply the custom stats filter.


### PR DESCRIPTION
Added note for trying out WebAssembly sandbox for metadata  exchange filter

Please provide a description for what this PR is for.
This is to help users tryout wasm for mixerless telemetry

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
