### PR TITLE
Option 2 need to create istio namespace

### DIFF
--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -183,6 +183,14 @@ to manage the lifecycle of Istio.
     {{< text bash >}}
     $ helm init --service-account tiller
     {{< /text >}}
+    
+    
+1. Create a namespace for the `istio-system` components:
+
+    {{< text bash >}}
+    $ kubectl create namespace istio-system
+    {{< /text >}}
+
 
 1. Install the `istio-init` chart to bootstrap all the Istio's CRDs:
 


### PR DESCRIPTION
Option 2 need to create istio namespace in advanced as well as istio system is not a upfront namespace in Kubernetes. It has to be specified by users

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
