### PR TITLE
Use --prune in upgrade to avoid issues.

### DIFF
--- a/content/en/docs/setup/upgrade/steps/index.md
+++ b/content/en/docs/setup/upgrade/steps/index.md
@@ -131,7 +131,7 @@ including configurations generated using
 
     {{< text bash >}}
     $ helm template install/kubernetes/helm/istio --name istio \
-      --namespace istio-system | kubectl apply -f -
+      --namespace istio-system | kubectl apply -f - --prune -l release=istio
     {{< /text >}}
 
     You must pass the same settings as when you first [installed Istio](/docs/setup/install/helm).


### PR DESCRIPTION
Add `--prune -l release=istio` in the control plane upgrade.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
