### PR TITLE
The current global hub and tag defaults are only for dev

### DIFF
--- a/content/en/docs/reference/config/installation-options/index.md
+++ b/content/en/docs/reference/config/installation-options/index.md
@@ -172,8 +172,8 @@ To customize Istio install using Helm, use the `--set <key>=<value>` option in H
 
 | Key | Default Value | Description |
 | --- | --- | --- |
-| `global.hub` | `gcr.io/istio-release` | `Default hub for Istio images. Releases are published to docker hub under 'istio' project. Daily builds from prow are on gcr.io` |
-| `global.tag` | `release-1.3-latest-daily` | `Default tag for Istio images.` |
+| `global.hub` | `` | `Default hub for Istio images. Releases are published to docker hub under 'istio' project. Daily builds from prow are on gcr.io` |
+| `global.tag` | `` | `Default tag for Istio images.` |
 | `global.logging.level` | `"default:info"` |  |
 | `global.monitoringPort` | `15014` | `monitoring port used by mixer, pilot, galley and sidecar injector` |
 | `global.k8sIngress.enabled` | `false` |  |


### PR DESCRIPTION
In release this is changed to below:
```yaml
global:
  # Default hub for Istio images.
  # Releases are published to docker hub under 'istio' project.
  # Daily builds from prow are on gcr.io
  hub: docker.io/istio

  # Default tag for Istio images.
  tag: 1.3.2
```
Not sure how to fix, but having the dev defaults here may be misleading.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
