### PR TITLE
1.3.3 release notes

### DIFF
--- a/content/en/news/2019/announcing-1.3.3/index.md
+++ b/content/en/news/2019/announcing-1.3.3/index.md
@@ -1,0 +1,21 @@
+---
+title: Announcing Istio 1.3.3
+description: Istio 1.3.3 release announcement.
+publishdate: 2019-10-14
+attribution: The Istio Team
+subtitle: Minor Update
+release: 1.3.3
+---
+
+This release includes bug fixes to improve robustness. This release note describes what's different between Istio 1.3.2 and Istio 1.3.3.
+
+{{< relnote >}}
+
+## Bug fixes
+
+- **Fixed** an issue which caused Prometheus to install improperly when using `istioctl x manifest apply`. ([Issue 16970](https://github.com/istio/istio/issues/16970))
+- **Fixed** a bug where locality load balancing can not read locality information from the node. ([Issue 17337](https://github.com/istio/istio/issues/17337))
+- **Fixed** a bug where long-lived connections were getting dropped by the Envoy proxy as the listeners were getting reconfigured without any user configuration changes. ([Issue 17383](https://github.com/istio/istio/issues/17383), [Issue 17139](https://github.com/istio/istio/issues/17139))
+- **Fixed** a crash in `istioctl x analyze` command. ([Issue 17449](https://github.com/istio/istio/issues/17449))
+- **Fixed** `istioctl x manifest diff` to diff text blocks in ConfigMaps. ([Issue 16828](https://github.com/istio/istio/issues/16828))
+- **Fixed** a segmentation fault crash in the Envoy proxy. ([Issue 17699](https://github.com/istio/istio/issues/17699))

--- a/data/args.yml
+++ b/data/args.yml
@@ -2,7 +2,7 @@
 version: "1.3"
 
 # The full Istio version identifier the docs describe
-full_version: "1.3.2"
+full_version: "1.3.3"
 
 # The previous Istio version identifier the docs describe, used for upgrade documentation
 previous_version: "1.2"


### PR DESCRIPTION
Cherry-pick the 1.3.3 release notes from https://github.com/istio/istio.io/pull/5122.
Update the `full_version` to `1.3.3`.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
