### PR TITLE
Add initial 1.4 upgrade notice

### DIFF
--- a/content/en/news/2019/announcing-1.4/upgrade-notes/index.md
+++ b/content/en/news/2019/announcing-1.4/upgrade-notes/index.md
@@ -9,3 +9,15 @@ Istio 1.3 to 1.4.  Here, we detail cases where we intentionally broke backwards
 compatibility.  We also mention cases where backwards compatibility was
 preserved but new behavior was introduced that would be surprising to someone
 familiar with the use and operation of Istio 1.3.
+
+## Traffic Management
+
+Services of type `http` are no longer allowed on port 443. This change was made to prevent protocol conflicts with external HTTPS services.
+
+If you depend on this behavior, there are a few options:
+
+* Move the application to another port.
+* Change the protocol from type `http` to type `tcp`
+* Specify the environment variable `PILOT_BLOCK_HTTP_ON_443=false` to the Pilot deployment. Note: this may be removed in future releases.
+
+See [Protocol Selection](/docs/ops/traffic-management/protocol-selection/) for more information about specifying the protocol of a port


### PR DESCRIPTION
I think it makes sense to check in a first iteration of this, then as
individuals add their own sections we can merge those in iteratively.

TODO: if this merges open up an issue to upgrade the link here to 1.4 release notes -- I have it linking to 1.3 release notes to pass lint
