### PR TITLE
Revert port back to 9411

### DIFF
--- a/content/en/docs/tasks/observability/distributed-tracing/jaeger/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/jaeger/index.md
@@ -21,7 +21,7 @@ To learn how Istio handles tracing, visit this task's [overview](../overview/).
 
     a) a demo/test environment by setting the `--set tracing.enabled=true`  Helm install option to enable tracing "out of the box"
 
-    b) a production environment by referencing an existing Jaeger instance, e.g. created with the [operator](https://github.com/jaegertracing/jaeger-operator), and then setting the `--set global.tracer.zipkin.address=<jaeger-collector-service>.<jaeger-collector-namespace>:16686` Helm install option.
+    b) a production environment by referencing an existing Jaeger instance, e.g. created with the [operator](https://github.com/jaegertracing/jaeger-operator), and then setting the `--set global.tracer.zipkin.address=<jaeger-collector-service>.<jaeger-collector-namespace>:9411` Helm install option.
 
     {{< warning >}}
     When you enable tracing, you can set the sampling rate that Istio uses for tracing.


### PR DESCRIPTION
Fix the port in the Jaeger install docs to refer to 9411 (as defined in the original PR https://github.com/istio/istio.io/pull/4210).

[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
