### PR TITLE
migrate Deployment apiVersion from extensions/v1beta1 to apps/v1 to support k8s 1.16

### DIFF
--- a/content/en/docs/ops/app-health-check/index.md
+++ b/content/en/docs/ops/app-health-check/index.md
@@ -124,7 +124,7 @@ The configuration changes above (by Helm or by the configuration map) effect all
 Rather than install Istio with different Helm option, you can annotate Pod with `sidecar.istio.io/rewriteAppHTTPProbers: "true"`.
 
 {{< text yaml >}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: liveness-http

--- a/content/en/docs/ops/troubleshooting/validation/index.md
+++ b/content/en/docs/ops/troubleshooting/validation/index.md
@@ -29,7 +29,7 @@ metadata:
     app: istio-galley
   name: istio-galley
   ownerReferences:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     blockOwnerDeletion: true
     controller: true
     kind: Deployment

--- a/content/en/docs/reference/config/istio.operator.v1alpha12.pb/index.html
+++ b/content/en/docs/reference/config/istio.operator.v1alpha12.pb/index.html
@@ -128,7 +128,7 @@ components:
   galley:
     k8s:
       overlays:
-      - apiVersion: extensions/v1beta1
+      - apiVersion: apps/v1
         kind: Deployment
         name: istio-galley
         patches:

--- a/content/en/docs/setup/additional-setup/sidecar-injection/index.md
+++ b/content/en/docs/setup/additional-setup/sidecar-injection/index.md
@@ -171,7 +171,7 @@ value `false` to the pod template spec to override the default and disable injec
 The following example uses the `sidecar.istio.io/inject` annotation to disable sidecar injection.
 
 {{< text yaml >}}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ignored

--- a/content/en/docs/tasks/observability/logs/fluentd/index.md
+++ b/content/en/docs/tasks/observability/logs/fluentd/index.md
@@ -94,7 +94,7 @@ spec:
     app: elasticsearch
 ---
 # Elasticsearch Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: elasticsearch
@@ -157,7 +157,7 @@ spec:
     app: fluentd-es
 ---
 # Fluentd Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: fluentd-es
@@ -242,7 +242,7 @@ spec:
     app: kibana
 ---
 # Kibana Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kibana

--- a/content/en/docs/tasks/security/auth-sds/index.md
+++ b/content/en/docs/tasks/security/auth-sds/index.md
@@ -104,7 +104,7 @@ To enable the pod security policy, perform the following steps:
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -f -
-    apiVersion: extensions/v1beta1
+    apiVersion: policy/v1beta1
     kind: PodSecurityPolicy
     metadata:
       name: istio-nodeagent
@@ -164,7 +164,7 @@ To enable the pod security policy, perform the following steps:
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -f -
-    apiVersion: extensions/v1beta1
+    apiVersion: policy/v1beta1
     kind: PodSecurityPolicy
     metadata:
       name: istio-sds-uds
@@ -249,7 +249,7 @@ To enable the pod security policy, perform the following steps:
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -f -
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: normal
@@ -281,7 +281,7 @@ To enable the pod security policy, perform the following steps:
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -f -
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: malicious

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -537,7 +537,7 @@ to hold the configuration of the NGINX server:
       selector:
         app: sleep
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: sleep

--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -64,7 +64,7 @@ This example uses [Squid](http://www.squid-cache.org) but you can use any HTTPS 
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: squid

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
@@ -80,7 +80,7 @@ spec:
   selector:
     app: helloworld
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: helloworld
@@ -100,7 +100,7 @@ spec:
         ports:
         - containerPort: 5000
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-sds/index.md
@@ -143,7 +143,7 @@ need to create secrets for multiple hosts and update the gateway definitions.
       selector:
         app: httpbin
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: httpbin
@@ -328,7 +328,7 @@ retrieves unique credentials corresponding to a specific `credentialName`.
       selector:
         app: helloworld-v1
     ---
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: helloworld-v1

--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -26,7 +26,7 @@ you will apply a rule to mirror a portion of traffic to `v2`.
 
     {{< text bash >}}
     $ cat <<EOF | istioctl kube-inject -f - | kubectl create -f -
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: httpbin-v1
@@ -52,7 +52,7 @@ you will apply a rule to mirror a portion of traffic to `v2`.
 
     {{< text bash >}}
     $ cat <<EOF | istioctl kube-inject -f - | kubectl create -f -
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: httpbin-v2
@@ -100,7 +100,7 @@ you will apply a rule to mirror a portion of traffic to `v2`.
 
     {{< text bash >}}
     $ cat <<EOF | istioctl kube-inject -f - | kubectl create -f -
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     metadata:
       name: sleep


### PR DESCRIPTION
`apps/v1` for Deployment resource is available since k8s v1.9.
`extensions/v1beta1` is deprecated and removed in k8s v1.16.
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

To support k8s v1.16, examples should use `apps/v1`.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
