### PR TITLE
Workaround Hugo bug where it gets confused about directory parentage.

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -21,18 +21,21 @@
         {{ end }}
 
         {{ $parent := .Page }}
+        {{ $parentDir := (path.Dir .Page.File.Dir) }}
 
         {{ if $parent.Params.simple_list }}
             <ul>
                 {{ range $pages }}
-                    {{ if eq .Parent $parent }}
+                    {{ $pageLocation := (path.Dir (path.Dir .File.Dir)) }}
+                    {{ if eq $parentDir $pageLocation }}
                         <li><a href="{{ .Permalink }}">{{- .Title -}}</a></li>
                     {{ end }}
                 {{ end }}
             </ul>
         {{ else }}
             {{ range $pages }}
-                {{ if eq .Parent $parent }}
+                {{ $pageLocation := (path.Dir (path.Dir .File.Dir)) }}
+                {{ if eq $parentDir $pageLocation }}
                     <div class="entry">
                         <h5>
                             <a href="{{ .Permalink }}">

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,11 +1,16 @@
 {{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }}
 {{ $page := .Page }}
-{{ range $index, $element := split $url "/" }}
+{{ range $index := split $url "/" }}
     {{ if $page }}
         {{ $.Scratch.Add "urls" (slice $page.Permalink) }}
         {{ $.Scratch.Add "titles" (slice $page.LinkTitle) }}
         {{ $.Scratch.Add "descriptions" (slice $page.Description) }}
-        {{ $page = $page.Parent }}
+
+        {{ $old := $page }}
+        {{ $page = $page.GetPage (path.Dir (path.Dir $page.File.Path)) }}
+        {{ if eq $old $page }}
+            {{ $page = $page.Site.GetPage "home" }}
+        {{ end }}
     {{ end }}
 {{ end }}
 

--- a/layouts/partials/sidebar_level.html
+++ b/layouts/partials/sidebar_level.html
@@ -11,18 +11,22 @@
     {{ $pages = sort $pages ".Params.weight" "asc" }}
 {{ end }}
 
+{{ $parentDir := (path.Dir $parent.File.Dir) }}
+
 {{ $leafSection := true }}
 {{ range $pages }}
-    {{ if eq .Parent $parent }}
-            {{ if not .IsPage }}
-                {{ $leafSection = false }}
-            {{ end }}
+    {{ $pageLocation := (path.Dir (path.Dir .File.Dir)) }}
+    {{ if eq $parentDir $pageLocation }}
+        {{ if not .IsPage }}
+            {{ $leafSection = false }}
+        {{ end }}
     {{ end }}
 {{ end }}
 
 <ul role="{{ if $top }}tree{{ else }}group{{ end }}" aria-expanded="{{ if $collapse }}false{{ else }}true{{ end }}"{{ if $leafSection }} class="leaf-section"{{ end }} {{ if $labelledby}}aria-labelledby="{{ $labelledby }}"{{ end }}>
     {{ range $pages }}
-        {{ if eq .Parent $parent }}
+        {{ $pageLocation := (path.Dir (path.Dir .File.Dir)) }}
+        {{ if eq $parentDir $pageLocation }}
             {{ if not .IsPage }}
                 <li role="treeitem" aria-label="{{ .LinkTitle}}">
                     {{ $collapse := not (.IsAncestor $current) }}

--- a/layouts/shortcodes/relnote.html
+++ b/layouts/shortcodes/relnote.html
@@ -72,7 +72,7 @@
         {{ range $page := .Site.Pages }}
             {{ $release := $page.Params.release }}
             {{ if eq $release $base_version }}
-                {{ $path := printf "/%supgrade-notes" $page.Dir }}
+                {{ $path := printf "/%supgrade-notes" $page.File.Dir }}
                 {{ $upgrade_notes = .Page.GetPage $path }}
             {{ end }}
         {{ end }}


### PR DESCRIPTION
Hugo produces confused results when directories are named as subsets of other
directory names (announcing-1.3 vs. announcing-1.3.1). Instead of using Hugo's
.Parent variable, we compute parentage manually using path names.
