### PR TITLE
Remove warning from referenced blogs

### DIFF
--- a/content/en/blog/2017/0.1-canary/index.md
+++ b/content/en/blog/2017/0.1-canary/index.md
@@ -7,7 +7,6 @@ attribution: Frank Budinsky
 keywords: [traffic-management,canary]
 aliases:
     - /blog/canary-deployments-using-istio.html
-target_release: 0.7
 ---
 
 {{< tip >}}

--- a/content/en/blog/2019/egress-traffic-control-in-istio-part-1/index.md
+++ b/content/en/blog/2019/egress-traffic-control-in-istio-part-1/index.md
@@ -5,7 +5,6 @@ description: Attacks involving egress traffic and requirements for egress traffi
 publishdate: 2019-05-22
 attribution: Vadim Eisenberg (IBM)
 keywords: [traffic-management,egress,security]
-target_release: 1.1
 ---
 
 This is part 1 in a new series about secure control of egress traffic in Istio that I am going to publish.

--- a/content/en/blog/2019/performance-best-practices/index.md
+++ b/content/en/blog/2019/performance-best-practices/index.md
@@ -6,7 +6,6 @@ last_update: 2019-09-05
 subtitle:
 attribution: Megan O'Keefe (Google), John Howard (Google), Mandar Jog (Google)
 keywords: [performance,scalability,scale,benchmarks]
-target_release: 1.2
 ---
 
 Service meshes add a lot of functionality to application deployments, including [traffic policies](/docs/concepts/what-is-istio/#traffic-management), [observability](/docs/concepts/what-is-istio/#observability), and [secure communication](/docs/concepts/what-is-istio/#security). But adding a service mesh to your environment comes at a cost, whether that's time (added latency) or resources (CPU cycles). To make an informed decision on whether a service mesh is right for your use case, it's important to evaluate how your application performs when deployed with a service mesh.

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -206,4 +206,4 @@ other = "Description"
 other = "Level"
 
 [target_release]
-other = "This blog post was written a while ago and assumed Istio %v. Be aware that there have been many improvements to Isito since then and so some of this content may now be outdated."
+other = "This blog post was written assuming Istio %v, so some of this content may now be outdated."


### PR DESCRIPTION
Removed the potentially outdated warning from blogs that are referenced from other docs and toned down the warning for the rest, since the majority of them are fine.


Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
