### PR TITLE
Simplify CRD check step

### DIFF
--- a/content/en/boilerplates/verify-crds.md
+++ b/content/en/boilerplates/verify-crds.md
@@ -1,6 +1,5 @@
-Verify that all `23` Istio CRDs were committed to the Kubernetes api-server using the following command:
+Wait for all Istio CRDs to be created:
 
 {{< text bash >}}
-$ kubectl get crds | grep 'istio.io' | wc -l
-23
+$ kubectl -n istio-system wait --for=condition=complete job --all
 {{< /text >}}

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -80,7 +80,7 @@ deployed and you don't want to install it.
 
 1. Install all the Istio
     [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)
-    (CRDs) using `kubectl apply`, and wait a few seconds for the CRDs to be committed in the Kubernetes API-server:
+    (CRDs) using `kubectl apply`:
 
     {{< text bash >}}
     $ helm template install/kubernetes/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -

--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -102,7 +102,7 @@ Cross-cluster communication occurs over Istio gateways of the respective cluster
 
     * Install all the Istio
     [Custom Resource Definitions](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)
-    (CRDs) using `kubectl apply`, and wait a few seconds for the CRDs to be committed in the Kubernetes API-server:
+    (CRDs) using `kubectl apply`:
 
     {{< text bash >}}
     $ helm template install/kubernetes/helm/istio-init --name istio-init --namespace istio-system | kubectl apply -f -


### PR DESCRIPTION
Currently we are asking users to get a count of their CRDs. This is hard
because the docs fall out of sync very frequently, they may have CRDs
for the operator or something, etc. In generally its really hard to be
right here, and it involves the users manually running this command over
and over until it works.

Instead, we can just wait for the jobs to complete. This has the benefit
of working regardless of their environment, and won't fall out of date.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
