### PR TITLE
Simplify our Authentication Policy w.r.t auto mTLS feature in 1.4

### DIFF
--- a/content/en/docs/tasks/security/authn-policy/index.md
+++ b/content/en/docs/tasks/security/authn-policy/index.md
@@ -252,7 +252,6 @@ command terminated with exit code 56
 If we have more services in namespace `bar`, we should see traffic to them won't be affected. Instead of adding more services to demonstrate this behavior,
 we edit the policy slightly to apply on a specific port:
 
-
 <!-- What's this part for? I don't think we have a port 1234 for httpbin service. -->
 
 {{< text bash >}}

--- a/content/en/docs/tasks/security/automtls/index.md
+++ b/content/en/docs/tasks/security/automtls/index.md
@@ -1,0 +1,602 @@
+---
+title: Authentication Policy
+description: Shows you how to use Istio authentication policy to setup mutual TLS and basic end-user authentication.
+weight: 10
+keywords: [security,authentication]
+aliases:
+    - /docs/tasks/security/istio-auth.html
+---
+
+This task covers the primary activities you might need to perform when enabling, configuring, and using Istio authentication policies. Find out more about
+the underlying concepts in the [authentication overview](/docs/concepts/security/#authentication).
+
+## Before you begin
+
+* Understand Istio [authentication policy](/docs/concepts/security/#authentication-policies) and related
+[mutual TLS authentication](/docs/concepts/security/#mutual-tls-authentication) concepts.
+
+* Have a Kubernetes cluster with Istio installed, without global mutual TLS enabled (e.g use `install/kubernetes/istio-demo.yaml` as described in
+[installation steps](/docs/setup/install/kubernetes/#installation-steps), or set `global.mtls.enabled` to false using
+[Helm](/docs/setup/install/helm/)).
+
+{{< warning >}}
+This tutorial assume you're using Istio 1.4 with auto mutual TLS turned on via Helm flag
+`global.mtls.auto` to true.
+If you're using Istio 1.3 or previous releases, or disable the auto mutual TLS, please refer to previous docs
+[release doc](https://archive.istio.io/v1.2/docs/tasks/security/authn-policy/).
+{{< /warning >}}
+
+### Setup
+
+Our examples use two namespaces `foo` and `bar`, with two services, `httpbin` and `sleep`, both running with an Envoy sidecar proxy. We also use second
+instances of `httpbin` and `sleep` running without the sidecar  in the `legacy` namespace. If you’d like to use the same examples when trying the tasks,
+run the following:
+
+{{< text bash >}}
+$ kubectl create ns foo
+$ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin.yaml@) -n foo
+$ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@) -n foo
+$ kubectl create ns bar
+$ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin.yaml@) -n bar
+$ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@) -n bar
+$ kubectl create ns legacy
+$ kubectl apply -f @samples/httpbin/httpbin.yaml@ -n legacy
+$ kubectl apply -f @samples/sleep/sleep.yaml@ -n legacy
+{{< /text >}}
+
+You can verify setup by sending an HTTP request with `curl` from any `sleep` pod in the namespace `foo`, `bar` or `legacy` to either `httpbin.foo`,
+`httpbin.bar` or `httpbin.legacy`. All requests should succeed with HTTP code 200.
+
+For example, here is a command to check `sleep.bar` to `httpbin.foo` reachability:
+
+{{< text bash >}}
+$ kubectl exec $(kubectl get pod -l app=sleep -n bar -o jsonpath={.items..metadata.name}) -c sleep -n bar -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
+200
+{{< /text >}}
+
+This one-liner command conveniently iterates through all reachability combinations:
+
+{{< text bash >}}
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+sleep.foo to httpbin.foo: 200
+sleep.foo to httpbin.bar: 200
+sleep.foo to httpbin.legacy: 200
+sleep.bar to httpbin.foo: 200
+sleep.bar to httpbin.bar: 200
+sleep.bar to httpbin.legacy: 200
+sleep.legacy to httpbin.foo: 200
+sleep.legacy to httpbin.bar: 200
+sleep.legacy to httpbin.legacy: 200
+{{< /text >}}
+
+You should also verify that there is a default mesh authentication policy in the system, which you can do as follows:
+
+{{< text bash >}}
+$ kubectl get policies.authentication.istio.io --all-namespaces
+No resources found.
+{{< /text >}}
+
+{{< text bash >}}
+$ kubectl get meshpolicies.authentication.istio.io
+NAME      AGE
+default   3m
+{{< /text >}}
+
+Last but not least, verify that there are no destination rules that apply on the example services. You can do this by checking the `host:` value of
+ existing destination rules and make sure they do not match. For example:
+
+{{< text bash >}}
+$ kubectl get destinationrules.networking.istio.io --all-namespaces -o yaml | grep "host:"
+    host: istio-policy.istio-system.svc.cluster.local
+    host: istio-telemetry.istio-system.svc.cluster.local
+{{< /text >}}
+
+## Globally enabling Istio mutual TLS
+
+To set a mesh-wide authentication policy that enables mutual TLS, submit *mesh authentication policy* like below:
+
+{{< text bash >}}
+$ kubectl apply -f - <<EOF
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "MeshPolicy"
+metadata:
+  name: "default"
+spec:
+  peers:
+  - mtls: {}
+EOF
+{{< /text >}}
+
+{{< tip >}}
+The mesh authentication policy uses the [regular authentication policy API](/docs/reference/config/istio.authentication.v1alpha1/)
+ it is defined in the cluster-scoped `MeshPolicy` CRD.
+ {{< /tip >}}
+
+This policy specifies that all workloads in the mesh will only accept encrypted requests using TLS. As you can see, this authentication policy has the kind:
+ `MeshPolicy`. The name of the policy must be `default`, and it contains no `targets` specification (as it is intended to apply to all services in the mesh).
+
+At this point, only the receiving side is configured to use mutual TLS. If you run the `curl` command between *Istio services* (i.e those with sidecars), all
+ requests will fail with a 503 error code as the client side is still using plain-text.
+
+{{< text bash >}}
+$ for from in "foo" "bar"; do for to in "foo" "bar"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+sleep.foo to httpbin.foo: 200
+sleep.foo to httpbin.bar: 200
+sleep.bar to httpbin.foo: 200
+sleep.bar to httpbin.bar: 200
+{{< /text >}}
+
+### Request from non-Istio services to Istio services
+
+The non-Istio service, e.g `sleep.legacy` doesn't have a sidecar, so it cannot initiate the required TLS connection to Istio services. As a result,
+requests from `sleep.legacy` to `httpbin.foo` or `httpbin.bar` will fail:
+
+{{< text bash >}}
+$ for from in "legacy"; do for to in "foo" "bar"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+sleep.legacy to httpbin.foo: 000
+command terminated with exit code 56
+sleep.legacy to httpbin.bar: 000
+command terminated with exit code 56
+{{< /text >}}
+
+{{< tip >}}
+Due to the way Envoy rejects plain-text requests, you will see `curl` exit code 56 (failure with receiving network data) in this case.
+{{< /tip >}}
+
+This works as intended, and unfortunately, there is no solution for this without reducing authentication requirements for these services.
+
+### Request from Istio services to non-Istio services
+
+Try to send requests to `httpbin.legacy` from `sleep.foo` (or `sleep.bar`). Istio automatically configures
+client sidecars to send plain-text traffic for legacy workloads without sidecar.
+
+{{< text bash >}}
+$ for from in "foo" "bar"; do for to in "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+sleep.foo to httpbin.legacy: 200
+sleep.bar to httpbin.legacy: 200
+{{< /text >}}
+
+This applies to Kubernetes API server as well, which doesn't have a sidecar. Istio automatically configure
+clients to send plain-text traffic to Kubernetes API server.
+
+Run the testing command above to confirm that it returns 200.
+
+{{< text bash >}}
+$ TOKEN=$(kubectl describe secret $(kubectl get secrets | grep default-token | cut -f1 -d ' ' | head -1) | grep -E '^token' | cut -f2 -d':' | tr -d '\t')
+$ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl https://kubernetes.default/api --header "Authorization: Bearer $TOKEN" --insecure -s -o /dev/null -w "%{http_code}\n"
+200
+{{< /text >}}
+
+### Cleanup part 1
+
+Remove global authentication policy:
+
+{{< text bash >}}
+$ kubectl delete meshpolicy default
+{{< /text >}}
+
+## Enable mutual TLS per namespace or service
+
+In addition to specifying an authentication policy for your entire mesh, Istio also lets you specify policies for particular namespaces or services. A
+namespace-wide policy takes precedence over the mesh-wide policy, while a service-specific policy has higher precedence still.
+
+### Namespace-wide policy
+
+The example below shows the policy to enable mutual TLS for all services in namespace `foo`. As you can see, it uses kind: "Policy” rather than "MeshPolicy”,
+and specifies a namespace, in this case, `foo`. If you don’t specify a namespace value the policy will apply to the default namespace.
+
+{{< text bash >}}
+$ kubectl apply -f - <<EOF
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "default"
+  namespace: "foo"
+spec:
+  peers:
+  - mtls: {}
+EOF
+{{< /text >}}
+
+{{< tip >}}
+Similar to *mesh-wide policy*, namespace-wide policy must be named `default`, and doesn't restrict any specific service (no `targets` section)
+{{< /tip >}}
+
+As these policy in namespace `foo` only, you should see only request from client-without-sidecar (`sleep.legacy`) to `httpbin.foo` start to fail.
+
+{{< text bash >}}
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+sleep.foo to httpbin.foo: 200
+sleep.foo to httpbin.bar: 200
+sleep.foo to httpbin.legacy: 200
+sleep.bar to httpbin.foo: 200
+sleep.bar to httpbin.bar: 200
+sleep.bar to httpbin.legacy: 200
+sleep.legacy to httpbin.foo: 000
+command terminated with exit code 56
+sleep.legacy to httpbin.bar: 200
+sleep.legacy to httpbin.legacy: 200
+{{< /text >}}
+
+### Service-specific policy
+
+You can also set authentication policy for a specific service. Run this command to set another policy only for `httpbin.bar` service.
+
+{{< text bash >}}
+$ cat <<EOF | kubectl apply -n bar -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "httpbin"
+spec:
+  targets:
+  - name: httpbin
+  peers:
+  - mtls: {}
+EOF
+{{< /text >}}
+
+{{< tip >}}
+* In this example, we do **not** specify namespace in metadata but put it in the command line (`-n bar`), which has an identical effect.
+* There is no restriction on the authentication policy name. This example uses the name of the service itself for simplicity.
+{{< /tip >}}
+
+Again, run the probing command. As expected, request from `sleep.legacy` to `httpbin.bar` starts failing with the same reasons.
+
+{{< text plain >}}
+...
+sleep.legacy to httpbin.bar: 000
+command terminated with exit code 56
+{{< /text >}}
+
+If we have more services in namespace `bar`, we should see traffic to them won't be affected. Instead of adding more services to demonstrate this behavior,
+we edit the policy slightly to apply on a specific port:
+
+<!-- What's this part for? I don't think we have a port 1234 for httpbin service. -->
+
+{{< text bash >}}
+$ cat <<EOF | kubectl apply -n bar -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "httpbin"
+spec:
+  targets:
+  - name: httpbin
+    ports:
+    - number: 1234
+  peers:
+  - mtls: {}
+EOF
+{{< /text >}}
+
+This new policy will apply only to the `httpbin` service on port `1234`. As a result, mutual TLS is disabled (again) on port `8000` and requests from
+`sleep.legacy` will resume working.
+
+{{< text bash >}}
+$ kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.bar:8000/ip -s -o /dev/null -w "%{http_code}\n"
+200
+{{< /text >}}
+
+### Policy precedence
+
+To illustrate how a service-specific policy takes precedence over namespace-wide policy, you can add a policy to disable mutual TLS for `httpbin.foo` as below.
+Note that you've already created a namespace-wide policy that enables mutual TLS for all services in namespace `foo` and observe that requests from
+`sleep.legacy` to `httpbin.foo` are failing (see above).
+
+{{< text bash >}}
+$ cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "overwrite-example"
+spec:
+  targets:
+  - name: httpbin
+EOF
+{{< /text >}}
+
+Re-running the request from `sleep.legacy`, you should see a success return code again (200), confirming service-specific policy overrides the namespace-wide policy.
+
+{{< text bash >}}
+$ kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
+200
+{{< /text >}}
+
+### Cleanup part 2
+
+Remove policies created in the above steps:
+
+{{< text bash >}}
+$ kubectl delete policy default overwrite-example -n foo
+$ kubectl delete policy httpbin -n bar
+{{< /text >}}
+
+## End-user authentication
+
+To experiment with this feature, you need a valid JWT. The JWT must correspond to the JWKS endpoint you want to use for the demo. In
+this tutorial, we use this [JWT test]({{< github_file >}}/security/tools/jwt/samples/demo.jwt) and this
+[JWKS endpoint]({{< github_file >}}/security/tools/jwt/samples/jwks.json) from the Istio code base.
+
+Also, for convenience, expose `httpbin.foo` via `ingressgateway` (for more details, see the [ingress task](/docs/tasks/traffic-management/ingress/)).
+
+{{< text bash >}}
+$ kubectl apply -f - <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: httpbin-gateway
+  namespace: foo
+spec:
+  selector:
+    istio: ingressgateway # use Istio default gateway implementation
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "*"
+EOF
+{{< /text >}}
+
+{{< text bash >}}
+$ kubectl apply -f - <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: httpbin
+  namespace: foo
+spec:
+  hosts:
+  - "*"
+  gateways:
+  - httpbin-gateway
+  http:
+  - route:
+    - destination:
+        port:
+          number: 8000
+        host: httpbin.foo.svc.cluster.local
+EOF
+{{< /text >}}
+
+Get ingress IP
+
+{{< text bash >}}
+$ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+{{< /text >}}
+
+And run a test query
+
+{{< text bash >}}
+$ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
+200
+{{< /text >}}
+
+Now, add a policy that requires end-user JWT for `httpbin.foo`. The next command assumes there is no service-specific policy for `httpbin.foo` (which should
+be the case if you run [cleanup](#cleanup-part-2) as described). You can run `kubectl get policies.authentication.istio.io -n foo` to confirm.
+
+{{< text bash >}}
+$ cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "jwt-example"
+spec:
+  targets:
+  - name: httpbin
+  origins:
+  - jwt:
+      issuer: "testing@secure.istio.io"
+      jwksUri: "{{< github_file >}}/security/tools/jwt/samples/jwks.json"
+  principalBinding: USE_ORIGIN
+EOF
+{{< /text >}}
+
+The same `curl` command from before will return with 401 error code, as a result of server is expecting JWT but none was provided:
+
+{{< text bash >}}
+$ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
+401
+{{< /text >}}
+
+Attaching the valid token generated above returns success:
+
+{{< text bash >}}
+$ TOKEN=$(curl {{< github_file >}}/security/tools/jwt/samples/demo.jwt -s)
+$ curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
+200
+{{< /text >}}
+
+To observe other aspects of JWT validation, use the script [`gen-jwt.py`]({{< github_tree >}}/security/tools/jwt/samples/gen-jwt.py) to
+generate new tokens to test with different issuer, audiences, expiry date, etc. The script can be downloaded from the Istio repository:
+
+{{< text bash >}}
+$ wget {{< github_file >}}/security/tools/jwt/samples/gen-jwt.py
+$ chmod +x gen-jwt.py
+{{< /text >}}
+
+You also need the `key.pem` file:
+
+{{< text bash >}}
+$ wget {{< github_file >}}/security/tools/jwt/samples/key.pem
+{{< /text >}}
+
+{{< tip >}}
+Download the [jwcrypto](https://pypi.org/project/jwcrypto) library,
+if you haven't installed it on your system.
+{{< /tip >}}
+
+For example, the command below creates a token that
+expires in 5 seconds. As you see, Istio authenticates requests using that token successfully at first but rejects them after 5 seconds:
+
+{{< text bash >}}
+$ TOKEN=$(./gen-jwt.py ./key.pem --expire 5)
+$ for i in `seq 1 10`; do curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"; sleep 1; done
+200
+200
+200
+200
+200
+401
+401
+401
+401
+401
+{{< /text >}}
+
+You can also add a JWT policy to an ingress gateway (e.g., service `istio-ingressgateway.istio-system.svc.cluster.local`).
+This is often used to define a JWT policy for all services bound to the gateway, instead of for individual services.
+
+### End-user authentication with per-path requirements
+
+End-user authentication can be enabled or disabled based on request path. This is useful if you want to
+disable authentication for some paths, for example, the path used for health check or status report.
+You can also specify different JWT requirements on different paths.
+
+{{< warning >}}
+The end-user authentication with per-path requirements is an experimental feature in Istio 1.1 and
+is **NOT** recommended for production use.
+{{< /warning >}}
+
+#### Disable End-user authentication for specific paths
+
+Modify the `jwt-example` policy to disable End-user authentication for path `/user-agent`:
+
+{{< text bash >}}
+$ cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "jwt-example"
+spec:
+  targets:
+  - name: httpbin
+  origins:
+  - jwt:
+      issuer: "testing@secure.istio.io"
+      jwksUri: "{{< github_file >}}/security/tools/jwt/samples/jwks.json"
+      trigger_rules:
+      - excluded_paths:
+        - exact: /user-agent
+  principalBinding: USE_ORIGIN
+EOF
+{{< /text >}}
+
+Confirm it's allowed to access the path `/user-agent` without JWT tokens:
+
+{{< text bash >}}
+$ curl $INGRESS_HOST/user-agent -s -o /dev/null -w "%{http_code}\n"
+200
+{{< /text >}}
+
+Confirm it's denied to access paths other than `/user-agent` without JWT tokens:
+
+{{< text bash >}}
+$ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
+401
+{{< /text >}}
+
+#### Enable End-user authentication for specific paths
+
+Modify the `jwt-example` policy to enable End-user authentication only for path `/ip`:
+
+{{< text bash >}}
+$ cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "jwt-example"
+spec:
+  targets:
+  - name: httpbin
+  origins:
+  - jwt:
+      issuer: "testing@secure.istio.io"
+      jwksUri: "{{< github_file >}}/security/tools/jwt/samples/jwks.json"
+      trigger_rules:
+      - included_paths:
+        - exact: /ip
+  principalBinding: USE_ORIGIN
+EOF
+{{< /text >}}
+
+Confirm it's allowed to access paths other than `/ip` without JWT tokens:
+
+{{< text bash >}}
+$ curl $INGRESS_HOST/user-agent -s -o /dev/null -w "%{http_code}\n"
+200
+{{< /text >}}
+
+Confirm it's denied to access the path `/ip` without JWT tokens:
+
+{{< text bash >}}
+$ curl $INGRESS_HOST/ip -s -o /dev/null -w "%{http_code}\n"
+401
+{{< /text >}}
+
+Confirm it's allowed to access the path `/ip` with a valid JWT token:
+
+{{< text bash >}}
+$ TOKEN=$(curl {{< github_file >}}/security/tools/jwt/samples/demo.jwt -s)
+$ curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/ip -s -o /dev/null -w "%{http_code}\n"
+200
+{{< /text >}}
+
+### End-user authentication with mutual TLS
+
+End-user authentication and mutual TLS can be used together. Modify the policy above to define both mutual TLS and end-user JWT authentication:
+
+{{< text bash >}}
+$ cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "authentication.istio.io/v1alpha1"
+kind: "Policy"
+metadata:
+  name: "jwt-example"
+spec:
+  targets:
+  - name: httpbin
+  peers:
+  - mtls: {}
+  origins:
+  - jwt:
+      issuer: "testing@secure.istio.io"
+      jwksUri: "{{< github_file >}}/security/tools/jwt/samples/jwks.json"
+  principalBinding: USE_ORIGIN
+EOF
+{{< /text >}}
+
+{{< tip >}}
+If you already enable mutual TLS mesh-wide or namespace-wide, you still need to add the `mtls` stanza to the authentication policy as the service-specific policy will override the mesh-wide (or namespace-wide) policy completely.
+{{< /tip >}}
+
+After these changes, traffic from Istio services, including ingress gateway, to `httpbin.foo` will use mutual TLS. The test command above will still work. Requests from Istio services directly to `httpbin.foo` also work, given the correct token:
+
+{{< text bash >}}
+$ TOKEN=$(curl {{< github_file >}}/security/tools/jwt/samples/demo.jwt -s)
+$ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n" --header "Authorization: Bearer $TOKEN"
+200
+{{< /text >}}
+
+However, requests from non-Istio services, which use plain-text will fail:
+
+{{< text bash >}}
+$ kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n" --header "Authorization: Bearer $TOKEN"
+000
+command terminated with exit code 56
+{{< /text >}}
+
+### Cleanup part 3
+
+1. Remove authentication policy:
+
+    {{< text bash >}}
+    $ kubectl -n foo delete policy jwt-example
+    {{< /text >}}
+
+1. If you are not planning to explore any follow-on tasks, you can remove all resources simply by deleting test namespaces.
+
+    {{< text bash >}}
+    $ kubectl delete ns foo bar legacy
+    {{< /text >}}

--- a/content/en/docs/tasks/security/automtls/index.md
+++ b/content/en/docs/tasks/security/automtls/index.md
@@ -1,79 +1,107 @@
 ---
-title: Authentication Policy
-description: Shows you how to use Istio authentication policy to setup mutual TLS and basic end-user authentication.
+title: Automatic mutual TLS
+description: A simplified workflow to adopt mutual TLS with minimal configuration overhead.
 weight: 10
-keywords: [security,authentication]
-aliases:
-    - /docs/tasks/security/istio-auth.html
+keywords: [security,mtls,ux]
 ---
 
-This task covers the primary activities you might need to perform when enabling, configuring, and using Istio authentication policies. Find out more about
-the underlying concepts in the [authentication overview](/docs/concepts/security/#authentication).
+This tasks shows a simplified workflow for mutual TLS adoption[authentication overview](/docs/concepts/security/#authentication).
+
+With Istio auto mutual TLS feature, you can adopt mutual TLS by only configuring Authentication Policy without worrying about destination rule.
+
+Istio tracks the server workloads are migrated to Istio sidecar, and configure client sidecar to send mutual TLS traffic to those workloads automatically, and send plain text traffic to workloads
+without sidecars. This allows you to adopt Istio mutual TLS incrementally with minimal manual configuration.
 
 ## Before you begin
 
 * Understand Istio [authentication policy](/docs/concepts/security/#authentication-policies) and related
 [mutual TLS authentication](/docs/concepts/security/#mutual-tls-authentication) concepts.
 
-* Have a Kubernetes cluster with Istio installed, without global mutual TLS enabled (e.g use `install/kubernetes/istio-demo.yaml` as described in
-[installation steps](/docs/setup/install/kubernetes/#installation-steps), or set `global.mtls.enabled` to false using
-[Helm](/docs/setup/install/helm/)).
+* Have a Kubernetes cluster with Istio installed (e.g use `install/kubernetes/istio-demo.yaml` as described in
+[installation steps](/docs/setup/install/kubernetes/#installation-steps), set `global.mtls.enabled` to false  and `global.mtls.auto` to true using [Helm](/docs/setup/install/helm/)). For example,
 
-{{< warning >}}
-This tutorial assume you're using Istio 1.4 with auto mutual TLS turned on via Helm flag
-`global.mtls.auto` to true.
-If you're using Istio 1.3 or previous releases, or disable the auto mutual TLS, please refer to previous docs
-[release doc](https://archive.istio.io/v1.2/docs/tasks/security/authn-policy/).
-{{< /warning >}}
+{{< text bash >}}
+$ helm template install/kubernetes/helm/istio --name istio --namespace istio-system  \
+  --set global.mtls.enabled=false  --set global.mtls.auto=true \
+  --values install/kubernetes/helm/istio/values-istio-demo.yaml | kubectl apply -f -
+{{< /text >}}
+
+## Instructions
 
 ### Setup
 
-Our examples use two namespaces `foo` and `bar`, with two services, `httpbin` and `sleep`, both running with an Envoy sidecar proxy. We also use second
-instances of `httpbin` and `sleep` running without the sidecar  in the `legacy` namespace. If you’d like to use the same examples when trying the tasks,
-run the following:
+Our examples use three namespaces, `foo`, `mixed`, and `legacy`. 
+
+Each namespace we deploy `httpbin` and `sleep`.
+
+All workloads in `foo` namespace have sidecar.
 
 {{< text bash >}}
 $ kubectl create ns foo
 $ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin.yaml@) -n foo
 $ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@) -n foo
-$ kubectl create ns bar
-$ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin.yaml@) -n bar
-$ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@) -n bar
+{{< /text >}}
+
+Some workloads in `mixed` have sidecar and some don't. 
+
+{{< text bash >}}
+$ kubectl create ns mixed
+$ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin.yaml@) -n mixed
+$ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@) -n mixed
+$ cat <<EOF | kubectl apply -n mixed -f -
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: nosidecar
+    spec:
+      containers:
+      - image: docker.io/kennethreitz/httpbin
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        ports:
+        - containerPort: 80
+EOF
+{{< /text >}}
+
+None of the workloads in `legacy` have sidecar.
+
+{{< text bash >}}
 $ kubectl create ns legacy
 $ kubectl apply -f @samples/httpbin/httpbin.yaml@ -n legacy
 $ kubectl apply -f @samples/sleep/sleep.yaml@ -n legacy
 {{< /text >}}
 
-You can verify setup by sending an HTTP request with `curl` from any `sleep` pod in the namespace `foo`, `bar` or `legacy` to either `httpbin.foo`,
-`httpbin.bar` or `httpbin.legacy`. All requests should succeed with HTTP code 200.
-
-For example, here is a command to check `sleep.bar` to `httpbin.foo` reachability:
+You can confirm the deployments in all namespaces.
 
 {{< text bash >}}
-$ kubectl exec $(kubectl get pod -l app=sleep -n bar -o jsonpath={.items..metadata.name}) -c sleep -n bar -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
-200
-{{< /text >}}
-
-This one-liner command conveniently iterates through all reachability combinations:
-
-{{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
-sleep.foo to httpbin.foo: 200
-sleep.foo to httpbin.bar: 200
-sleep.foo to httpbin.legacy: 200
-sleep.bar to httpbin.foo: 200
-sleep.bar to httpbin.bar: 200
-sleep.bar to httpbin.legacy: 200
-sleep.legacy to httpbin.foo: 200
-sleep.legacy to httpbin.bar: 200
-sleep.legacy to httpbin.legacy: 200
+$ kubectl get pods -n foo
+$ kubectl get pods -n mixed
+$ kubectl get pods -n legacy
+NAME                      READY   STATUS    RESTARTS   AGE
+httpbin-dcd949489-5cndk   2/2     Running   0          39s
+sleep-58d6644d44-gb55j    2/2     Running   0          38s
+NAME                       READY   STATUS    RESTARTS   AGE
+httpbin-6f6fc94fb6-8d62h   1/1     Running   0          10s
+httpbin-dcd949489-5fsbs    2/2     Running   0          12s
+sleep-58d6644d44-zmv8w     2/2     Running   0          11s
+NAME                       READY   STATUS    RESTARTS   AGE
+httpbin-54f5bb4957-lzxlg   1/1     Running   0          6s
+sleep-74564b477b-vb6h4     1/1     Running   0          4s
 {{< /text >}}
 
 You should also verify that there is a default mesh authentication policy in the system, which you can do as follows:
 
 {{< text bash >}}
 $ kubectl get policies.authentication.istio.io --all-namespaces
-No resources found.
+NAMESPACE      NAME                          AGE
+istio-system   grafana-ports-mtls-disabled   5m
 {{< /text >}}
 
 {{< text bash >}}
@@ -91,139 +119,43 @@ $ kubectl get destinationrules.networking.istio.io --all-namespaces -o yaml | gr
     host: istio-telemetry.istio-system.svc.cluster.local
 {{< /text >}}
 
-## Globally enabling Istio mutual TLS
+You can verify setup by sending an HTTP request with `curl` from any `sleep` pod in the namespace `foo`, `mixed` or `legacy` to either `httpbin.foo`, `httpbin.mixed` or `httpbin.legacy`. All requests should succeed with HTTP code 200.
 
-To set a mesh-wide authentication policy that enables mutual TLS, submit *mesh authentication policy* like below:
-
-{{< text bash >}}
-$ kubectl apply -f - <<EOF
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "MeshPolicy"
-metadata:
-  name: "default"
-spec:
-  peers:
-  - mtls: {}
-EOF
-{{< /text >}}
-
-{{< tip >}}
-The mesh authentication policy uses the [regular authentication policy API](/docs/reference/config/istio.authentication.v1alpha1/)
- it is defined in the cluster-scoped `MeshPolicy` CRD.
- {{< /tip >}}
-
-This policy specifies that all workloads in the mesh will only accept encrypted requests using TLS. As you can see, this authentication policy has the kind:
- `MeshPolicy`. The name of the policy must be `default`, and it contains no `targets` specification (as it is intended to apply to all services in the mesh).
-
-At this point, only the receiving side is configured to use mutual TLS. If you run the `curl` command between *Istio services* (i.e those with sidecars), all
- requests will fail with a 503 error code as the client side is still using plain-text.
+For example, here is a command to check `sleep.mixed` to `httpbin.foo` reachability:
 
 {{< text bash >}}
-$ for from in "foo" "bar"; do for to in "foo" "bar"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
-sleep.foo to httpbin.foo: 200
-sleep.foo to httpbin.bar: 200
-sleep.bar to httpbin.foo: 200
-sleep.bar to httpbin.bar: 200
-{{< /text >}}
-
-### Request from non-Istio services to Istio services
-
-The non-Istio service, e.g `sleep.legacy` doesn't have a sidecar, so it cannot initiate the required TLS connection to Istio services. As a result,
-requests from `sleep.legacy` to `httpbin.foo` or `httpbin.bar` will fail:
-
-{{< text bash >}}
-$ for from in "legacy"; do for to in "foo" "bar"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
-sleep.legacy to httpbin.foo: 000
-command terminated with exit code 56
-sleep.legacy to httpbin.bar: 000
-command terminated with exit code 56
-{{< /text >}}
-
-{{< tip >}}
-Due to the way Envoy rejects plain-text requests, you will see `curl` exit code 56 (failure with receiving network data) in this case.
-{{< /tip >}}
-
-This works as intended, and unfortunately, there is no solution for this without reducing authentication requirements for these services.
-
-### Request from Istio services to non-Istio services
-
-Try to send requests to `httpbin.legacy` from `sleep.foo` (or `sleep.bar`). Istio automatically configures
-client sidecars to send plain-text traffic for legacy workloads without sidecar.
-
-{{< text bash >}}
-$ for from in "foo" "bar"; do for to in "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
-sleep.foo to httpbin.legacy: 200
-sleep.bar to httpbin.legacy: 200
-{{< /text >}}
-
-This applies to Kubernetes API server as well, which doesn't have a sidecar. Istio automatically configure
-clients to send plain-text traffic to Kubernetes API server.
-
-Run the testing command above to confirm that it returns 200.
-
-{{< text bash >}}
-$ TOKEN=$(kubectl describe secret $(kubectl get secrets | grep default-token | cut -f1 -d ' ' | head -1) | grep -E '^token' | cut -f2 -d':' | tr -d '\t')
-$ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl https://kubernetes.default/api --header "Authorization: Bearer $TOKEN" --insecure -s -o /dev/null -w "%{http_code}\n"
+$ kubectl exec $(kubectl get pod -l app=sleep -n mixed -o jsonpath={.items..metadata.name}) -c sleep -n mixed -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
 200
 {{< /text >}}
 
-### Cleanup part 1
-
-Remove global authentication policy:
+This one-liner command conveniently iterates through all reachability combinations:
 
 {{< text bash >}}
-$ kubectl delete meshpolicy default
-{{< /text >}}
-
-## Enable mutual TLS per namespace or service
-
-In addition to specifying an authentication policy for your entire mesh, Istio also lets you specify policies for particular namespaces or services. A
-namespace-wide policy takes precedence over the mesh-wide policy, while a service-specific policy has higher precedence still.
-
-### Namespace-wide policy
-
-The example below shows the policy to enable mutual TLS for all services in namespace `foo`. As you can see, it uses kind: "Policy” rather than "MeshPolicy”,
-and specifies a namespace, in this case, `foo`. If you don’t specify a namespace value the policy will apply to the default namespace.
-
-{{< text bash >}}
-$ kubectl apply -f - <<EOF
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
-metadata:
-  name: "default"
-  namespace: "foo"
-spec:
-  peers:
-  - mtls: {}
-EOF
-{{< /text >}}
-
-{{< tip >}}
-Similar to *mesh-wide policy*, namespace-wide policy must be named `default`, and doesn't restrict any specific service (no `targets` section)
-{{< /tip >}}
-
-As these policy in namespace `foo` only, you should see only request from client-without-sidecar (`sleep.legacy`) to `httpbin.foo` start to fail.
-
-{{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "mixed" "legacy"; do for to in "foo" "mixed" "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
-sleep.foo to httpbin.bar: 200
+sleep.foo to httpbin.mixed: 200
 sleep.foo to httpbin.legacy: 200
-sleep.bar to httpbin.foo: 200
-sleep.bar to httpbin.bar: 200
-sleep.bar to httpbin.legacy: 200
-sleep.legacy to httpbin.foo: 000
-command terminated with exit code 56
-sleep.legacy to httpbin.bar: 200
+sleep.mixed to httpbin.foo: 200
+sleep.mixed to httpbin.mixed: 200
+sleep.mixed to httpbin.legacy: 200
+sleep.legacy to httpbin.foo: 200
+sleep.legacy to httpbin.mixed: 200
 sleep.legacy to httpbin.legacy: 200
 {{< /text >}}
 
-### Service-specific policy
+In the setup, we start with `PERMISSIVE` for all services in the mesh. Combined with automatic
+mutual TLS enabled, sleep from `foo` and `mixed` client, send mutual TLS traffic to `httpbin.foo`
+service and plain text to `httpbin.legacy` service. For `httpbin.mixed`, the client sidecar send
+mutual TLS to the pod with sidecar injected deployment, and plain text to the pod without sidecar.
 
-You can also set authentication policy for a specific service. Run this command to set another policy only for `httpbin.bar` service.
+### Configure mutual TLS STRICT
+
+The default installation configures all the service in `PERMISSIVE` mode by default, which accepts
+both plain text and mutual TLS traffic. Now we configure `httpbin.foo` service to mutual TLS
+`STRICT` mode, only accepting mutual TLS traffic.
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -n bar -f -
+$ cat <<EOF | kubectl apply -n foo -f -
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:
@@ -236,26 +168,28 @@ spec:
 EOF
 {{< /text >}}
 
-{{< tip >}}
-* In this example, we do **not** specify namespace in metadata but put it in the command line (`-n bar`), which has an identical effect.
-* There is no restriction on the authentication policy name. This example uses the name of the service itself for simplicity.
-{{< /tip >}}
-
-Again, run the probing command. As expected, request from `sleep.legacy` to `httpbin.bar` starts failing with the same reasons.
-
-{{< text plain >}}
-...
-sleep.legacy to httpbin.bar: 000
-command terminated with exit code 56
-{{< /text >}}
-
-If we have more services in namespace `bar`, we should see traffic to them won't be affected. Instead of adding more services to demonstrate this behavior,
-we edit the policy slightly to apply on a specific port:
-
-<!-- What's this part for? I don't think we have a port 1234 for httpbin service. -->
+Now the requests from the clients without sidecar start to fail.
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -n bar -f -
+$ for from in "foo" "mixed" "legacy"; do for to in "foo" "mixed" "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+sleep.foo to httpbin.foo: 200
+sleep.foo to httpbin.mixed: 200
+sleep.foo to httpbin.legacy: 200
+sleep.mixed to httpbin.foo: 200
+sleep.mixed to httpbin.mixed: 200
+sleep.mixed to httpbin.legacy: 200
+sleep.legacy to httpbin.foo: 000
+command terminated with exit code 56
+sleep.legacy to httpbin.mixed: 200
+sleep.legacy to httpbin.legacy: 200
+{{< /text >}}
+
+### Disable mutual TLS to plain text
+
+Now we can explicitly disable mutual TLS to plain text for `httpbin.foo`.
+
+{{< text bash >}}
+$ cat <<EOF | kubectl apply -n foo -f -
 apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:
@@ -263,340 +197,81 @@ metadata:
 spec:
   targets:
   - name: httpbin
-    ports:
-    - number: 1234
-  peers:
-  - mtls: {}
 EOF
 {{< /text >}}
 
-This new policy will apply only to the `httpbin` service on port `1234`. As a result, mutual TLS is disabled (again) on port `8000` and requests from
-`sleep.legacy` will resume working.
+In this case, since the service is in plain text mode. Isti automatically configure clients
+to send plain text traffic to avoid breakage. Confirm all the traffic still succeed.
 
 {{< text bash >}}
-$ kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.bar:8000/ip -s -o /dev/null -w "%{http_code}\n"
-200
-{{< /text >}}
-
-### Policy precedence
-
-To illustrate how a service-specific policy takes precedence over namespace-wide policy, you can add a policy to disable mutual TLS for `httpbin.foo` as below.
-Note that you've already created a namespace-wide policy that enables mutual TLS for all services in namespace `foo` and observe that requests from
-`sleep.legacy` to `httpbin.foo` are failing (see above).
-
-{{< text bash >}}
-$ cat <<EOF | kubectl apply -n foo -f -
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
-metadata:
-  name: "overwrite-example"
-spec:
-  targets:
-  - name: httpbin
-EOF
-{{< /text >}}
-
-Re-running the request from `sleep.legacy`, you should see a success return code again (200), confirming service-specific policy overrides the namespace-wide policy.
-
-{{< text bash >}}
-$ kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
-200
-{{< /text >}}
-
-### Cleanup part 2
-
-Remove policies created in the above steps:
-
-{{< text bash >}}
-$ kubectl delete policy default overwrite-example -n foo
-$ kubectl delete policy httpbin -n bar
-{{< /text >}}
-
-## End-user authentication
-
-To experiment with this feature, you need a valid JWT. The JWT must correspond to the JWKS endpoint you want to use for the demo. In
-this tutorial, we use this [JWT test]({{< github_file >}}/security/tools/jwt/samples/demo.jwt) and this
-[JWKS endpoint]({{< github_file >}}/security/tools/jwt/samples/jwks.json) from the Istio code base.
-
-Also, for convenience, expose `httpbin.foo` via `ingressgateway` (for more details, see the [ingress task](/docs/tasks/traffic-management/ingress/)).
-
-{{< text bash >}}
-$ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  name: httpbin-gateway
-  namespace: foo
-spec:
-  selector:
-    istio: ingressgateway # use Istio default gateway implementation
-  servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-    - "*"
-EOF
-{{< /text >}}
-
-{{< text bash >}}
-$ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
-kind: VirtualService
-metadata:
-  name: httpbin
-  namespace: foo
-spec:
-  hosts:
-  - "*"
-  gateways:
-  - httpbin-gateway
-  http:
-  - route:
-    - destination:
-        port:
-          number: 8000
-        host: httpbin.foo.svc.cluster.local
-EOF
-{{< /text >}}
-
-Get ingress IP
-
-{{< text bash >}}
-$ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-{{< /text >}}
-
-And run a test query
-
-{{< text bash >}}
-$ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
-200
-{{< /text >}}
-
-Now, add a policy that requires end-user JWT for `httpbin.foo`. The next command assumes there is no service-specific policy for `httpbin.foo` (which should
-be the case if you run [cleanup](#cleanup-part-2) as described). You can run `kubectl get policies.authentication.istio.io -n foo` to confirm.
-
-{{< text bash >}}
-$ cat <<EOF | kubectl apply -n foo -f -
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
-metadata:
-  name: "jwt-example"
-spec:
-  targets:
-  - name: httpbin
-  origins:
-  - jwt:
-      issuer: "testing@secure.istio.io"
-      jwksUri: "{{< github_file >}}/security/tools/jwt/samples/jwks.json"
-  principalBinding: USE_ORIGIN
-EOF
-{{< /text >}}
-
-The same `curl` command from before will return with 401 error code, as a result of server is expecting JWT but none was provided:
-
-{{< text bash >}}
-$ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
-401
-{{< /text >}}
-
-Attaching the valid token generated above returns success:
-
-{{< text bash >}}
-$ TOKEN=$(curl {{< github_file >}}/security/tools/jwt/samples/demo.jwt -s)
-$ curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
-200
-{{< /text >}}
-
-To observe other aspects of JWT validation, use the script [`gen-jwt.py`]({{< github_tree >}}/security/tools/jwt/samples/gen-jwt.py) to
-generate new tokens to test with different issuer, audiences, expiry date, etc. The script can be downloaded from the Istio repository:
-
-{{< text bash >}}
-$ wget {{< github_file >}}/security/tools/jwt/samples/gen-jwt.py
-$ chmod +x gen-jwt.py
-{{< /text >}}
-
-You also need the `key.pem` file:
-
-{{< text bash >}}
-$ wget {{< github_file >}}/security/tools/jwt/samples/key.pem
-{{< /text >}}
-
-{{< tip >}}
-Download the [jwcrypto](https://pypi.org/project/jwcrypto) library,
-if you haven't installed it on your system.
-{{< /tip >}}
-
-For example, the command below creates a token that
-expires in 5 seconds. As you see, Istio authenticates requests using that token successfully at first but rejects them after 5 seconds:
-
-{{< text bash >}}
-$ TOKEN=$(./gen-jwt.py ./key.pem --expire 5)
-$ for i in `seq 1 10`; do curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"; sleep 1; done
-200
-200
-200
-200
-200
-401
-401
-401
-401
-401
-{{< /text >}}
-
-You can also add a JWT policy to an ingress gateway (e.g., service `istio-ingressgateway.istio-system.svc.cluster.local`).
-This is often used to define a JWT policy for all services bound to the gateway, instead of for individual services.
-
-### End-user authentication with per-path requirements
-
-End-user authentication can be enabled or disabled based on request path. This is useful if you want to
-disable authentication for some paths, for example, the path used for health check or status report.
-You can also specify different JWT requirements on different paths.
-
-{{< warning >}}
-The end-user authentication with per-path requirements is an experimental feature in Istio 1.1 and
-is **NOT** recommended for production use.
-{{< /warning >}}
-
-#### Disable End-user authentication for specific paths
-
-Modify the `jwt-example` policy to disable End-user authentication for path `/user-agent`:
-
-{{< text bash >}}
-$ cat <<EOF | kubectl apply -n foo -f -
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
-metadata:
-  name: "jwt-example"
-spec:
-  targets:
-  - name: httpbin
-  origins:
-  - jwt:
-      issuer: "testing@secure.istio.io"
-      jwksUri: "{{< github_file >}}/security/tools/jwt/samples/jwks.json"
-      trigger_rules:
-      - excluded_paths:
-        - exact: /user-agent
-  principalBinding: USE_ORIGIN
-EOF
-{{< /text >}}
-
-Confirm it's allowed to access the path `/user-agent` without JWT tokens:
-
-{{< text bash >}}
-$ curl $INGRESS_HOST/user-agent -s -o /dev/null -w "%{http_code}\n"
-200
-{{< /text >}}
-
-Confirm it's denied to access paths other than `/user-agent` without JWT tokens:
-
-{{< text bash >}}
-$ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
-401
-{{< /text >}}
-
-#### Enable End-user authentication for specific paths
-
-Modify the `jwt-example` policy to enable End-user authentication only for path `/ip`:
-
-{{< text bash >}}
-$ cat <<EOF | kubectl apply -n foo -f -
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
-metadata:
-  name: "jwt-example"
-spec:
-  targets:
-  - name: httpbin
-  origins:
-  - jwt:
-      issuer: "testing@secure.istio.io"
-      jwksUri: "{{< github_file >}}/security/tools/jwt/samples/jwks.json"
-      trigger_rules:
-      - included_paths:
-        - exact: /ip
-  principalBinding: USE_ORIGIN
-EOF
-{{< /text >}}
-
-Confirm it's allowed to access paths other than `/ip` without JWT tokens:
-
-{{< text bash >}}
-$ curl $INGRESS_HOST/user-agent -s -o /dev/null -w "%{http_code}\n"
-200
-{{< /text >}}
-
-Confirm it's denied to access the path `/ip` without JWT tokens:
-
-{{< text bash >}}
-$ curl $INGRESS_HOST/ip -s -o /dev/null -w "%{http_code}\n"
-401
-{{< /text >}}
-
-Confirm it's allowed to access the path `/ip` with a valid JWT token:
-
-{{< text bash >}}
-$ TOKEN=$(curl {{< github_file >}}/security/tools/jwt/samples/demo.jwt -s)
-$ curl --header "Authorization: Bearer $TOKEN" $INGRESS_HOST/ip -s -o /dev/null -w "%{http_code}\n"
-200
-{{< /text >}}
-
-### End-user authentication with mutual TLS
-
-End-user authentication and mutual TLS can be used together. Modify the policy above to define both mutual TLS and end-user JWT authentication:
-
-{{< text bash >}}
-$ cat <<EOF | kubectl apply -n foo -f -
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
-metadata:
-  name: "jwt-example"
-spec:
-  targets:
-  - name: httpbin
-  peers:
-  - mtls: {}
-  origins:
-  - jwt:
-      issuer: "testing@secure.istio.io"
-      jwksUri: "{{< github_file >}}/security/tools/jwt/samples/jwks.json"
-  principalBinding: USE_ORIGIN
-EOF
-{{< /text >}}
-
-{{< tip >}}
-If you already enable mutual TLS mesh-wide or namespace-wide, you still need to add the `mtls` stanza to the authentication policy as the service-specific policy will override the mesh-wide (or namespace-wide) policy completely.
-{{< /tip >}}
-
-After these changes, traffic from Istio services, including ingress gateway, to `httpbin.foo` will use mutual TLS. The test command above will still work. Requests from Istio services directly to `httpbin.foo` also work, given the correct token:
-
-{{< text bash >}}
-$ TOKEN=$(curl {{< github_file >}}/security/tools/jwt/samples/demo.jwt -s)
-$ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n" --header "Authorization: Bearer $TOKEN"
-200
-{{< /text >}}
-
-However, requests from non-Istio services, which use plain-text will fail:
-
-{{< text bash >}}
-$ kubectl exec $(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name}) -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n" --header "Authorization: Bearer $TOKEN"
-000
+$ for from in "foo" "mixed" "legacy"; do for to in "foo" "mixed" "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+sleep.foo to httpbin.foo: 200
+sleep.foo to httpbin.mixed: 200
+sleep.foo to httpbin.legacy: 200
+sleep.mixed to httpbin.foo: 200
+sleep.mixed to httpbin.mixed: 200
+sleep.mixed to httpbin.legacy: 200
+sleep.legacy to httpbin.foo: 000
 command terminated with exit code 56
+sleep.legacy to httpbin.mixed: 200
+sleep.legacy to httpbin.legacy: 200
 {{< /text >}}
 
-### Cleanup part 3
 
-1. Remove authentication policy:
+### Destination rule overrides
 
-    {{< text bash >}}
-    $ kubectl -n foo delete policy jwt-example
-    {{< /text >}}
+For backward compatability, you can still use destination rule to override the TLS configuration as
+before. For example, you can explicitly configure destination rule for `httpbin.foo` to enable
+mutual TLS explicitly
 
-1. If you are not planning to explore any follow-on tasks, you can remove all resources simply by deleting test namespaces.
+{{< text bash >}}
+$ cat <<EOF | kubectl apply -n foo -f -
+apiVersion: "networking.istio.io/v1alpha3"
+kind: "DestinationRule"
+metadata:
+  name: "httpbin-foo-mtls"
+spec:
+  host: httpbin.foo.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL
+EOF
+{{< /text >}}
 
-    {{< text bash >}}
-    $ kubectl delete ns foo bar legacy
-    {{< /text >}}
+Since in previous steps, we already disable the authentication policy for `httpbin.foo` to disable
+mutual TLS, we should see the traffic from clients with sidecar starts to fail.
+
+
+{{< text bash >}}
+$ for from in "foo" "mixed" "legacy"; do for to in "foo" "mixed" "legacy"; do kubectl exec $(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name}) -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+sleep.foo to httpbin.foo: 503
+sleep.foo to httpbin.mixed: 200
+sleep.foo to httpbin.legacy: 200
+sleep.mixed to httpbin.foo: 503
+sleep.mixed to httpbin.mixed: 200
+sleep.mixed to httpbin.legacy: 200
+sleep.legacy to httpbin.foo: 200
+sleep.legacy to httpbin.mixed: 200
+sleep.legacy to httpbin.legacy: 200
+{{< /text >}}
+
+### Cleanup
+
+{{< text bash >}}
+$ kubectl delete ns foo mixed legacy
+{{< /text >}}
+
+## Summary
+
+Automatic mutual TLS configures the client sidecar to send TLS traffic by default between sidecars.
+This means corresponding TLS overhead.
+
+As aforementioned, automatical mutual TLS is a mesh wide Helm installation option. You have to
+re-deploy Istio to enable or disable the feature. When disabling the feature, if you already rely
+on it to automatically encrypt the traffic, then traffic can **fall back to plain text**, which
+can affect your **security posture or break the traffic**, if the service is already configured as
+`STRICT` to only accept mutual TLS traffic.
+
+Currently, automatic mutual TLS is an Alpha stage feature, please be aware of the risk.
+We're considering to make this feature the default enabled. Please consider to send your feedback
+or encountered issues when trying auto mutual TLS via [Github](https://github.com/istio/istio/issues/18548).

--- a/content/en/docs/tasks/security/automtls/index.md
+++ b/content/en/docs/tasks/security/automtls/index.md
@@ -200,7 +200,7 @@ spec:
 EOF
 {{< /text >}}
 
-In this case, since the service is in plain text mode. Isti automatically configure clients
+In this case, since the service is in plain text mode. Istio automatically configure clients
 to send plain text traffic to avoid breakage. Confirm all the traffic still succeed.
 
 {{< text bash >}}
@@ -217,10 +217,9 @@ sleep.legacy to httpbin.mixed: 200
 sleep.legacy to httpbin.legacy: 200
 {{< /text >}}
 
-
 ### Destination rule overrides
 
-For backward compatability, you can still use destination rule to override the TLS configuration as
+For backward compatibility, you can still use destination rule to override the TLS configuration as
 before. For example, you can explicitly configure destination rule for `httpbin.foo` to enable
 mutual TLS explicitly
 
@@ -266,7 +265,7 @@ $ kubectl delete ns foo mixed legacy
 Automatic mutual TLS configures the client sidecar to send TLS traffic by default between sidecars.
 This means corresponding TLS overhead.
 
-As aforementioned, automatical mutual TLS is a mesh wide Helm installation option. You have to
+As aforementioned, automatic mutual TLS is a mesh wide Helm installation option. You have to
 re-deploy Istio to enable or disable the feature. When disabling the feature, if you already rely
 on it to automatically encrypt the traffic, then traffic can **fall back to plain text**, which
 can affect your **security posture or break the traffic**, if the service is already configured as
@@ -274,4 +273,4 @@ can affect your **security posture or break the traffic**, if the service is alr
 
 Currently, automatic mutual TLS is an Alpha stage feature, please be aware of the risk.
 We're considering to make this feature the default enabled. Please consider to send your feedback
-or encountered issues when trying auto mutual TLS via [Github](https://github.com/istio/istio/issues/18548).
+or encountered issues when trying auto mutual TLS via [Git Hub](https://github.com/istio/istio/issues/18548).


### PR DESCRIPTION
https://github.com/istio/istio/issues/14524

We decide to make auto mTLS default on and thus all references of the `DestinationRule` can be removed.

Manually verified with a master branch built image installation

```bash
helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
    --values install/kubernetes/helm/istio/values-istio-demo.yaml \
   -- set global.mtls.auto=true \
--set global.hub="gcr.io/istio-testing" \
 --set global.tag="1.5-alpha.c46286bfcecb2e6e11ed75224d5f2b09976b9452" > istio-demo-auto.yaml
```

[ ] Configuration Infrastructure
[ X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X] Security
[ ] Test and Release
[X ] User Experience
[ ] Developer Infrastructure
