### PR TITLE
Operator docs fixes

### DIFF
--- a/content/en/docs/setup/install/standalone-operator/index.md
+++ b/content/en/docs/setup/install/standalone-operator/index.md
@@ -29,7 +29,7 @@ instead, which is a stable feature.
     {{< /text >}}
 
 {{< warning >}}
-This is only for demo usage and should not be used in production.
+This profile is only for demo usage and should not be used in production.
 {{< /warning >}}
 
 1. (Optionally) change profiles from the demo profile to one of the following profiles:
@@ -87,7 +87,8 @@ $ kubectl apply -f https://preliminary.istio.io/operator-profile-sds.yaml
 {{< /tab >}}
 
 {{< tab name="default" cookie-value="default" >}}
-This profile enables Istio's default settings. Run the following command to switch to this profile:
+This profile enables Istio's default settings which contains recommended
+production settings. Run the following command to switch to this profile:
 
 {{< text bash >}}
 $ kubectl apply -f https://preliminary.istio.io/operator-profile-default.yaml

--- a/content/en/docs/setup/install/standalone-operator/index.md
+++ b/content/en/docs/setup/install/standalone-operator/index.md
@@ -16,8 +16,6 @@ instead, which is a stable feature.
 
 ## Prerequisites
 
-1. [Download the Istio release](/docs/setup/#downloading-the-release).
-
 1. Perform any necessary [platform-specific setup](/docs/setup/platform-setup/).
 
 1. Check the [Requirements for Pods and Services](/docs/setup/additional-setup/requirements/).
@@ -29,6 +27,10 @@ instead, which is a stable feature.
     {{< text bash >}}
     $ kubectl apply -f https://preliminary.istio.io/operator.yaml
     {{< /text >}}
+
+{{< warning >}}
+This is only for demo usage and should not be used in production.
+{{< /warning >}}
 
 1. (Optionally) change profiles from the demo profile to one of the following profiles:
 

--- a/content/en/docs/setup/install/standalone-operator/index.md
+++ b/content/en/docs/setup/install/standalone-operator/index.md
@@ -22,7 +22,7 @@ instead, which is a stable feature.
 
 ## Installation steps
 
-1. Install Istio using the operator with the default profile:
+1. Install Istio using the operator with the demo profile:
 
     {{< text bash >}}
     $ kubectl apply -f https://preliminary.istio.io/operator.yaml


### PR DESCRIPTION
* Remove reference to downloading the Istio release as pre-requisite.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
