### PR TITLE
Remove unnecessary backslashes from example SVID

### DIFF
--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -93,7 +93,7 @@ across heterogeneous environments.
 
 Istio and SPIFFE share the same identity document: [SVID](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE-ID.md) (SPIFFE Verifiable Identity Document).
 For example, in Kubernetes, the X.509 certificate has the URI field in the format of
-`spiffe://\<domain\>/ns/\<namespace\>/sa/\<serviceaccount\>`.
+`spiffe://<domain>/ns/<namespace>/sa/<serviceaccount>`.
 This enables Istio services to establish and accept connections with other SPIFFE-compliant systems.
 
 Istio security and [SPIRE](https://spiffe.io/spire/), which is the implementation of SPIFFE, differ in the PKI implementation details.


### PR DESCRIPTION
reads: `spiffe://\<domain\>/ns/\<namespace\>/sa/\<serviceaccount\>`
should read: `spiffe://<domain>/ns/<namespace>/sa/<serviceaccount>`

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
