### PR TITLE
Add documentation for galley.enableAnalysis

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -516,6 +516,7 @@ subdomains
 subnet
 subnets
 subnetworks
+subresource
 subresources
 substring
 Superfeet

--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -127,7 +127,7 @@ the kind of information you should provide.
 Starting with Istio 1.4, Galley can be set up to perform configuration analysis alongside the configuration distribution that it is primarily responsible for, via the `galley.enableAnalysis` flag.
 This analysis uses the same logic and error messages as when using `istioctl analyze`. Validation messages from the analysis are written to the status subresource of the affected Istio resource.
 
-e.g. if you have a misconfigured gateway on your "ratings" VirtualService, running `kubectl get virtualservice ratings` would give you something like:
+e.g. if you have a misconfigured gateway on your "ratings" virtual service, running `kubectl get virtualservice ratings` would give you something like:
 
 {{< text plain >}}
 apiVersion: networking.istio.io/v1alpha3

--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -162,13 +162,13 @@ status:
 To enable this feature with `helm template`:
 
 {{< text bash >}}
-helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
+$ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
     --set galley.enableAnalysis=true | kubectl apply -f -
 {{< /text >}}
 
 Or with `helm install`:
 
 {{< text bash >}}
-helm install install/kubernetes/helm/istio --name istio --namespace istio-system \
+$ helm install install/kubernetes/helm/istio --name istio --namespace istio-system \
     --set galley.enableAnalysis=true
 {{< /text >}}

--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -160,7 +160,7 @@ status:
     message: 'Referenced gateway not found: "bogus-gateway"'
 {{< /text >}}
 
-`enableAnalysis` runs in the background, and will keep the status field of a resource up to date with its current validation status. Note that this can't replace the utility of `istioctl analyze`:
+`enableAnalysis` runs in the background, and will keep the status field of a resource up to date with its current validation status. Note that this isn't a replacement for `istioctl analyze`:
 
 - Not all resources have a custom status field (e.g. Kubernetes *namespace* resources), so messages attached to those resources won't show validation messages.
 - `enableAnalysis` only works on Istio versions starting with 1.4, while `istioctl analyze` can be used on older cluster versions.

--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -116,6 +116,10 @@ the kind of information you should provide.
 
       Today, the analysis is purely based on Kubernetes configuration, but in the future we’d like to expand beyond that. For example, we could allow analyzers to also look at logs to generate recommendations.
 
+- **Where can I find out how to fix the errors I'm getting?**
+
+      Reference for configuration analysis messages can be found [here](/docs/reference/config/analysis/).
+
 ## Enabling Validation Messages for Resource Status
 
 *Note that this feature is experimental.*

--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -118,9 +118,9 @@ the kind of information you should provide.
 
 - **Where can I find out how to fix the errors I'm getting?**
 
-      Reference for configuration analysis messages can be found [here](/docs/reference/config/analysis/).
+      The set of [configuration analysis messages](/docs/reference/config/analysis/) contain descriptions of each message along with suggested fixes.
 
-## Enabling Validation Messages for Resource Status
+## Enabling validation messages for resource status
 
 *Note that this feature is experimental.*
 

--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -118,18 +118,18 @@ the kind of information you should provide.
 
 - **Where can I find out how to fix the errors I'm getting?**
 
-      The set of [configuration analysis messages](/docs/reference/config/analysis/) contain descriptions of each message along with suggested fixes.
+      The set of [configuration analysis messages](/docs/reference/config/analysis/) contains descriptions of each message along with suggested fixes.
 
 ## Enabling validation messages for resource status
 
-*Note that this feature is experimental.*
+{{< boilerplate experimental-feature-warning >}}
 
 Starting with Istio 1.4, Galley can be set up to perform configuration analysis alongside the configuration distribution that it is primarily responsible for, via the `galley.enableAnalysis` flag.
 This analysis uses the same logic and error messages as when using `istioctl analyze`. Validation messages from the analysis are written to the status subresource of the affected Istio resource.
 
-e.g. if you have a misconfigured gateway on your "ratings" virtual service, running `kubectl get virtualservice ratings` would give you something like:
+For example. if you have a misconfigured gateway on your "ratings" virtual service, running `kubectl get virtualservice ratings` would give you something like:
 
-{{< text plain >}}
+{{< text yaml >}}
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -162,18 +162,18 @@ status:
 
 `enableAnalysis` runs in the background, and will keep the status field of a resource up to date with its current validation status. Note that this isn't a replacement for `istioctl analyze`:
 
-- Not all resources have a custom status field (e.g. Kubernetes *namespace* resources), so messages attached to those resources won't show validation messages.
-- `enableAnalysis` only works on Istio versions starting with 1.4, while `istioctl analyze` can be used on older cluster versions.
+- Not all resources have a custom status field (e.g. Kubernetes `namespace` resources), so messages attached to those resources won't show validation messages.
+- `enableAnalysis` only works on Istio versions starting with 1.4, while `istioctl analyze` can be used with older versions.
 - While it makes it easy to see what's wrong with a particular resource, it's harder to get a holistic view of validation status in the mesh.
 
-To enable this feature with `helm template`:
+You can enable this feature with:
 
 {{< text bash >}}
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
     --set galley.enableAnalysis=true | kubectl apply -f -
 {{< /text >}}
 
-Or with `helm install`:
+Or with:
 
 {{< text bash >}}
 $ helm install install/kubernetes/helm/istio --name istio --namespace istio-system \

--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -124,7 +124,8 @@ the kind of information you should provide.
 
 *Note that this feature is experimental.*
 
-Starting with Istio 1.4, Galley can be set up to perform configuration analysis alongside the configuration distribution that it is primarily responsible for. Validation messages from the analysis are written to the status subresource of the affected Istio resource. This lets you find many configuration errors in your mesh without needing to run a separate command. This analysis uses the same logic and error messages as when using `istioctl analyze`.
+Starting with Istio 1.4, Galley can be set up to perform configuration analysis alongside the configuration distribution that it is primarily responsible for, via the `galley.enableAnalysis` flag.
+This analysis uses the same logic and error messages as when using `istioctl analyze`. Validation messages from the analysis are written to the status subresource of the affected Istio resource.
 
 e.g. if you have a misconfigured gateway on your "ratings" VirtualService, running `kubectl get virtualservice ratings` would give you something like:
 
@@ -158,6 +159,12 @@ status:
     level: Error
     message: 'Referenced gateway not found: "bogus-gateway"'
 {{< /text >}}
+
+`enableAnalysis` runs in the background, and will keep the status field of a resource up to date with its current validation status. Note that this can't replace the utility of `istioctl analyze`:
+
+- Not all resources have a custom status field (e.g. Kubernetes *namespace* resources), so messages attached to those resources won't show validation messages.
+- `enableAnalysis` only works on Istio versions starting with 1.4, while `istioctl analyze` can be used on older cluster versions.
+- While it makes it easy to see what's wrong with a particular resource, it's harder to get a holistic view of validation status in the mesh.
 
 To enable this feature with `helm template`:
 


### PR DESCRIPTION
Add basic documentation for galley.enableAnalysis

Also add a link to validation message reference docs and fix the format of the CLI message.

For now, at least, I'm bundling this with the `istioctl analyze` doc. At some point it will probably need to get its own page. 

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
