### PR TITLE
Fix protocol sniffing docs

### DIFF
--- a/content/en/docs/ops/traffic-management/protocol-selection/index.md
+++ b/content/en/docs/ops/traffic-management/protocol-selection/index.md
@@ -13,13 +13,6 @@ Istio supports proxying all TCP traffic by default, but in order to provide addi
 such as routing and rich metrics, the protocol must be determined.
 This can be done automatically or explicitly specified.
 
-## Automatic Protocol Selection
-
-By default, Istio will automatically detect HTTP and HTTP/2 traffic.
-If the protocol cannot automatically be determined, traffic will be treated as plain TCP traffic.
-
-This feature can be turned off by providing the Helm value `--set pilot.enableProtocolSniffing=false`.
-
 ## Manual Protocol Selection
 
 Protocols can be specified manually by naming the Service port `name: <protocol>[-<suffix>]`.
@@ -52,3 +45,10 @@ spec:
   - number: 80
     name: http-web
 {{< /text >}}
+
+## Automatic Protocol Selection (Experimental)
+
+Istio can automatically detect HTTP and HTTP/2 traffic. If the protocol cannot automatically be determined, traffic will be treated as plain TCP traffic.
+
+This feature is experimental and off by default. It can be turned on by providing the Helm value `--set pilot.enableProtocolSniffingForOutbound=true --set pilot.enableProtocolSniffingForInbound=true`.
+

--- a/content/en/docs/ops/traffic-management/protocol-selection/index.md
+++ b/content/en/docs/ops/traffic-management/protocol-selection/index.md
@@ -13,7 +13,7 @@ Istio supports proxying all TCP traffic by default, but in order to provide addi
 such as routing and rich metrics, the protocol must be determined.
 This can be done automatically or explicitly specified.
 
-## Manual Protocol Selection
+## Manual protocol selection
 
 Protocols can be specified manually by naming the Service port `name: <protocol>[-<suffix>]`.
 The following protocols are supported:
@@ -46,7 +46,7 @@ spec:
     name: http-web
 {{< /text >}}
 
-## Automatic Protocol Selection (Experimental)
+## Automatic protocol selection (experimental)
 
 Istio can automatically detect HTTP and HTTP/2 traffic. If the protocol cannot automatically be determined, traffic will be treated as plain TCP traffic.
 


### PR DESCRIPTION
These were outdated

Since I marked automated detection as experimental (which it is), I also moved it to the bottom, since it seemed to make sense to have the stable docs on top

