### PR TITLE
Add podAnnotations param for cni helm chart

### DIFF
--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -68,6 +68,7 @@ The following table shows all the options that the `istio-cni` Helm chart suppor
 | `cniConfDir` | | `/etc/cni/net.d` | Must be the same as the environment's `--cni-conf-dir` setting (`kubelet` parameter). |
 | `cniConfFileName` | | | Leave unset to auto-find the first file in the `cni-conf-dir` (as `kubelet` does).  Primarily used for testing `install-cni` plugin configuration.  If set, `install-cni` will inject the plugin configuration into this file in the `cni-conf-dir`. |
 | `psp_cluster_role` | | | This value refers to a `ClusterRole` and can be used to create a `RoleBinding` in the namespace of `istio-cni`. This is useful if you use [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy) and want to allow `istio-cni` to run as `priviliged` Pods. |
+| `podAnnotations` | | `{}` | Additional custom annotations to be set on pod level |
 
 ### Excluding specific Kubernetes namespaces
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -68,7 +68,7 @@ The following table shows all the options that the `istio-cni` Helm chart suppor
 | `cniConfDir` | | `/etc/cni/net.d` | Must be the same as the environment's `--cni-conf-dir` setting (`kubelet` parameter). |
 | `cniConfFileName` | | | Leave unset to auto-find the first file in the `cni-conf-dir` (as `kubelet` does).  Primarily used for testing `install-cni` plugin configuration.  If set, `install-cni` will inject the plugin configuration into this file in the `cni-conf-dir`. |
 | `psp_cluster_role` | | | This value refers to a `ClusterRole` and can be used to create a `RoleBinding` in the namespace of `istio-cni`. This is useful if you use [Pod Security Policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy) and want to allow `istio-cni` to run as `priviliged` Pods. |
-| `podAnnotations` | | `{}` | Additional custom annotations to be set on pod level |
+| `podAnnotations` | | `{}` | Additional custom annotations to be set on pod level. |
 
 ### Excluding specific Kubernetes namespaces
 


### PR DESCRIPTION
This PR adds the `podAnnotations` param to the documentation of the CNI Helm chart. It has been added in PR https://github.com/istio/cni/pull/206 to the CNI project.