### PR TITLE
s/10514/15014/

### DIFF
--- a/content/en/docs/ops/common-problems/injection/index.md
+++ b/content/en/docs/ops/common-problems/injection/index.md
@@ -179,7 +179,7 @@ istio-sidecar-injector-5dbbbdb746-d676g   1/1       Running   0          2d
 {{< text bash >}}
 $ kubectl -n istio-system get endpoints istio-sidecar-injector
 NAME           ENDPOINTS                          AGE
-istio-sidecar-injector   10.48.6.108:10514,10.48.6.108:443   3d
+istio-sidecar-injector   10.48.6.108:15014,10.48.6.108:443   3d
 {{< /text >}}
 
 If the pods or endpoints aren't ready, check the pod logs and status

--- a/content/en/docs/ops/common-problems/validation/index.md
+++ b/content/en/docs/ops/common-problems/validation/index.md
@@ -284,7 +284,7 @@ istio-galley-5dbbbdb746-d676g   1/1       Running   0          2d
 {{< text bash >}}
 $ kubectl -n istio-system get endpoints istio-galley
 NAME           ENDPOINTS                          AGE
-istio-galley   10.48.6.108:10514,10.48.6.108:443   3d
+istio-galley   10.48.6.108:15014,10.48.6.108:443   3d
 {{< /text >}}
 
 If the pods or endpoints aren't ready, check the pod logs and

--- a/content/en/docs/ops/diagnostic-tools/proxy-cmd/index.md
+++ b/content/en/docs/ops/diagnostic-tools/proxy-cmd/index.md
@@ -120,7 +120,7 @@ BlackHoleCluster                                                                
 details.default.svc.cluster.local                                                9080      -          outbound      EDS
 heapster.kube-system.svc.cluster.local                                           80        -          outbound      EDS
 istio-citadel.istio-system.svc.cluster.local                                     8060      -          outbound      EDS
-istio-citadel.istio-system.svc.cluster.local                                     10514     -          outbound      EDS
+istio-citadel.istio-system.svc.cluster.local                                     15014     -          outbound      EDS
 istio-egressgateway.istio-system.svc.cluster.local                               80        -          outbound      EDS
 ...
 {{< /text >}}
@@ -160,7 +160,7 @@ to send a request from the `productpage` pod to the `reviews` pod at `reviews:90
     0.0.0.0            15010     HTTP   |
     0.0.0.0            15003     HTTP   |
     0.0.0.0            15004     HTTP   |
-    0.0.0.0            10514     HTTP   |   Receives outbound HTTP traffic for relevant port from listener `0.0.0.0_15001`
+    0.0.0.0            15014     HTTP   |   Receives outbound HTTP traffic for relevant port from listener `0.0.0.0_15001`
     0.0.0.0            15007     HTTP   |
     0.0.0.0            8080      HTTP   |
     0.0.0.0            9091      HTTP   |

--- a/content/en/faq/mixer/mixer-self-monitoring.md
+++ b/content/en/faq/mixer/mixer-self-monitoring.md
@@ -3,7 +3,7 @@ title: Does Mixer provide any self-monitoring?
 weight: 30
 ---
 
-Mixer exposes a monitoring endpoint (default port: `10514`). There are a few
+Mixer exposes a monitoring endpoint (default port: `15014`). There are a few
 useful paths to investigate Mixer performance and audit
 function:
 

--- a/content/zh/docs/ops/common-problems/injection/index.md
+++ b/content/zh/docs/ops/common-problems/injection/index.md
@@ -179,7 +179,7 @@ istio-sidecar-injector-5dbbbdb746-d676g   1/1       Running   0          2d
 {{< text bash >}}
 $ kubectl -n istio-system get endpoints istio-sidecar-injector
 NAME           ENDPOINTS                          AGE
-istio-sidecar-injector   10.48.6.108:10514,10.48.6.108:443   3d
+istio-sidecar-injector   10.48.6.108:15014,10.48.6.108:443   3d
 {{< /text >}}
 
 If the pods or endpoints aren't ready, check the pod logs and status

--- a/content/zh/docs/ops/common-problems/validation/index.md
+++ b/content/zh/docs/ops/common-problems/validation/index.md
@@ -284,7 +284,7 @@ istio-galley-5dbbbdb746-d676g   1/1       Running   0          2d
 {{< text bash >}}
 $ kubectl -n istio-system get endpoints istio-galley
 NAME           ENDPOINTS                          AGE
-istio-galley   10.48.6.108:10514,10.48.6.108:443   3d
+istio-galley   10.48.6.108:15014,10.48.6.108:443   3d
 {{< /text >}}
 
 If the pods or endpoints aren't ready, check the pod logs and

--- a/content/zh/docs/ops/diagnostic-tools/proxy-cmd/index.md
+++ b/content/zh/docs/ops/diagnostic-tools/proxy-cmd/index.md
@@ -120,7 +120,7 @@ BlackHoleCluster                                                                
 details.default.svc.cluster.local                                                9080      -          outbound      EDS
 heapster.kube-system.svc.cluster.local                                           80        -          outbound      EDS
 istio-citadel.istio-system.svc.cluster.local                                     8060      -          outbound      EDS
-istio-citadel.istio-system.svc.cluster.local                                     10514     -          outbound      EDS
+istio-citadel.istio-system.svc.cluster.local                                     15014     -          outbound      EDS
 istio-egressgateway.istio-system.svc.cluster.local                               80        -          outbound      EDS
 ...
 {{< /text >}}
@@ -160,7 +160,7 @@ to send a request from the `productpage` pod to the `reviews` pod at `reviews:90
     0.0.0.0            15010     HTTP   |
     0.0.0.0            15003     HTTP   |
     0.0.0.0            15004     HTTP   |
-    0.0.0.0            10514     HTTP   |   Receives outbound HTTP traffic for relevant port from listener `0.0.0.0_15001`
+    0.0.0.0            15014     HTTP   |   Receives outbound HTTP traffic for relevant port from listener `0.0.0.0_15001`
     0.0.0.0            15007     HTTP   |
     0.0.0.0            8080      HTTP   |
     0.0.0.0            9091      HTTP   |

--- a/content/zh/faq/mixer/mixer-self-monitoring.md
+++ b/content/zh/faq/mixer/mixer-self-monitoring.md
@@ -3,7 +3,7 @@ title: Mixer 是否提供内部监控？
 weight: 30
 ---
 
-Mixer 提供了监控端点（默认端口：`10514`）。Mixer 提供的性能和审计功能的服务路径如下：
+Mixer 提供了监控端点（默认端口：`15014`）。Mixer 提供的性能和审计功能的服务路径如下：
 
 - `/metrics` 提供有关 Mixer 处理的 Prometheus 指标、API 调用相关的 gRPC 指标和 adapter 调度指标。
 - `/debug/pprof` 提供了性能剖析相关的数据，格式为 [pprof](https://golang.org/pkg/net/http/pprof/)。


### PR DESCRIPTION
Admittedly this is a naive suggestion as I don't know the history of port 10514.  Perhaps it used to be used for something?  However, in all the instances I found it seems to just be a typo that should really refer to port 15014.