### PR TITLE
add port name "tls" to both Service and Endpoints in Kubernetes Services for Egress task

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
@@ -156,6 +156,7 @@ $ kubectl delete service my-httpbin
       ports:
       - protocol: TCP
         port: 443
+        name: tls
     EOF
     {{< /text >}}
 
@@ -173,6 +174,7 @@ $ kubectl delete service my-httpbin
           - ip: 198.35.26.96
         ports:
           - port: 443
+            name: tls
     EOF
     {{< /text >}}
 


### PR DESCRIPTION
otherwise the service is treated as HTTP, causing an error

Fixes https://github.com/istio/istio/issues/18208.