### PR TITLE
Fix certificates generation in secure gateways

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
@@ -17,8 +17,6 @@ Then you configure a gateway to provide ingress access to the service via host `
 
 ## Generate client and server certificates and keys
 
-Generate the certificates and keys in the same way as in the [Securing Gateways with HTTPS](/docs/tasks/traffic-management/ingress/secure-ingress-mount/#generate-client-and-server-certificates-and-keys) task.
-
 1.  Clone the <https://github.com/nicholasjackson/mtls-go-example> repository:
 
     {{< text bash >}}

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-mount/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-mount/index.md
@@ -479,7 +479,7 @@ $ openssl x509 -req -days 365 -CA example.com.crt -CAkey example.com.key -set_se
 
     {{< text bash >}}
     $ kubectl exec -i -n istio-system $(kubectl get pod -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')  -- cat /etc/istio/ingressgateway-certs/tls.crt | openssl x509 -text -noout | grep 'Subject:'
-        Subject: C=US, ST=Denial, L=Springfield, O=Dis, CN=httpbin.example.com
+        Subject: CN=httpbin.example.com, O=httpbin organization
     {{< /text >}}
 
 *   Verify that the proxy of the ingress gateway is aware of the certificates:
@@ -511,7 +511,7 @@ In addition to the steps in the previous section, perform the following:
     $ kubectl exec -it -n istio-system $(kubectl -n istio-system get pods -l istio=ingressgateway -o jsonpath='{.items[0].metadata.name}') -- ls -al /etc/istio/ingressgateway-ca-certs
     {{< /text >}}
 
-    `ca-chain.cert.pem` should exist in the directory contents.
+    `example.com.crt` should exist in the directory contents.
 
 *   If you created the `istio-ingressgateway-ca-certs` secret, but the CA
     certificate is not loaded, delete the ingress gateway pod and force it to
@@ -524,8 +524,8 @@ In addition to the steps in the previous section, perform the following:
 *   Verify that the `Subject` is correct in the CA certificate of the ingress gateway:
 
     {{< text bash >}}
-    $ kubectl exec -i -n istio-system $(kubectl get pod -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')  -- cat /etc/istio/ingressgateway-ca-certs/ca-chain.cert.pem | openssl x509 -text -noout | grep 'Subject:'
-    Subject: C=US, ST=Denial, L=Springfield, O=Dis, CN=httpbin.example.com
+    $ kubectl exec -i -n istio-system $(kubectl get pod -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')  -- cat /etc/istio/ingressgateway-ca-certs/example.com.crt | openssl x509 -text -noout | grep 'Subject:'
+    Subject: O=example Inc., CN=example.com
     {{< /text >}}
 
 ## Cleanup

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress-mount/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress-mount/index.md
@@ -44,7 +44,7 @@ For this task you can use your favorite tool to generate certificates and keys. 
     $ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj '/O=example Inc./CN=example.com' -keyout example.com.key -out example.com.crt
     {{< /text >}}
 
-1.  Create a certificates and a private key for `httpbin.example.com`:
+1.  Create a certificate and a private key for `httpbin.example.com`:
 
     {{< text bash >}}
     $ openssl req -out httpbin.example.com.csr -newkey rsa:2048 -nodes -keyout httpbin.example.com.key -subj "/CN=httpbin.example.com/O=httpbin organization"
@@ -255,7 +255,7 @@ the server will use to verify its clients. Create the secret `istio-ingressgatew
     This time you will get an error since the server refuses to accept unauthenticated requests. You need to pass _curl_
     a client certificate and your private key for signing the request.
 
-1.  Generate a client certificate for the `httpbin.example.com` service. You can designate the client by the
+1.  Create a client certificate for the `httpbin.example.com` service. You can designate the client by the
     `httpbin-client.example.com` URI, or use any other URI.
 
     {{< text bash >}}
@@ -291,7 +291,7 @@ Unlike the previous sections, the Istio default ingress gateway will not work ou
 preconfigured to support one secure host. You'll need to first configure and redeploy the ingress gateway
 server with another secret, before you can use it to handle a second host.
 
-### Generate a server certificate and private key for `bookinfo.com`
+### Create a server certificate and private key for `bookinfo.com`
 
 {{< text bash >}}
 $ openssl req -out bookinfo.com.csr -newkey rsa:2048 -nodes -keyout bookinfo.com.key -subj "/CN=bookinfo.com/O=bookinfo organization"


### PR DESCRIPTION
Simplify the certificate generation and make it more standard: use the openssl command, use a root certificate to sign certificates, use the root certificate as the trusted certificate, generate a separate client certificate for mutual TLS. 