### PR TITLE
remove completed pods

### DIFF
--- a/content/en/docs/setup/install/kubernetes/index.md
+++ b/content/en/docs/setup/install/kubernetes/index.md
@@ -75,14 +75,11 @@ $ istioctl manifest apply --set profile=demo
     NAME                                                           READY   STATUS      RESTARTS   AGE
     grafana-f8467cc6-rbjlg                                         1/1     Running     0          1m
     istio-citadel-78df5b548f-g5cpw                                 1/1     Running     0          1m
-    istio-cleanup-secrets-release-1.1-20190308-09-16-8s2mp         0/1     Completed   0          2m
     istio-egressgateway-78569df5c4-zwtb5                           1/1     Running     0          1m
     istio-galley-74d5f764fc-q7nrk                                  1/1     Running     0          1m
-    istio-grafana-post-install-release-1.1-20190308-09-16-2p7m5    0/1     Completed   0          2m
     istio-ingressgateway-7ddcfd665c-dmtqz                          1/1     Running     0          1m
     istio-pilot-f479bbf5c-qwr28                                    2/2     Running     0          1m
     istio-policy-6fccc5c868-xhblv                                  2/2     Running     2          1m
-    istio-security-post-install-release-1.1-20190308-09-16-bmfs4   0/1     Completed   0          2m
     istio-sidecar-injector-78499d85b8-x44m6                        1/1     Running     0          1m
     istio-telemetry-78b96c6cb6-ldm9q                               2/2     Running     2          1m
     istio-tracing-69b5f778b7-s2zvw                                 1/1     Running     0          1m

--- a/content/en/docs/setup/install/kubernetes/index.md
+++ b/content/en/docs/setup/install/kubernetes/index.md
@@ -78,10 +78,10 @@ $ istioctl manifest apply --set profile=demo
     istio-egressgateway-78569df5c4-zwtb5                           1/1     Running     0          1m
     istio-galley-74d5f764fc-q7nrk                                  1/1     Running     0          1m
     istio-ingressgateway-7ddcfd665c-dmtqz                          1/1     Running     0          1m
-    istio-pilot-f479bbf5c-qwr28                                    2/2     Running     0          1m
-    istio-policy-6fccc5c868-xhblv                                  2/2     Running     2          1m
+    istio-pilot-f479bbf5c-qwr28                                    1/1     Running     0          1m
+    istio-policy-6fccc5c868-xhblv                                  1/1     Running     2          1m
     istio-sidecar-injector-78499d85b8-x44m6                        1/1     Running     0          1m
-    istio-telemetry-78b96c6cb6-ldm9q                               2/2     Running     2          1m
+    istio-telemetry-78b96c6cb6-ldm9q                               1/1     Running     2          1m
     istio-tracing-69b5f778b7-s2zvw                                 1/1     Running     0          1m
     kiali-99f7467dc-6rvwp                                          1/1     Running     0          1m
     prometheus-67cdb66cbb-9w2hm                                    1/1     Running     0          1m


### PR DESCRIPTION
as they aren't shown any more, not seeing them in the generated manifest via `istioctl manifest generate --set profile=demo`.  Believe they are removed from operator.