### PR TITLE
Mention OpenShift specific instructions on Bookinfo tutorial

### DIFF
--- a/content/en/docs/examples/bookinfo/index.md
+++ b/content/en/docs/examples/bookinfo/index.md
@@ -70,6 +70,10 @@ If you use GKE, please ensure your cluster has at least 4 standard GKE nodes. If
     $ kubectl label namespace default istio-injection=enabled
     {{< /text >}}
 
+    {{< warning >}}
+    If you use OpenShift, make sure to give appropriate permissions to service accounts on the namespace as described in [OpenShift setup page](/docs/setup/platform-setup/openshift/#privileged-security-context-constraints-for-application-sidecars).
+    {{< /warning >}}
+
 1.  Deploy your application using the `kubectl` command:
 
     {{< text bash >}}


### PR DESCRIPTION
It's easy to skip that step, and when deployment fails it will
take some time to people realize what was the mistake.