### PR TITLE
Split up install to separate CRs

### DIFF
--- a/static/default-cr.yaml
+++ b/static/default-cr.yaml
@@ -1,3 +1,4 @@
+...
 ---
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
@@ -5,5 +6,6 @@ metadata:
   namespace: istio-operator
   name: example-istiocontrolplane
 spec:
-  profile: demo
+  profile: default
 ...
+---

--- a/static/default-cr.yaml
+++ b/static/default-cr.yaml
@@ -1,4 +1,3 @@
-...
 ---
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane

--- a/static/demo-cr.yaml
+++ b/static/demo-cr.yaml
@@ -1,3 +1,4 @@
+...
 ---
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
@@ -7,3 +8,4 @@ metadata:
 spec:
   profile: demo
 ...
+---

--- a/static/demo-cr.yaml
+++ b/static/demo-cr.yaml
@@ -1,4 +1,3 @@
-...
 ---
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane

--- a/static/minimal-cr.yaml
+++ b/static/minimal-cr.yaml
@@ -1,3 +1,4 @@
+...
 ---
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
@@ -5,5 +6,6 @@ metadata:
   namespace: istio-operator
   name: example-istiocontrolplane
 spec:
-  profile: demo
+  profile: minimal
 ...
+---

--- a/static/minimal-cr.yaml
+++ b/static/minimal-cr.yaml
@@ -1,4 +1,3 @@
-...
 ---
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane

--- a/static/operator-profile-demo-auth.yaml
+++ b/static/operator-profile-demo-auth.yaml
@@ -1,8 +1,0 @@
-apiVersion: install.istio.io/v1alpha2
-kind: IstioControlPlane
-metadata:
-  namespace: istio-operator
-  name: example-istiocontrolplane
-spec:
-  profile: demo-auth
----

--- a/static/operator.yaml
+++ b/static/operator.yaml
@@ -164,7 +164,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps  
+  - configmaps
   - endpoints
   - events
   - namespaces
@@ -172,7 +172,7 @@ rules:
   - persistentvolumeclaims
   - secrets
   - services
-  - serviceaccounts  
+  - serviceaccounts
   verbs:
   - '*'
 ...
@@ -252,11 +252,3 @@ spec:
               value: "istio-operator"
 ...
 ---
-apiVersion: install.istio.io/v1alpha2
-kind: IstioControlPlane
-metadata:
-  namespace: istio-operator
-  name: example-istiocontrolplane
-spec:
-  profile: demo
-...

--- a/static/sds-cr.yaml
+++ b/static/sds-cr.yaml
@@ -1,3 +1,4 @@
+...
 ---
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane
@@ -5,5 +6,6 @@ metadata:
   namespace: istio-operator
   name: example-istiocontrolplane
 spec:
-  profile: demo
+  profile: sds
 ...
+---

--- a/static/sds-cr.yaml
+++ b/static/sds-cr.yaml
@@ -1,4 +1,3 @@
-...
 ---
 apiVersion: install.istio.io/v1alpha2
 kind: IstioControlPlane


### PR DESCRIPTION
Existing install manifest can race leading to install errors. 