### PR TITLE
Update install text

### DIFF
--- a/content/en/docs/setup/install/kubernetes/index.md
+++ b/content/en/docs/setup/install/kubernetes/index.md
@@ -14,14 +14,9 @@ This installation lets you quickly evaluate Istio in a Kubernetes cluster on any
 {{< warning >}}
 The demo configuration profile is not suitable for performance evaluation. It
 is designed to showcase Istio functionality with high levels of tracing and
-access logging.
+access logging. To install Istio for production use, we recommend using the
+[Installing with {{< istioctl >}} guide](/docs/setup/install/istioctl/) instead.
 {{< /warning >}}
-
-To install Istio for production use, we recommend using the
-[Installing with {{< istioctl >}} guide](/docs/setup/install/istioctl/)
-instead, which provides many more options for selecting and managing the Istio
-configuration. This permits customization of Istio to operator specific
-requirements.
 
 ## Prerequisites
 


### PR DESCRIPTION
It's not accurate to say that the istioctl install option offers more options, since it's using the same mechanism. It does offer more detailed documentation and a more appropriate starting profile, but that can be changed post-install. 
Still needed is verification on the services and deployments that are expected to be running. 