### PR TITLE
Fix auth installation and its references.

### DIFF
--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -130,7 +130,7 @@ $ helm template install/kubernetes/helm/istio --name istio --namespace istio-sys
 
 {{< /tab >}}
 
-{{< tab name="mTLS enabled" cookie-value="mtls" >}}
+{{< tab name="Mutual TLS" cookie-value="mtls" >}}
 
 {{< text bash >}}
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
@@ -141,7 +141,7 @@ $ helm template install/kubernetes/helm/istio --name istio --namespace istio-sys
 
 {{< /tab >}}
 
-{{< tab name="mTLS (SDS) enabled" cookie-value="sds" >}}
+{{< tab name="Mutual TLS with SDS" cookie-value="sds" >}}
 
 {{< text bash >}}
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
@@ -236,7 +236,7 @@ $ helm install install/kubernetes/helm/istio --name istio --namespace istio-syst
 
 {{< /tab >}}
 
-{{< tab name="mTLS enabled" cookie-value="mtls" >}}
+{{< tab name="Mutual TLS" cookie-value="mtls" >}}
 
 {{< text bash >}}
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
@@ -247,7 +247,7 @@ $ helm template install/kubernetes/helm/istio --name istio --namespace istio-sys
 
 {{< /tab >}}
 
-{{< tab name="mTLS (SDS) enabled" cookie-value="sds" >}}
+{{< tab name="Mutual TLS with SDS" cookie-value="sds" >}}
 
 {{< text bash >}}
 $ helm install install/kubernetes/helm/istio --name istio --namespace istio-system \
@@ -326,7 +326,7 @@ $ kubectl delete namespace istio-system
 
 {{< /tab >}}
 
-{{< tab name="mTLS enabled" cookie-value="mtls" >}}
+{{< tab name="Mutual TLS" cookie-value="mtls" >}}
 
 {{< text bash >}}
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
@@ -337,7 +337,7 @@ $ helm template install/kubernetes/helm/istio --name istio --namespace istio-sys
 
 {{< /tab >}}
 
-{{< tab name="mTLS (SDS) enabled" cookie-value="sds" >}}
+{{< tab name="Mutual TLS with SDS" cookie-value="sds" >}}
 
 {{< text bash >}}
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -130,7 +130,18 @@ $ helm template install/kubernetes/helm/istio --name istio --namespace istio-sys
 
 {{< /tab >}}
 
-{{< tab name="sds" cookie-value="sds" >}}
+{{< tab name="mTLS enabled" cookie-value="mtls" >}}
+
+{{< text bash >}}
+$ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
+    --values install/kubernetes/helm/istio/values-istio-demo.yaml \
+    --set global.controlPlaneSecurityEnabled=true \
+    --set global.mtls.enabled=true | kubectl apply -f -
+{{< /text >}}
+
+{{< /tab >}}
+
+{{< tab name="mTLS (SDS) enabled" cookie-value="sds" >}}
 
 {{< text bash >}}
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
@@ -225,7 +236,18 @@ $ helm install install/kubernetes/helm/istio --name istio --namespace istio-syst
 
 {{< /tab >}}
 
-{{< tab name="sds" cookie-value="sds" >}}
+{{< tab name="mTLS enabled" cookie-value="mtls" >}}
+
+{{< text bash >}}
+$ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
+    --values install/kubernetes/helm/istio/values-istio-demo.yaml \
+    --set global.controlPlaneSecurityEnabled=true \
+    --set global.mtls.enabled=true | kubectl apply -f -
+{{< /text >}}
+
+{{< /tab >}}
+
+{{< tab name="mTLS (SDS) enabled" cookie-value="sds" >}}
 
 {{< text bash >}}
 $ helm install install/kubernetes/helm/istio --name istio --namespace istio-system \
@@ -304,7 +326,18 @@ $ kubectl delete namespace istio-system
 
 {{< /tab >}}
 
-{{< tab name="sds" cookie-value="sds" >}}
+{{< tab name="mTLS enabled" cookie-value="mtls" >}}
+
+{{< text bash >}}
+$ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \
+    --values install/kubernetes/helm/istio/values-istio-demo.yaml \
+    --set global.controlPlaneSecurityEnabled=true \
+    --set global.mtls.enabled=true | kubectl apply -f -
+{{< /text >}}
+
+{{< /tab >}}
+
+{{< tab name="mTLS (SDS) enabled" cookie-value="sds" >}}
 
 {{< text bash >}}
 $ helm template install/kubernetes/helm/istio --name istio --namespace istio-system \

--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -39,6 +39,13 @@ Kubernetes configuration. The `default` profile is a good starting point
 for establishing a production environment, unlike the larger `demo` profile that
 is intended for evaluating a broad set of Istio features.
 
+If you want to enable security on top of the `default` profile, you can set the
+security related configuration parameters:
+
+{{< text bash >}}
+$ istioctl manifest apply --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true
+{{< /text >}}
+
 ## Install a different profile
 
 Other Istio configuration profiles can be installed in a cluster by passing the
@@ -57,7 +64,6 @@ accessible to `istioctl` by using this command:
 {{< text bash >}}
 $ istioctl profile list
     default
-    demo-auth
     demo
     minimal
     sds
@@ -267,10 +273,10 @@ In addition to installing any of Istio's built-in
 - [The `IstioControlPlane` API](/docs/reference/config/istio.operator.v1alpha12.pb/)
 
 The configuration parameters in this API can be set individually using `--set` options on the command
-line. For example, to disable the telemetry feature in a default configuration profile, use this command:
+line. For example, to enable the security feature in a default configuration profile, use this command:
 
 {{< text bash >}}
-$ istioctl manifest apply --set telemetry.enabled=false
+$ istioctl manifest apply --set values.global.mtls.enabled=true --set values.global.controlPlaneSecurityEnabled=true
 {{< /text >}}
 
 Alternatively, the `IstioControlPlane` configuration can be specified in a YAML file and passed to

--- a/content/en/docs/tasks/security/authorization/authz-http/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-http/index.md
@@ -17,7 +17,7 @@ The activities in this task assume that you:
 
 * Read the [authorization concept](/docs/concepts/security/#authorization).
 
-* Follow the [Kubernetes quick start](/docs/setup/install/kubernetes/) to install Istio with mutual TLS enabled.
+* Follow the [Istio installation guide](/docs/setup/install/istioctl/) to install Istio with mutual TLS enabled.
 
 * Deploy the [Bookinfo](/docs/examples/bookinfo/#deploying-the-application) sample application.
 

--- a/content/en/docs/tasks/security/authorization/authz-tcp/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-tcp/index.md
@@ -17,7 +17,7 @@ The activities in this task assume that you:
 
 * Read the [authorization concept](/docs/concepts/security/#authorization).
 
-* Follow the [Kubernetes quick start](/docs/setup/install/kubernetes/) to install Istio with mutual TLS enabled.
+* Follow the [Istio installation guide](/docs/setup/install/istioctl/) to install Istio with mutual TLS enabled.
 
 * Deploy the [Bookinfo](/docs/examples/bookinfo/#deploying-the-application) sample application.
 

--- a/content/en/docs/tasks/security/authorization/rbac-groups/index.md
+++ b/content/en/docs/tasks/security/authorization/rbac-groups/index.md
@@ -22,9 +22,8 @@ and the related
 [mutual TLS authentication](/docs/concepts/security/#mutual-tls-authentication)
 concepts.
 
-* Create a Kubernetes cluster with Istio installed and mutual TLS enabled.
-To fulfill this prerequisite you can follow the Kubernetes
-[installation instructions](/docs/setup/install/kubernetes/).
+* Follow the [Istio installation guide](/docs/setup/install/istioctl/)
+to install Istio with mutual TLS enabled.
 
 ## Setup the required namespace and workloads
 

--- a/content/en/docs/tasks/security/citadel-config/auth-sds/index.md
+++ b/content/en/docs/tasks/security/citadel-config/auth-sds/index.md
@@ -49,8 +49,7 @@ This approach has the following benefits:
 
 ## Before you begin
 
-* Follow the [install instructions](/docs/setup/install/istioctl/)
-  to set up Istio with SDS and global mutual TLS enabled.
+Follow the [Istio installation guide](/docs/setup/install/helm/) to set up Istio with SDS and global mutual TLS enabled.
 
 ## Service-to-service mutual TLS using key/certificate provisioned through SDS
 

--- a/content/en/docs/tasks/security/citadel-config/ca-namespace-targeting/index.md
+++ b/content/en/docs/tasks/security/citadel-config/ca-namespace-targeting/index.md
@@ -14,7 +14,7 @@ To complete this task, you should first take the following actions:
 
 * Read the [security concept](/docs/concepts/security/#how-citadel-determines-whether-to-create-service-account-secrets).
 
-* Follow the [Kubernetes quick start](/docs/setup/install/kubernetes/) to install Istio.
+* Follow the [Istio installation guide](/docs/setup/install/istioctl/) to install Istio with mutual TLS enabled.
 
 ### Deactivating service account secret generation for a single namespace
 

--- a/content/en/docs/tasks/security/citadel-config/health-check/index.md
+++ b/content/en/docs/tasks/security/citadel-config/health-check/index.md
@@ -26,13 +26,7 @@ this feature is not needed if the production setup is not using the
 
 ## Before you begin
 
-To complete this task, you can [install Istio](/docs/setup/install/istioctl/) with the `global.mtls.enabled` option set to `true`.
-
-{{< tip >}}
-Use an [authentication policy](/docs/concepts/security/#authentication-policies) to configure mutual TLS for
-all or only selected services in a namespace. You must repeat the policy for all namespaces to configure the setting globally.
-See the [authentication policy task](/docs/tasks/security/authentication/authn-policy/) for details.
-{{< /tip >}}
+Follow the [Istio installation guide](/docs/setup/install/istioctl/) to install Istio with mutual TLS enabled.
 
 ## Deploying Citadel with health checking
 

--- a/content/en/docs/tasks/security/citadel-config/plugin-ca-cert/index.md
+++ b/content/en/docs/tasks/security/citadel-config/plugin-ca-cert/index.md
@@ -15,11 +15,7 @@ operator-specified root certificate. This task demonstrates an example to plug c
 
 ## Before you begin
 
-* Set up Istio by following the instructions in the [quick start](/docs/setup/install/kubernetes/):
-
-{{< tip >}}
-You can use [authentication policy](/docs/concepts/security/#authentication-policies) to configure mutual TLS for all/selected services in a namespace (repeated for all namespaces to get global setting). See [authentication policy task](/docs/tasks/security/authentication/authn-policy/)
-{{< /tip >}}
+Follow the [Istio installation guide](/docs/setup/install/istioctl/) to install Istio with mutual TLS enabled.
 
 ## Plugging in the existing certificate and key
 


### PR DESCRIPTION
In previous PRs, we removed "demo-auth" from the installation guide, but we didn't add general auth enablement instructions, so users won't be able to learn how to enable auth from the installation page. Also the security tasks are referring to the installation page which is missing the security enablement instructions. This PR fixes these issues.