### PR TITLE
Update telemetry v2 to use istio/istio test data

### DIFF
--- a/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
+++ b/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
@@ -41,7 +41,7 @@ To generate service-level metrics directly in the Envoy proxies, follow these st
 1. To actually generate the service-level metrics, you must apply the custom stats filter.
 
     {{< text bash >}}
-    $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/{{< source_branch_name >}}/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
+    $ kubectl -n istio-system apply -f @tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml@
     {{< /text >}}
 
 1. Go to the **Istio Mesh** Grafana dashboard. Verify that the dashboard displays the same telemetry as before but without

--- a/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
+++ b/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
@@ -35,13 +35,13 @@ To generate service-level metrics directly in the Envoy proxies, follow these st
    A custom filter handles this exchange. Enable the metadata exchange filter with the following command:
 
     {{< text bash >}}
-    $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/{{< source_branch_name >}}/extensions/stats/testdata/istio/metadata-exchange_filter.yaml
+    $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/{{< source_branch_name >}}/tests/integration/telemetry/stats/prometheus/testdata/metadata_exchange_filter.yaml
     {{< /text >}}
 
 1. To actually generate the service-level metrics, you must apply the custom stats filter.
 
     {{< text bash >}}
-    $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/proxy/{{< source_branch_name >}}/extensions/stats/testdata/istio/stats_filter.yaml
+    $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/{{< source_branch_name >}}/tests/integration/telemetry/stats/prometheus/testdata/stats_filter.yaml
     {{< /text >}}
 
 1. Go to the **Istio Mesh** Grafana dashboard. Verify that the dashboard displays the same telemetry as before but without

--- a/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
+++ b/content/en/docs/ops/telemetry/in-proxy-service-telemetry/index.md
@@ -35,7 +35,7 @@ To generate service-level metrics directly in the Envoy proxies, follow these st
    A custom filter handles this exchange. Enable the metadata exchange filter with the following command:
 
     {{< text bash >}}
-    $ kubectl -n istio-system apply -f https://raw.githubusercontent.com/istio/istio/{{< source_branch_name >}}/tests/integration/telemetry/stats/prometheus/testdata/metadata_exchange_filter.yaml
+    $ kubectl -n istio-system apply -f @tests/integration/telemetry/stats/prometheus/testdata/metadata_exchange_filter.yaml@
     {{< /text >}}
 
 1. To actually generate the service-level metrics, you must apply the custom stats filter.


### PR DESCRIPTION
Switch telemetry v2 instruction to use the test config in istio/istio, the istio/proxy config is not examined by integration test and easy to get out of dated. Ideally the instruction should use installer, which is working in progress and not yet tested by Istio/istio integration test. 