### PR TITLE
update release notes to link to blog post for authz v1beta1

### DIFF
--- a/content/en/news/2019/announcing-1.4/change-notes/index.md
+++ b/content/en/news/2019/announcing-1.4/change-notes/index.md
@@ -15,7 +15,7 @@ weight: 10
 
 ## Security
 
-- **Added** the [`v1beta1` authorization policy model](/docs/concepts/security#authorization) for enforcing access control. This will eventually replace the [`v1alpha1` RBAC policy](/docs/reference/config/security/istio.rbac.v1alpha1/).
+- **Added** the [`v1beta1` authorization policy model](/blog/2019/v1beta1-authorization-policy/) for enforcing access control. This will eventually replace the [`v1alpha1` RBAC policy](/docs/reference/config/security/istio.rbac.v1alpha1/).
 - **Improved** Citadel to periodically check and rotate the expired root certificate when running in self-sign CA mode.
 
 ## Telemetry


### PR DESCRIPTION
@geeknoid I feel it's better to link to the blog post which does a better job in introducing the new policy for customers coming from the release notes page.