### PR TITLE
Add grpc-web as port prefix example to docs

### DIFF
--- a/content/en/docs/ops/traffic-management/protocol-selection/index.md
+++ b/content/en/docs/ops/traffic-management/protocol-selection/index.md
@@ -19,6 +19,7 @@ Protocols can be specified manually by naming the Service port `name: <protocol>
 The following protocols are supported:
 
 - `grpc`
+- `grpc-web`
 - `http`
 - `http2`
 - `https`

--- a/content/zh/docs/ops/traffic-management/protocol-selection/index.md
+++ b/content/zh/docs/ops/traffic-management/protocol-selection/index.md
@@ -17,6 +17,7 @@ Istio 默认支持代理所有 TCP 流量，但为了提供附加的能力，比
 下列协议是被支持的：
 
 - `grpc`
+- `grpc-web`
 - `http`
 - `http2`
 - `https`


### PR DESCRIPTION
Documentation of native grpc-web support doesn't exist. This should at least give some hint that grpc-web is recognized as a port name.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
