### PR TITLE
Fix root transition file download path.

### DIFF
--- a/content/en/docs/ops/security/root-transition/index.md
+++ b/content/en/docs/ops/security/root-transition/index.md
@@ -42,11 +42,11 @@ please follow the procedure and check whether you will be affected.
 
 1. Check when the root certificate expires:
 
-    Download this [script](https://raw.githubusercontent.com/istio/tools/master/bin/root-transition.sh)
+    Download this [script](https://raw.githubusercontent.com/istio/tools/root-transition/bin/root-transition.sh)
     on a machine that has `kubectl` access to the cluster.
 
     {{< text bash>}}
-    $ wget https://raw.githubusercontent.com/istio/tools/master/bin/root-transition.sh
+    $ wget https://raw.githubusercontent.com/istio/tools/root-transition/bin/root-transition.sh
     $ chmod +x root-transition.sh
     $ ./root-transition.sh check
     ...

--- a/content/en/docs/ops/security/root-transition/index.md
+++ b/content/en/docs/ops/security/root-transition/index.md
@@ -42,11 +42,11 @@ please follow the procedure and check whether you will be affected.
 
 1. Check when the root certificate expires:
 
-    Download this [script](https://raw.githubusercontent.com/istio/tools/{{< source_branch_name >}}/bin/root-transition.sh)
+    Download this [script](https://raw.githubusercontent.com/istio/tools/master/bin/root-transition.sh)
     on a machine that has `kubectl` access to the cluster.
 
     {{< text bash>}}
-    $ wget https://raw.githubusercontent.com/istio/tools/{{< source_branch_name >}}/bin/root-transition.sh
+    $ wget https://raw.githubusercontent.com/istio/tools/master/bin/root-transition.sh
     $ chmod +x root-transition.sh
     $ ./root-transition.sh check
     ...


### PR DESCRIPTION
The root_transition.sh file doesn't change between different versions. So it doesn't make sense to use branch-specific files. Actually this is causing improvements to the file need to be back ported to previous versions, which increases our workload.