### PR TITLE
Temporarily remove SDS profile from docs

### DIFF
--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -68,7 +68,6 @@ $ istioctl profile list
     default
     demo
     minimal
-    sds
 {{< /text >}}
 
 ## Display the configuration of a profile


### PR DESCRIPTION
SDS is not working, this takes out the profile reference in the docs until the fix is in.