### PR TITLE
update istioctl download instruction

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -34,7 +34,7 @@ Install the `istioctl` binary with `curl`:
 1. Download the latest release with the command:
 
     {{< text bash >}}
-    $ curl -sL https://istio.io/downloadIstioctl.sh | sh -
+    $ curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=1.4.0 sh -
     {{< /text >}}
 
 1. Add the `istioctl` client to your path, on a macOS or Linux system:

--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -34,7 +34,7 @@ Install the `istioctl` binary with `curl`:
 1. Download the latest release with the command:
 
     {{< text bash >}}
-    $ curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION=1.4.0 sh -
+    $ curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION={{< istio_full_version >}} sh -
     {{< /text >}}
 
 1. Add the `istioctl` client to your path, on a macOS or Linux system:


### PR DESCRIPTION
```
$ curl -L https://istio.io/downloadIstioctl | ISTIO_VERSION=1.4.0 sh - 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   101  100   101    0     0    261      0 --:--:-- --:--:-- --:--:--   260
100  2339  100  2339    0     0   4524      0 --:--:-- --:--:-- --:--:--  4524
Downloading istioctl-1.4.0-osx.tar.gz from https://github.com/istio/istio/releases/download/1.4.0/istioctl-1.4.0-osx.tar.gz ... 
istioctl-1.4.0-osx.tar.gz download complete!

Add the istioctl to your path with:
  export PATH=$PATH:$HOME/.istioctl/bin 

Begin the Istio pre-installation verification check by running:
	 istioctl verify-install 

Need more information? Visit https://istio.io/docs/reference/commands/istioctl/
```