### PR TITLE
Fixes to the release note action buttons.

### DIFF
--- a/content/zh/docs/setup/getting-started/index.md
+++ b/content/zh/docs/setup/getting-started/index.md
@@ -40,3 +40,7 @@ The next step is to deploy your own applications.
 
 As you continue to use Istio, we look forward to hearing from you and welcoming
 you to our [community](/about/community/join/).
+
+## Download
+
+Placeholder

--- a/layouts/shortcodes/relnote.html
+++ b/layouts/shortcodes/relnote.html
@@ -91,11 +91,12 @@
             <p>{{ i18n "relnote_download_detail" }}</p>
         </div>
     {{ else }}
+        {{ $download_link := printf "https://github.com/istio/istio/releases/tag/%s" $full_version }}
         {{ if ne $latest_full_version $full_version }}
             {{ .Page.Scratch.Set "needPopper" true }}
             <a class="update-notice entry"
                 data-title='{{ i18n "relnote_update_notice" }}'
-                data-downloadhref="https://github.com/istio/istio/releases/tag/{{ $full_version }}"
+                data-downloadhref="{{ $download_link }}"
                 data-downloadbuttontext="DOWNLOAD {{ $full_version }}"
                 data-updateadvice='{{ printf (i18n "relnote_update_advice") $release_name }}'
                 data-updatebutton='{{ printf (i18n "relnote_update_button") $latest_full_version }}'
@@ -104,7 +105,15 @@
                 <p>{{ i18n "relnote_download_detail" }}</p>
             </a>
         {{ else }}
-            <a class="entry" href="https://github.com/istio/istio/releases/tag/{{ $full_version }}">
+            {{ if eq $release_location "main" }}
+                {{ if .Site.Data.args.preliminary }}
+                    {{ $download_link = printf "https://istio.io%s/docs/setup/getting-started/#download" $lang }}
+                {{ else if not .Site.Data.args.archive }}
+                    {{ $download_link = printf "%s/docs/setup/getting-started/#download" $lang }}
+                {{ end }}
+            {{ end }}
+
+            <a class="entry" href="{{ $download_link }}">
                 <h5>{{ i18n "relnote_download_title" }}</h5>
                 <p>{{ i18n "relnote_download_detail" }}</p>
             </a>
@@ -113,6 +122,7 @@
 
     {{ $doc_link := printf "https://istio.io%s/docs" $lang }}
     {{ if eq $release_location "archive" }}
+        {{ $doc_link = printf "https://archive.istio.io/v%s/docs" $version }}
     {{ else if eq $release_location "preliminary" }}
         {{ $doc_link = printf "https://preliminry.istio.io%s/docs" $lang }}
     {{ else if .Site.Data.args.preliminary }}

--- a/src/sass/misc/_relnote-actions.scss
+++ b/src/sass/misc/_relnote-actions.scss
@@ -9,9 +9,18 @@
         color: $textColor;
         text-decoration: none;
 
+        h5 {
+            margin-bottom: 0;
+            color: $linkColor;
+        }
+
         &:hover {
-            color: $textColor;
+            color: $textBrandColor;
             text-decoration: none;
+
+            h5 {
+                color: $textBrandColor;
+            }
         }
     }
 
@@ -20,6 +29,8 @@
         padding: 1rem;
         border: $tabsetBorderColor 1px dashed;
         display: block;
+        cursor: pointer;
+        text-decoration: none;
 
         @media (min-width: $bp-md) {
             padding: 1rem 4rem;
@@ -27,15 +38,17 @@
 
         &:hover {
             background-color: $mainBrandColor;
-            cursor: pointer;
+            color: $textBrandColor;
+        }
+
+        &:focus {
+            color: $textBrandColor;
+            background-color: $mainBrandColor;
         }
 
         &:active {
             background-color: $buttonActiveColor;
-        }
-
-        &:focus {
-            background-color: $textBrandColor;
+            color: $textBrandColor;
         }
     }
 
@@ -54,11 +67,6 @@
         &:focus {
             background-color: $backgroundColor;
         }
-    }
-
-    h5 {
-        margin-bottom: 0;
-        color: $linkColor;
     }
 
     p {


### PR DESCRIPTION
- For the page for the current release, have the DOWNLOAD selection take you to the getting started install page. In other cases, it throws you to GitHub's releases page.

- Fix color highlighting for the action areas. Some text was becoming invisible on
hover and the buttons generally didn't follow our color scheme & transitions. Now
they behave like buttons do in terms of colors.