### PR TITLE
Site improvements.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -20,7 +20,7 @@
             {{ else if .Site.Data.args.preliminary }}
                 <span class="name">Istio Prelim {{ .Site.Data.args.version }}</span>
             {{ else }}
-                <span class="name">Istio</span>
+                <span class="name">Istio {{ .Site.Data.args.version }}</span>
             {{ end }}
         </a>
 

--- a/layouts/partials/sidebar_level.html
+++ b/layouts/partials/sidebar_level.html
@@ -30,6 +30,9 @@
             {{ if not .IsPage }}
                 <li role="treeitem" aria-label="{{ .LinkTitle}}">
                     {{ $collapse := not (.IsAncestor $current) }}
+                    {{ if eq . $current }}
+                        {{ $collapse = true }}
+                    {{ end }}
 
                     <button{{ if not $collapse }} class="show"{{ end }} aria-hidden="true"></button><a {{ if eq $current.Permalink .Permalink }}class="current"{{ end }} title="{{ .Description }}" href="{{ .Permalink }}">{{ .LinkTitle}}</a>
 

--- a/src/sass/misc/_footer.scss
+++ b/src/sass/misc/_footer.scss
@@ -16,12 +16,13 @@ footer {
         display: none;
     }
 
-    @media (min-width: $bp-sm) {
+    @media (min-width: $bp-md) {
         padding: 1.5rem 1.25rem 1rem;
+        grid-template-columns: [user-links] 65% [info] 35% [dev-links] 0;
     }
 
     @media (min-width: $bp-lg) {
-        grid-template-columns: [user-links] 30% [info] 40% [dev-links] 30%;
+        grid-template-columns: [user-links] 35% [info] 30% [dev-links] 35%;
     }
 
     .user-links {


### PR DESCRIPTION
- Display the version number in the site header. The version number was only displayed
in tiny font in the footer, now it's quite a bit more obvious.

- Fix layout of the footer to avoid the icons wrapping on two lines when the browser was
specific widths.

- Clicking on a folder in the left navigation area no longer expands the
folder. It only brings up the page associated with the folder in the main
page area. This was always my intent, I never got around to it til now.