### PR TITLE
Remove operator from `make update-all`

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -63,7 +63,7 @@ update_operator_yamls:
 update_examples:
 	@scripts/grab_examples.sh $(SOURCE_BRANCH_NAME)
 
-update_all: update_ref_docs update_operator_yamls update_examples
+update_all: update_ref_docs update_examples
 
 include common/Makefile.common.mk
 


### PR DESCRIPTION
We will hopefully transition to a GCS bucket plan as the current model
is not very maintainable and the GCS model (if it works) should be superior.

For master and 1.4.