### PR TITLE
Fix problems with the glossary page.

### DIFF
--- a/content/en/docs/reference/glossary/index.md
+++ b/content/en/docs/reference/glossary/index.md
@@ -6,8 +6,6 @@ layout: glossary
 aliases:
   - /glossary
   - /docs/welcome/glossary.html
-  - /docs/reference/glossary.html
   - /help/glossary
 icon: glossary
 ---
-∑∑

--- a/layouts/_default/glossary.html
+++ b/layouts/_default/glossary.html
@@ -1,5 +1,11 @@
 {{ define "main" }}
 
+<style>
+    .primary .article-container article {
+        overflow-x: visible;
+    }
+</style>
+
 {{ partial "primary_top.html" . }}
 
 {{ .Content }}


### PR DESCRIPTION
- Remove some stray characters at the top of the page.

- Fix scrolling behavior such that the selected letter stays on the
screen. This broke due to a bug fix on the istioctl page which had
an unexpected side effect,

- Remove extraneous alias that could lead to infinite redirect loops.