### PR TITLE
Remove Istio version from download commands

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -34,7 +34,7 @@ Install the `istioctl` binary with `curl`:
 1. Download the latest release with the command:
 
     {{< text bash >}}
-    $ curl -sL https://istio.io/downloadIstioctl | ISTIO_VERSION={{< istio_full_version >}} sh -
+    $ curl -sL https://istio.io/downloadIstioctl | sh -
     {{< /text >}}
 
 1. Add the `istioctl` client to your path, on a macOS or Linux system:

--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -37,7 +37,7 @@ Download the Istio release which includes installation files, samples, and the
     extract the latest release automatically:
 
     {{< text bash >}}
-    $ curl -L https://istio.io/downloadIstio | ISTIO_VERSION={{< istio_full_version >}} sh -
+    $ curl -L https://istio.io/downloadIstio | sh -
     {{< /text >}}
 
 1.  Move to the Istio package directory. For example, if the package is


### PR DESCRIPTION
  scripts now find latest non-candidate versions

fixes: https://github.com/istio/istio/issues/19017