### PR TITLE
Use subset in the destination rule of TLS origination

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -168,6 +168,7 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
         route:
         - destination:
             host: edition.cnn.com
+            subset: tls-origination
             port:
               number: 443
     ---
@@ -177,14 +178,16 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
       name: edition-cnn-com
     spec:
       host: edition.cnn.com
-      trafficPolicy:
-        loadBalancer:
-          simple: ROUND_ROBIN
-        portLevelSettings:
-        - port:
-            number: 443
-          tls:
-            mode: SIMPLE # initiates HTTPS when accessing edition.cnn.com
+      subsets:
+      - name: tls-origination
+        trafficPolicy:
+          loadBalancer:
+            simple: ROUND_ROBIN
+          portLevelSettings:
+          - port:
+              number: 443
+            tls:
+              mode: SIMPLE # initiates HTTPS when accessing edition.cnn.com
     EOF
     {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -217,6 +217,17 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
     programmatically, the code does not need to be changed. You get the benefits of TLS origination by configuring Istio,
     without changing a line of code.
 
+1.  Note that the applications that used HTTPS to access the external service continue to work as before:
+
+    {{< text bash >}}
+    $ kubectl exec -it $SOURCE_POD -c sleep -- curl -sL -o /dev/null -D - https://edition.cnn.com/politics
+    HTTP/1.1 200 OK
+    Content-Type: text/html; charset=utf-8
+    ...
+    Content-Length: 151654
+    ...
+    {{< /text >}}
+
 ## Additional security considerations
 
 Because the traffic between the application pod and the sidecar proxy on the local host is still unencrypted,


### PR DESCRIPTION
This way the TLS origination will only be applied for the traffic directed by the
virtual service for TLS origination. TLS origination will not be applied for the original TLS traffic.

The problem raised by @fcantournet (cc @howardjohn)