### PR TITLE
Make CoreDNS docs for Multi Cluster more precise

### DIFF
--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -183,7 +183,7 @@ EOF
 
 {{< /tab >}}
 
-{{< tab name="CoreDNS (>= 1.4.0)" category-value="coredns-after-1.4.0" >}}
+{{< tab name="CoreDNS (== 1.4.0)" cookie-value="coredns-1.4.0" >}}
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -197,6 +197,43 @@ data:
     .:53 {
         errors
         health
+        kubernetes cluster.local in-addr.arpa ip6.arpa {
+           pods insecure
+           upstream
+           fallthrough in-addr.arpa ip6.arpa
+        }
+        prometheus :9153
+        forward . /etc/resolv.conf
+        cache 30
+        loop
+        reload
+        loadbalance
+    }
+    global:53 {
+        errors
+        cache 30
+        forward . $(kubectl get svc -n istio-system istiocoredns -o jsonpath={.spec.clusterIP})
+    }
+EOF
+{{< /text >}}
+
+{{< /tab >}}
+
+{{< tab name="CoreDNS (>= 1.4.0)" cookie-value="coredns-after-1.4.0" >}}
+
+{{< text bash >}}
+$ kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        health
+        ready
         kubernetes cluster.local in-addr.arpa ip6.arpa {
            pods insecure
            upstream

--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -212,7 +212,7 @@ data:
     global:53 {
         errors
         cache 30
-        forward . $(kubectl get svc -n istio-system istiocoredns -o jsonpath={.spec.clusterIP})
+        forward . $(kubectl get svc -n istio-system istiocoredns -o jsonpath={.spec.clusterIP}):53
     }
 EOF
 {{< /text >}}
@@ -249,7 +249,7 @@ data:
     global:53 {
         errors
         cache 30
-        forward . $(kubectl get svc -n istio-system istiocoredns -o jsonpath={.spec.clusterIP})
+        forward . $(kubectl get svc -n istio-system istiocoredns -o jsonpath={.spec.clusterIP}):53
     }
 EOF
 {{< /text >}}


### PR DESCRIPTION

Fixes the CoreDNS issue explained here: https://github.com/istio/istio/issues/18971

TLDR: newer CoreDNS versions (1.5.0+) have the ready plugin to provide information if CoreDNS can serve DNS queries if the plugin is not activated the ready interface will never be available in setups with `kubeadm` the CoreDNS deployment has a `readinessProbe` which will then fail. If a user just takes the content as it is he will get an CoreDNS deployment with no ready Pods.