### PR TITLE
Site improvements.

### DIFF
--- a/layouts/partials/primary_bottom.html
+++ b/layouts/partials/primary_bottom.html
@@ -39,8 +39,8 @@
             <div id="feedback">
                 <div>
                     {{ i18n "feedback_title" }}<br>
-                    <button class="btn feedback" onclick="sendFeedback(1)">{{ i18n "feedback_yes" }}</button>
-                    <button class="btn feedback" onclick="sendFeedback(0)">{{ i18n "feedback_no" }}</button>
+                    <button class="btn feedback" onclick="sendFeedback('{{.Site.Language}}', 1)">{{ i18n "feedback_yes" }}</button>
+                    <button class="btn feedback" onclick="sendFeedback('{{.Site.Language}}', 0)">{{ i18n "feedback_no" }}</button>
                 </div>
             </div>
         {{ end }}

--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -326,6 +326,11 @@ div.aliases::before {
     }
 }
 
+sup {
+    font-size: 50%;
+    vertical-align: super;
+}
+
 .icon {
     width: 1em;
     height: 1em;

--- a/src/sass/misc/_feedback.scss
+++ b/src/sass/misc/_feedback.scss
@@ -2,6 +2,10 @@
     text-align: center;
     margin-top: 3rem;
 
+    @media print {
+        display: none;
+    }
+
     div {
         display: inline-block;
         margin: 0 auto;

--- a/src/sass/misc/_section-index.scss
+++ b/src/sass/misc/_section-index.scss
@@ -1,21 +1,19 @@
 .section-index {
     display: grid;
     grid-template-columns: [entry] 1fr;
+    grid-column-gap: 2rem;
+    grid-row-gap: 2rem;
 
     @media (min-width: $bp-sm) {
         grid-template-columns: [entry] 1fr [entry] 1fr;
     }
 
-    @media (min-width: $bp-xl) {
-        grid-template-columns: [entry] 1fr [entry] 1fr [entry] 1fr;
+    @media (min-width: $bp-md) {
+        grid-column-gap: 4rem;
     }
 
-    .entry {
-        padding: 1rem;
-
-        @media (min-width: $bp-md) {
-            padding: 1rem 4rem;
-        }
+    @media (min-width: $bp-xl) {
+        grid-template-columns: [entry] 1fr [entry] 1fr [entry] 1fr;
     }
 
     h5 {

--- a/src/ts/feedback.ts
+++ b/src/ts/feedback.ts
@@ -14,8 +14,8 @@
 
 declare function gtag(type: string, action: string, payload: any): void;
 
-function sendFeedback(value: number) {
-    gtag("event", "click", {
+function sendFeedback(language: string, value: number): void {
+    gtag("event", "click-" + language, {
         event_category: "Helpful",
         event_label: window.location.pathname,
         value,


### PR DESCRIPTION
- The Yes/No feedback buttons now produce analytics events that include the
page language so that we can key off of that in the reports.

- Improve the layout of directory pages (_index.md) by removing excessive
blank space around each entry, which makes better use of the display area.

- Hide the Yea/No feedback buttons when printing.

- Fix the superscript link endnotes used when printing. These were
being rendered as full-size text instead of superscripts. This has
been broken for a long time it seems.