### PR TITLE
fix istioctl instruction install instruction on gke

### DIFF
--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -121,7 +121,7 @@ The following table shows the required settings for many common Kubernetes envir
 
 | Hosted Cluster Type | Required Istio CNI Setting Overrides | Required Platform Setting Overrides |
 |---------------------|--------------------------------------|-------------------------------------|
-| GKE 1.9+ (see [GKE setup](#gke-setup) below for details)| `--set values.cni.cniBinDir=/home/kubernetes/bin` | enable [network-policy](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy) |
+| GKE 1.9+ (see [GKE setup](#gke-setup) below for details)| `--set cni.components.cni.namespace=kube-system --set values.cni.cniBinDir=/home/kubernetes/bin` | enable [network-policy](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy) |
 | IKS (IBM cloud) | _(none)_ | _(none)_ |
 | EKS (AWS) | _(none)_ | _(none)_ |
 | AKS (Azure) | _(none)_ | _(none)_ |


### PR DESCRIPTION
`istioctl manifest apply --set profile=demo --set cni.enabled=true --set values.cni.cniBinDir=/home/kubernetes/bin` by default put the `istio-cni-node` daemonset in istio-system namespace. The cni pod fails to create.

According to the helm command here https://github.com/istio/cni/blob/3fc0e65d94c3d5752d4032d4ccaa8ea462c5cbfe/README.md#usage `istio manifest` should set cni.namespace to kube-system on gke

It does work. 

Verify by running `istioctl manifest apply --set profile=demo --set cni.enabled=true --set values.cni.cniBinDir=/home/kubernetes/bin --set cni.components.cni.namespace=kube-system`

Signed-off-by: Yuchen Dai <silentdai@gmail.com>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
