### PR TITLE
Remove incorrect escape character.

### DIFF
--- a/content/en/docs/reference/config/security/istio.rbac.v1alpha1/index.html
+++ b/content/en/docs/reference/config/security/istio.rbac.v1alpha1/index.html
@@ -24,7 +24,7 @@ the following standard fields:</p>
 
 <ul>
 <li>services: a list of services.</li>
-<li>methods: A list of HTTP methods. You can set the value to <code>\*</code> to include all HTTP methods.
+<li>methods: A list of HTTP methods. You can set the value to <code>["*"]</code> to include all HTTP methods.
          This field should not be set for TCP services. The policy will be ignored.
          For gRPC services, only <code>POST</code> is allowed; other methods will result in denying services.</li>
 <li>paths: HTTP paths or gRPC methods. Note that gRPC methods should be


### PR DESCRIPTION
Also add full syntax for the YAML value, to remove ambiguity.