### PR TITLE
Fix rendering issues with banners and stickers.

### DIFF
--- a/layouts/partials/events.html
+++ b/layouts/partials/events.html
@@ -41,7 +41,7 @@
                         {{- if .Params.link -}}
                             <a href="{{ .Params.link }}"
                             class="{{ $kind }}"
-                            data-title="{{- .Params.title -}}"
+                            data-title="{{- .Params.title -}} - {{- $periodStart -}}"
                             data-period-start='{{ div $periodStart.UnixNano 1000000 }}'
                             data-period-end='{{ div $periodEnd.UnixNano 1000000 }}'
                             data-max-impressions="{{ .Params.max_impressions }}"
@@ -49,7 +49,7 @@
                         {{- else -}}
                             <div
                             class="{{ $kind }}"
-                            data-title="{{- .Params.title -}}"
+                            data-title="{{- .Params.title -}} - {{- $periodStart -}}"
                             data-period-start='{{ div $periodStart.UnixNano 1000000 }}'
                             data-period-end='{{ div $periodEnd.UnixNano 1000000 }}'
                             data-max-impressions="{{ .Params.max_impressions }}"
@@ -62,13 +62,13 @@
 
                             <div class="wrap">
                                 <div class="content">
-                                    {{ .Content | markdownify }}
+                                    {{ .Content }}
                                 </div>
                             </div>
                             <div class="frame"></div>
                         {{- else -}}
                             <div class="content">
-                                {{ .Content | markdownify }}
+                                {{ .Content }}
                             </div>
                             <div class="frame"></div>
                         {{- end -}}

--- a/src/sass/misc/_banners.scss
+++ b/src/sass/misc/_banners.scss
@@ -1,5 +1,8 @@
-@media screen {
-    .banner-container {
+.banner-container {
+    display: none;
+
+    @media screen AND (min-width: $bp-md) {
+        display: block;
         position: relative;
         top: -.8rem;
         width: 100%;
@@ -28,6 +31,28 @@
 
         .content {
             top: 0;
+
+            p {
+                margin: 0;
+            }
+        }
+
+        a {
+            color: $bannerLinkColor;
+        }
+
+        a:hover, a:focus {
+            color: $bannerLinkHoverColor;
+            text-decoration: none;
+        }
+
+        a.disabled {
+            color: $bannerLinkDisabledColor;
+        }
+
+        a.active {
+            color: $bannerLinkActiveColor;
+            text-decoration: none;
         }
     }
 }

--- a/src/sass/misc/_stickers.scss
+++ b/src/sass/misc/_stickers.scss
@@ -1,8 +1,10 @@
 .sticker-container {
-
-    --trapezoid-edge: 3.3rem;
+    display: none;
 
     @media screen AND (min-width: $bp-md) {
+        display: block;
+        --trapezoid-edge: 3.3rem;
+
         .sticker {
             display: none;
             position: fixed;
@@ -15,8 +17,6 @@
             background: $stickerBackgroundColor;
             transform: rotate(45deg);
             transform-origin: bottom right;
-            text-align: center;
-            vertical-align: middle;
 
             .wrap {
                 display: flex;
@@ -26,10 +26,14 @@
 
             .content {
                 margin: auto 0;
-                top: 0;
+
+                p {
+                    margin: 0;
+                }
             }
 
             .frame {
+                position: absolute;
                 top: 2px;
                 left: 2rem;
                 border-color: transparent;
@@ -38,7 +42,6 @@
                 background: transparent;
                 width: calc(100% - 4rem);
                 height: calc(100% - 4px);
-                position: absolute;
             }
 
             .left {
@@ -58,6 +61,24 @@
                 shape-outside: polygon(0 100%, 100% 100%, 100% 0);
                 clip-path: polygon(0 100%, 100% 100%, 100% 0);
             }
+        }
+
+        a {
+            color: $stickerLinkColor;
+        }
+
+        a:hover, a:focus {
+            color: $stickerLinkHoverColor;
+            text-decoration: none;
+        }
+
+        a.disabled {
+            color: $stickerLinkDisabledColor;
+        }
+
+        a.active {
+            color: $stickerLinkActiveColor;
+            text-decoration: none;
         }
     }
 }

--- a/src/sass/themes/_dark-theme.scss
+++ b/src/sass/themes/_dark-theme.scss
@@ -86,10 +86,18 @@
     --stickerBackgroundColor: rgba(34, 139, 34, 1);
     --stickerTextColor: white;
     --stickerBorderColor: rgba(59, 164, 59, 1);
+    --stickerLinkColor: #e9ffaa;
+    --stickerLinkHoverColor: #de7d40;
+    --stickerLinkDisabledColor: #444444;
+    --stickerLinkActiveColor: #de7d40;
 
     --bannerBackgroundColor: rgba(34, 139, 34, 1);
     --bannerTextColor: white;
     --bannerBorderColor: rgba(59, 164, 59, 1);
+    --bannerLinkColor: #e9ffaa;
+    --bannerLinkHoverColor: #de7d40;
+    --bannerLinkDisabledColor: #444444;
+    --bannerLinkActiveColor: #de7d40;
 
     --textWeight: 300;
     --linkWeight: 300;

--- a/src/sass/themes/_light-theme.scss
+++ b/src/sass/themes/_light-theme.scss
@@ -85,10 +85,18 @@ html {
     --stickerBackgroundColor: rgba(34, 139, 34, 1);
     --stickerTextColor: white;
     --stickerBorderColor: rgba(59, 164, 59, 1);
+    --stickerLinkColor: #e9ffaa;
+    --stickerLinkHoverColor: #de7d40;
+    --stickerLinkDisabledColor: #444444;
+    --stickerLinkActiveColor: #de7d40;
 
     --bannerBackgroundColor: rgba(34, 139, 34, 1);
     --bannerTextColor: white;
-    --banner1BorderColor: rgba(59, 164, 59, 1);
+    --bannerBorderColor: rgba(59, 164, 59, 1);
+    --bannerLinkColor: #e9ffaa;
+    --bannerLinkHoverColor: #de7d40;
+    --bannerLinkDisabledColor: #444444;
+    --bannerLinkActiveColor: #de7d40;
 
     --textWeight: 400;
     --linkWeight: 400;

--- a/src/sass/themes/_vars.scss
+++ b/src/sass/themes/_vars.scss
@@ -85,10 +85,18 @@ $pillTextColor: var(--pillTextColor);
 $stickerBackgroundColor: var(--stickerBackgroundColor);
 $stickerTextColor: var(--stickerTextColor);
 $stickerBorderColor: var(--stickerBorderColor);
+$stickerLinkColor: var(--stickerLinkColor);
+$stickerLinkHoverColor: var(--stickerLinkHoverColor);
+$stickerLinkDisabledColor: var(--stickerLinkDisabledColor);
+$stickerLinkActiveColor: var(--stickerLinkActiveColor);
 
 $bannerBackgroundColor: var(--bannerBackgroundColor);
 $bannerTextColor: var(--bannerTextColor);
 $bannerBorderColor: var(--bannerBorderColor);
+$bannerLinkColor: var(--bannerLinkColor);
+$bannerLinkHoverColor: var(--bannerLinkHoverColor);
+$bannerLinkDisabledColor: var(--bannerLinkDisabledColor);
+$bannerLinkActiveColor: var(--bannerLinkActiveColor);
 
 $textWeight: var(--textWeight);
 $linkWeight: var(--linkWeight);


### PR DESCRIPTION
- Pick a better color for links in banners and sticks in the light theme.

- Don't underline banners when they're used as links.

- Properly vertically center single-line stickers