### PR TITLE
Improve the "latest releaae" banner.

### DIFF
--- a/content/en/about/contribute/creating-and-editing-pages/index.md
+++ b/content/en/about/contribute/creating-and-editing-pages/index.md
@@ -746,7 +746,8 @@ file per event. Within these files, you use the following dedicated front-matter
         <tr>
             <td><code>link</code></td>
             <td>You can specify a URL, which turns the whole item into a clickable target. Once the user clicks on the item,
-            the item is no longer shown to the user.
+            the item is no longer shown to the user. The special value `latest_release` can be used here to introduce a link
+            to the current release's announcement page.
             </td>
         </tr>
     </tbody>

--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -20,7 +20,7 @@ To get started with Istio, just follow these three steps:
 Before you can install Istio, you need a {{< gloss >}}cluster{{< /gloss >}} running a compatible version of Kubernetes.
 Istio {{< istio_version >}} has been tested with Kubernetes releases {{< supported_kubernetes_versions >}}.
 
-- Create a cluster by selecting the appropriate [platform-specific setup instructions](/docs/setup/platform-setup/).
+Create a cluster by selecting the appropriate [platform-specific setup instructions](/docs/setup/platform-setup/).
 
 Some platforms provide a {{< gloss >}}managed control plane{{< /gloss >}} which you can use instead of
 installing Istio manually. If this is the case with your selected platform, and you choose to use it,

--- a/content/en/events/banners/latest-release.md
+++ b/content/en/events/banners/latest-release.md
@@ -3,7 +3,7 @@ title: Latest Release
 period_start: latest_release
 period_duration: 7
 max_impressions: 3
-link: /docs/setup/getting-started/#download
+link: latest_release
 ---
 
-Istio {{< istio_version >}} is now available! Click here to download it.
+Istio {{< istio_release_name >}} is now available! Click here to learn more

--- a/layouts/partials/events.html
+++ b/layouts/partials/events.html
@@ -12,16 +12,20 @@
                 {{- if .Params.draft -}}
                     {{/* do nothing */}}
                 {{- else -}}
-                    {{ $periodStart := $now }}
-                    {{- if eq .Params.period_start "latest_release" -}}
-                        {{/* find the latest release note and get its publication date as the period start */}}
+                    {{- $latest_release := "" -}}
+                    {{- if or (eq .Params.period_start "latest_release") (eq $.Params.link "latest_release") -}}
                         {{- range .Site.Pages -}}
                             {{- if eq .Page.Params.release .Site.Data.args.full_version -}}
                                 {{- if not .Page.Params.draft -}}
-                                    {{- $periodStart = .PublishDate -}}
+                                    {{- $latest_release = . -}}
                                 {{- end -}}
                             {{- end -}}
                         {{- end -}}
+                    {{- end -}}
+
+                    {{ $periodStart := $now }}
+                    {{- if eq .Params.period_start "latest_release" -}}
+                        {{- $periodStart = $latest_release.PublishDate -}}
                     {{- else -}}
                         {{ $periodStart = time .Params.period_start }}
                     {{- end -}}
@@ -39,7 +43,12 @@
                         {{- $periodEnd = $periodEnd.UTC -}}
 
                         {{- if .Params.link -}}
-                            <a href="{{ .Params.link }}"
+                            {{- $link := .Params.link -}}
+                            {{- if eq $link "latest_release" -}}
+                                {{ $link = $latest_release.Permalink -}}
+                            {{- end -}}
+
+                            <a href="{{ $link }}"
                             class="{{ $kind }}"
                             data-title="{{- .Params.title -}} - {{- $periodStart -}}"
                             data-period-start='{{ div $periodStart.UnixNano 1000000 }}'


### PR DESCRIPTION
The banner now points to the current release's announcement page, which is really
the 'dashboard' for a new release, and has all the right links for the user.