### PR TITLE
Simplify istioctl diff command

### DIFF
--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -158,9 +158,7 @@ which is useful for checking the effects of customizations before applying chang
 You can show differences between the default and demo profiles using these commands:
 
 {{< text bash >}}
-$ istioctl profile dump default > 1.yaml
-$ istioctl profile dump demo > 2.yaml
-$ istioctl profile diff 1.yaml 2.yaml
+$ istioctl profile diff <(istioctl profile dump default) <(istioctl profile dump demo)
  gateways:
    components:
      egressGateway:


### PR DESCRIPTION
Please provide a description for what this PR is for.

If I just want to see the difference of the profiles I don't need to create a file on my machine (and clean it up afterwards). There are some other parts where I personally would also prefer not writing a file on disk just for comparison e.g. the `verify-install` step.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
