### PR TITLE
Stop collecting written feedback from users.

### DIFF
--- a/layouts/partials/primary_bottom.html
+++ b/layouts/partials/primary_bottom.html
@@ -43,8 +43,8 @@
                     <button class="btn feedback" onclick="sendFeedback('{{.Site.Language}}', 0)">{{ i18n "feedback_no" }}</button>
                 </div>
                 <div id="feedback-comment">
-                    {{ i18n "feedback_ask_for_comment" }}<br>
-                    <input id="feedback-textbox" type="text" placeholder='{{ i18n "feedback_comment_placeholder"}}' onchange="sendComment('{{.Site.Language}}', this.value)"/>
+                    {{ i18n "feedback_ask_for_comment" }}<br><br>
+                    <input id="feedback-textbox" type="text" placeholder='{{ i18n "feedback_comment_placeholder"}}' data-lang='{{.Site.Language}}'/>
                 </div>
                 <div id="feedback-thankyou">
                     {{ i18n "feedback_thankyou" }}

--- a/src/sass/misc/_feedback.scss
+++ b/src/sass/misc/_feedback.scss
@@ -35,4 +35,12 @@
     #feedback-thankyou {
         display: none;
     }
+
+    input {
+        color: $textColor;
+        background: $backgroundColor;
+        width: 400px;
+        font-size: $font-size--primary;
+        padding: .1rem;
+    }
 }

--- a/src/ts/feedback.ts
+++ b/src/ts/feedback.ts
@@ -26,31 +26,47 @@ function sendFeedback(language: string, value: number): void {
         initial.style.display = "none";
     }
 
-    let next = "feedback-thankyou";
-    if (value === 0) {
-        next = "feedback-comment";
-    }
-
-    const ne = getById(next);
-    if (ne) {
-        ne.style.display = "block";
-    }
-}
-
-function sendComment(language: string, value: string): void {
-    gtag("event", "comment-" + language, {
-        event_category: "Helpful",
-        event_label: window.location.pathname,
-        value,
-    });
-
-    const comment = getById("feedback-comment");
-    if (comment) {
-        comment.style.display = "none";
-    }
-
     const ty = getById("feedback-thankyou");
-    if (ty) {
-        ty.style.display = "block";
+    if (!ty) {
+        return;
     }
+
+    // say thank you and leave
+    ty.style.display = "inline-block";
+
+    /*
+    TODO: this code is disabled since at the moment there isn't a good place to send any written feedback to.
+
+    if (value === 1) {
+        // say thank you and leave
+        ty.style.display = "inline-block";
+        return;
+    }
+
+    const cm = getById("feedback-comment");
+    if (!cm) {
+        return
+    }
+
+    const tb = getById("feedback-textbox");
+    if (!tb) {
+        return
+    }
+
+    cm.style.display = "inline-block";
+    tb.focus();
+
+    listen(tb, "keypress", o => {
+        const e = o as KeyboardEvent;
+
+        if (e.keyCode != keyCodes.RETURN) {
+            return;
+        }
+
+        // TODO: send the feedback somewhere
+
+        cm.style.display = "none";
+        ty.style.display = "inline-block";
+    });
+     */
 }


### PR DESCRIPTION
- I recently added support to collect written feedback about their
use of the site. The resulting text was being pushed to Google Analytics
as events. Looking for responses today, I came to realize that Google Analytics
only consumes numerical metrics, no text. I couldn't find a replacement spot
where to dump the user's comments, so this feature needs to be turned off for now.

Conceivably, a collection endpoint could be added to eng.istio.io if we really want
this data.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
