### PR TITLE
many prs can't pass lint check , due to the kubernetes new release 1.17 url changes

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/locality-load-balancing/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/locality-load-balancing/index.md
@@ -28,7 +28,7 @@ pass the `--set global.localityLbSetting.enabled=false` flag when installing Ist
 ## Requirements
 
 Currently, the service discovery platform populates the locality automatically.
-In Kubernetes, a pod's locality is determined via the [well-known labels for region and zone](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domain-beta-kubernetes-io-region)
+In Kubernetes, a pod's locality is determined via the [well-known labels for region and zone](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesioregion)
 on the node it is deployed. If you are using a hosted Kubernetes service your cloud provider
 should configure this for you. If you are running your own Kubernetes cluster you will need
 to add these labels to your nodes. The sub-zone concept doesn't exist in Kubernetes.

--- a/content/zh/docs/ops/configuration/traffic-management/locality-load-balancing/index.md
+++ b/content/zh/docs/ops/configuration/traffic-management/locality-load-balancing/index.md
@@ -26,7 +26,7 @@ aliases:
 
 目前，服务发现平台会自动填充地域。
 
-在 Kubernetes 中，Pod 的地域是通过在已部署的节点上的 [Region 和 Zone 的标签](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domain-beta-kubernetes-io-region)决定的。
+在 Kubernetes 中，Pod 的地域是通过在已部署的节点上的 [Region 和 Zone 的标签](https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesioregion)决定的。
 如果您正在使用托管的 Kubernetes 服务，那么云供应商会进行配置。
 如果您正在运行自己的 Kubernetes 集群，那么需要将这些标签添加到您的节点中。
 Kubernetes 中不存在 sub-zone 的概念。因此，该字段不需要配置。


### PR DESCRIPTION
fix 
https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domain-beta-kubernetes-io-region

->

https://kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesioregion

due to kubernetes 1.17  broken this url , many prs can't pass lint check.

