### PR TITLE
Set Kiali username and password on separate prompt

### DIFF
--- a/content/en/docs/tasks/observability/kiali/index.md
+++ b/content/en/docs/tasks/observability/kiali/index.md
@@ -41,11 +41,13 @@ authenticate to Kiali.
 First, define the credentials you want to use as the Kiali username and passphrase:
 
 This will prompt you to provide Kiali Username.
+
 {{< text bash >}}
 $ KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo -n $uval | base64)
 {{< /text >}}
 
 This will prompt you to provide Kiali Passphrase.
+
 {{< text bash >}}
 $ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo -n $pval | base64)
 {{< /text >}}
@@ -53,11 +55,13 @@ $ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo -n $pval | base6
 If you are using the Z Shell, `zsh`, use the following to define the credentials:
 
 This will prompt you to provide Kiali Username.
+
 {{< text bash >}}
 $ KIALI_USERNAME=$(read '?Kiali Username: ' uval && echo -n $uval | base64)
 {{< /text >}}
 
 This will prompt you to provide Kiali Passphrase.
+
 {{< text bash >}}
 $ KIALI_PASSPHRASE=$(read -s "?Kiali Passphrase: " pval && echo -n $pval | base64)
 {{< /text >}}

--- a/content/en/docs/tasks/observability/kiali/index.md
+++ b/content/en/docs/tasks/observability/kiali/index.md
@@ -40,15 +40,25 @@ authenticate to Kiali.
 
 First, define the credentials you want to use as the Kiali username and passphrase:
 
+This will prompt you to provide Kiali Username.
 {{< text bash >}}
 $ KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo -n $uval | base64)
+{{< /text >}}
+
+This will prompt you to provide Kiali Passphrase.
+{{< text bash >}}
 $ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo -n $pval | base64)
 {{< /text >}}
 
 If you are using the Z Shell, `zsh`, use the following to define the credentials:
 
+This will prompt you to provide Kiali Username.
 {{< text bash >}}
 $ KIALI_USERNAME=$(read '?Kiali Username: ' uval && echo -n $uval | base64)
+{{< /text >}}
+
+This will prompt you to provide Kiali Passphrase.
+{{< text bash >}}
 $ KIALI_PASSPHRASE=$(read -s "?Kiali Passphrase: " pval && echo -n $pval | base64)
 {{< /text >}}
 

--- a/content/en/docs/tasks/observability/kiali/index.md
+++ b/content/en/docs/tasks/observability/kiali/index.md
@@ -54,15 +54,8 @@ $ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo -n $pval | base6
 
 If you are using the Z Shell, `zsh`, use the following to define the credentials:
 
-This will prompt you to provide Kiali Username.
-
 {{< text bash >}}
 $ KIALI_USERNAME=$(read '?Kiali Username: ' uval && echo -n $uval | base64)
-{{< /text >}}
-
-This will prompt you to provide Kiali Passphrase.
-
-{{< text bash >}}
 $ KIALI_PASSPHRASE=$(read -s "?Kiali Passphrase: " pval && echo -n $pval | base64)
 {{< /text >}}
 

--- a/content/en/docs/tasks/observability/kiali/index.md
+++ b/content/en/docs/tasks/observability/kiali/index.md
@@ -40,13 +40,13 @@ authenticate to Kiali.
 
 First, define the credentials you want to use as the Kiali username and passphrase:
 
-This will prompt you to provide Kiali Username.
+Enter a Kiali username when prompted:
 
 {{< text bash >}}
 $ KIALI_USERNAME=$(read -p 'Kiali Username: ' uval && echo -n $uval | base64)
 {{< /text >}}
 
-This will prompt you to provide Kiali Passphrase.
+Enter a Kiali passphrase when prompted:
 
 {{< text bash >}}
 $ KIALI_PASSPHRASE=$(read -sp 'Kiali Passphrase: ' pval && echo -n $pval | base64)

--- a/content/en/docs/tasks/observability/kiali/index.md
+++ b/content/en/docs/tasks/observability/kiali/index.md
@@ -38,7 +38,7 @@ If you plan on installing Kiali using the Istio demo profile as described in the
 Create a secret in your Istio namespace with the credentials that you use to
 authenticate to Kiali.
 
-First, define the credentials you want to use as the Kiali username and passphrase:
+First, define the credentials you want to use as the Kiali username and passphrase.
 
 Enter a Kiali username when prompted:
 


### PR DESCRIPTION
This fix #6078 

Asking for Kiali username and passphrase in separate prompt will set passphrase properly.

[X ] Docs
[ X] User Experience
