### PR TITLE
Remove virtual service from glossary

### DIFF
--- a/content/en/docs/reference/glossary/routing-rules.md
+++ b/content/en/docs/reference/glossary/routing-rules.md
@@ -4,4 +4,5 @@ title: Routing Rules
 Routing rules, which you configure in a [virtual service](/docs/concepts/traffic-management/#virtual-services),
 define the paths that requests follow within the service mesh. With routing rules, you can define
 conditions to route traffic addressed to the virtual service's host to specific
-destination workloads. Routing rules let you set up complex traffic routing scenarios.
+destination workloads. Routing rules let you control traffic for tasks
+like A/B testing, canary rollouts, and staged rollouts with percentage-based traffic splits.

--- a/content/en/docs/reference/glossary/routing-rules.md
+++ b/content/en/docs/reference/glossary/routing-rules.md
@@ -1,9 +1,7 @@
 ---
 title: Routing Rules
 ---
-Routing rules, which you configure in a [virtual service](#virtual-service), define the paths that
-requests follow within the service mesh. With routing rules, you can define
-conditions to route traffic addressed to the [virtual service](#virtual-service)'s host to specific
-destination workloads. Routing rules let you set up complex
-[traffic routing](/docs/concepts/traffic-management/#virtual-services)
-scenarios.
+Routing rules, which you configure in a [virtual service](/docs/concepts/traffic-management/#virtual-services),
+define the paths that requests follow within the service mesh. With routing rules, you can define
+conditions to route traffic addressed to the virtual service's host to specific
+destination workloads. Routing rules let you set up complex traffic routing scenarios.

--- a/content/en/docs/reference/glossary/virtual-service.md
+++ b/content/en/docs/reference/glossary/virtual-service.md
@@ -1,8 +1,0 @@
----
-title: Virtual Service
----
-A virtual service is a resource you can use to configure how [Envoy](#envoy) proxies route
-requests to a service within an Istio service mesh. The routing rules that you
-define in a virtual service let you set up complex
-[traffic routing](/docs/concepts/traffic-management/#virtual-services)
-scenarios.


### PR DESCRIPTION
Virtual service is not a terms that belong in the glossary. It's the name of a configuration resource. Like all other configuration resources, references to it should point to its doc entry.