### PR TITLE
remove bin reference to istioctl

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -15,7 +15,7 @@ apply changes to a cluster.
 You can analyze your current Kubernetes cluster by running:
 
 {{< text bash >}}
-$ ./istioctl analyze -k
+$ istioctl analyze -k
 {{< /text >}}
 
 And that’s it! It’ll give you any recommendations that apply.
@@ -35,22 +35,22 @@ Typically, this is used to analyze the entire set of configuration files that ar
 Analyze a specific set of local Kubernetes yaml files:
 
 {{< text bash >}}
-$ ./istioctl analyze a.yaml b.yaml
+$ istioctl analyze a.yaml b.yaml
 {{< /text >}}
 
 Analyze all yaml files in the current folder:
 
 {{< text bash >}}
-$ ./istioctl analyze *.yaml
+$ istioctl analyze *.yaml
 {{< /text >}}
 
 Simulate applying the files in the current folder to the current cluster:
 
 {{< text bash >}}
-$ ./istioctl analyze -k *.yaml
+$ istioctl analyze -k *.yaml
 {{< /text >}}
 
-You can run `./istioctl analyze --help` to see the full set of options.
+You can run `istioctl analyze --help` to see the full set of options.
 
 ## Helping us improve this tool
 

--- a/content/en/docs/tasks/security/authentication/https-overlay/index.md
+++ b/content/en/docs/tasks/security/authentication/https-overlay/index.md
@@ -61,7 +61,7 @@ replicationcontroller "my-nginx" created
 Then, create another pod to call this service.
 
 {{< text bash >}}
-$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/sleep/sleep.yaml@)
+$ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@)
 {{< /text >}}
 
 Get the pods
@@ -111,7 +111,7 @@ $ kubectl delete -f @samples/https/nginx-app.yaml@
 Deploy it with a sidecar
 
 {{< text bash >}}
-$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/https/nginx-app.yaml@)
+$ kubectl apply -f <(istioctl kube-inject -f @samples/https/nginx-app.yaml@)
 {{< /text >}}
 
 Make sure the pod is up and running
@@ -191,10 +191,10 @@ prometheus-86cb6dd77c-ntw88                1/1       Running     0          23h
 Then redeploy the HTTPS service and sleep service
 
 {{< text bash >}}
-$ kubectl delete -f <(bin/istioctl kube-inject -f @samples/sleep/sleep.yaml@)
-$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/sleep/sleep.yaml@)
-$ kubectl delete -f <(bin/istioctl kube-inject -f @samples/https/nginx-app.yaml@)
-$ kubectl apply -f <(bin/istioctl kube-inject -f @samples/https/nginx-app.yaml@)
+$ kubectl delete -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@)
+$ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@)
+$ kubectl delete -f <(istioctl kube-inject -f @samples/https/nginx-app.yaml@)
+$ kubectl apply -f <(istioctl kube-inject -f @samples/https/nginx-app.yaml@)
 {{< /text >}}
 
 Make sure the pod is up and running


### PR DESCRIPTION
as all of our other tasks assume istioctl is on the path already.  Having it cause me an alert on my mac:

“istioctl” can’t be opened because Apple cannot check it for malicious software.