### PR TITLE
V1/2_POD_IP error when there are other pods labelled version=v1/2

### DIFF
--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -271,8 +271,8 @@ log entries for `v1` and none for `v2`:
 
     {{< text bash >}}
     $ export SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})
-    $ export V1_POD_IP=$(kubectl get pod -l app=httpbin -l version=v1 -o jsonpath={.items..status.podIP})
-    $ export V2_POD_IP=$(kubectl get pod -l app=httpbin -l version=v2 -o jsonpath={.items..status.podIP})
+    $ export V1_POD_IP=$(kubectl get pod -l app=httpbin,version=v1 -o jsonpath={.items..status.podIP})
+    $ export V2_POD_IP=$(kubectl get pod -l app=httpbin,version=v2 -o jsonpath={.items..status.podIP})
     $ kubectl exec -it $SLEEP_POD -c istio-proxy -- sudo tcpdump -A -s 0 host $V1_POD_IP or host $V2_POD_IP
     tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
     listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes

--- a/content/zh/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/zh/docs/tasks/traffic-management/mirroring/index.md
@@ -256,8 +256,8 @@ keywords: [traffic-management,mirroring]
 
     {{< text bash >}}
     $ export SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})
-    $ export V1_POD_IP=$(kubectl get pod -l app=httpbin -l version=v1 -o jsonpath={.items..status.podIP})
-    $ export V2_POD_IP=$(kubectl get pod -l app=httpbin -l version=v2 -o jsonpath={.items..status.podIP})
+    $ export V1_POD_IP=$(kubectl get pod -l app=httpbin,version=v1 -o jsonpath={.items..status.podIP})
+    $ export V2_POD_IP=$(kubectl get pod -l app=httpbin,version=v2 -o jsonpath={.items..status.podIP})
     $ kubectl exec -it $SLEEP_POD -c istio-proxy -- sudo tcpdump -A -s 0 host $V1_POD_IP or host $V2_POD_IP
     tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
     listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes


### PR DESCRIPTION
When there are multiple pods labelled version=v1, the V1_POD_IP is error, and so does V2_POD_IP. In my case for example, except httpbin, bookinfo example is also deployed in the cluster, which includes some pods labelled as version=v1, the result is like:

```
$ k g po
NAME                              READY   STATUS    RESTARTS   AGE
details-v1-78d78fbddf-fvgn5       2/2     Running   0          21h
httpbin-v1-6b4c749d6-cvk5r        2/2     Running   0          20h
httpbin-v2-5748c488bc-k7bwk       2/2     Running   0          20h
productpage-v1-596598f447-pmndz   2/2     Running   0          21h
ratings-v1-6c9dbf6b45-cchmb       2/2     Running   0          21h
reviews-v1-7bb8ffd9b6-2ljlx       2/2     Running   0          21h
reviews-v2-d7d75fff8-6p48p        2/2     Running   0          21h
reviews-v3-68964bc4c8-hxgsk       2/2     Running   0          21h
sleep-bb596f69d-wdlrj             2/2     Running   0          21h
$ export V1_POD_IP=$(kubectl get pod -l app=httpbin -l version=v1 -o jsonpath={.items..status.podIP})
$ echo $V1_POD_IP
10.244.50.74 10.244.193.205 10.244.50.78 10.244.50.75 10.244.193.204
```

After fixing it as the patch method, the result would be

```
$ export V1_POD_IP=$(kubectl get pod -l app=httpbin,version=v1 -o jsonpath={.items..status.podIP})
$ echo $V1_POD_IP
10.244.193.205
```