### PR TITLE
Update index.md installation options

### DIFF
--- a/content/en/docs/reference/config/installation-options/index.md
+++ b/content/en/docs/reference/config/installation-options/index.md
@@ -326,11 +326,11 @@ To get the exact set of supported options, please see the [Helm charts]({{< gith
 | `grafana.dashboardProviders.dashboardproviders.providers.orgId.disableDeletion` | `false` |  |
 | `grafana.dashboardProviders.dashboardproviders.providers.orgId.options.path` | `/var/lib/grafana/dashboards/istio` |  |
 
-## `istio_cni` options
+## `cni` options
 
 | Key | Default Value | Description |
 | --- | --- | --- |
-| `istio_cni.enabled` | `false` |  |
+| `cni.enabled` | `false` |  |
 
 ## `istiocoredns` options
 


### PR DESCRIPTION
if the user passed istio_cni it will trigger this error `error: bad path=value (values.istio_cni.enabled=true): unknown field "istio_cni" in v1alpha1.Values`
the right value is here: https://istio.io/docs/setup/additional-setup/cni/#installation which is supposed to be "cni.enabled=true"

Please provide a description for what this PR is for:
update a false key in the installation options docs