### PR TITLE
zh-transliation: 

### DIFF
--- a/content/zh/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
+++ b/content/zh/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
@@ -200,4 +200,4 @@ type: LoadBalancer
     ...
     {{< /text >}}
 
-您已经准备好[测试应用](/docs/examples/microservices-istio/production-testing)了。
+您已经准备好[测试应用](/zh/docs/examples/microservices-istio/production-testing)了。


### PR DESCRIPTION
Fixs link of references on master:

```bash
Total in 80946 ms
>> 495 files are free from spelling errors
>> 495 files are free from spelling errors
./content/zh/docs/examples/microservices-istio/bookinfo-kubernetes/index.md:203:您已经准备好[测试应用](/docs/examples/microservices-istio/production-testing)了。
Ensure translated content doesn't include references to English content
Running ["ImageCheck", "ScriptCheck", "OpenGraphCheck", "HtmlCheck", "LinkCheck"] on ["./public"] on *.html... 
```