### PR TITLE
zh-translation: change pass-though translate

### DIFF
--- a/content/zh/blog/2019/introducing-istio-operator/index.md
+++ b/content/zh/blog/2019/introducing-istio-operator/index.md
@@ -98,7 +98,7 @@ Operator controller 和 `istioctl` 命令共享相同的实现。重要的区别
 
 ## 从 Helm 迁移{#migration-from-helm}
 
-为了方便从使用 Helm 过渡，`istioctl` 和 controller 支持对 Helm 安装 API 的直通访问。
+为了方便从使用 Helm 过渡，`istioctl` 和 controller 支持对 Helm 安装 API 的透传访问。
 
 您可以使用 `istioctl --set` 来传递 Helm 配置选项，方法是将字符串 `values.` 放在配置选项前面。例如，对于这个 Helm 命令：
 

--- a/content/zh/docs/setup/install/istioctl/index.md
+++ b/content/zh/docs/setup/install/istioctl/index.md
@@ -40,7 +40,7 @@ $ istioctl manifest apply --set values.global.mtls.enabled=true --set values.glo
 {{< /text >}}
 
 通常，您可以像使用 [helm](/zh/docs/setup/install/helm/) 一样在 `istioctl` 中配置 `--set` 标志。
-唯一的区别是必须为配置路径增加 `values.` 前缀，因为这是 Helm 直通 API 的路径，如下所述。
+唯一的区别是必须为配置路径增加 `values.` 前缀，因为这是 Helm 透传 API 的路径，如下所述。
 
 ## 从外部 Chart 安装{#install-from-external-charts}
 

--- a/content/zh/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
@@ -1,6 +1,6 @@
 ---
 title: 无 TLS 终止的 Ingress Gateway
-description: 说明了如何为一个 ingress gateway 配置 SNI 直通。
+description: 说明了如何为一个 ingress gateway 配置 SNI 透传。
 weight: 30
 keywords: [traffic-management,ingress,https]
 aliases:
@@ -8,7 +8,7 @@ aliases:
 ---
 
 [安全网关](/zh/docs/tasks/traffic-management/ingress/secure-ingress-mount/)说明了如何为 HTTP 服务配置 HTTPS 访问入口。
-而本示例将说明如何为 HTTPS 服务配置 HTTPS 访问入口，即配置 Ingress Gateway 以执行 SNI 直通，而不是对传入请求进行 TLS 终止。
+而本示例将说明如何为 HTTPS 服务配置 HTTPS 访问入口，即配置 Ingress Gateway 以执行 SNI 透传，而不是对传入请求进行 TLS 终止。
 
 本任务中的 HTTPS 示例服务是一个简单的 [NGINX](https://www.nginx.com) 服务。
 在接下来的步骤中，你会先在你的 Kubernetes 集群中创建一个 NGINX 服务。


### PR DESCRIPTION
- [x] Docs

Change `pass-though` translate  from `直通`  to `透传` now.

Ref: [Wikipedia](https://zh.wikipedia.org/wiki/%E9%80%8F%E4%BC%A0) and [百度百科](https://baike.baidu.com/item/%E9%80%8F%E4%BC%A0)
