### PR TITLE
Add note about required permissions for `istioctl analyze`

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -97,6 +97,12 @@ the kind of information you should provide.
 
       The set of [configuration analysis messages](/docs/reference/config/analysis/) contains descriptions of each message along with suggested fixes.
 
+- **What permissions are needed to run this tool?**
+
+      `istioctl analyze` needs cluster-level read permissions on resources that can be analyzed, which includes all Istio resources as well as many Kubernetes resources.
+      A Kubernetes `ClusterRole` named `istio-analyze` defines the required permissions and is included with the Istio installation.
+      This `ClusterRole` can be bound to a user or service account as needed.
+
 ## Advanced
 
 ### Getting the latest version of `istioctl analyze`


### PR DESCRIPTION
Intended to accompany https://github.com/istio/istio/pull/19890. Helps fix https://github.com/istio/istio/issues/18177 by documenting the permissions requirements for `istioctl analyze`.