### PR TITLE
add notes for enabling mTLS for authz

### DIFF
--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -804,6 +804,21 @@ spec:
        ports: ["27017"]
 {{< /text >}}
 
+### Dependency on mutual TLS
+
+Istio uses mutual TLS to securely pass some information from the client to the
+server. Mutual TLS must be enabled before using any of the following fields in
+the authorization policy:
+
+- the `principals` field under the `source` section
+- the `namespaces` field under the `source` section
+- the `source.principal` custom condition
+- the `source.namespace` custom condition
+- the `connection.sni` custom condition
+
+Mutual TLS is not required if you don't use any of the above fields in the
+authorization policy.
+
 ### Using other authorization mechanisms
 
 While we strongly recommend using the Istio authorization mechanisms,

--- a/content/en/docs/reference/config/security/conditions/index.md
+++ b/content/en/docs/reference/config/security/conditions/index.md
@@ -21,15 +21,15 @@ For more information, refer to the [authorization concept page](/docs/concepts/s
 |------|-------------|--------------------|---------|
 | `request.headers` | HTTP request headers. The actual header name is surrounded by brackets | HTTP only | `key: request.headers[User-Agent]`<br/>`values: ["Mozilla/*"]` |
 | `source.ip`  | Source workload instance IP address, supports single IP or CIDR | HTTP and TCP | `key: source.ip`<br/>`values: ["10.1.2.3"]` |
-| `source.namespace`  | Source workload instance namespace | HTTP and TCP | `key: source.namespace`<br/>`values: ["default"]` |
-| `source.principal` | The identity of the source workload | HTTP and TCP | `key: source.principal`<br/>`values: ["cluster.local/ns/default/sa/productpage"]` |
+| `source.namespace`  | Source workload instance namespace, requires mutual TLS enabled | HTTP and TCP | `key: source.namespace`<br/>`values: ["default"]` |
+| `source.principal` | The identity of the source workload, requires mutual TLS enabled | HTTP and TCP | `key: source.principal`<br/>`values: ["cluster.local/ns/default/sa/productpage"]` |
 | `request.auth.principal` | The authenticated principal of the request. | HTTP only | `key: request.auth.principal`<br/>`values: ["accounts.my-svc.com/104958560606"]` |
 | `request.auth.audiences` | The intended audience(s) for this authentication information | HTTP only | `key: request.auth.audiences`<br/>`values: ["my-svc.com"]` |
 | `request.auth.presenter` | The authorized presenter of the credential | HTTP only | `key: request.auth.presenter`<br/>`values: ["123456789012.my-svc.com"]` |
 | `request.auth.claims` | Claims from the origin JWT. The actual claim name is surrounded by brackets | HTTP only | `key: request.auth.claims[iss]`<br/>`values: ["*@foo.com"]` |
 | `destination.ip` | Destination workload instance IP address, supports single IP or CIDR | HTTP and TCP | `key: destination.ip`<br/>`values: ["10.1.2.3", "10.2.0.0/16"]` |
 | `destination.port` | The recipient port on the server IP address, must be in the range [0, 65535] | HTTP and TCP | `key: destination.port`<br/>`values: ["80", "443"]` |
-| `connection.sni` | The server name indication | HTTP and TCP | `key: connection.sni`<br/>`values: ["www.example.com"]` |
+| `connection.sni` | The server name indication, requires mutual TLS enabled | HTTP and TCP | `key: connection.sni`<br/>`values: ["www.example.com"]` |
 | `experimental.envoy.filters.*` | Experimental metadata matching for filters, values wrapped in `[]` are matched as a list | HTTP and TCP | `key: experimental.envoy.filters.network.mysql_proxy[db.table]`<br/>`values: ["[update]"]` |
 
 {{< warning >}}

--- a/content/en/docs/tasks/security/authorization/authz-http/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-http/index.md
@@ -36,6 +36,11 @@ If you don't see the expected output in the browser as you follow the task, retr
 because some delay is possible due to caching and other propagation overhead.
 {{< /tip >}}
 
+{{< warning >}}
+This task requires mutual TLS enabled because the following examples use principal
+and namespace in the policies.
+{{< /warning >}}
+
 ## Configure access control for workloads using HTTP traffic
 
 Using Istio, you can easily setup access control for {{< gloss "workload" >}}workloads{{< /gloss >}}

--- a/content/en/docs/tasks/security/authorization/authz-tcp/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-tcp/index.md
@@ -36,6 +36,11 @@ If you don't see the expected output in the browser as you follow the task, retr
 because some delay is possible due to caching and other propagation overhead.
 {{< /tip >}}
 
+{{< warning >}}
+This task requires mutual TLS enabled because the following examples use principal
+and namespace in the policies.
+{{< /warning >}}
+
 ## Configure access control for a TCP workload
 
 By default, the [Bookinfo](/docs/examples/bookinfo/) example application only uses the HTTP protocol.


### PR DESCRIPTION
Make it clear some fields require mTLS as this is confusing many customers, we need another PR to add this directly in the API.