### PR TITLE
remove invalid anchor for lint

### DIFF
--- a/content/en/blog/2019/monitoring-external-service-traffic/index.md
+++ b/content/en/blog/2019/monitoring-external-service-traffic/index.md
@@ -98,7 +98,7 @@ This is where the BlackHole and Passthrough clusters are used.
     }
   {{< /text >}}
 
-  The route is setup as [direct response](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#envoy-api-msg-route-directresponseaction)
+  The route is setup as [direct response](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto)
   with `502` response code which means if no other routes match the Envoy proxy
   will directly return a `502` HTTP status code.
 

--- a/content/zh/blog/2019/monitoring-external-service-traffic/index.md
+++ b/content/zh/blog/2019/monitoring-external-service-traffic/index.md
@@ -98,7 +98,7 @@ This is where the BlackHole and Passthrough clusters are used.
     }
   {{< /text >}}
 
-  The route is setup as [direct response](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#envoy-api-msg-route-directresponseaction)
+  The route is setup as [direct response](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto)
   with `502` response code which means if no other routes match the Envoy proxy
   will directly return a `502` HTTP status code.
 


### PR DESCRIPTION
Because the [anchor of the external link](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#envoy-api-msg-route-directresponseaction) is invalid, all lint exceptions are caused (e.g. [some one pr](https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio.io/6295/lint_istio.io/3887/build-log.txt)). Can you merge them?

![image](https://user-images.githubusercontent.com/32058002/71825013-e10b4180-30d5-11ea-8393-06f4d9268a83.png)

![image](https://user-images.githubusercontent.com/32058002/71796732-27d14b00-3086-11ea-833b-c63521c0602b.png)