### PR TITLE
More accurate link to AuthorizationPolicy#conditions from conditions page

### DIFF
--- a/content/en/docs/reference/config/security/conditions/index.md
+++ b/content/en/docs/reference/config/security/conditions/index.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 This page describes the supported keys and value formats you can use as conditions
-in the `when` field of [authorization policy resources](/docs/reference/config/security/authorization-policy/).
+in the `when` field of an [authorization policy rule](/docs/reference/config/security/authorization-policy/#Rule).
 
 {{< warning >}}
 Unsupported keys and values are silently ignored.

--- a/content/pt-br/docs/reference/config/security/conditions/index.md
+++ b/content/pt-br/docs/reference/config/security/conditions/index.md
@@ -7,7 +7,7 @@ aliases:
 ---
 
 This page describes the supported keys and value formats you can use as conditions
-in the `when` field of [authorization policy resources](/pt-br/docs/reference/config/security/authorization-policy/).
+in the `when` field of an [authorization policy rule](/pt-br/docs/reference/config/security/authorization-policy/#Rule).
 
 {{< warning >}}
 Unsupported keys and values are silently ignored.


### PR DESCRIPTION
Linking Conditions page to Conditions header in AuthorizationPolicy page. I guess it is more accurate.