### PR TITLE
update documentation for TCP traffic shifting: use a dedicated namesp…

### DIFF
--- a/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
+++ b/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
@@ -58,13 +58,13 @@ weighted routing feature.
         $ kubectl apply -f @samples/tcp-echo/tcp-echo-services.yaml@ -n istio-io-tcp-traffic-shifting
         {{< /text >}}
 
-2.  Next, route all TCP traffic to the `v1` version of the `tcp-echo` microservice.
+1.  Next, route all TCP traffic to the `v1` version of the `tcp-echo` microservice.
 
     {{< text bash >}}
     $ kubectl apply -f @samples/tcp-echo/tcp-echo-all-v1.yaml@ -n istio-io-tcp-traffic-shifting
     {{< /text >}}
 
-3.  Confirm that the `tcp-echo` service is up and running.
+1.  Confirm that the `tcp-echo` service is up and running.
 
     The `$INGRESS_HOST` variable below is the External IP address of the ingress, as explained in
 the [Ingress Gateways](/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports) doc. To obtain the

--- a/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
+++ b/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
@@ -28,11 +28,16 @@ weighted routing feature.
 
 1.  To get started, deploy the `v1` version of the `tcp-echo` microservice.
 
+    *   First, create a namespace for testing TCP traffic shifting
+        {{< text bash >}}
+        $ kubectl create namespace istio-io-tcp-traffic-shifting
+        {{< /text >}}
+
     *   If you are using [manual sidecar injection](/docs/setup/additional-setup/sidecar-injection/#manual-sidecar-injection),
         use the following command
 
         {{< text bash >}}
-        $ kubectl apply -f <(istioctl kube-inject -f @samples/tcp-echo/tcp-echo-services.yaml@)
+        $ kubectl apply -f <(istioctl kube-inject -f @samples/tcp-echo/tcp-echo-services.yaml@) -n istio-io-tcp-traffic-shifting
         {{< /text >}}
 
         The [`istioctl kube-inject`](/docs/reference/commands/istioctl/#istioctl-kube-inject) command is used to manually modify the `tcp-echo-services.yaml`
@@ -40,25 +45,25 @@ weighted routing feature.
 
     *   If you are using a cluster with
         [automatic sidecar injection](/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection)
-        enabled, label the `default` namespace with `istio-injection=enabled`
+        enabled, label the `istio-io-tcp-traffic-shifting` namespace with `istio-injection=enabled`
 
         {{< text bash >}}
-        $ kubectl label namespace default istio-injection=enabled
+        $ kubectl label namespace istio-io-tcp-traffic-shifting istio-injection=enabled
         {{< /text >}}
 
         Then simply deploy the services using `kubectl`
 
         {{< text bash >}}
-        $ kubectl apply -f @samples/tcp-echo/tcp-echo-services.yaml@
+        $ kubectl apply -f @samples/tcp-echo/tcp-echo-services.yaml@ -n istio-io-tcp-traffic-shifting
         {{< /text >}}
 
-1.  Next, route all TCP traffic to the `v1` version of the `tcp-echo` microservice.
+2.  Next, route all TCP traffic to the `v1` version of the `tcp-echo` microservice.
 
     {{< text bash >}}
-    $ kubectl apply -f @samples/tcp-echo/tcp-echo-all-v1.yaml@
+    $ kubectl apply -f @samples/tcp-echo/tcp-echo-all-v1.yaml@ -n istio-io-tcp-traffic-shifting
     {{< /text >}}
 
-1.  Confirm that the `tcp-echo` service is up and running.
+3.  Confirm that the `tcp-echo` service is up and running.
 
     The `$INGRESS_HOST` variable below is the External IP address of the ingress, as explained in
 the [Ingress Gateways](/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports) doc. To obtain the
@@ -96,7 +101,7 @@ was routed to the `v1` version of the `tcp-echo` service.
 1.  Transfer 20% of the traffic from `tcp-echo:v1` to `tcp-echo:v2` with the following command:
 
     {{< text bash >}}
-    $ kubectl apply -f @samples/tcp-echo/tcp-echo-20-v2.yaml@
+    $ kubectl apply -f @samples/tcp-echo/tcp-echo-20-v2.yaml@ -n istio-io-tcp-traffic-shifting
     {{< /text >}}
 
     Wait a few seconds for the new rules to propagate.
@@ -104,7 +109,7 @@ was routed to the `v1` version of the `tcp-echo` service.
 1. Confirm that the rule was replaced:
 
     {{< text bash yaml >}}
-    $ kubectl get virtualservice tcp-echo -o yaml
+    $ kubectl get virtualservice tcp-echo -o yaml -n istio-io-tcp-traffic-shifting
     apiVersion: networking.istio.io/v1alpha3
     kind: VirtualService
     metadata:
@@ -175,6 +180,7 @@ article [Canary Deployments using Istio](/blog/2017/0.1-canary/).
 1. Remove the `tcp-echo` application and routing rules:
 
     {{< text bash >}}
-    $ kubectl delete -f @samples/tcp-echo/tcp-echo-all-v1.yaml@
-    $ kubectl delete -f @samples/tcp-echo/tcp-echo-services.yaml@
+    $ kubectl delete -f @samples/tcp-echo/tcp-echo-all-v1.yaml@ -n istio-io-tcp-traffic-shifting
+    $ kubectl delete -f @samples/tcp-echo/tcp-echo-services.yaml@ -n istio-io-tcp-traffic-shifting
+    $ kubectl delete namespace istio-io-tcp-traffic-shifting
     {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
+++ b/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
@@ -29,6 +29,7 @@ weighted routing feature.
 1.  To get started, deploy the `v1` version of the `tcp-echo` microservice.
 
     *   First, create a namespace for testing TCP traffic shifting
+
         {{< text bash >}}
         $ kubectl create namespace istio-io-tcp-traffic-shifting
         {{< /text >}}


### PR DESCRIPTION
Use dedicated namespace `istio-io-tcp-traffic-shifting` instead of `default` for running the test.
This is part of the changes - https://github.com/istio/istio/issues/18285

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure