### PR TITLE
adding layer5 adapter to the repos

### DIFF
--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -37,6 +37,7 @@ REPOS=(
     https://github.com/apigee/istio-mixer-adapter.git@master
     https://github.com/osswangxining/alicloud-istio-grpcadapter.git@master
     https://github.com/vmware/wavefront-adapter-for-istio.git@master
+    https://github.com/layer5io/layer5-istio-adapter.git@master
     https://github.com/apache/skywalking-data-collect-protocol.git@master
     https://github.com/ibm-cloud-security/app-identity-and-access-adapter.git@master
     https://github.com/newrelic/newrelic-istio-adapter.git@master


### PR DESCRIPTION
This PR adds Layer5 adapter to the list of adapters.

The areas that this PR affects.

[ ] Configuration Infrastructure
[ X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
