### PR TITLE
Updated cert-manager version

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
@@ -141,7 +141,7 @@ In order to have a certificate issued and managed by cert-manager you need to cr
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: ingress-cert

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-certmgr/index.md
@@ -186,7 +186,7 @@ Now to switch to the production `letsencrypt` issuer.  First we'll reapply the c
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: ingress-cert
@@ -210,7 +210,7 @@ EOF
 {{< /text >}}
 
 {{< text plain>}}
-certificate.certmanager.k8s.io/ingress-cert configured
+certificate.cert-manager.io/ingress-cert configured
 {{< /text >}}
 
 Now delete the secret to force cert-manager to request a new certificate from the production issuer:


### PR DESCRIPTION
As of v.10 of cert-manager the `apiVersion` has changed to `cert-manager.io/v1alpha2`


Update version of cert-manager to more recent version as of Oct of last year. If not this, then we should specify that the user must install an older version of cert-manager.


[ ] Configuration Infrastructure
[ x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure