### PR TITLE
Add option for Chinese

### DIFF
--- a/layouts/index.redir
+++ b/layouts/index.redir
@@ -19,7 +19,7 @@
 https://istio.netlify.com/* https://istio.io/:splat 301!
 
 # Redirect to translated sites
-# /  /zh   302  Language=zh
+/  /zh   302  Language=zh
 
 # Redirect for the helm charts
 /charts/ https://storage.googleapis.com/istio-release/releases/{{ .Site.Data.args.full_version }}/charts/ 301

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -76,12 +76,10 @@
                 </button>
 
                 <div id="gearDropdownContent" class="menu-content" aria-labelledby="gearDropdownButton" role="menu">
-                    <!--
                     <a tabindex="-1" role="menuitem" lang="en" id="switch-lang-en" {{ if eq $home.Lang "en" }}class="active"{{ end }}>English</a>
                     <a tabindex="-1" role="menuitem" lang="zh" id="switch-lang-zh" {{ if eq $home.Lang "zh" }}class="active"{{ end }}>中文</a>
 
                     <div role="separator"></div>
-                    -->
 
                     <a tabindex="-1" role="menuitem" class="active" id="light-theme-item">{{ i18n "light_theme" }}</a>
                     <a tabindex="-1" role="menuitem" id="dark-theme-item">{{ i18n "dark_theme" }}</a>


### PR DESCRIPTION
- [x] Docs

Hi, The translation of Istio Chinese by ServiceMesher is almost complete. Now, we wanna to make Chinese as an optional, I released the annotates in the header (i.e. this pr changed content) according to the [documentation](https://github.com/istio/istio.io#multi-language-support). 

In addition, I have two questions:

1. After modifying the `layouts/index.redir` file, the automatic redirection is not in my native language as described by [document](https://github.com/istio/istio.io#multi-language-support). This is caused by the lag of the document, or because the construction process of [preliminary](https://preliminary.istio.io/) and [release 1.4](https://istio.io/) are different?

![image](https://user-images.githubusercontent.com/32058002/73813202-3a23dd80-481a-11ea-88e9-1c70f44bc8a7.png)

2. I noticed that [preliminary](https://preliminary.istio.io/) now has a new language switch button, similar to this:

![image](https://user-images.githubusercontent.com/32058002/73812173-e6fc5b80-4816-11ea-90a3-acc3ebb35468.png)

But I think its user experience is not very good. It is not possible to directly select a language. You can only switch according to the list. You know, like polling, and I removed the annotates of the `layouts/partials/headers.html` file according to the [document](https://github.com/istio/istio.io#multi-language-support). It can select a language directly in the header like [Istio 1.2](https://archive.istio.io/v1.2/).

![image](https://user-images.githubusercontent.com/32058002/73813226-4dcf4400-481a-11ea-929e-7f20e7cc4165.png)

![image](https://user-images.githubusercontent.com/32058002/73812235-1f9c3500-4817-11ea-924e-059129b077b1.png)

I'm not sure my approach is correct, please help me to confirm it, thank you very much!

/cc @geeknoid  @rcaballeromx  @rootsongjc 

