### PR TITLE
Revert "Standealone Operator is beta in 1.5. (#6425)"

### DIFF
--- a/content/en/about/feature-stages/index.md
+++ b/content/en/about/feature-stages/index.md
@@ -86,7 +86,7 @@ Below is our list of existing features and their current phases. This informatio
 
 | Feature           | Phase
 |-------------------|-------------------
-| [Standalone Operator](/docs/setup/install/standalone-operator/) | Beta
+| [Standalone Operator](/docs/setup/install/standalone-operator/) | Alpha
 | [Kubernetes: Envoy Installation and Traffic Interception](/docs/setup/) | Stable
 | [Kubernetes: Istio Control Plane Installation](/docs/setup/) | Stable
 | [Attribute Expression Language](/docs/reference/config/policy-and-telemetry/expression-language/) | Stable


### PR DESCRIPTION
As per agreement in Environments WG meeting on Feb 12, 2020,
moving operator to Alpha.

This reverts commit b3713a2654fc0e4dff407772d1ffdfee78334f08.