### PR TITLE
Point to 1.5 branch of Istio

### DIFF
--- a/content/en/about/contribute/code-blocks/index.md
+++ b/content/en/about/contribute/code-blocks/index.md
@@ -264,14 +264,14 @@ repository. For the link to point to a different Istio repository
 instead, you can use the `repo` attribute, for example:
 
 {{< text markdown >}}
-{{</* text syntax="bash" repo="operator" */>}}
+{{</* text syntax="bash" repo="api" */>}}
 $ cat @README.md@
 {{</* /text */>}}
 {{< /text >}}
 
-The path renders as a link to the `README.md` file of the `istio/operator` repository:
+The path renders as a link to the `README.md` file of the `istio/api` repository:
 
-{{< text syntax="bash" repo="operator" >}}
+{{< text syntax="bash" repo="api" >}}
 $ cat @README.md@
 {{< /text >}}
 

--- a/content/pt-br/about/contribute/creating-and-editing-pages/index.md
+++ b/content/pt-br/about/contribute/creating-and-editing-pages/index.md
@@ -493,14 +493,14 @@ Normally, links will point to the current release branch of the `istio/istio` re
 that points to a different Istio repository instead, you can use the `repo` attribute:
 
 {{< text markdown >}}
-{{</* text syntax="bash" repo="operator" */>}}
+{{</* text syntax="bash" repo="api" */>}}
 $ cat @README.md@
 {{</* /text */>}}
 {{< /text >}}
 
 which renders as:
 
-{{< text syntax="bash" repo="operator" >}}
+{{< text syntax="bash" repo="api" >}}
 $ cat @README.md@
 {{< /text >}}
 

--- a/data/args.yml
+++ b/data/args.yml
@@ -25,7 +25,7 @@ archive_date: YYYY-MM-DD
 archive_search_refinement: "V1.1"
 
 # GitHub branch names used when the docs have links to GitHub
-source_branch_name: master
+source_branch_name: release-1.5
 doc_branch_name: master
 
 # The list of supported versions described by the docs


### PR DESCRIPTION
The linter is broken because a file was deleted from master. This file should exist in 1.5, but not master. However, the master docs for istio.io are the docs for release 1.5, so we cannot remove references to these files.