### PR TITLE
Doc fix [Standalone Operator Install]

### DIFF
--- a/content/en/docs/setup/install/standalone-operator/index.md
+++ b/content/en/docs/setup/install/standalone-operator/index.md
@@ -38,8 +38,9 @@ To install the Istio `demo` [configuration profile](/docs/setup/additional-setup
 using the operator, run the following command:
 
 {{< text bash >}}
+$ kubectl create ns istio-system
 $ kubectl apply -f - <<EOF
-apiVersion: install.istio.io/v1alpha2
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   namespace: istio-system
@@ -103,9 +104,8 @@ For example, you can switch the installation to the `default`
 profile with the following command:
 
 {{< text bash >}}
-$ kubectl create ns istio-system
 $ kubectl apply -f - <<EOF
-apiVersion: install.istio.io/v1alpha2
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   namespace: istio-system
@@ -120,7 +120,7 @@ For example, to enable the `Grafana` component and increase pilot memory request
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: install.istio.io/v1alpha2
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   namespace: istio-system

--- a/content/pt-br/docs/setup/install/standalone-operator/index.md
+++ b/content/pt-br/docs/setup/install/standalone-operator/index.md
@@ -40,8 +40,9 @@ To install the Istio `demo` [configuration profile](/pt-br/docs/setup/additional
 using the operator, run the following command:
 
 {{< text bash >}}
+$ kubectl create ns istio-system
 $ kubectl apply -f - <<EOF
-apiVersion: install.istio.io/v1alpha2
+apiVersion: install.istio.io/v1alpha1
 kind: IstioControlPlane
 metadata:
   namespace: istio-operator
@@ -111,7 +112,7 @@ profile with the following command:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: install.istio.io/v1alpha2
+apiVersion: install.istio.io/v1alpha1
 kind: IstioControlPlane
 metadata:
   namespace: istio-operator
@@ -126,7 +127,7 @@ For example, to disable the telemetry feature:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: install.istio.io/v1alpha2
+apiVersion: install.istio.io/v1alpha1
 kind: IstioControlPlane
 metadata:
   namespace: istio-operator

--- a/content/zh/docs/setup/install/standalone-operator/index.md
+++ b/content/zh/docs/setup/install/standalone-operator/index.md
@@ -37,8 +37,9 @@ aliases:
 运行以下命令用 operator 安装 Istio `demo` [配置文件](/zh/docs/setup/additional-setup/config-profiles/)：
 
 {{< text bash >}}
+$ kubectl create ns istio-system
 $ kubectl apply -f - <<EOF
-apiVersion: install.istio.io/v1alpha2
+apiVersion: install.istio.io/v1alpha1
 kind: IstioControlPlane
 metadata:
   namespace: istio-operator
@@ -99,7 +100,7 @@ prometheus-67cdb66cbb-9w2hm                                    1/1     Running  
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: install.istio.io/v1alpha2
+apiVersion: install.istio.io/v1alpha1
 kind: IstioControlPlane
 metadata:
   namespace: istio-operator
@@ -114,7 +115,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: install.istio.io/v1alpha2
+apiVersion: install.istio.io/v1alpha1
 kind: IstioControlPlane
 metadata:
   namespace: istio-operator


### PR DESCRIPTION
found during community testing:
- The version of API was incorrect.
- The first step of the doc did not have the namespace creation (it was
  in a 2nd step in the English version)