### PR TITLE
Add tip to download specific Istio version

### DIFF
--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -54,6 +54,13 @@ Download the Istio release which includes installation files, samples, and the
     $ curl -L https://istio.io/downloadIstio | sh -
     {{< /text >}}
 
+    {{< tip >}}
+    The command above downloads the latest release (numerically) of Istio.
+    To download a specific version, you can add a variable on the command line.
+    For example to download Istio 1.4.3, you would run
+      `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.4.3 sh -`
+    {{< /tip >}}
+
 1.  Move to the Istio package directory. For example, if the package is
     `istio-{{< istio_full_version >}}`:
 


### PR DESCRIPTION
Fixes #6530 

This desirable since on a Mac, one can't download the tar from the releases page and expect things to work. Using this command works, but we don't tell anyone how to use it to get an earlier release if needed.