### PR TITLE
(#6542) - add install, samples and out directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,12 @@ public
 resources
 node_modules
 generated
-install
-samples
-out
+
+# install generated files
+install/**
+
+# contains samples to demo Istio 
+samples/**
+
+# contains the built artifacts
+out/**

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ public
 resources
 node_modules
 generated
+install
+samples
+out


### PR DESCRIPTION
Output directories and directories created for the sake of running tests must be ignored. So add these to .gitignore directory.