### PR TITLE
(#6544) cloned istio repository path should not have double quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,7 @@ install/**
 samples/**
 
 # contains the built artifacts
-out/**
+out/** 
+
+# contains cloned istio repository
+go/**

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -14,7 +14,7 @@ GOPATH ?= $(shell cd ${ISTIOIO_GO}/../../..; pwd)
 export GOPATH
 
 # Set the directory for Istio source.
-ISTIO_GO ?= "${GOPATH}/src/istio.io/istio"
+ISTIO_GO ?= ${GOPATH}/src/istio.io/istio
 export ISTIO_GO
 
 # If GOPATH is made up of several paths, use the first one for our targets in this Makefile


### PR DESCRIPTION
Cloned Istio repository during testing should not map to a directory with double-quote (") as its name. It is very annoying.  