### PR TITLE
Updated pilot options

### DIFF
--- a/content/en/docs/reference/config/installation-options/index.md
+++ b/content/en/docs/reference/config/installation-options/index.md
@@ -445,7 +445,8 @@ To get the exact set of supported options, please see the [Helm charts]({{< gith
 | `pilot.image` | `pilot` |  |
 | `pilot.sidecar` | `true` |  |
 | `pilot.traceSampling` | `1.0` |  |
-| `pilot.enableProtocolSniffing` | `false` | `if protocol sniffing is enabled. Default to false.` |
+| `pilot.enableProtocolSniffingForOutbound` | `true` | `if protocol sniffing is enabled for outbound` |
+| `pilot.enableProtocolSniffingForInbound` | `false` | `if protocol sniffing is enabled for inbound` |
 | `pilot.resources.requests.cpu` | `500m` |  |
 | `pilot.resources.requests.memory` | `2048Mi` |  |
 | `pilot.env.PILOT_PUSH_THROTTLE` | `100` |  |


### PR DESCRIPTION
pilot no longer use `enableProtocolSniffing` anymore, it has two separate settings for both inbound and outbound instead.