### PR TITLE
Update docs and manifest for kubectl install of operator

### DIFF
--- a/content/en/docs/setup/install/standalone-operator/index.md
+++ b/content/en/docs/setup/install/standalone-operator/index.md
@@ -34,11 +34,11 @@ instead.
 
     Alternatively, you can deploy using `kubectl` from a pre-rendered manifest, which will install the latest released
     version of the operator:
-    
+
     {{< text bash >}}
     $ kubectl apply -f https://istio.io/operator.yaml
     {{< /text >}}
-    
+
 ## Install
 
 To install the Istio `demo` [configuration profile](/docs/setup/additional-setup/config-profiles/)

--- a/content/en/docs/setup/install/standalone-operator/index.md
+++ b/content/en/docs/setup/install/standalone-operator/index.md
@@ -32,6 +32,13 @@ instead.
     - A service to access operator metrics
     - Necessary Istio operator RBAC rules
 
+    Alternatively, you can deploy using `kubectl` from a pre-rendered manifest, which will install the latest released
+    version of the operator:
+    
+    {{< text bash >}}
+    $ kubectl apply -f https://istio.io/operator.yaml
+    {{< /text >}}
+    
 ## Install
 
 To install the Istio `demo` [configuration profile](/docs/setup/additional-setup/config-profiles/)
@@ -128,13 +135,14 @@ metadata:
 spec:
   profile: default
   components:
+    pilot:
+      k8s:
+        resources:
+          requests:
+            memory: 3072Mi
+  addonComponents:
     grafana:
       enabled: true
-  pilot:
-    k8s:
-      resources:
-        requests:
-          memory: 3072Mi
 EOF
 {{< /text >}}
 

--- a/static/operator.yaml
+++ b/static/operator.yaml
@@ -196,9 +196,9 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: gcr.io/istio-testing/operator:1.6-dev
+          image: docker.io/istio/operator:1.5.0-beta.4
           command:
-          - manager
+          - operator
           - server
           imagePullPolicy: IfNotPresent
           resources:
@@ -210,7 +210,7 @@ spec:
               memory: 128Mi
           env:
             - name: WATCH_NAMESPACE
-              value: "istio-operator"
+              value: "istio-system"
             - name: LEADER_ELECTION_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This restores the previously deleted option of installing from pre-rendered manifest and updates said manifest.