### PR TITLE
Removed unneeded command from snippet

### DIFF
--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -241,7 +241,7 @@ For example, to configure the **demo** profile with mutual TLS enabled:
 $ helm install install/kubernetes/helm/istio --name istio --namespace istio-system \
     --values install/kubernetes/helm/istio/values-istio-demo.yaml \
     --set global.controlPlaneSecurityEnabled=true \
-    --set global.mtls.enabled=true | kubectl apply -f -
+    --set global.mtls.enabled=true
 {{< /text >}}
 
 {{< /tab >}}


### PR DESCRIPTION
> Should address https://github.com/istio/istio.io/issues/6647.. The PR removes an seemingly erroneously included command in the Helm install (with Tiller) docs for 1.5 beta.3 (specifically, but it also shows in 1.4 and earlier docs. 