### PR TITLE
Fixed anchor links to point at glossary

### DIFF
--- a/content/en/docs/reference/glossary/adapters.md
+++ b/content/en/docs/reference/glossary/adapters.md
@@ -2,7 +2,7 @@
 title: Adapters
 ---
 
-Adapters are plug-ins to [Mixer](#mixer), Istio's [policy and telemetry](/docs/reference/config/policy-and-telemetry/) component, which enable it to interface
+Adapters are plug-ins to [Mixer](/docs/reference/glossary/#mixer), Istio's [policy and telemetry](/docs/reference/config/policy-and-telemetry/) component, which enable it to interface
 with an open-ended set of infrastructure backends that deliver core functionality, such as logging,
 monitoring, quotas, ACL checking, and more.
 The exact set of adapters used at runtime is determined through configuration and can easily be

--- a/content/en/docs/reference/glossary/data-plane.md
+++ b/content/en/docs/reference/glossary/data-plane.md
@@ -3,5 +3,5 @@ title: Data Plane
 ---
 
 The data plane is the part of the mesh that directly controls communication between workload instances.
-Istio's data plane uses intelligent [Envoy](#envoy) proxies deployed as sidecars to mediate and control all
+Istio's data plane uses intelligent [Envoy](/docs/reference/glossary/#envoy) proxies deployed as sidecars to mediate and control all
 traffic that your mesh services send and receive.

--- a/content/en/docs/reference/glossary/destination.md
+++ b/content/en/docs/reference/glossary/destination.md
@@ -1,4 +1,4 @@
 ---
 title: Destination
 ---
-A remote [service](#service) that [Envoy](#envoy) interacts with on behalf of a [source](#source) [workload](#workload).
+A remote [service](/docs/reference/glossary/#service) that [Envoy](/docs/reference/glossary/#envoy) interacts with on behalf of a [source](/docs/reference/glossary/#source) [workload](/docs/reference/glossary/#workload).

--- a/content/en/docs/reference/glossary/envoy.md
+++ b/content/en/docs/reference/glossary/envoy.md
@@ -1,5 +1,5 @@
 ---
 title: Envoy
 ---
-The high-performance proxy that Istio uses to mediate inbound and outbound traffic for all [services](#service) in the
-[service mesh](#service-mesh). [Learn more about Envoy](https://envoyproxy.github.io/envoy/).
+The high-performance proxy that Istio uses to mediate inbound and outbound traffic for all [services](/docs/reference/glossary/#service) in the
+[service mesh](/docs/reference/glossary/#service-mesh). [Learn more about Envoy](https://envoyproxy.github.io/envoy/).

--- a/content/en/docs/reference/glossary/mixer-handler.md
+++ b/content/en/docs/reference/glossary/mixer-handler.md
@@ -4,4 +4,4 @@ title: Mixer Handler
 
 Handlers represent fully configured Mixer adapters. A single binary adapter can be used
 with different configurations, each such configuration is known as a handler. At
-runtime, Mixer routes [instances](#mixer-instance) to one or more handlers.
+runtime, Mixer routes [instances](/docs/reference/glossary/#mixer-instance) to one or more handlers.

--- a/content/en/docs/reference/glossary/mixer-instance.md
+++ b/content/en/docs/reference/glossary/mixer-instance.md
@@ -2,6 +2,6 @@
 title: Mixer Instance
 ---
 
-An instance represents a chunk of Mixer data that is produced by inspecting a set of request [attributes](#attribute) and applying the operator-supplied configuration.
-Instances are delivered to individual [handlers](#mixer-handler), on their way to
+An instance represents a chunk of Mixer data that is produced by inspecting a set of request [attributes](/docs/reference/glossary/#attribute) and applying the operator-supplied configuration.
+Instances are delivered to individual [handlers](/docs/reference/glossary/#mixer-handler), on their way to
 infrastructure backends.

--- a/content/en/docs/reference/glossary/mixer.md
+++ b/content/en/docs/reference/glossary/mixer.md
@@ -2,6 +2,6 @@
 title: Mixer
 ---
 
-The Istio component is responsible for enforcing access control and usage policies across the [service mesh](#service-mesh) and collecting telemetry data
-from [Envoy](#envoy) and other services.
+The Istio component is responsible for enforcing access control and usage policies across the [service mesh](/docs/reference/glossary/#service-mesh) and collecting telemetry data
+from [Envoy](/docs/reference/glossary/#envoy) and other services.
 [Learn more about Mixer](/docs/reference/config/policy-and-telemetry/).

--- a/content/en/docs/reference/glossary/pilot.md
+++ b/content/en/docs/reference/glossary/pilot.md
@@ -1,4 +1,4 @@
 ---
 title: Pilot
 ---
-The Istio component that programs the [Envoy](#envoy) proxies, responsible for service discovery, load balancing, and routing.
+The Istio component that programs the [Envoy](/docs/reference/glossary/#envoy) proxies, responsible for service discovery, load balancing, and routing.

--- a/content/en/docs/reference/glossary/pod.md
+++ b/content/en/docs/reference/glossary/pod.md
@@ -3,5 +3,5 @@ title: Pod
 ---
 A Pod is a group of one or more containers (such as [Docker](https://www.docker.com/) containers),
 with shared storage and network, and a specification for how to run the containers.
-Pods are the [workload instances](#workload-instance) in a
+Pods are the [workload instances](/docs/reference/glossary/#workload-instance) in a
 [Kubernetes](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/) deployment of Istio.

--- a/content/en/docs/reference/glossary/secure-naming.md
+++ b/content/en/docs/reference/glossary/secure-naming.md
@@ -1,5 +1,5 @@
 ---
 title: Secure Naming
 ---
-Provides a mapping between a [service name](#service-name) and the [workload instance principals](#workload-instance-principal) that are authorized to
-run the [workload instances](#workload-instance) implementing a [service](#service).
+Provides a mapping between a [service name](/docs/reference/glossary/#service-name) and the [workload instance principals](/docs/reference/glossary/#workload-instance-principal) that are authorized to
+run the [workload instances](/docs/reference/glossary/#workload-instance) implementing a [service](/docs/reference/glossary/#service).

--- a/content/en/docs/reference/glossary/service-consumer.md
+++ b/content/en/docs/reference/glossary/service-consumer.md
@@ -1,4 +1,4 @@
 ---
 title: Service Consumer
 ---
-The agent that is using a [service](#service).
+The agent that is using a [service](/docs/reference/glossary/#service).

--- a/content/en/docs/reference/glossary/service-endpoint.md
+++ b/content/en/docs/reference/glossary/service-endpoint.md
@@ -1,6 +1,6 @@
 ---
 title: Service Endpoint
 ---
-The network-reachable manifestation of a [service](#service).
-[Workload instances](#workload-instance) expose service endpoints but not all
+The network-reachable manifestation of a [service](/docs/reference/glossary/#service).
+[Workload instances](/docs/reference/glossary/#workload-instance) expose service endpoints but not all
 services have service endpoints.

--- a/content/en/docs/reference/glossary/service-mesh.md
+++ b/content/en/docs/reference/glossary/service-mesh.md
@@ -11,5 +11,5 @@ the `bar` service in the `foo` namespace in `cluster-1` is considered the same
 service as the `bar` service in the `foo` namespace in `cluster-2`.
 
 Since [identities](/docs/reference/glossary/#identity) are shared within the service
-mesh, [workload instances](#workload-instance) can authenticate communication with any other [workload
-instance](#workload-instance) within the same service mesh.
+mesh, [workload instances](/docs/reference/glossary/#workload-instance) can authenticate communication with any other [workload
+instance](/docs/reference/glossary/#workload-instance) within the same service mesh.

--- a/content/en/docs/reference/glossary/service-name.md
+++ b/content/en/docs/reference/glossary/service-name.md
@@ -1,6 +1,6 @@
 ---
 title: Service Name
 ---
-A name that uniquely identifies a [service](#service) within the [service mesh](#service-mesh).
+A name that uniquely identifies a [service](/docs/reference/glossary/#service) within the [service mesh](/docs/reference/glossary/#service-mesh).
 A service may not be renamed while maintaining its identity.
-A service may have multiple [versions](#service-version), but a service name is version-independent.
+A service may have multiple [versions](/docs/reference/glossary/#service-version), but a service name is version-independent.

--- a/content/en/docs/reference/glossary/service-operator.md
+++ b/content/en/docs/reference/glossary/service-operator.md
@@ -1,5 +1,5 @@
 ---
 title: Service Operator
 ---
-The agent that manages a [service](#service) within a [service mesh](#service-mesh) by manipulating configuration state
+The agent that manages a [service](/docs/reference/glossary/#service) within a [service mesh](/docs/reference/glossary/#service-mesh) by manipulating configuration state
 and monitoring the service's health via a variety of dashboards.

--- a/content/en/docs/reference/glossary/service-producer.md
+++ b/content/en/docs/reference/glossary/service-producer.md
@@ -1,4 +1,4 @@
 ---
 title: Service Producer
 ---
-The agent that creates a [service](#service).
+The agent that creates a [service](/docs/reference/glossary/#service).

--- a/content/en/docs/reference/glossary/service-registry.md
+++ b/content/en/docs/reference/glossary/service-registry.md
@@ -2,12 +2,12 @@
 title: Service Registry
 ---
 
-Istio maintains an internal service registry containing the set of [services](#service),
-and their corresponding [service endpoints](#service-endpoint), running in a service mesh.
-Istio uses the service registry to generate [Envoy](#envoy) configuration.
+Istio maintains an internal service registry containing the set of [services](/docs/reference/glossary/#service),
+and their corresponding [service endpoints](/docs/reference/glossary/#service-endpoint), running in a service mesh.
+Istio uses the service registry to generate [Envoy](/docs/reference/glossary/#envoy) configuration.
 
 Istio does not provide [service discovery](https://en.wikipedia.org/wiki/Service_discovery),
-although most services are automatically added to the registry by [Pilot](#pilot)
+although most services are automatically added to the registry by [Pilot](/docs/reference/glossary/#pilot)
 adapters that reflect the discovered services of the underlying platform (Kubernetes, Consul, plain DNS).
 Additional services can also be registered manually using a
 [`ServiceEntry`](/docs/concepts/traffic-management/#service-entries) configuration.

--- a/content/en/docs/reference/glossary/service-version.md
+++ b/content/en/docs/reference/glossary/service-version.md
@@ -1,5 +1,5 @@
 ---
 title: Service Version
 ---
-Distinct variants of a [service](#service), typically backed by different versions of a [workload](#workload) binary.
+Distinct variants of a [service](/docs/reference/glossary/#service), typically backed by different versions of a [workload](/docs/reference/glossary/#workload) binary.
 Common scenarios where multiple service versions may be used include A/B testing and canary rollouts.

--- a/content/en/docs/reference/glossary/service.md
+++ b/content/en/docs/reference/glossary/service.md
@@ -1,8 +1,8 @@
 ---
 title: Service
 ---
-A delineated group of related behaviors within a [service mesh](#service-mesh). Services are identified using a
-[service name](#service-name),
+A delineated group of related behaviors within a [service mesh](/docs/reference/glossary/#service-mesh). Services are identified using a
+[service name](/docs/reference/glossary/#service-name),
 and Istio policies such as load balancing and routing are applied using these names.
-A service is typically materialized by one or more [service endpoints](#service-endpoint), and may consist of multiple
-[service versions](#service-version).
+A service is typically materialized by one or more [service endpoints](/docs/reference/glossary/#service-endpoint), and may consist of multiple
+[service versions](/docs/reference/glossary/#service-version).

--- a/content/en/docs/reference/glossary/source.md
+++ b/content/en/docs/reference/glossary/source.md
@@ -1,7 +1,7 @@
 ---
 title: Source
 ---
-The downstream client of the [Envoy](#envoy) proxy.
-Within the [service mesh](#service-mesh) a source is typically a
-[workload](#workload), but the source for ingress traffic may include other clients such as a
+The downstream client of the [Envoy](/docs/reference/glossary/#envoy) proxy.
+Within the [service mesh](/docs/reference/glossary/#service-mesh) a source is typically a
+[workload](/docs/reference/glossary/#workload), but the source for ingress traffic may include other clients such as a
 browser or mobile app.

--- a/content/en/docs/reference/glossary/workload-instance-principal.md
+++ b/content/en/docs/reference/glossary/workload-instance-principal.md
@@ -1,9 +1,9 @@
 ---
 title: Workload Instance Principal
 ---
-The verifiable authority under which a [workload instance](#workload-instance) runs.
+The verifiable authority under which a [workload instance](/docs/reference/glossary/#workload-instance) runs.
 Istio's service-to-service authentication is used to produce the workload principal.
 By default workload principals are compliant with the SPIFFE ID format.
 
 Workload instance principals are available in policy and telemetry configuration
-using the `source.principal` and `destination.principal` [attributes](#attribute).
+using the `source.principal` and `destination.principal` [attributes](/docs/reference/glossary/#attribute).

--- a/content/en/docs/reference/glossary/workload-instance.md
+++ b/content/en/docs/reference/glossary/workload-instance.md
@@ -1,9 +1,9 @@
 ---
 title: Workload Instance
 ---
-A single instantiation of a [workload's](#workload) binary.
-A workload instance can expose zero or more [service endpoints](#service-endpoint),
-and can consume zero or more [services](#service).
+A single instantiation of a [workload's](/docs/reference/glossary/#workload) binary.
+A workload instance can expose zero or more [service endpoints](/docs/reference/glossary/#service-endpoint),
+and can consume zero or more [services](/docs/reference/glossary/#service).
 
 Workload instances have a number of properties:
 

--- a/content/en/docs/reference/glossary/workload.md
+++ b/content/en/docs/reference/glossary/workload.md
@@ -1,13 +1,13 @@
 ---
 title: Workload
 ---
-A binary deployed by [operators](#operator) to deliver some function of a service mesh application.
+A binary deployed by [operators](/docs/reference/glossary/#operator) to deliver some function of a service mesh application.
 Workloads have names, namespaces, and unique ids. These properties are available in policy and telemetry configuration
-using the following [attributes](#attribute):
+using the following [attributes](/docs/reference/glossary/#attribute):
 
 * `source.workload.name`, `source.workload.namespace`, `source.workload.uid`
 * `destination.workload.name`, `destination.workload.namespace`, `destination.workload.uid`
 
 In Kubernetes, a workload typically corresponds to a Kubernetes deployment,
-while a [workload instance](#workload-instance) corresponds to an individual [pod](#pod) managed
+while a [workload instance](/docs/reference/glossary/#workload-instance) corresponds to an individual [pod](/docs/reference/glossary/#pod) managed
 by the deployment.


### PR DESCRIPTION
This fixes #6651. In it, many pages, are local links (i.e. #envoy). This works when the user views the glossary page itself, but fails when the user takes advantage of the embedded definitions in other pages due to the fact that the anchors are now located on those other pages. 


[ ] Configuration Infrastructure
[ x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure