### PR TITLE
change example for setting additional param

### DIFF
--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -41,10 +41,10 @@ Kubernetes configuration. The `default` profile is a good starting point
 for establishing a production environment, unlike the larger `demo` profile that
 is intended for evaluating a broad set of Istio features.
 
-If you want to secure Istio control plane service endpoints on top of the `default` profile, you can set the security related configuration parameters:
+If you want to enable mesh wide mutual TLS on top of the `default` profile, you can set the security related configuration parameters:
 
 {{< text bash >}}
-$ istioctl manifest apply --set values.global.controlPlaneSecurityEnabled=true
+$ istioctl manifest apply --set values.global.mtls.enabled=true
 {{< /text >}}
 
 In general, you can use the `--set` flag in `istioctl` as you would with

--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -41,10 +41,10 @@ Kubernetes configuration. The `default` profile is a good starting point
 for establishing a production environment, unlike the larger `demo` profile that
 is intended for evaluating a broad set of Istio features.
 
-If you want to enable mesh wide mutual TLS on top of the `default` profile, you can set the security related configuration parameters:
+If you want to use Kubernetes as the certificate provider for DNS certificates on top of the `default` profile, you can set the following configuration parameter:
 
 {{< text bash >}}
-$ istioctl manifest apply --set values.global.mtls.enabled=true
+$ istioctl manifest apply --set values.global.pilotCertProvider=kubernetes
 {{< /text >}}
 
 In general, you can use the `--set` flag in `istioctl` as you would with


### PR DESCRIPTION
because the control plane security enabled is already true by default so overwriting it won't do anything.



[ ] Configuration Infrastructure
[x ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure