### PR TITLE
authz: add task for IP allow list and black list on ingress gateway

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -9,7 +9,7 @@ This task shows you how to enforce access control on an Istio ingress gateway
 using an authorization policy.
 
 An Istio authorization policy supports IP-based allow lists or deny lists as well as
-attribute-based allow list or deny list previously provided by the Mixer policy.
+the attribute-based allow lists or deny lists previously provided by Mixer policy.
 The Mixer policy is deprecated in 1.5 and not recommended for production use.
 
 ## Before you begin

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -6,10 +6,10 @@ keywords: [security,access-control,rbac,authorization,ingress,ip,whitelist,black
 ---
 
 This task shows you how to enforce access control on an Istio ingress gateway
-using an authorization policy. 
+using an authorization policy.
 
-The authorization policy supports IP-based whitelists or blacklists and
-attribute-based whitelists or blacklists previously provided by the Mixer policy.
+The authorization policy supports IP-based allow list or deny list and
+attribute-based allow list or deny list previously provided by the Mixer policy.
 The Mixer policy is deprecated in 1.5 and not recommended for production use.
 
 ## Before you begin
@@ -21,7 +21,7 @@ Before you begin this task, perform the following actions:
 * Install Istio using the [Istio installation guide](/docs/setup/install/istioctl/).
 
 * Deploy a workload, `httpbin` in a namespace named, for example, `foo` and expose it
-through the Istio ingress gateway with this command:
+through the Istio ingress gateway with this command.
 
     {{< text bash >}}
     $ kubectl create ns foo
@@ -31,22 +31,23 @@ through the Istio ingress gateway with this command:
 
 * Update the ingress gateway to set `externalTrafficPolicy: local` to preserve the
 original client source IP on the ingress gateway using the following command.
-See [Source IP for Services with Type=NodePort](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport)
+See [Source IP for Services with `Type=NodePort`](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport)
 for more information.
 
     {{< text bash >}}
     $ kubectl patch svc istio-ingressgateway -n istio-system -p '{"spec":{"externalTrafficPolicy":"Local"}}'
     {{< /text >}}
- 
+
 * Verify that the `httpbin` workload and ingress gateway are working as expected using this command.
+
     {{< text bash >}}
     $ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
     $ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
- 
+
 * Verify the ingress gateway receives the original client source IP address, which
-will be used in the authorization policy in this task:
+will be used in the authorization policy in this task.
 
     {{< text bash >}}
     $ CLIENT_IP=$(curl $INGRESS_HOST/ip -s | grep "origin" | cut -d'"' -f 4) && echo $CLIENT_IP
@@ -58,7 +59,7 @@ If you don’t see the expected output as you follow the task, retry after a few
 Caching and propagation overhead can cause some delay.
 {{< /warning >}}
 
-## IP-based whitelists and blacklists
+## IP-based allow list and deny list
 
 1. The following command creates the authorization policy, `ingress-policy`, for
 the Istio ingress gateway. The following policy sets the `action` field to `ALLOW` to

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -1,6 +1,6 @@
 ---
 title: Authorization on Ingress Gateway
-description: How to set up access control on ingress gateway.
+description: How to set up access control on an ingress gateway.
 weight: 50
 keywords: [security,access-control,rbac,authorization,ingress,ip,allowlist,denylist]
 ---

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -1,0 +1,168 @@
+---
+title: Authorization on Ingress Gateway
+description: Shows how to set up access control on ingress gateway.
+weight: 50
+keywords: [security,access-control,rbac,authorization,ingress,ip,whitelist,blacklist]
+---
+
+This task shows you how to enforce access control on an Istio ingress gateway
+using an authorization policy. 
+
+The authorization policy supports IP-based whitelists or blacklists and
+attribute-based whitelists or blacklists previously provided by the Mixer policy.
+The Mixer policy is deprecated in 1.5 and not recommended for production use.
+
+## Before you begin
+
+Before you begin this task, perform the following actions:
+
+* Read the [Authorization conceptual documentation](/docs/concepts/security/#authorization).
+
+* Install Istio using the [Istio installation guide](/docs/setup/install/istioctl/).
+
+* Deploy a workload, `httpbin` in a namespace named, for example, `foo` and expose it
+through the Istio ingress gateway with this command:
+
+    {{< text bash >}}
+    $ kubectl create ns foo
+    $ kubectl apply -f <(istioctl kube-inject -f samples/httpbin/httpbin.yaml) -n foo
+    $ kubectl apply -f <(istioctl kube-inject -f samples/httpbin/httpbin-gateway.yaml) -n foo
+    {{< /text >}}
+
+* Update the ingress gateway to set `externalTrafficPolicy: local` to preserve the
+original client source IP on the ingress gateway using the following command.
+See [Source IP for Services with Type=NodePort](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport)
+for more information.
+
+    {{< text bash >}}
+    $ kubectl patch svc istio-ingressgateway -n istio-system -p '{"spec":{"externalTrafficPolicy":"Local"}}'
+    {{< /text >}}
+ 
+* Verify that the `httpbin` workload and ingress gateway are working as expected using this command.
+    {{< text bash >}}
+    $ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    $ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
+    200
+    {{< /text >}}
+ 
+* Verify the ingress gateway receives the original client source IP address, which
+will be used in the authorization policy in this task:
+
+    {{< text bash >}}
+    $ CLIENT_IP=$(curl $INGRESS_HOST/ip -s | grep "origin" | cut -d'"' -f 4) && echo $CLIENT_IP
+    105.133.10.12
+    {{< /text >}}
+
+{{< warning >}}
+If you don’t see the expected output as you follow the task, retry after a few seconds.
+Caching and propagation overhead can cause some delay.
+{{< /warning >}}
+
+## IP-based whitelists and blacklists
+
+1. The following command creates the authorization policy, `ingress-policy`, for
+the Istio ingress gateway. The following policy sets the `action` field to `ALLOW` to
+allow the IP addresses specified in the `ipBlocks` to access the ingress gateway,
+IP addresses not in the list will be denied, also known as whitelist-style access control.
+The `ipBlocks` supports both single IP address and CIDR notation.
+
+    {{< text bash >}}
+    $ kubectl apply -f - <<EOF
+    apiVersion: security.istio.io/v1beta1
+    kind: AuthorizationPolicy
+    metadata:
+      name: ingress-policy
+      namespace: istio-system
+    spec:
+      selector:
+        matchLabels:
+          app: istio-ingressgateway
+      action: ALLOW
+      rules:
+      - from:
+        - source:
+           ipBlocks: ["1.2.3.4", "5.6.7.0/24"]
+    EOF
+    {{< /text >}}
+
+1. Verify that a request to the ingress gateway is denied.
+
+    {{< text bash >}}
+    $ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
+    403
+    {{< /text >}}
+
+1. Update the `ingress-policy` to include your client IP address.
+
+    {{< text bash >}}
+    $ kubectl apply -f - <<EOF
+    apiVersion: security.istio.io/v1beta1
+    kind: AuthorizationPolicy
+    metadata:
+      name: ingress-policy
+      namespace: istio-system
+    spec:
+      selector:
+        matchLabels:
+          app: istio-ingressgateway
+      action: ALLOW
+      rules:
+      - from:
+        - source:
+           ipBlocks: ["1.2.3.4", "5.6.7.0/24", "$CLIENT_IP"]
+    EOF
+    {{< /text >}}
+
+1. Verify that a request to the ingress gateway is allowed.
+
+    {{< text bash >}}
+    $ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
+    200
+    {{< /text >}}
+
+1. The following command updates the `ingress-policy` authorization policy to set
+the `action` key to `DENY` so that the IP addresses specified in the `ipBlocks` are
+not allowed to access the ingress gateway, also known as blacklist-style access control:
+
+    {{< text bash >}}
+    $ kubectl apply -f - <<EOF
+    apiVersion: security.istio.io/v1beta1
+    kind: AuthorizationPolicy
+    metadata:
+      name: ingress-policy
+      namespace: istio-system
+    spec:
+      selector:
+        matchLabels:
+          app: istio-ingressgateway
+      action: DENY
+      rules:
+      - from:
+        - source:
+           ipBlocks: ["$CLIENT_IP"]
+    EOF
+    {{< /text >}}
+
+1. Verify that a request to the ingress gateway is denied.
+
+    {{< text bash >}}
+    $ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
+    403
+    {{< /text >}}
+
+1. You could use an online proxy service to access the ingress gateway that uses a
+different client IP to verify the request is allowed.
+
+## Clean up
+
+1. Remove the namespace `foo` from your configuration:
+
+    {{< text bash >}}
+    $ kubectl delete namespace foo
+    {{< /text >}}
+
+1. Remove the authorization policy:
+
+    {{< text bash >}}
+    $ kubectl delete authorizationpolicy ingress-policy -n istio-system
+    {{< /text >}}

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -8,7 +8,7 @@ keywords: [security,access-control,rbac,authorization,ingress,ip,allowlist,denyl
 This task shows you how to enforce access control on an Istio ingress gateway
 using an authorization policy.
 
-The authorization policy supports IP-based allow list or deny list and
+An Istio authorization policy supports IP-based allow lists or deny lists as well as
 attribute-based allow list or deny list previously provided by the Mixer policy.
 The Mixer policy is deprecated in 1.5 and not recommended for production use.
 

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -14,14 +14,14 @@ The Mixer policy is deprecated in 1.5 and not recommended for production use.
 
 ## Before you begin
 
-Before you begin this task, perform the following actions:
+Before you begin this task, do the following:
 
 * Read the [Authorization conceptual documentation](/docs/concepts/security/#authorization).
 
 * Install Istio using the [Istio installation guide](/docs/setup/install/istioctl/).
 
-* Deploy a workload, `httpbin` in a namespace named, for example, `foo` and expose it
-through the Istio ingress gateway with this command.
+* Deploy a workload, `httpbin` in a namespace, for example `foo`, and expose it
+through the Istio ingress gateway with this command:
 
     {{< text bash >}}
     $ kubectl create ns foo
@@ -46,8 +46,7 @@ for more information.
     200
     {{< /text >}}
 
-* Verify the ingress gateway receives the original client source IP address, which
-will be used in the authorization policy in this task.
+* Verify the output of the following command to ensure the ingress gateway receives the original client source IP address, which will be used in the authorization policy.
 
     {{< text bash >}}
     $ CLIENT_IP=$(curl $INGRESS_HOST/ip -s | grep "origin" | cut -d'"' -f 4) && echo $CLIENT_IP
@@ -55,15 +54,15 @@ will be used in the authorization policy in this task.
     {{< /text >}}
 
 {{< warning >}}
-If you don’t see the expected output as you follow the task, retry after a few seconds.
-Caching and propagation overhead can cause some delay.
+If you don’t see the expected output, retry after a few seconds.
+Caching and propagation overhead can cause a delay.
 {{< /warning >}}
 
 ## IP-based allow list and deny list
 
 1. The following command creates the authorization policy, `ingress-policy`, for
 the Istio ingress gateway. The following policy sets the `action` field to `ALLOW` to
-allow the IP addresses specified in the `ipBlocks` to access the ingress gateway,
+allow the IP addresses specified in the `ipBlocks` to access the ingress gateway.
 IP addresses not in the list will be denied, also known as whitelist-style access control.
 The `ipBlocks` supports both single IP address and CIDR notation.
 
@@ -151,7 +150,7 @@ not allowed to access the ingress gateway, also known as blacklist-style access 
     403
     {{< /text >}}
 
-1. You could use an online proxy service to access the ingress gateway that uses a
+1. You could use an online proxy service to access the ingress gateway using a
 different client IP to verify the request is allowed.
 
 ## Clean up

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -1,8 +1,8 @@
 ---
 title: Authorization on Ingress Gateway
-description: Shows how to set up access control on ingress gateway.
+description: How to set up access control on ingress gateway.
 weight: 50
-keywords: [security,access-control,rbac,authorization,ingress,ip,whitelist,blacklist]
+keywords: [security,access-control,rbac,authorization,ingress,ip,allowlist,denylist]
 ---
 
 This task shows you how to enforce access control on an Istio ingress gateway
@@ -25,20 +25,19 @@ through the Istio ingress gateway with this command:
 
     {{< text bash >}}
     $ kubectl create ns foo
-    $ kubectl apply -f <(istioctl kube-inject -f samples/httpbin/httpbin.yaml) -n foo
-    $ kubectl apply -f <(istioctl kube-inject -f samples/httpbin/httpbin-gateway.yaml) -n foo
+    $ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin.yaml@) -n foo
+    $ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin-gateway.yaml@) -n foo
     {{< /text >}}
 
-* Update the ingress gateway to set `externalTrafficPolicy: local` to preserve the
-original client source IP on the ingress gateway using the following command.
-See [Source IP for Services with `Type=NodePort`](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport)
-for more information.
+* See [Source IP for Services with `Type=NodePort`](https://kubernetes.io/docs/tutorials/services/source-ip/#source-ip-for-services-with-type-nodeport)
+for more information. Update the ingress gateway to set `externalTrafficPolicy: local` to preserve the
+original client source IP on the ingress gateway using the following command:
 
     {{< text bash >}}
     $ kubectl patch svc istio-ingressgateway -n istio-system -p '{"spec":{"externalTrafficPolicy":"Local"}}'
     {{< /text >}}
 
-* Verify that the `httpbin` workload and ingress gateway are working as expected using this command.
+* Verify that the `httpbin` workload and ingress gateway are working as expected using this command:
 
     {{< text bash >}}
     $ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
@@ -46,7 +45,8 @@ for more information.
     200
     {{< /text >}}
 
-* Verify the output of the following command to ensure the ingress gateway receives the original client source IP address, which will be used in the authorization policy.
+* Verify the output of the following command to ensure the ingress gateway receives
+the original client source IP address, which will be used in the authorization policy:
 
     {{< text bash >}}
     $ CLIENT_IP=$(curl $INGRESS_HOST/ip -s | grep "origin" | cut -d'"' -f 4) && echo $CLIENT_IP
@@ -63,8 +63,8 @@ Caching and propagation overhead can cause a delay.
 1. The following command creates the authorization policy, `ingress-policy`, for
 the Istio ingress gateway. The following policy sets the `action` field to `ALLOW` to
 allow the IP addresses specified in the `ipBlocks` to access the ingress gateway.
-IP addresses not in the list will be denied, also known as whitelist-style access control.
-The `ipBlocks` supports both single IP address and CIDR notation.
+IP addresses not in the list will be denied. The `ipBlocks` supports both single IP address and CIDR notation.
+Create the authorization policy:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
@@ -85,14 +85,14 @@ The `ipBlocks` supports both single IP address and CIDR notation.
     EOF
     {{< /text >}}
 
-1. Verify that a request to the ingress gateway is denied.
+1. Verify that a request to the ingress gateway is denied:
 
     {{< text bash >}}
     $ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 
-1. Update the `ingress-policy` to include your client IP address.
+1. Update the `ingress-policy` to include your client IP address:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
@@ -113,16 +113,16 @@ The `ipBlocks` supports both single IP address and CIDR notation.
     EOF
     {{< /text >}}
 
-1. Verify that a request to the ingress gateway is allowed.
+1. Verify that a request to the ingress gateway is allowed:
 
     {{< text bash >}}
     $ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
 
-1. The following command updates the `ingress-policy` authorization policy to set
+1. Update the `ingress-policy` authorization policy to set
 the `action` key to `DENY` so that the IP addresses specified in the `ipBlocks` are
-not allowed to access the ingress gateway, also known as blacklist-style access control:
+not allowed to access the ingress gateway:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
@@ -143,7 +143,7 @@ not allowed to access the ingress gateway, also known as blacklist-style access 
     EOF
     {{< /text >}}
 
-1. Verify that a request to the ingress gateway is denied.
+1. Verify that a request to the ingress gateway is denied:
 
     {{< text bash >}}
     $ curl $INGRESS_HOST/headers -s -o /dev/null -w "%{http_code}\n"
@@ -155,7 +155,7 @@ different client IP to verify the request is allowed.
 
 ## Clean up
 
-1. Remove the namespace `foo` from your configuration:
+1. Remove the namespace `foo`:
 
     {{< text bash >}}
     $ kubectl delete namespace foo

--- a/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
@@ -1,7 +1,7 @@
 ---
 title: Authorization Policy Trust Domain Migration
 description: Shows how to migrate from one trust domain to another without changing authorization policy.
-weight: 50
+weight: 60
 keywords: [security,access-control,rbac,authorization,trust domain, migration]
 ---
 


### PR DESCRIPTION
This PR adds a new authorization task to show IP-based whitelist and blacklist on ingress gateway.

The content was previously reviewed by @adammil2000 in a google doc following the new doc process. Thanks Adam for reviewing and making tons of comments in the doc directly to make it much easier to follow and understand.