### PR TITLE
Updated guide for Authorization Policy Trust Domain Migration

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
@@ -111,17 +111,6 @@ Notice that it may take tens of seconds for the authorization policy to be propa
 
     Istio mesh is now running with a new trust domain, `new-td`.
 
-1. Delete secrets of `sleep` and `httpbin` in `default` namespace and in `sleep-allow` namespace. Notice if you install Istio with SDS,
-you don't need to follow this step. Learn more about [Provisioning Identity through SDS](/docs/tasks/security/citadel-config/auth-sds/)
-
-    {{< text bash >}}
-    $ kubectl delete secrets istio.sleep; kubectl delete secrets istio.httpbin;
-    {{< /text >}}
-
-    {{< text bash >}}
-    $ kubectl delete secrets istio.sleep -n sleep-allow
-    {{< /text >}}
-
 1. Redeploy the `httpbin` and `sleep` applications to pick up changes from the new Istio control plane.
 
     {{< text bash >}}
@@ -201,8 +190,8 @@ as the old trust domain without you having to include the aliases.
 
 {{< text bash >}}
 $ kubectl delete authorizationpolicy service-httpbin.default.svc.cluster.local
-$ kubectl delete deploy httpbin; k delete service httpbin; k delete serviceaccount httpbin
-$ kubectl delete deploy sleep; k delete service sleep; k delete serviceaccount sleep
+$ kubectl delete deploy httpbin; kubectl delete service httpbin; kubectl delete serviceaccount httpbin
+$ kubectl delete deploy sleep; kubectl delete service sleep; kubectl delete serviceaccount sleep
 $ kubectl delete namespace sleep-allow
 $ istioctl manifest generate --set profile=demo -f td-installation.yaml | kubectl delete -f -
 {{< /text >}}


### PR DESCRIPTION
Remove an outdated step from the guide.
SDS is enabled by default, and the secrets istio.sleep and istio.httpbin do not exist.