### PR TITLE
Add lint-fast target for local development

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -85,6 +85,9 @@ clean:
 lint: clean_public build_nominify lint-copyright-banner lint-python lint-yaml lint-dockerfiles lint-scripts lint-sass lint-typescript lint-go
 	@scripts/lint_site.sh
 
+lint-fast:
+	@SKIP_LINK_CHECK=true scripts/lint_site.sh
+
 serve: gen
 	@hugo serve --baseURL "http://${ISTIO_SERVE_DOMAIN}:1313/" --bind 0.0.0.0 --disableFastRender
 

--- a/scripts/lint_site.sh
+++ b/scripts/lint_site.sh
@@ -140,8 +140,10 @@ find ./content/zh -type f \( -name '*.html' -o -name '*.md' \) -print0 | while I
     fi
 done
 
-if ! htmlproofer ./public --assume-extension --http-status-ignore "0" --check-html --check-external-hash --check-opengraph --timeframe 2d --storage-dir .htmlproofer --url-ignore "/archive.istio.io/,/localhost/,/github.com/istio/istio.io/edit/,/github.com/istio/istio/issues/new/choose/,/groups.google.com/forum/,/www.trulia.com/,/apporbit.com/,/www.mysql.com/,/www.oreilly.com/"; then
-    FAILED=1
+if [[ ${SKIP_LINK_CHECK:-} == "" ]]; then
+    if ! htmlproofer ./public --assume-extension --http-status-ignore "0" --check-html --check-external-hash --check-opengraph --timeframe 2d --storage-dir .htmlproofer --url-ignore "/archive.istio.io/,/localhost/,/github.com/istio/istio.io/edit/,/github.com/istio/istio/issues/new/choose/,/groups.google.com/forum/,/www.trulia.com/,/apporbit.com/,/www.mysql.com/,/www.oreilly.com/"; then
+        FAILED=1
+    fi
 fi
 
 if [[ ${FAILED} -eq 1 ]]; then


### PR DESCRIPTION
This takes 30s and runs the spellcheck and some other quick linters.