### PR TITLE
[release-1.5] Add empty profile to the list of Installation Configuration Profiles

### DIFF
--- a/content/en/docs/setup/additional-setup/config-profiles/index.md
+++ b/content/en/docs/setup/additional-setup/config-profiles/index.md
@@ -28,6 +28,8 @@ your specific needs. The following built-in configuration profiles are currently
     This profile enables high levels of tracing and access logging so it is not suitable for performance tests.
     {{< /warning >}}
 
+1. **empty**: The empty profile has everything disabled. This is useful as a base for custom user configuration.
+
 1. **minimal**: the minimal set of components necessary to use Istio's [traffic management](/docs/tasks/traffic-management/) features.
 
 1. **sds**: similar to the **default** profile, but also enables Istio's [SDS (secret discovery service)](/docs/tasks/security/citadel-config/auth-sds).


### PR DESCRIPTION
This is to fix #6713 

Ref file: https://github.com/istio/istio/blob/release-1.5/operator/data/profiles/empty.yaml