### PR TITLE
[Release-1.5] operator.yaml: Update image tag to 1.5.0

### DIFF
--- a/static/operator.yaml
+++ b/static/operator.yaml
@@ -196,7 +196,7 @@ spec:
       serviceAccountName: istio-operator
       containers:
         - name: istio-operator
-          image: docker.io/istio/operator:1.5.0-beta.4
+          image: docker.io/istio/operator:1.5.0
           command:
           - operator
           - server


### PR DESCRIPTION
Note that the image has not been released yet, merging this should wait on the publishing of 1.5.0