### PR TITLE
[Release-1.5] remove mixer references from egress tasks and deprecate where needed

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -96,8 +96,8 @@ You can then decide to [configure access to external services](#controlled-acces
 Congratulations! You successfully sent egress traffic from your mesh.
 
 This simple approach to access external services, has the drawback that you lose Istio monitoring and control
-for traffic to external services; calls to external services will not appear in the Mixer log, for example.
-The next section shows you how to monitor and control your mesh's access to external services.
+for traffic to external services. The next section shows you how to monitor and control your mesh's access to 
+external services.
 
 ## Controlled access to external services
 
@@ -187,17 +187,6 @@ any other unintentional accesses.
 
     Note the entry related to your HTTP request to `httpbin.org/headers`.
 
-1.  Check the Mixer log. If Istio is deployed in the `istio-system` namespace, the command to print the log is:
-
-    {{< text bash >}}
-    $ kubectl -n istio-system logs -l istio-mixer-type=telemetry -c mixer | grep 'httpbin.org'
-    {"level":"info","time":"2019-01-24T12:17:11.855496Z","instance":"accesslog.logentry.istio-system","apiClaims":"","apiKey":"","clientTraceId":"","connection_security_policy":"unknown","destinationApp":"","destinationIp":"I60GXg==","destinationName":"unknown","destinationNamespace":"default","destinationOwner":"unknown","destinationPrincipal":"","destinationServiceHost":"httpbin.org","destinationWorkload":"unknown","grpcMessage":"","grpcStatus":"","httpAuthority":"httpbin.org","latency":"214.661667ms","method":"GET","permissiveResponseCode":"none","permissiveResponsePolicyID":"none","protocol":"http","receivedBytes":270,"referer":"","reporter":"source","requestId":"17fde8f7-fa62-9b39-8999-302324e6def2","requestSize":0,"requestedServerName":"","responseCode":200,"responseSize":599,"responseTimestamp":"2019-01-24T12:17:11.855521Z","sentBytes":806,"sourceApp":"sleep","sourceIp":"AAAAAAAAAAAAAP//rB5tUg==","sourceName":"sleep-88ddbcfdd-rgk77","sourceNamespace":"default","sourceOwner":"kubernetes://apis/apps/v1/namespaces/default/deployments/sleep","sourcePrincipal":"","sourceWorkload":"sleep","url":"/headers","userAgent":"curl/7.60.0","xForwardedFor":"0.0.0.0"}
-    {{< /text >}}
-
-    Note that the `destinationServiceHost` attribute is equal to `httpbin.org`. Also notice the HTTP-related attributes:
-    `method`, `url`, `responseCode` and others. Using Istio egress traffic control, you can monitor access to external
-    HTTP services, including the HTTP-related information of each access.
-
 ### Access an external HTTPS service
 
 1.  Create a `ServiceEntry` to allow access to an external HTTPS service.
@@ -235,21 +224,6 @@ any other unintentional accesses.
     {{< /text >}}
 
     Note the entry related to your HTTPS request to `www.google.com`.
-
-1.  Check the Mixer log. If Istio is deployed in the `istio-system` namespace, the command to print the log is:
-
-    {{< text bash >}}
-    $ kubectl -n istio-system logs -l istio-mixer-type=telemetry -c mixer | grep 'www.google.com'
-    {"level":"info","time":"2019-01-24T12:48:56.266553Z","instance":"tcpaccesslog.logentry.istio-system","connectionDuration":"1.289085134s","connectionEvent":"close","connection_security_policy":"unknown","destinationApp":"","destinationIp":"rNmhJA==","destinationName":"unknown","destinationNamespace":"default","destinationOwner":"unknown","destinationPrincipal":"","destinationServiceHost":"www.google.com","destinationWorkload":"unknown","protocol":"tcp","receivedBytes":601,"reporter":"source","requestedServerName":"www.google.com","sentBytes":17766,"sourceApp":"sleep","sourceIp":"rB5tUg==","sourceName":"sleep-88ddbcfdd-rgk77","sourceNamespace":"default","sourceOwner":"kubernetes://apis/apps/v1/namespaces/default/deployments/sleep","sourcePrincipal":"","sourceWorkload":"sleep","totalReceivedBytes":601,"totalSentBytes":17766}
-    {{< /text >}}
-
-    Note that the `requestedServerName` attribute is equal to `www.google.com`. Using Istio egress traffic control, you
-    can monitor access to external HTTPS services, in particular the
-    [SNI](https://en.wikipedia.org/wiki/Server_Name_Indication) and the number of sent and received bytes. Note that in
-    HTTPS all the HTTP-related information like method, URL path, response code, is encrypted so Istio cannot see and
-    cannot monitor that information for HTTPS. If you need to monitor HTTP-related information in access to external
-    HTTPS services, you may want to let your applications issue HTTP requests and
-    [configure Istio to perform TLS origination](/docs/tasks/traffic-management/egress/egress-tls-origination/).
 
 ### Manage traffic to external services
 
@@ -436,8 +410,8 @@ $ kubectl exec -it $SOURCE_POD -c sleep curl http://httpbin.org/headers
 {{< /text >}}
 
 Unlike accessing external services through HTTP or HTTPS, you don't see any headers related to the Istio sidecar and the
-requests sent to external services appear neither in the log of the sidecar nor in the Mixer log.
-Bypassing the Istio sidecars means you can no longer monitor the access to external services.
+requests sent to external services do not appear in the log of the sidecar. Bypassing the Istio sidecars means you can 
+no longer monitor the access to external services.
 
 ### Cleanup the direct access to external services
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -96,7 +96,7 @@ You can then decide to [configure access to external services](#controlled-acces
 Congratulations! You successfully sent egress traffic from your mesh.
 
 This simple approach to access external services, has the drawback that you lose Istio monitoring and control
-for traffic to external services. The next section shows you how to monitor and control your mesh's access to 
+for traffic to external services. The next section shows you how to monitor and control your mesh's access to
 external services.
 
 ## Controlled access to external services
@@ -410,7 +410,7 @@ $ kubectl exec -it $SOURCE_POD -c sleep curl http://httpbin.org/headers
 {{< /text >}}
 
 Unlike accessing external services through HTTP or HTTPS, you don't see any headers related to the Istio sidecar and the
-requests sent to external services do not appear in the log of the sidecar. Bypassing the Istio sidecars means you can 
+requests sent to external services do not appear in the log of the sidecar. Bypassing the Istio sidecars means you can
 no longer monitor the access to external services.
 
 ### Cleanup the direct access to external services

--- a/content/en/docs/tasks/traffic-management/egress/egress_sni_monitoring_and_policies/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress_sni_monitoring_and_policies/index.md
@@ -1,11 +1,25 @@
 ---
-title: Monitoring and Policies for TLS Egress
+title: Monitoring and Policies for TLS Egress (Deprecated)
 description: Describes how to configure SNI monitoring and apply policies on TLS egress traffic.
 keywords: [traffic-management,egress,telemetry,policies]
 weight: 51
 aliases:
   - /docs/examples/advanced-gateways/egress_sni_monitoring_and_policies/
 ---
+
+{{< warning >}}
+The mixer policy is deprecated in Istio 1.5 and not recommended for production usage.
+
+* Rate limiting: Consider using [Envoy native rate limiting](https://www.envoyproxy.io/docs/envoy/v1.13.0/intro/arch_overview/other_features/global_rate_limiting)
+instead of mixer rate limiting. Istio will add support for native rate limiting API through the Istio extensions API.
+
+* Control headers and routing: Consider using Envoy [`ext_authz` filter](https://www.envoyproxy.io/docs/envoy/v1.13.0/intro/arch_overview/security/ext_authz_filter),
+[`lua` filter](https://www.envoyproxy.io/docs/envoy/v1.13.0/configuration/http/http_filters/lua_filter),
+or write a filter using the [`Envoy-wasm` sandbox](https://github.com/envoyproxy/envoy-wasm/tree/master/test/extensions/filters/http/wasm/test_data).
+
+* Denials and White/Black Listing: Please use the [Authorization Policy](/docs/concepts/security/#authorization) for
+enforcing access control to a workload.
+{{< /warning >}}
 
 The [Configure Egress Traffic using Wildcard Hosts](/docs/tasks/traffic-management/egress/wildcard-egress-hosts/) example
 describes how to enable TLS egress traffic for a set of hosts in a common domain, in that case `*.wikipedia.org`. This

--- a/content/en/docs/tasks/traffic-management/egress/egress_sni_monitoring_and_policies/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress_sni_monitoring_and_policies/index.md
@@ -1,5 +1,5 @@
 ---
-title: Monitoring and Policies for TLS Egress (Deprecated)
+title: Monitoring and Policies for TLS Egress with Mixer (Deprecated)
 description: Describes how to configure SNI monitoring and apply policies on TLS egress traffic.
 keywords: [traffic-management,egress,telemetry,policies]
 weight: 51

--- a/content/en/docs/tasks/traffic-management/egress/egress_sni_monitoring_and_policies/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress_sni_monitoring_and_policies/index.md
@@ -11,7 +11,7 @@ aliases:
 The mixer policy is deprecated in Istio 1.5 and not recommended for production usage.
 
 * Rate limiting: Consider using [Envoy native rate limiting](https://www.envoyproxy.io/docs/envoy/v1.13.0/intro/arch_overview/other_features/global_rate_limiting)
-instead of mixer rate limiting. Istio will add support for native rate limiting API through the Istio extensions API.
+instead of mixer rate limiting. Istio will add support for the native rate limiting API through the Istio extensions API.
 
 * Control headers and routing: Consider using Envoy [`ext_authz` filter](https://www.envoyproxy.io/docs/envoy/v1.13.0/intro/arch_overview/security/ext_authz_filter),
 [`lua` filter](https://www.envoyproxy.io/docs/envoy/v1.13.0/configuration/http/http_filters/lua_filter),

--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
@@ -421,10 +421,6 @@ The SNI proxy will forward the traffic to port `443`.
     Choose the instructions corresponding to whether or not you want to enable
     [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/) between the source pod and the egress gateway.
 
-    {{< idea >}}
-    You may want to enable mutual TLS to let the egress gateway monitor the identity of the source pods and to enable Mixer policy enforcement based on that identity.
-    {{< /idea >}}
-
     {{< tabset category-name="mtls" >}}
 
     {{< tab name="mutual TLS enabled" category-value="enabled" >}}
@@ -648,16 +644,6 @@ The SNI proxy will forward the traffic to port `443`.
     127.0.0.1 [01/Aug/2018:15:32:02 +0000] TCP [en.wikipedia.org]200 81513 280 0.600
     127.0.0.1 [01/Aug/2018:15:32:03 +0000] TCP [de.wikipedia.org]200 67745 291 0.659
     {{< /text >}}
-
-1.  Check the mixer log. If Istio is deployed in the `istio-system` namespace, the command to print the
-    log is:
-
-    {{< text bash >}}
-    $ kubectl -n istio-system logs -l istio-mixer-type=telemetry -c mixer | grep '"connectionEvent":"open"' | grep '"sourceName":"istio-egressgateway' | grep 'wikipedia.org'
-    {"level":"info","time":"2018-08-26T16:16:34.784571Z","instance":"tcpaccesslog.logentry.istio-system","connectionDuration":"0s","connectionEvent":"open","connection_security_policy":"unknown","destinationApp":"","destinationIp":"127.0.0.1","destinationName":"unknown","destinationNamespace":"default","destinationOwner":"unknown","destinationPrincipal":"cluster.local/ns/istio-system/sa/istio-egressgateway-with-sni-proxy-service-account","destinationServiceHost":"","destinationWorkload":"unknown","protocol":"tcp","receivedBytes":298,"reporter":"source","requestedServerName":"en.wikipedia.org","sentBytes":0,"sourceApp":"istio-egressgateway-with-sni-proxy","sourceIp":"172.30.146.88","sourceName":"istio-egressgateway-with-sni-proxy-7c4f7868fb-rc8pr","sourceNamespace":"istio-system","sourceOwner":"kubernetes://apis/extensions/v1beta1/namespaces/istio-system/deployments/istio-egressgateway-with-sni-proxy","sourcePrincipal":"cluster.local/ns/sleep/sa/default","sourceWorkload":"istio-egressgateway-with-sni-proxy","totalReceivedBytes":298,"totalSentBytes":0}
-    {{< /text >}}
-
-    Note the `requestedServerName` attribute.
 
 #### Cleanup wildcard configuration for arbitrary domains
 


### PR DESCRIPTION

Remove mixer references from egress tasks and deprecate where needed.  Deprecation method is copied from policy and monitoring tasks


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ X ] Networking
[ ] Performance and Scalability
[ X ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure