### PR TITLE
[1.5] fixed link in blog post, fixed typo in relnote template

### DIFF
--- a/content/en/blog/2020/tradewinds-2020/index.md
+++ b/content/en/blog/2020/tradewinds-2020/index.md
@@ -50,7 +50,7 @@ and [authorization](/docs/concepts/security/#authorization) policies, which
 allow you to control workload-to-workload and end-user-to-workload authorization
 directly in the proxy. Common monitoring use cases have already moved into the
 proxy too - we have
-[introduced in-proxy support](/docs/reference/config/telemetry/metrics//docs/ops/configuration/telemetry/in-proxy-service-telemetry/)
+[introduced in-proxy support](/docs/reference/config/telemetry/metrics)
 for sending telemetry to Prometheus and Stackdriver.
 
 Our benchmarking shows that the new telemetry model reduces our latency

--- a/content/en/blog/2020/tradewinds-2020/index.md
+++ b/content/en/blog/2020/tradewinds-2020/index.md
@@ -50,7 +50,7 @@ and [authorization](/docs/concepts/security/#authorization) policies, which
 allow you to control workload-to-workload and end-user-to-workload authorization
 directly in the proxy. Common monitoring use cases have already moved into the
 proxy too - we have
-[introduced in-proxy support]/docs/ops/configuration/telemetry/in-proxy-service-telemetry/)
+[introduced in-proxy support](/docs/reference/config/telemetry/metrics//docs/ops/configuration/telemetry/in-proxy-service-telemetry/)
 for sending telemetry to Prometheus and Stackdriver.
 
 Our benchmarking shows that the new telemetry model reduces our latency

--- a/content/en/blog/2020/wasm-announce/index.md
+++ b/content/en/blog/2020/wasm-announce/index.md
@@ -162,7 +162,7 @@ community project in a future release, where it will remain available for legacy
 ## Developer Experience
 
 Powerful tooling is nothing without a great developer experience. Solo.io
-[recently announced](https://medium.com/solo-io/introducing-the-webassembly-hub-a-service-for-building-deploying-sharing-and-discovering-wasm-d461719383ca)
+[recently announced](https://www.solo.io/blog/an-extended-and-improved-webassembly-hub-to-helps-bring-the-power-of-webassembly-to-envoy-and-istio/)
 the release of [WebAssembly Hub](https://webassemblyhub.io/), a set of tools and repository for
 building, deploying, sharing and discovering Envoy Proxy Wasm extensions for Envoy and Istio.
 

--- a/layouts/shortcodes/relnote.html
+++ b/layouts/shortcodes/relnote.html
@@ -122,7 +122,7 @@
     {{ if eq $release_location "archive" }}
         {{ $doc_link = printf "https://archive.istio.io/v%s/docs" $version }}
     {{ else if eq $release_location "preliminary" }}
-        {{ $doc_link = printf "https://preliminry.istio.io%s/docs" $lang }}
+        {{ $doc_link = printf "https://preliminary.istio.io%s/docs" $lang }}
     {{ else if .Site.Data.args.preliminary }}
         {{ $doc_link = "https://istio.io/docs" }}
     {{ end }}


### PR DESCRIPTION
Fixed a link in the wasm blog, and fixed a typo in the relnote.html template