### PR TITLE
authz: use shorter title in tasks

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-deny/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-deny/index.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization policies with a deny action
+title: Deny policy
 description: Shows how to set up access control to deny traffic explicitly.
 weight: 40
 keywords: [security,access-control,rbac,authorization,deny]
@@ -24,8 +24,8 @@ Before tackling this task you must perform the following actions:
 
     {{< text bash >}}
     $ kubectl create ns foo
-    $ kubectl apply -f <(istioctl kube-inject -f samples/httpbin/httpbin.yaml) -n foo
-    $ kubectl apply -f <(istioctl kube-inject -f samples/sleep/sleep.yaml) -n foo
+    $ kubectl apply -f <(istioctl kube-inject -f @samples/httpbin/httpbin.yaml@) -n foo
+    $ kubectl apply -f <(istioctl kube-inject -f @samples/sleep/sleep.yaml@) -n foo
     {{< /text >}}
 
 * Verify that `sleep` talks to `httpbin` with the following command:

--- a/content/en/docs/tasks/security/authorization/authz-http/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-http/index.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization for HTTP traffic
+title: HTTP traffic
 description: Shows how to set up access control for HTTP traffic.
 weight: 10
 keywords: [security,access-control,rbac,authorization]

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization on Ingress Gateway
+title: Ingress Gateway
 description: How to set up access control on an ingress gateway.
 weight: 50
 keywords: [security,access-control,rbac,authorization,ingress,ip,allowlist,denylist]

--- a/content/en/docs/tasks/security/authorization/authz-jwt/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-jwt/index.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization with JWT
+title: JWT
 description: How to set up access control with JWT in Istio.
 weight: 30
 keywords: [security,authorization,jwt,claim]

--- a/content/en/docs/tasks/security/authorization/authz-tcp/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-tcp/index.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization for TCP traffic
+title: TCP traffic
 description: How to set up access control for TCP traffic.
 weight: 20
 keywords: [security,access-control,rbac,tcp,authorization]

--- a/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
@@ -1,5 +1,5 @@
 ---
-title: Authorization Policy Trust Domain Migration
+title: Trust Domain Migration
 description: Shows how to migrate from one trust domain to another without changing authorization policy.
 weight: 60
 keywords: [security,access-control,rbac,authorization,trust domain, migration]


### PR DESCRIPTION
@liminw @adammil2000  @rcaballeromx I feel the current task title is a little bit too long, probably remove the `authorization` from the title as it's already under the authorization section?