### PR TITLE
replace Citadel with Istio CA

### DIFF
--- a/content/en/docs/tasks/security/plugin-ca-cert/index.md
+++ b/content/en/docs/tasks/security/plugin-ca-cert/index.md
@@ -30,7 +30,7 @@ Note that if your `ca-cert.pem` is the same as `root-cert.pem`, the `cert-chain.
 These files are ready to use in the `samples/certs/` directory.
 
   {{< tip >}}
-  The default Istio's CA installation sets [command line options](/docs/reference/commands/istio_ca/index.html) to configure the location of certificates and keys based on the predefined secret and file names used in the command below (i.e., secret named `cacert`, root certificate in a file named `root-cert.pem`, Citadel key in `ca-key.pem`, etc.)
+  The default Istio's CA installation sets [command line options](/docs/reference/commands/istio_ca/index.html) to configure the location of certificates and keys based on the predefined secret and file names used in the command below (i.e., secret named `cacert`, root certificate in a file named `root-cert.pem`, Istio CA's key in `ca-key.pem`, etc.)
   You must use these specific secret and file names, or reconfigure Istio's CA when you deploy it.
   {{< /tip >}}
 


### PR DESCRIPTION
Since Citadel is now built in into istiod, the certificate authority should be called Istio CA