### PR TITLE
Fix exposing container port CONTAINER_OPTIONS on Docker when running on Mac

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # expose port 1313 from the container in order to support 'make serve' which runs a Hugo web server
-CONTAINER_OPTIONS = -p 1313:1313
+export CONTAINER_OPTIONS := -p 1313:1313
 
 # this repo is on the container plan by default
 BUILD_WITH_CONTAINER ?= 1


### PR DESCRIPTION
export CONTAINER_OPTIONS make env variable so run.sh script can see it; running on Mac/Bash/Docker for Mac


