### PR TITLE
Gke private firewall port

### DIFF
--- a/content/en/docs/setup/platform-setup/gke/index.md
+++ b/content/en/docs/setup/platform-setup/gke/index.md
@@ -36,6 +36,27 @@ Follow these instructions to prepare a GKE cluster for Istio.
     the `gcloud container clusters create` command.
     {{< /warning >}}
 
+    {{< warning >}}
+    For private GKE clusters, the firewall rule that is created does not open the port (15017) needed by the validation webhook for master access.
+    
+    To review this firewall rule for master access:
+
+        {{< text bash >}}
+        $ gcloud compute firewall-rules list \
+          --filter="name~gke-<cluster-name>-[0-9a-z]\*-master" \
+          --format="value(name)"
+        {{< /text >}}
+    
+    To replace the existing rule and allow master access:
+
+        {{< text bash >}}
+        $ gcloud compute firewall-rules update \
+          <firewall-rule> \
+          --allow tcp:10250,tcp:443,tcp:15017
+        {{< /text >}}
+        
+    {{< /warning >}}
+
 1. Retrieve your credentials for `kubectl`.
 
     {{< text bash >}}

--- a/content/en/docs/setup/platform-setup/gke/index.md
+++ b/content/en/docs/setup/platform-setup/gke/index.md
@@ -38,21 +38,20 @@ Follow these instructions to prepare a GKE cluster for Istio.
 
     {{< warning >}}
     **For private GKE clusters**
-    
-    An automatically created firewall rule does not open port 15017.  This is needed by the Pilot discovery validation webhook.
-    
+
+    An automatically created firewall rule does not open port 15017. This is needed by the Pilot discovery validation webhook.
+
     To review this firewall rule for master access:
 
         {{< text bash >}}
         $ gcloud compute firewall-rules list --filter="name~gke-<cluster-name>-[0-9a-z]*-master"
         {{< /text >}}
-    
+
     To replace the existing rule and allow master access:
 
         {{< text bash >}}
         $ gcloud compute firewall-rules update <firewall-rule-name> --allow tcp:10250,tcp:443,tcp:15017
         {{< /text >}}
-        
     {{< /warning >}}
 
 1. Retrieve your credentials for `kubectl`.

--- a/content/en/docs/setup/platform-setup/gke/index.md
+++ b/content/en/docs/setup/platform-setup/gke/index.md
@@ -43,15 +43,15 @@ Follow these instructions to prepare a GKE cluster for Istio.
 
     To review this firewall rule for master access:
 
-        {{< text bash >}}
-        $ gcloud compute firewall-rules list --filter="name~gke-<cluster-name>-[0-9a-z]*-master"
-        {{< /text >}}
+    {{< text bash >}}
+    $ gcloud compute firewall-rules list --filter="name~gke-<cluster-name>-[0-9a-z]*-master"
+    {{< /text >}}
 
     To replace the existing rule and allow master access:
 
-        {{< text bash >}}
-        $ gcloud compute firewall-rules update <firewall-rule-name> --allow tcp:10250,tcp:443,tcp:15017
-        {{< /text >}}
+    {{< text bash >}}
+    $ gcloud compute firewall-rules update <firewall-rule-name> --allow tcp:10250,tcp:443,tcp:15017
+    {{< /text >}}
 
     {{< /warning >}}
 

--- a/content/en/docs/setup/platform-setup/gke/index.md
+++ b/content/en/docs/setup/platform-setup/gke/index.md
@@ -52,6 +52,7 @@ Follow these instructions to prepare a GKE cluster for Istio.
         {{< text bash >}}
         $ gcloud compute firewall-rules update <firewall-rule-name> --allow tcp:10250,tcp:443,tcp:15017
         {{< /text >}}
+
     {{< /warning >}}
 
 1. Retrieve your credentials for `kubectl`.

--- a/content/en/docs/setup/platform-setup/gke/index.md
+++ b/content/en/docs/setup/platform-setup/gke/index.md
@@ -37,22 +37,20 @@ Follow these instructions to prepare a GKE cluster for Istio.
     {{< /warning >}}
 
     {{< warning >}}
-    For private GKE clusters, the firewall rule that is created does not open the port (15017) needed by the validation webhook for master access.
+    **For private GKE clusters**
+    
+    An automatically created firewall rule does not open port 15017.  This is needed by the Pilot discovery validation webhook.
     
     To review this firewall rule for master access:
 
         {{< text bash >}}
-        $ gcloud compute firewall-rules list \
-          --filter="name~gke-<cluster-name>-[0-9a-z]\*-master" \
-          --format="value(name)"
+        $ gcloud compute firewall-rules list --filter="name~gke-<cluster-name>-[0-9a-z]*-master"
         {{< /text >}}
     
     To replace the existing rule and allow master access:
 
         {{< text bash >}}
-        $ gcloud compute firewall-rules update \
-          <firewall-rule> \
-          --allow tcp:10250,tcp:443,tcp:15017
+        $ gcloud compute firewall-rules update <firewall-rule-name> --allow tcp:10250,tcp:443,tcp:15017
         {{< /text >}}
         
     {{< /warning >}}


### PR DESCRIPTION
For GKE Private clusters, update firewall rule to allow access to the Pilot discovery webhook.