### PR TITLE
Add cert-manager integration doc

### DIFF
--- a/content/en/docs/ops/integrations/_index.md
+++ b/content/en/docs/ops/integrations/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Integrations
 description: Other softwares that Istio can integrate with to provide additional functionality.
-weight: 50
+weight: 60
 keywords: [ops, integrations]
 ---

--- a/content/en/docs/ops/integrations/_index.md
+++ b/content/en/docs/ops/integrations/_index.md
@@ -1,0 +1,6 @@
+---
+title: Integrations
+description: Other softwares that Istio can integrate with to provide additional functionality.
+weight: 50
+keywords: [ops, integrations]
+---

--- a/content/en/docs/ops/integrations/certmanager/index.md
+++ b/content/en/docs/ops/integrations/certmanager/index.md
@@ -1,0 +1,77 @@
+---
+title: cert-manager
+description: Information on how to integrate with cert-manager.
+weight: 20
+keywords: [integration,cert-manager]
+---
+
+[cert-manager](https://cert-manager.io/) is a tool that automates certificate management. This can be integrated with Istio gateways to manage TLS certificates
+
+## Configuration
+
+Consult the [cert-manager installation documentation](https://cert-manager.io/docs/installation/kubernetes/) to get started. No special changes are needed to work with Istio.
+
+## Usage
+
+### Istio Gateway
+
+cert-manager can be used to write a secret to Kubernetes, which can then be referenced by a Gateway. To get started, configure a `Certificate` resource, following the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/). The `Certificate` should be created in the same namespace as the `istio-ingressgateway` deployment. For example, a `Certificate` may look like:
+
+    {{< text yaml >}}
+    apiVersion: cert-manager.io/v1alpha2
+    kind: Certificate
+    metadata:
+      name: ingress-cert
+      namespace: istio-system
+    spec:
+      secretName: ingress-cert
+      commonName: my.example.com
+      dnsNames:
+      - my.example.com
+      ...
+    {{< /text >}}
+
+Once we have the certificate created, we should see the secret created in the `istio-system` namespace. This can then be referenced in the `tls` config for a Gateway under `credentialName`:
+
+    {{< text yaml >}}
+    apiVersion: networking.istio.io/v1alpha3
+    kind: Gateway
+    metadata:
+      name: gateway
+    spec:
+      selector:
+        istio: ingressgateway
+      servers:
+      - port:
+          number: 443
+          name: https
+          protocol: HTTPS
+        tls:
+          mode: SIMPLE
+          credentialName: ingress-cert # This should match the Certifcate secretName
+        hosts:
+        - my.example.com # This should match a DNS name in the Certificate
+    {{< /text >}}
+
+### Kubernetes Ingress
+
+cert-manager provides direct integration with Kubernetes Ingress by configuring an [annotation on the Ingress object](https://cert-manager.io/docs/usage/ingress/). If this method is used, the Ingress must reside in the same namespace as the `istio-ingressgateway` deployment, as secrets will only be read within the same namespace.
+
+Alternatively, a `Certificate` can be created as described in [Istio Gateway](#istio-gateway), then referenced in the `Ingress` object:
+
+    {{< text yaml >}}
+    apiVersion: extensions/v1beta1
+    kind: Ingress
+    metadata:
+      name: ingress
+      annotations:
+        kubernetes.io/ingress.class: istio
+    spec:
+      rules:
+      - host: my.example.com
+        http: ...
+      tls:
+      - hosts:
+        - my.example.com # This should match a DNS name in the Certificate
+        secretName: ingress-cert # This should match the Certifcate secretName
+    {{< /text >}}


### PR DESCRIPTION
This starts the new "Integrations" page, which will include many other
integrations in the future. For now, I have added cert-manager
integration. We have an existing doc for this at
https://istio.io/docs/tasks/traffic-management/ingress/ingress-certmgr/
which I think we can remove, but I did not do that in this PR.

Note to the reviewer: this is explicitly not a task, as we do not
control cert-manager. Having an explicit set of steps and verifications
requires an exact working directions, which is maintained as
cert-manager evolves, etc. The goal here was to link out to cert-manager
docs wherever possible, and just document the very minimal amount needed
to actually get things integrated with Istio. As you can see from the
doc this is fairly minimal - for the most part, its just referencing a
secret crated by cert-manager.