### PR TITLE
Add istiod to the glossary page

### DIFF
--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -162,7 +162,7 @@ Istio provides two types of authentication:
     - [Google Auth](https://developers.google.com/identity/protocols/OpenIDConnect)
 
 In all cases, Istio stores the authentication policies in the `Istio config
-store` via a custom Kubernetes API. Istiod keeps them up-to-date for each proxy,
+store` via a custom Kubernetes API. [Istiod](/docs/reference/glossary/#istiod) keeps them up-to-date for each proxy,
 along with the keys where appropriate. Additionally, Istio supports
 authentication in permissive mode to help you understand how a policy change can
 affect your security posture before it is enforced.

--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -162,7 +162,7 @@ Istio provides two types of authentication:
     - [Google Auth](https://developers.google.com/identity/protocols/OpenIDConnect)
 
 In all cases, Istio stores the authentication policies in the `Istio config
-store` via a custom Kubernetes API. [Istiod](/docs/reference/glossary/#istiod) keeps them up-to-date for each proxy,
+store` via a custom Kubernetes API. {{< gloss >}}Istiod{{< /gloss >}} keeps them up-to-date for each proxy,
 along with the keys where appropriate. Additionally, Istio supports
 authentication in permissive mode to help you understand how a policy change can
 affect your security posture before it is enforced.

--- a/content/en/docs/examples/virtual-machines/multi-network/index.md
+++ b/content/en/docs/examples/virtual-machines/multi-network/index.md
@@ -65,7 +65,7 @@ Next, run the following commands on each machine that you want to add to the mes
     {{< /text >}}
 
 1.  Add the IP address of Istio gateway to `/etc/hosts`. Revisit the [preparing the cluster](#preparing-the-kubernetes-cluster-for-vms) section to learn how to obtain the IP address.
-The following example updates the `/etc/hosts` file with the [Istiod](/docs/reference/glossary/#istiod) address:
+The following example updates the `/etc/hosts` file with the {{< gloss >}}Istiod{{< /gloss >}} address:
 
     {{< text bash >}}
     $ echo "${GWIP} istiod.istio-system.svc" | sudo tee -a /etc/hosts

--- a/content/en/docs/examples/virtual-machines/multi-network/index.md
+++ b/content/en/docs/examples/virtual-machines/multi-network/index.md
@@ -65,7 +65,7 @@ Next, run the following commands on each machine that you want to add to the mes
     {{< /text >}}
 
 1.  Add the IP address of Istio gateway to `/etc/hosts`. Revisit the [preparing the cluster](#preparing-the-kubernetes-cluster-for-vms) section to learn how to obtain the IP address.
-The following example updates the `/etc/hosts` file with the Istiod address:
+The following example updates the `/etc/hosts` file with the [Istiod](/docs/reference/glossary/#istiod) address:
 
     {{< text bash >}}
     $ echo "${GWIP} istiod.istio-system.svc" | sudo tee -a /etc/hosts

--- a/content/en/docs/examples/virtual-machines/single-network/index.md
+++ b/content/en/docs/examples/virtual-machines/single-network/index.md
@@ -77,7 +77,7 @@ following commands on a machine with cluster admin privileges:
    Alternatively, the user can create an explicit service of type `LoadBalancer` and use
     [internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer)
     type. User can also deploy a separate ingress Gateway, with internal load balancer type for both mesh expansion and
-    multicluster.  The main requirement is for the exposed address to do TCP load balancing to the Istiod deployment,
+    multicluster.  The main requirement is for the exposed address to do TCP load balancing to the [Istiod](/docs/reference/glossary/#istiod) deployment,
     and for the DNS name associated with the assigned load balancer address to match the certificate provisioned
     into Istiod deployment, defaulting to `istiod.istio-system.svc`.
 

--- a/content/en/docs/examples/virtual-machines/single-network/index.md
+++ b/content/en/docs/examples/virtual-machines/single-network/index.md
@@ -77,7 +77,7 @@ following commands on a machine with cluster admin privileges:
    Alternatively, the user can create an explicit service of type `LoadBalancer` and use
     [internal load balancer](https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer)
     type. User can also deploy a separate ingress Gateway, with internal load balancer type for both mesh expansion and
-    multicluster.  The main requirement is for the exposed address to do TCP load balancing to the [Istiod](/docs/reference/glossary/#istiod) deployment,
+    multicluster.  The main requirement is for the exposed address to do TCP load balancing to the {{< gloss >}}Istiod{{< /gloss >}} deployment,
     and for the DNS name associated with the assigned load balancer address to match the certificate provisioned
     into Istiod deployment, defaulting to `istiod.istio-system.svc`.
 

--- a/content/en/docs/ops/common-problems/security-issues/index.md
+++ b/content/en/docs/ops/common-problems/security-issues/index.md
@@ -84,7 +84,7 @@ matching requests should flow through. If all requests continue to be denied, yo
 
 1. Make sure there is no typo in your policy YAML file.
 
-1. Avoid enabling authorization for [Istiod](/docs/reference/glossary/#istiod). Istio authorization policy is designed for authorizing access to workloads in Istio Mesh. Enabling it for Istiod may cause unexpected behavior.
+1. Avoid enabling authorization for {{< gloss >}}Istiod{{< /gloss >}}. Istio authorization policy is designed for authorizing access to workloads in Istio Mesh. Enabling it for Istiod may cause unexpected behavior.
 
 1. Make sure that your authorization policies are in the right namespace (as specified in `metadata/namespace` field).
 

--- a/content/en/docs/ops/common-problems/security-issues/index.md
+++ b/content/en/docs/ops/common-problems/security-issues/index.md
@@ -84,7 +84,7 @@ matching requests should flow through. If all requests continue to be denied, yo
 
 1. Make sure there is no typo in your policy YAML file.
 
-1. Avoid enabling authorization for Istiod. Istio authorization policy is designed for authorizing access to workloads in Istio Mesh. Enabling it for Istiod may cause unexpected behavior.
+1. Avoid enabling authorization for [Istiod](/docs/reference/glossary/#istiod). Istio authorization policy is designed for authorizing access to workloads in Istio Mesh. Enabling it for Istiod may cause unexpected behavior.
 
 1. Make sure that your authorization policies are in the right namespace (as specified in `metadata/namespace` field).
 

--- a/content/en/docs/ops/diagnostic-tools/proxy-cmd/index.md
+++ b/content/en/docs/ops/diagnostic-tools/proxy-cmd/index.md
@@ -47,7 +47,7 @@ reviews-v3-7b9b5fdfd6-4r52s.default                    SYNCED     SYNCED     SYN
 If a proxy is missing from this list it means that it is not currently connected to a Istiod instance so will not be
 receiving any configuration.
 
-* `SYNCED` means that Envoy has acknowledged the last configuration [Istiod](/docs/reference/glossary/#istiod) has sent to it.
+* `SYNCED` means that Envoy has acknowledged the last configuration {{< gloss >}}Istiod{{< /gloss >}} has sent to it.
 * `NOT SENT` means that Istiod hasn't sent anything to Envoy. This usually is because Istiod has nothing to send.
 * `STALE` means that Istiod has sent an update to Envoy but has not received an acknowledgement. This usually indicates
 a networking issue between Envoy and Istiod or a bug with Istio itself.

--- a/content/en/docs/ops/diagnostic-tools/proxy-cmd/index.md
+++ b/content/en/docs/ops/diagnostic-tools/proxy-cmd/index.md
@@ -47,7 +47,7 @@ reviews-v3-7b9b5fdfd6-4r52s.default                    SYNCED     SYNCED     SYN
 If a proxy is missing from this list it means that it is not currently connected to a Istiod instance so will not be
 receiving any configuration.
 
-* `SYNCED` means that Envoy has acknowledged the last configuration Istiod has sent to it.
+* `SYNCED` means that Envoy has acknowledged the last configuration [Istiod](/docs/reference/glossary/#istiod) has sent to it.
 * `NOT SENT` means that Istiod hasn't sent anything to Envoy. This usually is because Istiod has nothing to send.
 * `STALE` means that Istiod has sent an update to Envoy but has not received an acknowledgement. This usually indicates
 a networking issue between Envoy and Istiod or a bug with Istio itself.

--- a/content/en/docs/reference/glossary/istiod.md
+++ b/content/en/docs/reference/glossary/istiod.md
@@ -4,4 +4,4 @@ title: Istiod
 
 The Istiod component is the consolidated monolithic control plane binary that encapsulates the functions of Pilot, Citadel, Mixer, and Galley.
 
-[Learn more about Istiod](/news/releases/1.5.x/announcing-1.5/#introducing-istiod).
+[Learn more about Istiod](/blog/2020/tradewinds-2020/#fewer-moving-parts).

--- a/content/en/docs/reference/glossary/istiod.md
+++ b/content/en/docs/reference/glossary/istiod.md
@@ -1,0 +1,7 @@
+---
+title: Istiod
+---
+
+The Istiod component is the consolidated monolithic control plane binary that encapsulates the functions of Pilot, Citadel, Mixer, and Galley.
+
+[Learn more about Istiod](/news/releases/1.5.x/announcing-1.5/#introducing-istiod).

--- a/content/en/docs/tasks/security/dns-cert/index.md
+++ b/content/en/docs/tasks/security/dns-cert/index.md
@@ -10,7 +10,7 @@ using [Chiron](/blog/2019/dns-cert/), a lightweight component linked with Istiod
 using the Kubernetes CA APIs without maintaining its own private key.
 Using this feature has the following advantages:
 
-* Unlike [Istiod](/docs/reference/glossary/#istiod), this feature doesn't require maintaining a private signing key, which enhances security.
+* Unlike {{< gloss >}}Istiod{{< /gloss >}}, this feature doesn't require maintaining a private signing key, which enhances security.
 
 * Simplified root certificate distribution to TLS clients. Clients no longer need to wait for Istiod to generate and distribute its CA certificate.
 

--- a/content/en/docs/tasks/security/dns-cert/index.md
+++ b/content/en/docs/tasks/security/dns-cert/index.md
@@ -10,7 +10,7 @@ using [Chiron](/blog/2019/dns-cert/), a lightweight component linked with Istiod
 using the Kubernetes CA APIs without maintaining its own private key.
 Using this feature has the following advantages:
 
-* Unlike Istiod, this feature doesn't require maintaining a private signing key, which enhances security.
+* Unlike [Istiod](/docs/reference/glossary/#istiod), this feature doesn't require maintaining a private signing key, which enhances security.
 
 * Simplified root certificate distribution to TLS clients. Clients no longer need to wait for Istiod to generate and distribute its CA certificate.
 


### PR DESCRIPTION
Adds the `istiod` to the glossary page. Fixes #6728 