### PR TITLE
Minor cleanup fixups

### DIFF
--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -531,9 +531,9 @@ $ istioctl --context=${REMOTE_CLUSTER_CTX} x create-remote-secret --name ${REMOT
     kubectl delete -f - --context=${MAIN_CLUSTER_CTX}
 $ istioctl --context=${REMOTE_CLUSTER_CTX} manifest generate -f istio-remote0-cluster.yaml | \
     kubectl delete -f - --context=${REMOTE_CLUSTER_CTX}
+$ kubectl --context=${REMOTE_CLUSTER_CTX} delete namespace sample
 $ unset REMOTE_CLUSTER_CTX REMOTE_CLUSTER_NAME REMOTE_CLUSTER_NETWORK
 $ rm istio-remote0-cluster.yaml
-$ kubectl --context=${REMOTE_CLUSTER_CTX} delete namespace sample
 {{< /text >}}
 
 To uninstall the main cluster, run the following command:
@@ -541,7 +541,7 @@ To uninstall the main cluster, run the following command:
 {{< text bash >}}
 $ istioctl --context=${MAIN_CLUSTER_CTX} manifest generate -f istio-main-cluster.yaml | \
     kubectl delete -f - --context=${MAIN_CLUSTER_CTX}
-$ unset MAIN_CLUSTER_CTX MAIN_CLUSTER_NAME MAIN_CLUSTER_NETWORK ISTIOD_REMOTE_EP
-$ rm istio-main-cluster.yaml cluster-aware-gateway.yaml 2>/dev/null
 $ kubectl --context=${MAIN_CLUSTER_CTX} delete namespace sample
+$ unset MAIN_CLUSTER_CTX MAIN_CLUSTER_NAME MAIN_CLUSTER_NETWORK ISTIOD_REMOTE_EP
+$ rm istio-main-cluster.yaml cluster-aware-gateway.yaml
 {{< /text >}}


### PR DESCRIPTION
Ran through the Shared multi-network instio-ingress gateway side of things after the PR was published.  One more issue I’ll fix for you. You try and delete the sample namespace on the remote context after unsetting the variable so it ended up deleting it in my current context (main) and then when I went to do the main cluster cleanup if wasn’t found. 

Another issue is that I use zsh and it prompts me before deleting files and those messages never came out since they were redirected to null. I had to enter two y’s to get by that step.