### PR TITLE
Copy iop-integration-test-defaults file from Istio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ install/**
 # contains samples to demo Istio 
 samples/**
 
+# configuration copied from Istio
+tests/integration/**
+
 # contains the built artifacts
 out/** 
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -57,6 +57,12 @@ rm -rf "${ISTIOIO_GO}/install" "${ISTIOIO_GO}/samples"
 cp -a "${ISTIO_GO}/install" "${ISTIOIO_GO}/install"
 cp -a "${ISTIO_GO}/samples" "${ISTIOIO_GO}/samples"
 
+# Copy the default configuration over from Istio.
+DEFAULTS_YAML="iop-integration-test-defaults.yaml"
+
+mkdir -p "${ISTIOIO_GO}/tests/integration"
+cp -a "${ISTIO_GO}/tests/integration/${DEFAULTS_YAML}" "${ISTIOIO_GO}/tests/integration"
+
 # For generating junit.xml files
 echo "Installing go-junit-report..."
 unset GOOS && unset GOARCH && CGO_ENABLED=1 go get github.com/jstemmer/go-junit-report

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,10 @@ replace github.com/docker/docker => github.com/docker/engine v1.4.2-0.2019101121
 
 require (
 	github.com/Masterminds/semver v1.4.2
+	github.com/google/go-github v17.0.0+incompatible // indirect
+	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/jstemmer/go-junit-report v0.9.1 // indirect
-	istio.io/istio v0.0.0-20200314140522-cbeb7a9d4e9f
+	istio.io/istio v0.0.0-20200327065932-5cb42eacf768
 )
 
 replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/circonus-labs/circonusllhist v0.1.4/go.mod h1:kMXHVDlOchFAehlya5ePtbp
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f h1:WBZRG4aNOuI15bLRrCgN8fCq8E5Xuty6jGbmSNEvSsU=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cncf/udpa/go v0.0.0-20200313221541-5f7e5dd04533 h1:8wZizuKuZVu5COB7EsBYxBQz8nRcXXn5d4Gt91eJLvU=
+github.com/cncf/udpa/go v0.0.0-20200313221541-5f7e5dd04533/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
@@ -163,6 +165,10 @@ github.com/envoyproxy/go-control-plane v0.9.2-0.20200122210702-14108a6abe04 h1:r
 github.com/envoyproxy/go-control-plane v0.9.2-0.20200122210702-14108a6abe04/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.4 h1:rEvIZUSZ3fx39WIi3JkQqQBitGwpELBIYWeBVh6wn+E=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
+github.com/envoyproxy/go-control-plane v0.9.5-0.20200316225419-d560923b20a0 h1:Y1vvhW74dZxUfG7KOs9nLLMohUkJC08zXAOah+dMdmM=
+github.com/envoyproxy/go-control-plane v0.9.5-0.20200316225419-d560923b20a0/go.mod h1:OXl5to++W0ctG+EHWTFUjiypVxC/Y4VLc/KFU+al13s=
+github.com/envoyproxy/go-control-plane v0.9.5-0.20200326174812-e8bd2869ff56 h1:SX76iRBhEsRqbtli8FMEbotrLPVGkzxd9lssASy0fko=
+github.com/envoyproxy/go-control-plane v0.9.5-0.20200326174812-e8bd2869ff56/go.mod h1:OXl5to++W0ctG+EHWTFUjiypVxC/Y4VLc/KFU+al13s=
 github.com/envoyproxy/protoc-gen-validate v0.1.0 h1:EQciDnbrYxy13PgWoY8AqoxGiPrpgBZ1R8UNe3ddc+A=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -269,6 +275,8 @@ github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
+github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -911,6 +919,10 @@ istio.io/api v0.0.0-20200303115641-9fc7ffee081d h1:QN18qPK2ww4d5MsqJ6HjzNlpAL9Wr
 istio.io/api v0.0.0-20200303115641-9fc7ffee081d/go.mod h1:bcY3prusO/6vA6zGHz4PNG2v79clPyTw06Xx3fprJSQ=
 istio.io/api v0.0.0-20200313095255-feb6af7f7b9e h1:+0tK+0KYEVXwATXoAKsHtrZc8gD/LZdYYjKudJPQsy0=
 istio.io/api v0.0.0-20200313095255-feb6af7f7b9e/go.mod h1:bcY3prusO/6vA6zGHz4PNG2v79clPyTw06Xx3fprJSQ=
+istio.io/api v0.0.0-20200324155120-32b3c4255353 h1:yUQVIgEvf47xEXA6G/jpQAyOvyP8KcNEwKNnAfVEif4=
+istio.io/api v0.0.0-20200324155120-32b3c4255353/go.mod h1:bcY3prusO/6vA6zGHz4PNG2v79clPyTw06Xx3fprJSQ=
+istio.io/api v0.0.0-20200325202443-3f88ef9cac2e h1:0m11ah/Oand+vJ0Irumc0lq1KLHcT4OcgwrLlLdcbTQ=
+istio.io/api v0.0.0-20200325202443-3f88ef9cac2e/go.mod h1:bcY3prusO/6vA6zGHz4PNG2v79clPyTw06Xx3fprJSQ=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
 istio.io/gogo-genproto v0.0.0-20200122005450-9b171d92064b h1:IGfxOYlHvdE5UeSCGvOFNHVQcPGJYAAUQ5iJm2Z7i18=
 istio.io/gogo-genproto v0.0.0-20200122005450-9b171d92064b/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
@@ -924,6 +936,12 @@ istio.io/istio v0.0.0-20200304151407-a11761a19432 h1:uCuVbV8QSt50YugqJWhat82Bx6j
 istio.io/istio v0.0.0-20200304151407-a11761a19432/go.mod h1:x0U/KPVWuw52Yo91asmKduaZwAP6jJ8xQkyxBKnsVcM=
 istio.io/istio v0.0.0-20200314140522-cbeb7a9d4e9f h1:S2hGCPQXyazSxhr++JJhjcs35E46wRnojIPVmJI/89U=
 istio.io/istio v0.0.0-20200314140522-cbeb7a9d4e9f/go.mod h1:x/D9l78LqWTJZoXdroQ2bHAHKtBvJJkTVXUJfGdl2Xw=
+istio.io/istio v0.0.0-20200325170823-7792cef71c2f h1:WhcHHDTPr2m744oOOaOWeZvprVeiEuPrEPEeJ8eiIQQ=
+istio.io/istio v0.0.0-20200325170823-7792cef71c2f/go.mod h1:aTCAF2DSBw3V/ochVxLF/oEIyTw4dgIDQhrnmaQ/CjI=
+istio.io/istio v0.0.0-20200326063228-f63181a5c5d8 h1:kdZMPX89zts01vBIf2vlmTTphIxcqF8Da49dLY6aEVk=
+istio.io/istio v0.0.0-20200326063228-f63181a5c5d8/go.mod h1:aTCAF2DSBw3V/ochVxLF/oEIyTw4dgIDQhrnmaQ/CjI=
+istio.io/istio v0.0.0-20200327065932-5cb42eacf768 h1:0o4l8bJtIkRj+VPxEoz6TRKxjAPW5N/QG/qeHUBfA+Y=
+istio.io/istio v0.0.0-20200327065932-5cb42eacf768/go.mod h1:Oalx3KST5pMXYEo2uAVmb6Edqgd/Pf0+SwMmsuFKZnM=
 istio.io/pkg v0.0.0-20200131182711-9ba13e0e34bb h1:ZEOEfPpz4ooW3lhX5qi+XA6dTO1Mb72EFaRniUb6Mvc=
 istio.io/pkg v0.0.0-20200131182711-9ba13e0e34bb/go.mod h1:pwGaxLUDLobzL/WvWV94z72LvBbB1dr2UUUyPuasfIU=
 istio.io/pkg v0.0.0-20200227125209-63966175aa01 h1:aiO57C3tGvBUWKMu1WrM5lUn3cC7ZIgR8YOUXaVPeoQ=


### PR DESCRIPTION
I was looking into istio/istio#21634, and found that the tests are broken with the latest istio master. As of istio/istio#21144, the default configuration values for the tests are looked for in the istio source tree as determined by the `REPO_ROOT` environment variable. However, when running the istio.io tests, `REPO_ROOT` points to the istio.io repo and not the istio repo, so the defaults aren't found and test setup fails.

This copies the defaults files from the istio source into the istio.io tree in `bin/init.sh` the way some other things are. Some other potential solutions:

- Change the `REPO_ROOT` environment variable to point to the istio source instead of the istio.io source in `Makefile.core.mk` and `common/scripts/run.sh`, but that seems confusing. Also, it looks like `run.sh` is updated automatically from the `common-files` repo, which might be a problem.

- Change the istio test framework to build-in the defaults files with `go-bindata` and avoid looking for them at run time.

- Just copy the `iop-integration-test-defaults.yaml` in the istio.io repo manually and commit it.

I'm new to the project -- not really sure what's best. Any suggestions?