### PR TITLE
fix typo in networking/envoy-filter, remove additional space.

### DIFF
--- a/content/en/docs/reference/config/networking/envoy-filter/index.html
+++ b/content/en/docs/reference/config/networking/envoy-filter/index.html
@@ -121,7 +121,7 @@ spec:
       value: # lua filter specification
        name: envoy.lua
        typed_config:
-          &quot;@type&quot;: &quot;type.googleapis.com/envoy.config.filter.http.lua.v2.Lua&quot;
+         &quot;@type&quot;: &quot;type.googleapis.com/envoy.config.filter.http.lua.v2.Lua&quot;
          inlineCode: |
            function envoy_on_request(request_handle)
              -- Make an HTTP call to an upstream host with the following headers, body, and timeout.


### PR DESCRIPTION
It was causing to error on applying the yaml. Related issue for istio wiki: https://github.com/istio/istio/issues/22585