### PR TITLE
Fix TCP Traffic Shifting test script

### DIFF
--- a/tests/trafficmanagement/scripts/tcp_trafficshifting_setup.txt
+++ b/tests/trafficmanagement/scripts/tcp_trafficshifting_setup.txt
@@ -32,3 +32,12 @@ $ kubectl label namespace istio-io-tcp-traffic-shifting istio-injection=enabled
 # $snippet deploy_tcp_echo_v1.sh
 $ kubectl apply -f @samples/tcp-echo/tcp-echo-services.yaml@ -n istio-io-tcp-traffic-shifting
 # $endsnippet
+
+# Add the TCP port to the ingress-gateway
+kubectl -n istio-system patch service istio-ingressgateway --patch "
+spec:
+  ports:
+    - port: 31400
+      targetPort: 31400
+      name: tcp
+"

--- a/tests/trafficmanagement/scripts/tcp_trafficshifting_test.txt
+++ b/tests/trafficmanagement/scripts/tcp_trafficshifting_test.txt
@@ -32,7 +32,7 @@ echo "sending traffic to $INGRESS_HOST:$INGRESS_PORT"
 # $snippet send_traffic_to_echo_v1.sh
 $ for i in {1..20}; do \
 docker run -e INGRESS_HOST=$INGRESS_HOST -e INGRESS_PORT=$INGRESS_PORT \
-  --rm busybox sh -c "(date; sleep 1) | nc $INGRESS_HOST:$INGRESS_PORT"
+  --rm busybox sh -c "(date; sleep 1) | nc $INGRESS_HOST $INGRESS_PORT"
 done
 # $verify verifier="notContains"
 two
@@ -71,7 +71,7 @@ spec:
 # $snippet more_tcp_traffic_to_echos.sh
 $ for i in {1..20}; do \
 docker run -e INGRESS_HOST=$INGRESS_HOST -e INGRESS_PORT=$INGRESS_PORT \
-  --rm busybox sh -c "(date; sleep 1) | nc $INGRESS_HOST:$INGRESS_PORT"
+  --rm busybox sh -c "(date; sleep 1) | nc $INGRESS_HOST $INGRESS_PORT"
 done
 # $verify verifier="contains"
 two


### PR DESCRIPTION
The `TestTCPTrafficShifting` test script relies on fetching the port
named "tcp" on the istio-ingressgateway service, but that port is not
present in the default installation profile -- only in the demo
profile.  This patches the service to add the port in the setup
script, and also fixes the usage of `nc` in the test script.