### PR TITLE
Suppress brittle link warnings

### DIFF
--- a/scripts/lint_site.sh
+++ b/scripts/lint_site.sh
@@ -157,10 +157,10 @@ while IFS= read -r -d '' f; do
         FAILED=1
     fi
 
-    if grep -H -n -e "\"https://github.*#L[0-9]*\"" "${f}"; then
-        echo "WARNING: content shoudn't use links to specific lines in GitHub files as those are too brittle"
-        #FAILED=1
-    fi
+    #if grep -H -n -e "\"https://github.*#L[0-9]*\"" "${f}"; then
+    #    echo "Ensure content only uses links to specific lines in GitHub files as those are too brittle"
+    #    FAILED=1
+    #fi
 done < <(find ./public "${find_exclude[@]}" -type f -name '*.html' -print0)
 
 if [[ ${SKIP_LINK_CHECK:-} != "true" ]]; then

--- a/scripts/lint_site.sh
+++ b/scripts/lint_site.sh
@@ -158,7 +158,7 @@ while IFS= read -r -d '' f; do
     fi
 
     #if grep -H -n -e "\"https://github.*#L[0-9]*\"" "${f}"; then
-    #    echo "Ensure content only uses links to specific lines in GitHub files as those are too brittle"
+    #    echo "Ensure content doesn't use links to specific lines in GitHub files as those are too brittle"
     #    FAILED=1
     #fi
 done < <(find ./public "${find_exclude[@]}" -type f -name '*.html' -print0)


### PR DESCRIPTION
Commenting out the warning about brittle links to specific lines in github files. They clutter the output and make it hard to see the actual errors that need to be fixed.

If we want to enforce this rule, instead, we'll first need to fix the docs that are currently doing this (in the translations too) before we can uncomment the check. Until that's done, it's best to suppress the warning entirely.
