### PR TITLE
Run examples tests under the demo profile

### DIFF
--- a/tests/examples/bookinfo_test.go
+++ b/tests/examples/bookinfo_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package security
+package examples
 
 import (
 	"testing"

--- a/tests/examples/main_test.go
+++ b/tests/examples/main_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package security
+package examples
 
 import (
 	"testing"
@@ -27,12 +27,18 @@ var (
 	ist istio.Instance
 )
 
+const profileDemo = "profile: demo"
+
 func TestMain(m *testing.M) {
 	// Integration test for the Bookinfo flow.
 	framework.
 		NewSuite("examples", m).
 		Label(label.CustomSetup).
-		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
 		RequireEnvironment(environment.Kube).
 		Run()
+}
+
+func setupConfig(cfg *istio.Config) {
+	cfg.ControlPlaneValues = profileDemo
 }


### PR DESCRIPTION
Most of the tasks in the docs assume the installation is using the demo profile, but the tests install Istio with the default profile.  At least one instance of an issue caused by this can be found in istio/istio#21556.  This changes the example tests to run against an installation using the demo profile.

Fixes: https://github.com/istio/istio/issues/21634

Maybe this is slightly less necessary after istio/istio#22467, but still seems like a good idea. There have been other cases of the mismatch causing test issues, e.g. #7016.