### PR TITLE
fix yaml indent in docs/concepts/security

### DIFF
--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -333,8 +333,8 @@ the selector field of a policy that applies to workloads with the
 
 {{< text yaml >}}
 selector:
-     matchLabels:
-       app:product-page
+  matchLabels:
+    app: product-page
 {{< /text >}}
 
 If you don't provide a value for the `selector` field, Istio matches the policy

--- a/content/zh/docs/concepts/security/index.md
+++ b/content/zh/docs/concepts/security/index.md
@@ -189,8 +189,8 @@ Peer 和 request 认证策略使用 `selector` 字段来指定该策略适用的
 
 {{< text yaml >}}
 selector:
-     matchLabels:
-       app:product-page
+  matchLabels:
+    app: product-page
 {{< /text >}}
 
 如果您没有为 `selector` 字段提供值，则 Istio 会将策略与策略存储范围内的所有工作负载进行匹配。因此，`selector` 字段可帮助您指定策略的范围：


### PR DESCRIPTION
fix text yaml indent in docs/concepts/security

Replace
```
{{< text yaml >}}
selector:
     matchLabels:
       app:product-page
{{< /text >}}
```
With
```
{{< text yaml >}}
selector:
  matchLabels:
    app: product-page
{{< /text >}}
```