### PR TITLE
Fixing incorrect quote type in istio-authorization blog post

### DIFF
--- a/content/en/blog/2018/istio-authorization/index.md
+++ b/content/en/blog/2018/istio-authorization/index.md
@@ -174,9 +174,9 @@ metadata:
   namespace: default
 spec:
   subjects:
-  - user: "cluster.local/ns/default/sa/bookstore-frontend”
+  - user: "cluster.local/ns/default/sa/bookstore-frontend"
     properties:
-      request.auth.claims[group]: "qualified-reviewer”
+      request.auth.claims[group]: "qualified-reviewer"
   roleRef:
     kind: ServiceRole
     name: "book-reader"


### PR DESCRIPTION
Blog post code sample for ServiceRoleBinding had trailing "fancy" quotes making the sample unusable.