### PR TITLE
Ignore copied tests/integration directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ install/**
 # contains samples to demo Istio 
 samples/**
 
+# copied from istio repository
+tests/integration/**
+
 # contains the built artifacts
 out/** 
 


### PR DESCRIPTION
The configuration for the Istio installation used in integration tests
is copied at run-time from the Istio repository by `bin/init.sh` as of
istio/istio.io#6999, but the directory is otherwise empty here.  This
adds it to `.gitignore` to avoid a dirty tree after every test run.