### PR TITLE
Pass utf-8 encoding as a param to opening md files

### DIFF
--- a/scripts/snip.py
+++ b/scripts/snip.py
@@ -70,7 +70,7 @@ snipfile = "snips.sh" if markdown.split('/')[-1] == "index.md" else markdown.spl
 
 print("generating snips: " + os.path.join(snipdir, snipfile))
 
-with open(markdown, 'rt') as mdfile:
+with open(markdown, 'rt', encoding='utf-8') as mdfile:
     for line in mdfile:
         linenum += 1
 
@@ -130,7 +130,7 @@ with open(markdown, 'rt') as mdfile:
                         multiline_cmd = True
                 current_snip["script"].append(line)
 
-with open(os.path.join(snipdir, snipfile), 'w') as f:
+with open(os.path.join(snipdir, snipfile), 'w', encoding='utf-8') as f:
     f.write(HEADER % markdown.split("content/en/")[1] if "content/en/" in markdown else markdown)
     for snippet in snippets:
         lines = snippet["script"]


### PR DESCRIPTION
To fix #7097 

As `python3` is specifically [used to generate the code snippet](https://github.com/istio/istio.io/blob/master/scripts/gen_snips.sh#L19), we [need to pass utf-8](https://stackoverflow.com/questions/41512427/codecs-ascii-decodeinput-self-errors0-unicodedecodeerror-ascii-codec-can#answer-43639339) encoding as a param for reading `.md` file. 