### PR TITLE
Add documentation for adding sidecar injector webhook annotations in 1.4

### DIFF
--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -136,13 +136,13 @@ The following table shows the required settings for many common Kubernetes envir
 | Red Hat OpenShift 3.10+ | _(none)_ | _(none)_ |
 | Red Hat OpenShift 4.2+ | `--set components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/etc/cni/multus/net.d --set values.cni.chained=false --set values.cni.cniConfFileName="istio-cni.conf" --set values.sidecarInjectorWebhook.injectedAnnotations."k8s\.v1\.cni\.cncf\.io/networks"=istio-cni` | _(none)_ |
 
-#### Istioctl support in 1.4.8+ for OpenShift 4.2+
+#### Instructions for Istio 1.4 and OpenShift
 
-Istioctl in 1.4.8+ does not support [escaping strings](https://github.com/istio/istio/issues/19196). To install on
-OpenShift 4.2+ you will need to create a file and pass that into istioctl:
+Due to a [limitation](https://github.com/istio/istio/issues/19196) in istioctl 1.4, you will need to create a file and
+pass that file to istioctl.
 
-cni-annotations.yaml
-```yaml
+{{< text yaml >}}
+cat <<'EOF' > cni-annotations.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
@@ -159,9 +159,11 @@ spec:
     sidecarInjectorWebhook:
       injectedAnnotations:
         "k8s.v1.cni.cncf.io/networks": istio-cni
-```
+EOF
+{{< /text >}}
 
-Then passing in the file in as an argument `-f cni-annotations.yaml`
+Then passing in the file in as an argument to istioctl: `-f cni-annotations.yaml`. The use of `--set` with custom
+variables can be appended to your istioctl.
 
 ### GKE setup
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -136,10 +136,10 @@ The following table shows the required settings for many common Kubernetes envir
 | Red Hat OpenShift 3.10+ | _(none)_ | _(none)_ |
 | Red Hat OpenShift 4.2+ | `--set components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/etc/cni/multus/net.d --set values.cni.chained=false --set values.cni.cniConfFileName="istio-cni.conf" --set values.sidecarInjectorWebhook.injectedAnnotations."k8s\.v1\.cni\.cncf\.io/networks"=istio-cni` | _(none)_ |
 
-#### Instructions for Istio 1.4 and OpenShift
+#### Instructions for Istio 1.4.x and OpenShift
 
-Due to a [limitation](https://github.com/istio/istio/issues/19196) in `istioctl` 1.4, you will need to create a file and
-pass that file to `istioctl`. The documentation for istio 1.4 is out of date for OpenShift installation.
+Due to a [limitation](https://github.com/istio/istio/issues/19196) in `istioctl` 1.4.x, you will need to create a file and
+pass that file to `istioctl`. The documentation for Istio 1.4.x is out of date for OpenShift installation.
 
 {{< text yaml >}}
 cat <<'EOF' > cni-annotations.yaml
@@ -163,7 +163,7 @@ EOF
 {{< /text >}}
 
 Then passing in the file in as an argument to istioctl: `-f cni-annotations.yaml`. The use of `--set` with custom
-variables can be appended to your istioctl.
+variables can be appended to your use of istioctl.
 
 ### GKE setup
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -163,7 +163,7 @@ spec:
 EOF
 {{< /text >}}
 
-Then pass in this file as an argument to `istioctl`, for example:
+Then pass this file as an argument to `istioctl`, for example:
 
 {{< text bash >}}
 $ istioctl manifest apply -f cni-annotations.yaml

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -138,8 +138,8 @@ The following table shows the required settings for many common Kubernetes envir
 
 #### Instructions for Istio 1.4.x and OpenShift
 
-Due to a [limitation](https://github.com/istio/istio/issues/19196) in `istioctl` 1.4.x, you will need to create a file and
-pass that file to `istioctl`. The documentation for Istio 1.4.x is out of date for OpenShift installation.
+Due to a [limitation](https://github.com/istio/istio/issues/19196) in `istioctl` 1.4.x, CNI will not work properly with the
+default installation of Istio on OpenShift. To work around this problem, create the following YAML file:
 
 {{< text yaml >}}
 cat <<'EOF' > cni-annotations.yaml

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -163,16 +163,13 @@ spec:
 EOF
 {{< /text >}}
 
-Then passing in the file in as an argument to istioctl: `-f cni-annotations.yaml`. The use of `--set` with custom
-variables can be appended to your use of istioctl.
-
-Then pass in this file as an argument to istioctl, for example:
+Then pass in this file as an argument to `istioctl`, for example:
 
 {{< text bash >}}
 $ istioctl manifest apply -f cni-annotations.yaml
 {{< /text >}}
 
-You can still pass other command line arguments with --set if you need to.
+You can still pass other command line arguments with `--set` if you need to.
 
 {{< warning >}}
 In order to deploy Istio 1.4 on OpenShift with CNI you need to use at least Istio 1.4.8.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -146,14 +146,22 @@ cni-annotations.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
+  components:
+    cni:
+      enabled: true
+      namespace: kube-system
   values:
+    cni:
+      chained: false
+      cniBinDir: /var/lib/cni/bin
+      cniConfDir: /etc/cni/multus/net.d
+      cniConfFileName: istio-cni.conf
     sidecarInjectorWebhook:
       injectedAnnotations:
         "k8s.v1.cni.cncf.io/networks": istio-cni
 ```
 
-Then passing in the arguments
-` -f cni-annotations.yaml --set components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/etc/cni/multus/net.d --set values.cni.chained=false --set values.cni.cniConfFileName="istio-cni.conf"`
+Then passing in the file in as an argument `-f cni-annotations.yaml`
 
 ### GKE setup
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -138,8 +138,8 @@ The following table shows the required settings for many common Kubernetes envir
 
 #### Instructions for Istio 1.4 and OpenShift
 
-Due to a [limitation](https://github.com/istio/istio/issues/19196) in istioctl 1.4, you will need to create a file and
-pass that file to istioctl. The documentation for istio 1.4 is out of date for OpenShift installation.
+Due to a [limitation](https://github.com/istio/istio/issues/19196) in `istioctl` 1.4, you will need to create a file and
+pass that file to `istioctl`. The documentation for istio 1.4 is out of date for OpenShift installation.
 
 {{< text yaml >}}
 cat <<'EOF' > cni-annotations.yaml

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -143,16 +143,17 @@ OpenShift 4.2+ you will need to create a file and pass that into istioctl:
 
 cni-annotations.yaml
 ```yaml
-global:
-  sidecarInjectorWebhook:
-    injectedAnnotations:
-      "k8s.v1.cni.cncf.io/networks": istio-cni
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    sidecarInjectorWebhook:
+      injectedAnnotations:
+        "k8s.v1.cni.cncf.io/networks": istio-cni
 ```
 
-Then installing
-{{< text bash >}}
-` -f cni-annotations.yaml --set components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/etc/cni/multus/net.d --set values.cni.chained=false --set values.cni.cniConfFileName="istio-cni.conf"` | _(none)_
-{{< /text >}}
+Then passing in the arguments
+` -f cni-annotations.yaml --set components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/etc/cni/multus/net.d --set values.cni.chained=false --set values.cni.cniConfFileName="istio-cni.conf"`
 
 ### GKE setup
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -139,7 +139,7 @@ The following table shows the required settings for many common Kubernetes envir
 #### Instructions for Istio 1.4 and OpenShift
 
 Due to a [limitation](https://github.com/istio/istio/issues/19196) in istioctl 1.4, you will need to create a file and
-pass that file to istioctl.
+pass that file to istioctl. The documentation for istio 1.4 is out of date for OpenShift installation.
 
 {{< text yaml >}}
 cat <<'EOF' > cni-annotations.yaml

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -136,6 +136,24 @@ The following table shows the required settings for many common Kubernetes envir
 | Red Hat OpenShift 3.10+ | _(none)_ | _(none)_ |
 | Red Hat OpenShift 4.2+ | `--set components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/etc/cni/multus/net.d --set values.cni.chained=false --set values.cni.cniConfFileName="istio-cni.conf" --set values.sidecarInjectorWebhook.injectedAnnotations."k8s\.v1\.cni\.cncf\.io/networks"=istio-cni` | _(none)_ |
 
+#### Istioctl support in 1.4.8+ for OpenShift 4.2+
+
+Istioctl in 1.4.8+ does not support [escaping strings](https://github.com/istio/istio/issues/19196). To install on
+OpenShift 4.2+ you will need to create a file and pass that into istioctl:
+
+cni-annotations.yaml
+```yaml
+global:
+  sidecarInjectorWebhook:
+    injectedAnnotations:
+      "k8s.v1.cni.cncf.io/networks": istio-cni
+```
+
+Then installing
+{{< text bash >}}
+` -f cni-annotations.yaml --set components.cni.namespace=kube-system --set values.cni.cniBinDir=/var/lib/cni/bin --set values.cni.cniConfDir=/etc/cni/multus/net.d --set values.cni.chained=false --set values.cni.cniConfFileName="istio-cni.conf"` | _(none)_
+{{< /text >}}
+
 ### GKE setup
 
 1.  Refer to the procedure to [prepare a GKE cluster for Istio](/docs/setup/platform-setup/gke/) and

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -146,10 +146,11 @@ cat <<'EOF' > cni-annotations.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
-  components:
-    cni:
-      enabled: true
-      namespace: kube-system
+  cni:
+    enabled: true
+    components:
+      cni:
+        namespace: kube-system
   values:
     cni:
       chained: false
@@ -164,6 +165,18 @@ EOF
 
 Then passing in the file in as an argument to istioctl: `-f cni-annotations.yaml`. The use of `--set` with custom
 variables can be appended to your use of istioctl.
+
+Then pass in this file as an argument to istioctl, for example:
+
+{{< text bash >}}
+$ istioctl manifest apply -f cni-annotations.yaml
+{{< /text >}}
+
+You can still pass other command line arguments with --set if you need to.
+
+{{< warning >}}
+In order to deploy Istio 1.4 on OpenShift with CNI you need to use at least Istio 1.4.8.
+{{< /warning >}}
 
 ### GKE setup
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -169,7 +169,7 @@ Then pass in this file as an argument to `istioctl`, for example:
 $ istioctl manifest apply -f cni-annotations.yaml
 {{< /text >}}
 
-You can still pass other command line arguments with `--set` if you need to.
+You can pass other command line arguments with `--set` if necessary.
 
 {{< warning >}}
 In order to deploy Istio 1.4 on OpenShift with CNI you need to use at least Istio 1.4.8.


### PR DESCRIPTION
Add documentation for installing istio 1.4.8 with istioctl. Due to https://github.com/istio/istio/pull/20949 not being backported to istio 1.4, but changes to support OpenShift 4.3.5 (https://github.com/istio/istio/issues/22449) documentation is required for installing.

We cannot update the archive for istio 1.4.

We can just update 1.5 or merge into master and cherry-pick into 1.5.