### PR TITLE
User guide tests for DNS certificate management

### DIFF
--- a/content/en/docs/tasks/security/dns-cert/index.md
+++ b/content/en/docs/tasks/security/dns-cert/index.md
@@ -3,6 +3,7 @@ title: Istio DNS Certificate Management
 description: Shows how to provision and manage DNS certificates in Istio.
 weight: 90
 keywords: [security,certificate]
+test: true
 ---
 
 This task shows how to provision and manage DNS certificates
@@ -35,8 +36,6 @@ EOF
 $ istioctl manifest apply -f ./istio.yaml
 {{< /text >}}
 
-* Install [`jq`](https://stedolan.github.io/jq/) for validating the results from running the task.
-
 ## DNS certificate provisioning and management
 
 Istio provisions the DNS names and secret names for the DNS certificates based on configuration you provide.
@@ -60,14 +59,14 @@ and that the certificate contains the configured DNS names, you need to get the 
 decode it, and view its text output with the following command:
 
 {{< text bash >}}
-$ kubectl get secret dns.example1-service-account -n istio-system -o json | jq -r '.data["cert-chain.pem"]' | base64 --decode | openssl x509 -in /dev/stdin -text -noout
+$ kubectl get secret dns.example1-service-account -n istio-system -o jsonpath="{.data['cert-chain\.pem']}" | base64 --decode | openssl x509 -in /dev/stdin -text -noout
 {{< /text >}}
 
 The text output should include:
 
 {{< text plain >}}
-X509v3 Subject Alternative Name:
-  DNS:example1.istio-system.svc, DNS:example1.istio-system
+            X509v3 Subject Alternative Name:
+                DNS:example1.istio-system.svc, DNS:example1.istio-system
 {{< /text >}}
 
 ## Regenerating a DNS certificate
@@ -86,12 +85,20 @@ contains the configured DNS names, you need to get the secret from Kubernetes, p
 and view its text output with the following command:
 
     {{< text bash >}}
-    $ kubectl get secret dns.example1-service-account -n istio-system -o json | jq -r '.data["cert-chain.pem"]' | base64 --decode | openssl x509 -in /dev/stdin -text -noout
+    $ sleep 10; kubectl get secret dns.example1-service-account -n istio-system -o jsonpath="{.data['cert-chain\.pem']}" | base64 --decode | openssl x509 -in /dev/stdin -text -noout
     {{< /text >}}
 
 The output should include:
 
 {{< text plain >}}
-X509v3 Subject Alternative Name:
-  DNS:example1.istio-system.svc, DNS:example1.istio-system
+            X509v3 Subject Alternative Name:
+                DNS:example1.istio-system.svc, DNS:example1.istio-system
 {{< /text >}}
+
+## Cleanup
+
+*   To remove the `istio-system` namespace:
+
+    {{< text bash >}}
+    $ kubectl delete ns istio-system
+    {{< /text >}}

--- a/content/en/docs/tasks/security/dns-cert/snips.sh
+++ b/content/en/docs/tasks/security/dns-cert/snips.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          docs/tasks/security/dns-cert/index.md
+####################################################################################################
+
+snip_before_you_begin_1() {
+cat <<EOF > ./istio.yaml
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  values:
+    global:
+      certificates:
+        - secretName: dns.example1-service-account
+          dnsNames: [example1.istio-system.svc, example1.istio-system]
+        - secretName: dns.example2-service-account
+          dnsNames: [example2.istio-system.svc, example2.istio-system]
+EOF
+istioctl manifest apply -f ./istio.yaml
+}
+
+snip_check_the_provisioning_of_dns_certificates_1() {
+kubectl get secret dns.example1-service-account -n istio-system -o jsonpath="{.data['cert-chain\.pem']}" | base64 --decode | openssl x509 -in /dev/stdin -text -noout
+}
+
+# shellcheck disable=SC2034
+! read -r -d '' snip_check_the_provisioning_of_dns_certificates_2 <<ENDSNIP
+            X509v3 Subject Alternative Name:
+                DNS:example1.istio-system.svc, DNS:example1.istio-system
+ENDSNIP
+
+snip_regenerating_a_dns_certificate_1() {
+kubectl delete secret dns.example1-service-account -n istio-system
+}
+
+snip_regenerating_a_dns_certificate_2() {
+sleep 10; kubectl get secret dns.example1-service-account -n istio-system -o jsonpath="{.data['cert-chain\.pem']}" | base64 --decode | openssl x509 -in /dev/stdin -text -noout
+}
+
+# shellcheck disable=SC2034
+! read -r -d '' snip_regenerating_a_dns_certificate_3 <<ENDSNIP
+            X509v3 Subject Alternative Name:
+                DNS:example1.istio-system.svc, DNS:example1.istio-system
+ENDSNIP
+
+snip_cleanup_1() {
+kubectl delete ns istio-system
+}

--- a/tests/security/dns_cert/dns_cert_test.go
+++ b/tests/security/dns_cert/dns_cert_test.go
@@ -1,0 +1,44 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dnscert
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+
+	"istio.io/istio.io/pkg/test/istioio"
+)
+
+//https://istio.io/docs/tasks/security/dns-cert/
+//https://github.com/istio/istio.io/blob/release-1.5/content/en/docs/tasks/security/dns-cert/index.md
+func TestDNSCert(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(istioio.NewBuilder("tasks__security___dns_cert").
+			Add(istioio.Script{
+				Input: istioio.Path("scripts/dns_cert.txt"),
+			}).
+			// Cleanup.
+			Defer(istioio.Script{
+				Input: istioio.Inline{
+					FileName: "cleanup.sh",
+					Value: `
+source ${REPO_ROOT}/content/en/docs/tasks/security/dns-cert/snips.sh
+snip_cleanup_1`,
+				},
+			}).
+			Build())
+}

--- a/tests/security/dns_cert/main_test.go
+++ b/tests/security/dns_cert/main_test.go
@@ -1,0 +1,51 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dnscert
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/label"
+	"istio.io/istio/pkg/test/framework/resource/environment"
+)
+
+var (
+	ist istio.Instance
+)
+
+func TestMain(m *testing.M) {
+	framework.NewSuite("dns_cert", m).
+		Label(label.CustomSetup).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, setupConfig)).
+		RequireEnvironment(environment.Kube).
+		Run()
+}
+
+func setupConfig(cfg *istio.Config) {
+	if cfg == nil {
+		return
+	}
+	cfg.ControlPlaneValues = `
+values:
+  meshConfig:
+    certificates:
+      - secretName: dns.example1-service-account
+        dnsNames: [example1.istio-system.svc, example1.istio-system]
+      - secretName: dns.example2-service-account
+        dnsNames: [example2.istio-system.svc, example2.istio-system]
+`
+}

--- a/tests/security/dns_cert/scripts/dns_cert.txt
+++ b/tests/security/dns_cert/scripts/dns_cert.txt
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+
+source ${REPO_ROOT}/content/en/docs/tasks/security/dns-cert/snips.sh
+
+out=$(snip_check_the_provisioning_of_dns_certificates_1 2>&1)
+# Remove trailing spaces
+out=$(echo "$out" | sed 's/[ ]*$//')
+if [[ "$out" != *"$snip_check_the_provisioning_of_dns_certificates_2"* ]]; then
+    echo "FAILED snip_check_the_provisioning_of_dns_certificates_1:$out"; exit 1
+fi
+
+snip_regenerating_a_dns_certificate_1
+
+out=$(snip_regenerating_a_dns_certificate_2 2>&1)
+# Remove trailing spaces
+out=$(echo "$out" | sed 's/[ ]*$//')
+if [[ "$out" != *"$snip_regenerating_a_dns_certificate_3"* ]]; then
+    echo "FAILED snip_regenerating_a_dns_certificate_2:$out"; exit 1
+fi

--- a/tests/security/dns_cert/scripts/dns_cert.txt
+++ b/tests/security/dns_cert/scripts/dns_cert.txt
@@ -23,15 +23,11 @@ source ${REPO_ROOT}/content/en/docs/tasks/security/dns-cert/snips.sh
 out=$(snip_check_the_provisioning_of_dns_certificates_1 2>&1)
 # Remove trailing spaces
 out=$(echo "$out" | sed 's/[ ]*$//')
-if [[ "$out" != *"$snip_check_the_provisioning_of_dns_certificates_2"* ]]; then
-    echo "FAILED snip_check_the_provisioning_of_dns_certificates_1:$out"; exit 1
-fi
+_verify_contains "$out" "$snip_check_the_provisioning_of_dns_certificates_2" "snip_check_the_provisioning_of_dns_certificates_1"
 
 snip_regenerating_a_dns_certificate_1
 
 out=$(snip_regenerating_a_dns_certificate_2 2>&1)
 # Remove trailing spaces
 out=$(echo "$out" | sed 's/[ ]*$//')
-if [[ "$out" != *"$snip_regenerating_a_dns_certificate_3"* ]]; then
-    echo "FAILED snip_regenerating_a_dns_certificate_2:$out"; exit 1
-fi
+_verify_contains "$out" "$snip_regenerating_a_dns_certificate_3" "snip_regenerating_a_dns_certificate_2"


### PR DESCRIPTION
Please provide a description for what this PR is for:
- Add user guide tests for DNS certificate management.
- Remove the user guide's dependency on jq.