### PR TITLE
Fix doc in 'Egress Gateways with TLS Origination'

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -90,7 +90,7 @@ be done by the egress gateway, as opposed to by the sidecar in the previous exam
 
     Your `ServiceEntry` was configured correctly if you see _301 Moved Permanently_ in the output.
 
-1.  Create an egress `Gateway` for _edition.cnn.com_, port 443, and a destination rule for
+1.  Create an egress `Gateway` for _edition.cnn.com_, port 80, and a destination rule for
     sidecar requests that will be directed to the egress gateway.
 
     {{< text bash >}}


### PR DESCRIPTION
The code in step 3 of Perform TLS origination with an egress gateway explains how to create egress Gateway for edition.cnn.com. port 80, so the title of this step should follow it.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
