### PR TITLE
Fix doc 'Using the Istioctl Command-line Tool'

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -91,7 +91,7 @@ To retrieve information about endpoint configuration for the Envoy instance in a
 $ istioctl proxy-config endpoints <pod-name> [flags]
 {{< /text >}}
 
-See [Debugging Envoy and Pilot](/docs/ops/diagnostic-tools/proxy-cmd/) for more advice on interpreting this information.
+See [Debugging Envoy and Istiod](/docs/ops/diagnostic-tools/proxy-cmd/) for more advice on interpreting this information.
 
 ## `istioctl` auto-completion
 


### PR DESCRIPTION
Pilot is now a part of istiod, so rename it to istiod as the title of the page the link refers to.