### PR TITLE
Fix doc 'Traffic Management'

### DIFF
--- a/content/en/docs/concepts/traffic-management/index.md
+++ b/content/en/docs/concepts/traffic-management/index.md
@@ -533,7 +533,7 @@ to control the traffic to destinations that aren't registered in the mesh.
 
 ### Service entry example {#service-entry-example}
 
-The following example mesh-external service entry adds the `ext-resource`
+The following example mesh-external service entry adds the `ext-svc.example.com`
 external dependency to Istio’s service registry:
 
 {{< text yaml >}}


### PR DESCRIPTION
The external service `ServiceEntry` adds in this chapter is `ext-svc.example.com`, so fix it from `ext-resource` to `ext-svc.example.com`.