### PR TITLE
Galley cmd removed in 1.6.

### DIFF
--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -50,7 +50,6 @@ COMPONENTS=(
     https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"@pilot/cmd/pilot-agent@pilot-agent
     https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"@pilot/cmd/pilot-discovery@pilot-discovery
     https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"@security/cmd/node_agent@node_agent
-    https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"@galley/cmd/galley@galley
     https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"@operator/cmd/operator@operator
 )
 


### PR DESCRIPTION
This is blocking merges into istio/istio, see https://prow.istio.io/view/gcs/istio-prow/pr-logs/pull/istio_istio/22873/update-ref-docs-dry-run_istio/10