### PR TITLE
Fix reference docs: galley cmd removed

### DIFF
--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -50,7 +50,6 @@ COMPONENTS=(
     https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"@pilot/cmd/pilot-agent@pilot-agent
     https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"@pilot/cmd/pilot-discovery@pilot-discovery
     https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"@security/cmd/node_agent@node_agent
-    https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"@galley/cmd/galley@galley
     https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"@operator/cmd/operator@operator
 )
 


### PR DESCRIPTION
[update-ref-docs_istio.io_periodic](https://prow.istio.io/job-history/istio-prow/logs/update-ref-docs_istio.io_periodic) has been failing for weeks.

Galley was removed upstream in https://github.com/istio/istio/pull/22632. Updating the reference docs script accordingly.

> I will add a job to verify this on presubmit after this is resolved. And will set the current check on istio/istio to **required**. https://github.com/istio/test-infra/pull/2607

cc @howardjohn 