### PR TITLE
Fix for running user guide tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -240,6 +240,7 @@ You can execute individual tests using Go test as shown below.
 
 ```bash
 make init
+export REPO_ROOT=$(git rev-parse --show-toplevel)
 go test ./tests/... -p 1  --istio.test.env kube \
     --istio.test.ci --istio.test.work_dir <my_dir>
 ```


### PR DESCRIPTION
Please provide a description for what this PR is for: fix for running user guide tests. Without this fix, running the user guide test through "go test ..." will result in an error saying REPO_ROOT isn't set.