### PR TITLE
Fix typo in https://istio.io/docs/reference/config/analysis/ist0118/

### DIFF
--- a/content/en/docs/reference/config/analysis/ist0118/index.md
+++ b/content/en/docs/reference/config/analysis/ist0118/index.md
@@ -32,7 +32,7 @@ spec:
     app: httpbin
 {{< /text >}}
 
-In this example, the port `foo-http` does follow the syntax: `name: <protocol>[-<suffix>]`.
+In this example, the port `foo-http` doesn't follow the syntax: `name: <protocol>[-<suffix>]`.
 
 ## How to resolve
 


### PR DESCRIPTION
Fix typo in:

> In this example, the port foo-http does follow the syntax: name: <protocol>[-<suffix>].
`foo-http` definitely *not* following the syntax.