### PR TITLE
Remove Galley Architecture section

### DIFF
--- a/content/en/docs/ops/deployment/architecture/index.md
+++ b/content/en/docs/ops/deployment/architecture/index.md
@@ -127,13 +127,6 @@ on relatively unstable layer 3 or layer 4 network identifiers. Starting from
 release 0.5, you can use [Istio's authorization feature](/docs/concepts/security/#authorization)
 to control who can access your services.
 
-### Galley
-
-Galley is Istio's configuration validation, ingestion, processing and
-distribution component. It is responsible for insulating
-the rest of the Istio components from the details of obtaining user
-configuration from the underlying platform (e.g. Kubernetes).
-
 ## Design goals
 
 A few key design goals informed Istio’s architecture. These goals are essential

--- a/content/en/news/releases/1.1.x/announcing-1.1/_index.md
+++ b/content/en/news/releases/1.1.x/announcing-1.1/_index.md
@@ -45,7 +45,7 @@ teams cannot interfere with each other.
 We have also improved the [multicluster capabilities and usability](/docs/ops/deployment/deployment-models/).
 We listened to the community and improved defaults for traffic control and
 policy. We introduced a new component called
-[Galley](/docs/ops/deployment/architecture/#galley). Galley validates that sweet,
+[Galley](https://archive.istio.io/v1.1/docs/concepts/what-is-istio/#galley). Galley validates that sweet,
 sweet YAML, reducing the chance of configuration errors. Galley will also be
 instrumental in [multicluster setups](/docs/setup/install/multicluster/),
 gathering service discovery information from each Kubernetes cluster. We are

--- a/content/en/news/releases/1.1.x/announcing-1.1/change-notes/index.md
+++ b/content/en/news/releases/1.1.x/announcing-1.1/change-notes/index.md
@@ -182,7 +182,7 @@ concise list of things you should know before upgrading your deployment to Istio
 
 ### Configuration management
 
-- **Galley**. Added [Galley](/docs/ops/deployment/architecture/#galley) as the
+- **Galley**. Added [Galley](https://archive.istio.io/v1.1/docs/concepts/what-is-istio/#galley) as the
   primary configuration ingestion and distribution mechanism within Istio. It
   provides a robust model to validate, transform, and distribute configuration
   states to Istio components insulating the Istio components from Kubernetes


### PR DESCRIPTION
Galley no longer exists as a command, and the information documented in this section has not been true since the introduction of IstioD.  We should probably look at the information in the Citadel section as well, but I am less certain of that.