### PR TITLE
Update automated test TAG to match go.mod istio commit

### DIFF
--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -40,7 +40,7 @@ export TEST_ENV=kind
 export PULL_POLICY=IfNotPresent
 
 export HUB=${HUB:-"gcr.io/istio-testing"}
-export TAG="${TAG:-"latest"}"
+export TAG="${TAG:-"1.6-alpha.1d3b136325a5592511f72a9b041ea396bdbd5180"}"
 
 # Setup junit report and verbose logging
 export T="${T:-"-v"}"


### PR DESCRIPTION
Currently the tests are using the `latest` TAG which varies as builds are done, and was pointing to a 1.7 image earlier. This will get the test to use a known image that matches the go.mod commit for istio/istio, which will hopefully get test passage better (only a few flakey tests).