### PR TITLE
Correct Envoy Access Log links

### DIFF
--- a/content/en/docs/ops/common-problems/network-issues/index.md
+++ b/content/en/docs/ops/common-problems/network-issues/index.md
@@ -22,7 +22,7 @@ $ kubectl logs PODNAME -c istio-proxy -n NAMESPACE
 In the default access log format, Envoy response flags and Mixer policy status are located after the response code,
 if you are using a custom log format, make sure to include `%RESPONSE_FLAGS%` and `%DYNAMIC_METADATA(istio.mixer:status)%`.
 
-Refer to the [Envoy response flags](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#config-access-log-format-response-flags)
+Refer to the [Envoy response flags](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags)
 for details of response flags.
 
 Common response flags are:

--- a/content/en/docs/reference/config/policy-and-telemetry/attribute-vocabulary/index.md
+++ b/content/en/docs/reference/config/policy-and-telemetry/attribute-vocabulary/index.md
@@ -82,7 +82,7 @@ deployments will have agents (Envoy or Mixer adapters) that produce these attrib
 | `context.time`          | timestamp | The timestamp of Mixer operation. | |
 | `context.reporter.kind` | string | Contextualizes the reported attribute set. Set to `inbound` for the server-side calls from sidecars and `outbound` for the client-side calls from sidecars and gateways | `inbound` |
 | `context.reporter.uid`  | string | Platform-specific identifier of the attribute reporter. | `kubernetes://my-svc-234443-5sffe.my-namespace` |
-| `context.proxy_error_code` | string | Additional details about the response or connection from proxy. In case of Envoy, see `%RESPONSE_FLAGS%` in [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#configuration) for more detail | `UH` |
+| `context.proxy_error_code` | string | Additional details about the response or connection from proxy. In case of Envoy, see `%RESPONSE_FLAGS%` in [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags) for more detail | `UH` |
 | `api.service` | string | The public service name. This is different than the in-mesh service identity and reflects the name of the service exposed to the client. | `my-svc.com` |
 | `api.version` | string | The API version. | `v1alpha1` |
 | `api.operation` | string | Unique string used to identify the operation. The id is unique among all operations described in a specific &lt;service, version&gt;. | `getPetsById` |

--- a/content/en/docs/reference/config/policy-and-telemetry/metrics/index.md
+++ b/content/en/docs/reference/config/policy-and-telemetry/metrics/index.md
@@ -157,7 +157,7 @@ For TCP traffic, Istio generates the following metrics:
     {{< /text >}}
 
 *   **Response Flags**: Additional details about the response or connection from proxy.
-    In case of Envoy, see `%RESPONSE_FLAGS%` in [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#configuration)
+    In case of Envoy, see `%RESPONSE_FLAGS%` in [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags)
     for more detail.
 
     {{< text yaml >}}

--- a/content/en/docs/reference/config/telemetry/metrics/index.md
+++ b/content/en/docs/reference/config/telemetry/metrics/index.md
@@ -93,7 +93,7 @@ For TCP traffic, Istio generates the following metrics:
     source since security policy cannot be properly populated.
 
 *   **Response Flags**: Additional details about the response or connection from proxy.
-    In case of Envoy, see `%RESPONSE_FLAGS%` in [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#configuration)
+    In case of Envoy, see `%RESPONSE_FLAGS%` in [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags)
     for more detail.
 
 *   **Canonical Service**: A workload belongs to exactly one canonical service, whereas it can belong to multiple services.

--- a/content/en/docs/tasks/observability/logs/access-log/index.md
+++ b/content/en/docs/tasks/observability/logs/access-log/index.md
@@ -9,7 +9,7 @@ aliases:
 ---
 
 The simplest kind of Istio logging is
-[Envoy's access logging](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log).
+[Envoy's access logging](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage).
 Envoy proxies print access information to their standard output.
 The standard output of Envoy's containers can then be printed by the `kubectl logs` command.
 
@@ -45,7 +45,7 @@ $ istioctl manifest apply --set profile=demo --set values.global.proxy.accessLog
 You can also choose between JSON and text by setting `accessLogEncoding` to `JSON` or `TEXT`.
 
 You may also want to customize the
-[format](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#format-rules) of the access log by editing `accessLogFormat`.
+[format](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-rules) of the access log by editing `accessLogFormat`.
 
 {{< tip >}}
 All three of these parameters may also be configured via [install options](https://archive.istio.io/v1.4/docs/reference/config/installation-options/):
@@ -97,7 +97,7 @@ All three of these parameters may also be configured via [install options](https
     [2019-03-06T09:31:27.360Z] "GET /status/418 HTTP/1.1" 418 - "-" 0 135 5 2 "-" "curl/7.60.0" "d209e46f-9ed5-9b61-bbdd-43e22662702a" "httpbin:8000" "127.0.0.1:80" inbound|8000|http|httpbin.default.svc.cluster.local - 172.30.146.73:80 172.30.146.82:38618 outbound_.8000_._.httpbin.default.svc.cluster.local
     {{< /text >}}
 
-Note that the messages corresponding to the request appear in logs of the Istio proxies of both the source and the destination, `sleep` and `httpbin`, respectively. You can see in the log the HTTP verb (`GET`), the HTTP path (`/status/418`), the response code (`418`) and other [request-related information](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#format-rules).
+Note that the messages corresponding to the request appear in logs of the Istio proxies of both the source and the destination, `sleep` and `httpbin`, respectively. You can see in the log the HTTP verb (`GET`), the HTTP path (`/status/418`), the response code (`418`) and other [request-related information](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-rules).
 
 ## Cleanup
 

--- a/content/pt-br/docs/ops/common-problems/network-issues/index.md
+++ b/content/pt-br/docs/ops/common-problems/network-issues/index.md
@@ -22,7 +22,7 @@ $ kubectl logs PODNAME -c istio-proxy -n NAMESPACE
 In the default access log format, Envoy response flags and Mixer policy status are located after the response code,
 if you are using a custom log format, make sure to include `%RESPONSE_FLAGS%` and `%DYNAMIC_METADATA(istio.mixer:status)%`.
 
-Refer to the [Envoy response flags](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#config-access-log-format-response-flags)
+Refer to the [Envoy response flags](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags)
 for details of response flags.
 
 Common response flags are:

--- a/content/pt-br/docs/reference/config/policy-and-telemetry/attribute-vocabulary/index.md
+++ b/content/pt-br/docs/reference/config/policy-and-telemetry/attribute-vocabulary/index.md
@@ -82,7 +82,7 @@ deployments will have agents (Envoy or Mixer adapters) that produce these attrib
 | `context.time`          | timestamp | The timestamp of Mixer operation. | |
 | `context.reporter.kind` | string | Contextualizes the reported attribute set. Set to `inbound` for the server-side calls from sidecars and `outbound` for the client-side calls from sidecars and gateways | `inbound` |
 | `context.reporter.uid`  | string | Platform-specific identifier of the attribute reporter. | `kubernetes://my-svc-234443-5sffe.my-namespace` |
-| `context.proxy_error_code` | string | Additional details about the response or connection from proxy. In case of Envoy, see `%RESPONSE_FLAGS%` in [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#configuration) for more detail | `UH` |
+| `context.proxy_error_code` | string | Additional details about the response or connection from proxy. In case of Envoy, see `%RESPONSE_FLAGS%` in [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags) for more detail | `UH` |
 | `api.service` | string | The public service name. This is different than the in-mesh service identity and reflects the name of the service exposed to the client. | `my-svc.com` |
 | `api.version` | string | The API version. | `v1alpha1` |
 | `api.operation` | string | Unique string used to identify the operation. The id is unique among all operations described in a specific &lt;service, version&gt;. | `getPetsById` |

--- a/content/pt-br/docs/reference/config/policy-and-telemetry/metrics/index.md
+++ b/content/pt-br/docs/reference/config/policy-and-telemetry/metrics/index.md
@@ -157,7 +157,7 @@ For TCP traffic, Istio generates the following metrics:
     {{< /text >}}
 
 *   **Response Flags**: Additional details about the response or connection from proxy.
-    In case of Envoy, see `%RESPONSE_FLAGS%` in [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#configuration)
+    In case of Envoy, see `%RESPONSE_FLAGS%` in [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags)
     for more detail.
 
     {{< text yaml >}}

--- a/content/pt-br/docs/tasks/observability/logs/access-log/index.md
+++ b/content/pt-br/docs/tasks/observability/logs/access-log/index.md
@@ -29,7 +29,7 @@ configmap "istio" replaced
 You can also choose between JSON and text by setting `accessLogEncoding` to `JSON` or `TEXT`.
 
 You may also want to customize the
-[format](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#format-rules) of the access log by editing `accessLogFormat`.
+[format](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-rules) of the access log by editing `accessLogFormat`.
 
 {{< tip >}}
 All three of these parameters may also be configured via [install options](/pt-br/docs/reference/config/installation-options/):
@@ -81,7 +81,7 @@ All three of these parameters may also be configured via [install options](/pt-b
     [2019-03-06T09:31:27.360Z] "GET /status/418 HTTP/1.1" 418 - "-" 0 135 5 2 "-" "curl/7.60.0" "d209e46f-9ed5-9b61-bbdd-43e22662702a" "httpbin:8000" "127.0.0.1:80" inbound|8000|http|httpbin.default.svc.cluster.local - 172.30.146.73:80 172.30.146.82:38618 outbound_.8000_._.httpbin.default.svc.cluster.local
     {{< /text >}}
 
-Note that the messages corresponding to the request appear in logs of the Istio proxies of both the source and the destination, `sleep` and `httpbin`, respectively. You can see in the log the HTTP verb (`GET`), the HTTP path (`/status/418`), the response code (`418`) and other [request-related information](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#format-rules).
+Note that the messages corresponding to the request appear in logs of the Istio proxies of both the source and the destination, `sleep` and `httpbin`, respectively. You can see in the log the HTTP verb (`GET`), the HTTP path (`/status/418`), the response code (`418`) and other [request-related information](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-rules).
 
 ## Cleanup
 

--- a/content/zh/docs/ops/common-problems/network-issues/index.md
+++ b/content/zh/docs/ops/common-problems/network-issues/index.md
@@ -19,7 +19,7 @@ $ kubectl logs PODNAME -c istio-proxy -n NAMESPACE
 
 在默认的访问日志输出格式中，Envoy 响应标志和 Mixer 策略状态位于响应状态码之后，如果你使用自定义日志输出格式，请确保包含 `%RESPONSE_FLAGS%` 和 `%DYNAMIC_METADATA(istio.mixer:status) %`。
 
-参考 [Envoy 响应标志](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#config-access-log-format-response-flags)查看更多有关响应标志的细节。
+参考 [Envoy 响应标志](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags)查看更多有关响应标志的细节。
 
 通用响应标志如下：
 

--- a/content/zh/docs/reference/config/policy-and-telemetry/attribute-vocabulary/index.md
+++ b/content/zh/docs/reference/config/policy-and-telemetry/attribute-vocabulary/index.md
@@ -82,7 +82,7 @@ Istio 中除了 Envoy 是首要的属性生产者外，Mixer 和服务也会产�
 | `context.time` | timestamp | Mixer 操作的时间戳。 | |
 | `context.reporter.kind` | string | 将报告的属性集上下文化。 对于来自 sidecars 的服务器端调用设置为 `inbound`，对于来自 sidecars 和网关的客户端调用设置为 `outbound` 。 | `inbound` |
 | `context.reporter.uid` | string | 属性报告者特定于平台的唯一标识符。 | `kubernetes://my-svc-234443-5sffe.my-namespace` |
-| `context.proxy_error_code` | string | 有关来自代理的响应或连接的其他详细信息。 如果是 Envoy, 请参阅 [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#configuration) 的 `%RESPONSE_FLAGS%` 查看更多信息 | `UH` |
+| `context.proxy_error_code` | string | 有关来自代理的响应或连接的其他详细信息。 如果是 Envoy, 请参阅 [Envoy Access Log](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage/#config-access-log-format-response-flags) 的 `%RESPONSE_FLAGS%` 查看更多信息 | `UH` |
 | `api.service` | string | 公开的服务名。和处于网格中的服务身份不同，它反映了暴露给客户端的服务名称。 | `my-svc.com` |
 | `api.version` | string | API 版本。 | `v1alpha1` |
 | `api.operation` | string | 用于辨别操作的唯一字符串。在特定的 &lt;service, version&gt; 描述的所有操作中，这个 ID 是唯一的。 | `getPetsById` |

--- a/content/zh/docs/reference/config/policy-and-telemetry/metrics/index.md
+++ b/content/zh/docs/reference/config/policy-and-telemetry/metrics/index.md
@@ -134,7 +134,7 @@ Istio 为 HTTP、HTTP/2 和 GRPC 流量创建了下列指标：
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
     {{< /text >}}
 
-* **Response Flags**: 来自代理服务器，包含了响应或者连接的额外细节。如果是 Envoy 代理，可以参考 [Envoy 访问日志](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#configuration)中的 `%RESPONSE_FLAGS%` 相关说明。
+* **Response Flags**: 来自代理服务器，包含了响应或者连接的额外细节。如果是 Envoy 代理，可以参考 [Envoy 访问日志](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags)中的 `%RESPONSE_FLAGS%` 相关说明。
 
     {{< text yaml >}}
     response_flags: context.proxy_error_code | "-"

--- a/content/zh/docs/reference/config/telemetry/metrics/index.md
+++ b/content/zh/docs/reference/config/telemetry/metrics/index.md
@@ -134,7 +134,7 @@ weight: 50
     connection_security_policy: conditional((context.reporter.kind | "inbound") == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls", "none"))
     {{< /text >}}
 
-*   **响应标志**：有关来自代理的响应或连接的其他详细信息。如果使用 Envoy ，请参阅 [Envoy 访问日志](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#configuration)中的 `％RESPONSE_FLAGS％` 以获取更多详细信息。
+*   **响应标志**：有关来自代理的响应或连接的其他详细信息。如果使用 Envoy ，请参阅 [Envoy 访问日志](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#config-access-log-format-response-flags)中的 `％RESPONSE_FLAGS％` 以获取更多详细信息。
 
     {{< text yaml >}}
     response_flags: context.proxy_error_code | "-"

--- a/content/zh/docs/tasks/observability/logs/access-log/index.md
+++ b/content/zh/docs/tasks/observability/logs/access-log/index.md
@@ -8,7 +8,7 @@ aliases:
     - /zh/docs/tasks/telemetry/logs/access-log/
 ---
 
-Istio 最简单的日志类型是 [Envoy 的访问日志](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log)。Envoy 代理打印访问信息到标准输出。Envoy 容器的标准输出能够通过 `kubectl logs` 命令打印出来。
+Istio 最简单的日志类型是 [Envoy 的访问日志](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage)。Envoy 代理打印访问信息到标准输出。Envoy 容器的标准输出能够通过 `kubectl logs` 命令打印出来。
 
 {{< boilerplate before-you-begin-egress >}}
 
@@ -25,7 +25,7 @@ configmap "istio" replaced
 
 您也可以通过设置 `accessLogEncoding` 为 `JSON` 或 `TEXT` 来在两种格式之间切换。
 
-您也许希望通过设置 `accessLogFormat` 来自定义访问日志的[格式](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#format-rules)。
+您也许希望通过设置 `accessLogFormat` 来自定义访问日志的[格式](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-rules)。
 
 {{< tip >}}
 这三种参数也可以通过[安装选项](/zh/docs/reference/config/installation-options/)来进行配置:
@@ -77,7 +77,7 @@ configmap "istio" replaced
     [2019-03-06T09:31:27.360Z] "GET /status/418 HTTP/1.1" 418 - "-" 0 135 5 2 "-" "curl/7.60.0" "d209e46f-9ed5-9b61-bbdd-43e22662702a" "httpbin:8000" "127.0.0.1:80" inbound|8000|http|httpbin.default.svc.cluster.local - 172.30.146.73:80 172.30.146.82:38618 outbound_.8000_._.httpbin.default.svc.cluster.local
     {{< /text >}}
 
-请注意，与请求相对应的信息分别出现在源（`sleep`）和目标（`httpbin`）的 Istio 代理日志中。您可以在日志中看到 HTTP 动词(`GET`)、HTTP 路径(`/status/418`)、响应码(`418`) 和其他[请求相关信息](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#format-rules)。
+请注意，与请求相对应的信息分别出现在源（`sleep`）和目标（`httpbin`）的 Istio 代理日志中。您可以在日志中看到 HTTP 动词(`GET`)、HTTP 路径(`/status/418`)、响应码(`418`) 和其他[请求相关信息](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-rules)。
 
 ## 清除{#cleanup}
 


### PR DESCRIPTION
Updates 404ing links to new sub page in Istio docs. In addition adds an anchor link to the relevant section of the page in a number of places referring to the `％RESPONSE_FLAGS％`