### PR TITLE
Update deprecated flags for meshConfig

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/locality-load-balancing/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/locality-load-balancing/index.md
@@ -23,7 +23,7 @@ the geographic location where requests are sent.
 ## Configuring locality load balancing
 
 This feature is enabled by default. To disable locality load balancing,
-pass the `--set global.localityLbSetting.enabled=false` flag when installing Istio.
+pass the `--set meshConfig.localityLbSetting.enabled=false` flag when installing Istio.
 
 ## Requirements
 
@@ -73,14 +73,14 @@ Sometimes, you need to constrain the traffic fail-over to avoid sending traffic 
 endpoints across the globe when there are not enough healthy endpoints in the
 same region. This behavior is useful when sending fail-over traffic across regions
 would not improve service health or many other reasons including regulatory controls.
-To constrain traffic to a region, configure the `values.localityLbSetting` option during install. See the
+To constrain traffic to a region, configure the `meshConfig.localityLbSetting` option during install. See the
 [Locality load balancing reference guide](/docs/reference/config/networking/destination-rule#LocalityLoadBalancerSetting)
 for options.
 
 An example configuration:
 
 {{< text yaml >}}
-global:
+meshConfig:
   localityLbSetting:
     enabled: true
     failover:
@@ -97,7 +97,7 @@ Locality-weighted load balancing distributes user-defined percentages of traffic
 For example, if we want to keep 80% of traffic within our region, and send 20% of traffic out of region:
 
 {{< text yaml >}}
-global:
+meshConfig:
   localityLbSetting:
     enabled: true
     distribute:

--- a/content/en/docs/tasks/observability/logs/access-log/index.md
+++ b/content/en/docs/tasks/observability/logs/access-log/index.md
@@ -26,7 +26,7 @@ In the example below, replace `demo` with the name of the profile you used when 
 {{< /tip >}}
 
 {{< text bash >}}
-$ istioctl manifest apply --set profile=demo --set values.global.proxy.accessLogFile="/dev/stdout"
+$ istioctl manifest apply --set profile=demo --set meshConfig.accessLogFile="/dev/stdout"
 - Applying manifest for component Base...
 ✔ Finished applying manifest for component Base.
 - Applying manifest for component Pilot...
@@ -51,9 +51,9 @@ You may also want to customize the
 All three of these parameters may also be configured via [install options](https://archive.istio.io/v1.4/docs/reference/config/installation-options/):
 {{< /tip >}}
 
-* `values.global.proxy.accessLogFile`
-* `values.global.proxy.accessLogEncoding`
-* `values.global.proxy.accessLogFormat`
+* `meshConfig.accessLogFile`
+* `meshConfig.accessLogEncoding`
+* `meshConfig.accessLogFormat`
 
 ## Test the access log
 

--- a/content/en/docs/tasks/policy-enforcement/enabling-policy/index.md
+++ b/content/en/docs/tasks/policy-enforcement/enabling-policy/index.md
@@ -24,7 +24,7 @@ This task shows you how to enable Istio policy enforcement.
 ## At install time
 
 In the default Istio installation profile, policy enforcement is disabled. To install Istio
-with policy enforcement on, use the `--set values.global.disablePolicyChecks=false` and `--set values.pilot.policy.enabled=true` install option.
+with policy enforcement on, use the `--set meshConfig.disablePolicyChecks=false` and `--set values.pilot.policy.enabled=true` install option.
 
 Alternatively, you may [install Istio using the demo profile](/docs/setup/getting-started/),
 which enables policy checks by default.
@@ -45,7 +45,7 @@ which enables policy checks by default.
     Execute the following command from the root Istio directory:
 
     {{< text bash >}}
-    $ istioctl manifest apply --set values.global.disablePolicyChecks=false --set values.pilot.policy.enabled=true
+    $ istioctl manifest apply --set meshConfig.disablePolicyChecks=false --set values.pilot.policy.enabled=true
     configuration "istio" replaced
     {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -51,8 +51,8 @@ This task shows you how to access external services in three different ways:
 
 ## Envoy passthrough to external services
 
-Istio has an [installation option](https://archive.istio.io/v1.4/docs/reference/config/installation-options/),
-`global.outboundTrafficPolicy.mode`, that configures the sidecar handling
+Istio has an [installation option](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-OutboundTrafficPolicy-Mode),
+`meshConfig.outboundTrafficPolicy.mode`, that configures the sidecar handling
 of external services, that is, those services that are not defined in Istio's internal service registry.
 If this option is set to `ALLOW_ANY`, the Istio proxy lets calls to unknown services pass through.
 If the option is set to `REGISTRY_ONLY`, then the Istio proxy blocks any host without an HTTP service or
@@ -62,7 +62,7 @@ without controlling access to external services.
 You can then decide to [configure access to external services](#controlled-access-to-external-services) later.
 
 1. To see this approach in action you need to ensure that your Istio installation is configured
-    with the `global.outboundTrafficPolicy.mode` option set to `ALLOW_ANY`. Unless you explicitly
+    with the `meshConfig.outboundTrafficPolicy.mode` option set to `ALLOW_ANY`. Unless you explicitly
     set it to `REGISTRY_ONLY` mode when you installed Istio, it is probably enabled by default.
 
     Run the following command to confirm it is configured correctly:
@@ -109,7 +109,7 @@ from within your Istio cluster. This section shows you how to configure access t
 ### Change to the blocking-by-default policy
 
 To demonstrate the controlled way of enabling access to external services, you need to change the
-`global.outboundTrafficPolicy.mode` option from the `ALLOW_ANY` mode to the `REGISTRY_ONLY` mode.
+`meshConfig.outboundTrafficPolicy.mode` option from the `ALLOW_ANY` mode to the `REGISTRY_ONLY` mode.
 
 {{< tip >}}
 You can add controlled access to services that are already accessible in `ALLOW_ANY` mode.
@@ -118,7 +118,7 @@ Once you've configured all of your services, you can then switch the mode to `RE
 any other unintentional accesses.
 {{< /tip >}}
 
-1.  Run the following command to change the `global.outboundTrafficPolicy.mode` option to `REGISTRY_ONLY`:
+1.  Run the following command to change the `meshConfig.outboundTrafficPolicy.mode` option to `REGISTRY_ONLY`:
 
     {{< text bash >}}
     $ kubectl get configmap istio -n istio-system -o yaml | sed 's/mode: ALLOW_ANY/mode: REGISTRY_ONLY/g' | kubectl replace -n istio-system -f -


### PR DESCRIPTION
Few flags are [moved into meshConfig](https://github.com/istio/istio/blob/a32319673a4dba81012018d76962db2c5a876d76/operator/pkg/apis/istio/v1alpha1/validation/validation.go#L62) and throws deprecation warning. This PR will update those flags to [avoid deprecation warning](https://github.com/istio/istio.io/issues/7149) during `manifest apply`

[X] Docs
[X] User Experience
