### PR TITLE
Remove experimental link in feature status page; change to development

### DIFF
--- a/content/en/about/feature-stages/index.md
+++ b/content/en/about/feature-stages/index.md
@@ -64,7 +64,6 @@ Below is our list of existing features and their current phases. This informatio
 | [Distributed Tracing to Zipkin / Jaeger](/docs/tasks/observability/distributed-tracing/) | Beta
 | [Logging with Fluentd](/docs/tasks/observability/mixer/logs/fluentd/) | Beta
 | [Trace Sampling](/docs/tasks/observability/distributed-tracing/configurability/#trace-sampling) | Beta
-| [Trace Configurability](/docs/tasks/observability/distributed-tracing/configurability/) | Experimental
 
 ### Security and policy enforcement
 

--- a/content/en/docs/tasks/observability/distributed-tracing/configurability/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/configurability/index.md
@@ -1,13 +1,13 @@
 ---
-title: Configurability (Beta/Experimental)
-description: How to configure tracing options (beta/experimental).
+title: Configurability (Beta/Development)
+description: How to configure tracing options (beta/development).
 weight: 60
 keywords: [telemetry,tracing]
 ---
 
 Istio provides the ability to configure advanced tracing options,
 including sampling rates and span tags. Sampling is a beta feature, but
-custom tags and tracing tag length are considered experimental for this release.
+custom tags and tracing tag length are considered in-development for this release.
 
 ## Create a `MeshConfig` with trace settings
 


### PR DESCRIPTION
Features in development should not be listed in the features stage. Change page to reflect development status.