### PR TITLE
Remove warning on hardening with distroless

### DIFF
--- a/content/en/docs/ops/configuration/security/harden-docker-images/index.md
+++ b/content/en/docs/ops/configuration/security/harden-docker-images/index.md
@@ -8,18 +8,6 @@ aliases:
 ---
 To ease the process of hardening docker images, Istio provides a set of images based on  [distroless images](https://github.com/GoogleContainerTools/distroless)
 
-{{< warning >}}
-The *distroless images* are work-in-progress.
-The following images haven't been updated to support *distroless*:
-
-- `proxyproxy`
-- `proxy_debug`
-- `kubectl`
-- `app_sidecar`
-
-For ease of the installation, they are available with a `-distroless` suffix.
-{{< /warning >}}
-
 ## Install distroless images
 
 Follow the [Installation Steps](/docs/setup/install/istioctl/) to setup Istio.


### PR DESCRIPTION
From Slack: https://istio.slack.com/archives/C6KA8TTSS/p1589217983374800

Distroless images. Page says proxyproxy , proxy_debug , kubectl , app_sidecar are works in progress. I suspect the first one should be proxytproxy. The others have tagged images. I’m assumeing we still don’t support them even if there are images? Or did we fix some/all to now be supported? (

John Howard:
@Eric Van Norman all of those images are removed now I think, except app_sidecar which is a test application running the debian sidecar image (so it doesn't even make sense to have distroless). **So I would remove the warning**