### PR TITLE
Add --all-namespace flag to istioctl analyze

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -15,7 +15,7 @@ apply changes to a cluster.
 You can analyze your current Kubernetes cluster by running:
 
 {{< text bash >}}
-$ istioctl analyze
+$ istioctl analyze --all-namespaces
 {{< /text >}}
 
 And that’s it! It’ll give you any recommendations that apply.


### PR DESCRIPTION
This implicitly documents that its namespaced, and is more accurate in actually "analyze your current Kubernetes cluster"