### PR TITLE
Add diagram to what-is-istio page

### DIFF
--- a/content/en/docs/concepts/what-is-istio/index.md
+++ b/content/en/docs/concepts/what-is-istio/index.md
@@ -45,7 +45,13 @@ between microservices, then configure and manage Istio using its control plane f
 
 * Secure service-to-service communication in a cluster with strong identity-based authentication and authorization.
 
-Istio is designed for extensibility and meets diverse deployment needs.
+Istio is designed for extensibility and meets diverse deployment needs. The following [architecture](/docs/ops/deployment/architecture/) diagram shows the various components.
+
+{{< image width="80%"
+    link="./arch.svg"
+    alt="The overall architecture of an Istio-based application."
+    caption="Istio Architecture"
+    >}}
 
 ## Core features
 

--- a/content/en/docs/concepts/what-is-istio/index.md
+++ b/content/en/docs/concepts/what-is-istio/index.md
@@ -45,7 +45,7 @@ between microservices, then configure and manage Istio using its control plane f
 
 * Secure service-to-service communication in a cluster with strong identity-based authentication and authorization.
 
-Istio is designed for extensibility and meets diverse deployment needs. The following [architecture](/docs/ops/deployment/architecture/) diagram shows the various components.
+Istio is designed for extensibility and meets diverse deployment needs. The following [architecture](/docs/ops/deployment/architecture/) diagram shows the various components:
 
 {{< image width="80%"
     link="./arch.svg"

--- a/content/en/docs/concepts/what-is-istio/index.md
+++ b/content/en/docs/concepts/what-is-istio/index.md
@@ -45,7 +45,7 @@ between microservices, then configure and manage Istio using its control plane f
 
 * Secure service-to-service communication in a cluster with strong identity-based authentication and authorization.
 
-Istio is designed for extensibility and meets diverse deployment needs. The following [architecture](/docs/ops/deployment/architecture/) diagram shows the various components:
+Istio is designed for extensibility and meets diverse deployment needs. It does this by intercepting and configuring mesh traffic as shown in the following diagram:
 
 {{< image width="80%"
     link="/docs/ops/deployment/architecture/arch.svg"

--- a/content/en/docs/concepts/what-is-istio/index.md
+++ b/content/en/docs/concepts/what-is-istio/index.md
@@ -53,6 +53,8 @@ Istio is designed for extensibility and meets diverse deployment needs. It does 
     caption="Istio Architecture"
     >}}
 
+Refer to [architecture](/docs/ops/deployment/architecture/) for more details.
+
 ## Core features
 
 Istio provides a number of key capabilities uniformly across a network of

--- a/content/en/docs/concepts/what-is-istio/index.md
+++ b/content/en/docs/concepts/what-is-istio/index.md
@@ -48,7 +48,7 @@ between microservices, then configure and manage Istio using its control plane f
 Istio is designed for extensibility and meets diverse deployment needs. The following [architecture](/docs/ops/deployment/architecture/) diagram shows the various components:
 
 {{< image width="80%"
-    link="./arch.svg"
+    link="/docs/ops/deployment/architecture/arch.svg"
     alt="The overall architecture of an Istio-based application."
     caption="Istio Architecture"
     >}}


### PR DESCRIPTION

The main What is Istio? page needs a diagram to quickly explain to users how Istio works without them having to read the entire page. It's currently only shown in /docs/ops/deployment/architecture/ which is pretty hidden.