### PR TITLE
Fix classify docs

### DIFF
--- a/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
@@ -327,7 +327,7 @@ If classification does not occur as expected, check the following potential caus
 Review the Envoy proxy logs for the pod that has the service on which you applied the configuration change. Check that there are no errors reported by the service in the Envoy proxy logs on the pod, (`pod-name`), where you configured classification by using the following command:
 
 {{< text bash >}}
-$ kubectl log pod-name -c istio-proxy | grep "Config Error"
+$ kubectl log pod-name -c istio-proxy | grep -e "Config Error" -e "envoy wasm"
 {{< /text >}}
 
 Additionally, ensure that there are no Envoy proxy crashes by looking for signs of restarts in the output of the following command:

--- a/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
@@ -295,7 +295,7 @@ spec:
                    {
                      "name": "requests_total",
                      "dimensions": {
-                       "response_code": "has(istio_responseClass)?istio_responseClass:response.code"
+                       "response_code": "istio_responseClass"
                      }
                    }]
                 }


### PR DESCRIPTION
Fixes issue observed with 1.6.0-beta.1 and this doc:

`2020-05-13T01:17:21.914198Z	warning	envoy wasm	[external/envoy/source/extensions/common/wasm/context.cc:1106] wasm log stats_outbound: [extensions/stats/plugin.cc:493]::addStringExpression() cannot create an expression: has(istio_responseClass)?istio_responseClass:response.code`

[ X ] Policies and Telemetry

Fixes: https://github.com/istio/istio.io/issues/7284