### PR TITLE
fix(metrics): Add multicluster labels to Standard Metrics doc

### DIFF
--- a/content/en/docs/reference/config/telemetry/metrics/index.md
+++ b/content/en/docs/reference/config/telemetry/metrics/index.md
@@ -105,3 +105,13 @@ For TCP traffic, Istio generates the following metrics:
     destination_canonical_service
     destination_canonical_revision
     {{< /text >}}
+
+### Multicluster Labels
+
+When Istio is used in multi-cluster environments, the following additional labels are configured by default:
+
+*   **Destination Cluster**: Name of the cluster for the destination workload.
+    This is set by: `global.multiCluster.clusterName` at cluster install time.
+
+*   **Source Cluster**: Name of the cluster for the source workload.
+    This is set by: `global.multiCluster.clusterName` at cluster install time.

--- a/content/en/docs/reference/config/telemetry/metrics/index.md
+++ b/content/en/docs/reference/config/telemetry/metrics/index.md
@@ -106,7 +106,7 @@ For TCP traffic, Istio generates the following metrics:
     destination_canonical_revision
     {{< /text >}}
 
-### Multicluster Labels
+### Multicluster labels
 
 When Istio is used in multi-cluster environments, the following additional labels are configured by default:
 


### PR DESCRIPTION
Updates the `Istio Standard Metrics` page to include the additional labels added in multicluster scenarios. These may move into the "always-on" category in subsequent releases.

/cc: @nmittler 

[ X ] Policies and Telemetry

Fixes: #7286 