### PR TITLE
Authz deny

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-deny/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-deny/index.md
@@ -3,6 +3,7 @@ title: Authorization policies with a deny action
 description: Shows how to set up access control to deny traffic explicitly.
 weight: 40
 keywords: [security,access-control,rbac,authorization,deny]
+test: true
 ---
 
 This task shows you how to set up Istio authorization policy that denies HTTP traffic
@@ -31,7 +32,7 @@ Before tackling this task you must perform the following actions:
 * Verify that `sleep` talks to `httpbin` with the following command:
 
 {{< text bash >}}
-$ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
+$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
 200
 {{< /text >}}
 
@@ -69,14 +70,14 @@ In this case, the policy denies requests if their method is `GET`.
 1. Verify that `GET` requests are denied:
 
     {{< text bash >}}
-    $ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -s -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 
 1. Verify that `POST` requests are allowed:
 
     {{< text bash >}}
-    $ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl "http://httpbin.foo:8000/post" -X POST -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/post" -X POST -s -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
 
@@ -110,14 +111,14 @@ a header value that is not `admin`:
 1. Verify that `GET` requests with the HTTP header `x-token: admin` are allowed:
 
     {{< text bash >}}
-    $ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
 
 1. Verify that GET requests with the HTTP header `x-token: guest` are denied:
 
     {{< text bash >}}
-    $ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: guest" -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: guest" -s -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 
@@ -148,7 +149,7 @@ to `ALLOW`. This type of policy is better known as an allow policy.
 by the `deny-method-get` policy. Deny policies takes precedence over the allow policies:
 
     {{< text bash >}}
-    $ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl "http://httpbin.foo:8000/ip" -X GET -H "x-token: guest" -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/ip" -X GET -H "x-token: guest" -s -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 
@@ -156,7 +157,7 @@ by the `deny-method-get` policy. Deny policies takes precedence over the allow p
 allowed by the `allow-path-ip` policy:
 
     {{< text bash >}}
-    $ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl "http://httpbin.foo:8000/ip" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/ip" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
 
@@ -164,7 +165,7 @@ allowed by the `allow-path-ip` policy:
 denied because they don’t match the `allow-path-ip` policy:
 
     {{< text bash >}}
-    $ kubectl exec $(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name}) -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 

--- a/content/en/docs/tasks/security/authorization/authz-deny/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-deny/snips.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2153,SC2155
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          docs/tasks/security/authorization/authz-deny/index.md
+####################################################################################################
+
+snip_before_you_begin_1() {
+kubectl create ns foo
+kubectl apply -f <(istioctl kube-inject -f samples/httpbin/httpbin.yaml) -n foo
+kubectl apply -f <(istioctl kube-inject -f samples/sleep/sleep.yaml) -n foo
+}
+
+snip_before_you_begin_2() {
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
+}
+
+! read -r -d '' snip_before_you_begin_2_out <<\ENDSNIP
+200
+ENDSNIP
+
+snip_explicitly_deny_a_request_1() {
+kubectl apply -f - <<EOF
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-method-get
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        methods: ["GET"]
+EOF
+}
+
+snip_explicitly_deny_a_request_2() {
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -s -o /dev/null -w "%{http_code}\n"
+}
+
+! read -r -d '' snip_explicitly_deny_a_request_2_out <<\ENDSNIP
+403
+ENDSNIP
+
+snip_explicitly_deny_a_request_3() {
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/post" -X POST -s -o /dev/null -w "%{http_code}\n"
+}
+
+! read -r -d '' snip_explicitly_deny_a_request_3_out <<\ENDSNIP
+200
+ENDSNIP
+
+snip_explicitly_deny_a_request_4() {
+kubectl apply -f - <<EOF
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: deny-method-get
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  action: DENY
+  rules:
+  - to:
+    - operation:
+        methods: ["GET"]
+    when:
+    - key: request.headers[x-token]
+      notValues: ["admin"]
+EOF
+}
+
+snip_explicitly_deny_a_request_5() {
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
+}
+
+! read -r -d '' snip_explicitly_deny_a_request_5_out <<\ENDSNIP
+200
+ENDSNIP
+
+snip_explicitly_deny_a_request_6() {
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: guest" -s -o /dev/null -w "%{http_code}\n"
+}
+
+! read -r -d '' snip_explicitly_deny_a_request_6_out <<\ENDSNIP
+403
+ENDSNIP
+
+snip_explicitly_deny_a_request_7() {
+kubectl apply -f - <<EOF
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: allow-path-ip
+  namespace: foo
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        paths: ["/ip"]
+EOF
+}
+
+snip_explicitly_deny_a_request_8() {
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/ip" -X GET -H "x-token: guest" -s -o /dev/null -w "%{http_code}\n"
+}
+
+! read -r -d '' snip_explicitly_deny_a_request_8_out <<\ENDSNIP
+403
+ENDSNIP
+
+snip_explicitly_deny_a_request_9() {
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/ip" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
+}
+
+! read -r -d '' snip_explicitly_deny_a_request_9_out <<\ENDSNIP
+200
+ENDSNIP
+
+snip_explicitly_deny_a_request_10() {
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
+}
+
+! read -r -d '' snip_explicitly_deny_a_request_10_out <<\ENDSNIP
+403
+ENDSNIP
+
+snip_clean_up_1() {
+kubectl delete namespace foo
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -167,6 +167,18 @@ The framework includes the following built-in verify functions:
    This function is useful for comparing the output of commands that include some run-specific
    values in the output (e.g., `kubectl get pods`), or when whitespace in the output may be different.
 
+In addition to the built-in verify functions, there is a set of functions that
+run a function and compares the result to the expected output.  An optional
+argument indicates how many times the function should be retried before failing.
+Each attempt has an exponential backoff.  The following are supported:
+
+1. **`_run_and_verify_same`** `func` `expected` [`max_attempts`]
+1. **`_run_and_verify_contains`** `func` `expected` [`max_attempts`]
+1. **`_run_and_verify_not_contains`** `func` `expected` [`max_attempts`]
+1. **`_run_and_verify_first_line`** `func` `expected` [`max_attempts`]
+1. **`_run_and_verify_elided`** `func` `expected` [`max_attempts`]
+1. **`_run_and_verify_like`** `func` `expected` [`max_attempts`]
+
 ## Builder
 
 The `istioio.NewBuilder` returns a `istioio.Builder` that is used to build an Istio

--- a/tests/examples/scripts/bookinfo.txt
+++ b/tests/examples/scripts/bookinfo.txt
@@ -27,22 +27,18 @@ snip_start_the_application_services_1
 
 snip_start_the_application_services_2
 
-out=$(snip_start_the_application_services_4 2>&1)
-_verify_like "$out" "$snip_start_the_application_services_4_out" "snip_start_the_application_services_4"
+_run_and_verify_like snip_start_the_application_services_4 "$snip_start_the_application_services_4_out"
 
 kubectl wait --for=condition=available deployment --all --timeout=300s
 kubectl wait --for=condition=Ready pod --all --timeout=300s
 
-out=$(snip_start_the_application_services_5 2>&1)
-_verify_like "$out" "$snip_start_the_application_services_5_out" "snip_start_the_application_services_5"
+_run_and_verify_like snip_start_the_application_services_5 "$snip_start_the_application_services_5_out"
 
-out=$(snip_start_the_application_services_6 2>&1)
-_verify_contains "$out" "$snip_start_the_application_services_6_out" "snip_start_the_application_services_6"
+_run_and_verify_contains snip_start_the_application_services_6 "$snip_start_the_application_services_6_out"
 
 snip_determine_the_ingress_ip_and_port_1
 
-out=$(snip_determine_the_ingress_ip_and_port_2 2>&1)
-_verify_like "$out" "$snip_determine_the_ingress_ip_and_port_2_out" "snip_determine_the_ingress_ip_and_port_2"
+_run_and_verify_like snip_determine_the_ingress_ip_and_port_2 "$snip_determine_the_ingress_ip_and_port_2_out"
 
 # give it some time to propagate
 sleep 5
@@ -52,5 +48,4 @@ export INGRESS_PORT={{ .ingressPortCommand }}
 
 snip_determine_the_ingress_ip_and_port_3
 
-out=$(snip_confirm_the_app_is_accessible_from_outside_the_cluster_1 2>&1)
-_verify_contains "$out" "$snip_confirm_the_app_is_accessible_from_outside_the_cluster_1_out" "snip_confirm_the_app_is_accessible_from_outside_the_cluster_1"
+_run_and_verify_contains snip_confirm_the_app_is_accessible_from_outside_the_cluster_1 "$snip_confirm_the_app_is_accessible_from_outside_the_cluster_1_out"

--- a/tests/security/authz_deny/authz_deny_test.go
+++ b/tests/security/authz_deny/authz_deny_test.go
@@ -1,0 +1,54 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authzdeny
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+
+	"istio.io/istio.io/pkg/test/istioio"
+)
+
+//https://istio.io/docs/tasks/security/authorization/authz-deny/
+//https://github.com/istio/istio.io/blob/release-1.5/content/en/docs/tasks/security/authorization/authz-deny/index.md
+func TestAuthzDeny(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(istioio.NewBuilder("tasks__security___authz_deny").
+			Add(istioio.Script{
+				Input: istioio.Inline{
+					FileName: "create_ns_foo_with_httpbin_sleep.sh",
+					Value: `
+source ${REPO_ROOT}/content/en/docs/tasks/security/authorization/authz-deny/snips.sh
+snip_before_you_begin_1`,
+				},
+			}).
+			Add(istioio.MultiPodWait("foo")).
+			Add(istioio.Script{
+				Input: istioio.Path("scripts/authz_deny.sh"),
+			}).
+
+			// Cleanup.
+			Defer(istioio.Script{
+				Input: istioio.Inline{
+					FileName: "cleanup.sh",
+					Value: `
+source ${REPO_ROOT}/content/en/docs/tasks/security/authorization/authz-deny/snips.sh
+snip_clean_up_1`,
+				},
+			}).
+			Build())
+}

--- a/tests/security/authz_deny/main_test.go
+++ b/tests/security/authz_deny/main_test.go
@@ -1,0 +1,34 @@
+// Copyright Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package authzdeny
+
+import (
+	"testing"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource/environment"
+)
+
+var (
+	ist istio.Instance
+)
+
+func TestMain(m *testing.M) {
+	framework.NewSuite("authz_deny", m).
+		SetupOnEnv(environment.Kube, istio.Setup(&ist, nil)).
+		RequireEnvironment(environment.Kube).
+		Run()
+}

--- a/tests/security/authz_deny/scripts/authz_deny.sh
+++ b/tests/security/authz_deny/scripts/authz_deny.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC2154
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+
+source "${REPO_ROOT}/content/en/docs/tasks/security/authorization/authz-deny/snips.sh"
+
+max_attempts=5
+
+_run_and_verify_same snip_before_you_begin_2 "$snip_before_you_begin_2_out" $max_attempts
+
+snip_explicitly_deny_a_request_1
+
+_run_and_verify_same snip_explicitly_deny_a_request_2 "$snip_explicitly_deny_a_request_2_out" $max_attempts
+
+_run_and_verify_same snip_explicitly_deny_a_request_3 "$snip_explicitly_deny_a_request_3_out" $max_attempts
+
+snip_explicitly_deny_a_request_4
+
+_run_and_verify_same snip_explicitly_deny_a_request_5 "$snip_explicitly_deny_a_request_5_out" $max_attempts
+
+_run_and_verify_same snip_explicitly_deny_a_request_6 "$snip_explicitly_deny_a_request_6_out" $max_attempts
+
+snip_explicitly_deny_a_request_7
+
+_run_and_verify_same snip_explicitly_deny_a_request_8 "$snip_explicitly_deny_a_request_8_out" $max_attempts
+
+_run_and_verify_same snip_explicitly_deny_a_request_9 "$snip_explicitly_deny_a_request_9_out" $max_attempts
+
+_run_and_verify_same snip_explicitly_deny_a_request_10 "$snip_explicitly_deny_a_request_10_out" $max_attempts

--- a/tests/security/authz_tcp/scripts/authz_tcp.txt
+++ b/tests/security/authz_tcp/scripts/authz_tcp.txt
@@ -30,38 +30,28 @@ export TCP_ECHO_IP=$(kubectl get pod $(kubectl get pod -l app=tcp-echo -n foo -o
 # stuck around from a previous test.
 kubectl delete peerauthentication --all-namespaces --all
 
-out=$(snip_before_you_begin_2 2>&1)
-_verify_same "$out" "$snip_before_you_begin_2_out" "snip_before_you_begin_2"
+_run_and_verify_same snip_before_you_begin_2 "$snip_before_you_begin_2_out"
 
-out=$(snip_before_you_begin_3 2>&1)
-_verify_same "$out" "$snip_before_you_begin_3_out" "snip_before_you_begin_3"
+_run_and_verify_same snip_before_you_begin_3 "$snip_before_you_begin_3_out"
 
-out=$(snip_before_you_begin_4 2>&1)
-_verify_same "$out" "$snip_before_you_begin_4_out" "snip_before_you_begin_4"
+_run_and_verify_same snip_before_you_begin_4 "$snip_before_you_begin_4_out"
 
 snip_configure_access_control_for_a_tcp_workload_1
 
-out=$(snip_configure_access_control_for_a_tcp_workload_2 2>&1)
-_verify_same "$out" "$snip_configure_access_control_for_a_tcp_workload_2_out" "snip_configure_access_control_for_a_tcp_workload_2"
+_run_and_verify_same snip_configure_access_control_for_a_tcp_workload_2 "$snip_configure_access_control_for_a_tcp_workload_2_out"
 
-out=$(snip_configure_access_control_for_a_tcp_workload_3 2>&1)
-_verify_same "$out" "$snip_configure_access_control_for_a_tcp_workload_3_out" "snip_configure_access_control_for_a_tcp_workload_3"
+_run_and_verify_same snip_configure_access_control_for_a_tcp_workload_3 "$snip_configure_access_control_for_a_tcp_workload_3_out"
 
-out=$(snip_configure_access_control_for_a_tcp_workload_4 2>&1)
-_verify_same "$out" "$snip_configure_access_control_for_a_tcp_workload_4_out" "snip_configure_access_control_for_a_tcp_workload_4"
+_run_and_verify_same snip_configure_access_control_for_a_tcp_workload_4 "$snip_configure_access_control_for_a_tcp_workload_4_out"
 
 snip_configure_access_control_for_a_tcp_workload_5
 
-out=$(snip_configure_access_control_for_a_tcp_workload_6 2>&1)
-_verify_same "$out" "$snip_configure_access_control_for_a_tcp_workload_6_out" "snip_configure_access_control_for_a_tcp_workload_6"
+_run_and_verify_same snip_configure_access_control_for_a_tcp_workload_6 "$snip_configure_access_control_for_a_tcp_workload_6_out"
 
-out=$(snip_configure_access_control_for_a_tcp_workload_7 2>&1)
-_verify_same "$out" "$snip_configure_access_control_for_a_tcp_workload_7_out" "snip_configure_access_control_for_a_tcp_workload_7"
+_run_and_verify_same snip_configure_access_control_for_a_tcp_workload_7 "$snip_configure_access_control_for_a_tcp_workload_7_out"
 
 snip_configure_access_control_for_a_tcp_workload_8
 
-out=$(snip_configure_access_control_for_a_tcp_workload_9 2>&1)
-_verify_same "$out" "$snip_configure_access_control_for_a_tcp_workload_9_out" "snip_configure_access_control_for_a_tcp_workload_9"
+_run_and_verify_same snip_configure_access_control_for_a_tcp_workload_9 "$snip_configure_access_control_for_a_tcp_workload_9_out"
 
-out=$(snip_configure_access_control_for_a_tcp_workload_10 2>&1)
-_verify_same "$out" "$snip_configure_access_control_for_a_tcp_workload_10_out" "snip_configure_access_control_for_a_tcp_workload_10"
+_run_and_verify_same snip_configure_access_control_for_a_tcp_workload_10 "$snip_configure_access_control_for_a_tcp_workload_10_out"

--- a/tests/security/plugin_ca_cert/scripts/plugin_ca_cert.txt
+++ b/tests/security/plugin_ca_cert/scripts/plugin_ca_cert.txt
@@ -34,11 +34,8 @@ set -o pipefail
 # Split the certificate chain to cert files
 snip_verifying_the_certificates_2
 
-out=$(snip_verifying_the_certificates_3 2>&1)
-_verify_same "$out" "$snip_verifying_the_certificates_3_out" "snip_verifying_the_certificates_3"
+_run_and_verify_same snip_verifying_the_certificates_3 "$snip_verifying_the_certificates_3_out"
 
-out=$(snip_verifying_the_certificates_4 2>&1)
-_verify_same "$out" "$snip_verifying_the_certificates_4_out" "snip_verifying_the_certificates_4"
+_run_and_verify_same snip_verifying_the_certificates_4 "$snip_verifying_the_certificates_4_out"
 
-out=$(snip_verifying_the_certificates_5 2>&1)
-_verify_same "$out" "$snip_verifying_the_certificates_5_out" "snip_verifying_the_certificates_5"
+_run_and_verify_same snip_verifying_the_certificates_5 "$snip_verifying_the_certificates_5_out"

--- a/tests/security/scripts/mtls_migration.txt
+++ b/tests/security/scripts/mtls_migration.txt
@@ -21,16 +21,13 @@ set -o pipefail
 source ${REPO_ROOT}/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
 
 # curl_foo_bar_legacy
-out=$(snip_set_up_the_cluster_3 2>&1)
-_verify_same "$out" "$snip_set_up_the_cluster_3_out" "snip_set_up_the_cluster_3"
+_run_and_verify_same snip_set_up_the_cluster_3 "$snip_set_up_the_cluster_3_out"
 
 # verify_initial_peerauthentications
-out=$(snip_set_up_the_cluster_4 2>&1)
-_verify_same "$out" "$snip_set_up_the_cluster_4_out" "snip_set_up_the_cluster_4"
+_run_and_verify_same snip_set_up_the_cluster_4 "$snip_set_up_the_cluster_4_out"
 
 # verify_initial_destinationrules
-out=$(snip_set_up_the_cluster_5 2>&1)
-_verify_same "$out" "$snip_set_up_the_cluster_5_out" "snip_set_up_the_cluster_5"
+_run_and_verify_same snip_set_up_the_cluster_5 "$snip_set_up_the_cluster_5_out"
 
 # configure_mtls_foo_peerauthentication
 snip_lock_down_to_mutual_tls_by_namespace_1
@@ -40,8 +37,7 @@ set +e
 set +o pipefail
 
 # curl_foo_bar_legacy_post_pa
-out=$(snip_lock_down_to_mutual_tls_by_namespace_2 2>&1)
-_verify_same "$out" "$snip_lock_down_to_mutual_tls_by_namespace_2_out" "snip_lock_down_to_mutual_tls_by_namespace_2"
+_run_and_verify_same snip_lock_down_to_mutual_tls_by_namespace_2 "$snip_lock_down_to_mutual_tls_by_namespace_2_out"
 
 # Restore error handling
 set -e
@@ -55,7 +51,6 @@ set +e
 set +o pipefail
 
 # curl_foo_bar_legacy_httpbin_foo_mtls
-out=$(snip_lock_down_mutual_tls_for_the_entire_mesh_2 2>&1)
 expected="sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.bar to httpbin.foo: 200
@@ -64,7 +59,7 @@ sleep.legacy to httpbin.foo: 000
 command terminated with exit code 56
 sleep.legacy to httpbin.bar: 000
 command terminated with exit code 56"
-_verify_same "$out" "$expected" "snip_lock_down_mutual_tls_for_the_entire_mesh_2"
+_run_and_verify_same snip_lock_down_mutual_tls_for_the_entire_mesh_2 "$expected"
 
 # Restore error handling
 set -e

--- a/tests/trafficmanagement/ingress/scripts/ingress_control.sh
+++ b/tests/trafficmanagement/ingress/scripts/ingress_control.sh
@@ -28,8 +28,7 @@ kubectl label namespace default istio-injection=enabled --overwrite
 startup_httpbin_sample
 
 # check for external load balancer
-out=$(snip_determining_the_ingress_ip_and_ports_1 2>&1)
-_verify_like "$out" "$snip_determining_the_ingress_ip_and_ports_1_out" "snip_determining_the_ingress_ip_and_ports_1"
+_run_and_verify_like snip_determining_the_ingress_ip_and_ports_1 "$snip_determining_the_ingress_ip_and_ports_1_out"
 
 # set INGRESS_HOST, INGRESS_PORT, SECURE_INGRESS_PORT, and TCP_INGRESS_PORT environment variables
 if [[ "$out" != *"<none>"* && "$out" != *"<pending>"* ]]; then
@@ -49,14 +48,12 @@ snip_configuring_ingress_using_an_istio_gateway_2
 sleep 5s # TODO: call proper wait utility (e.g., istioctl wait)
 
 # access the httpbin service
-out=$(snip_configuring_ingress_using_an_istio_gateway_3 2>&1)
-#_verify_first_line "$out" "$snip_configuring_ingress_using_an_istio_gateway_3_out" "snip_configuring_ingress_using_an_istio_gateway_3"
-_verify_contains "$out" "HTTP/1.1 200 OK" "snip_configuring_ingress_using_an_istio_gateway_3"
+#_run_and_verify_first_line snip_configuring_ingress_using_an_istio_gateway_3 "$snip_configuring_ingress_using_an_istio_gateway_3_out"
+_run_and_verify_contains snip_configuring_ingress_using_an_istio_gateway_3 "HTTP/1.1 200 OK"
 
 # access the httpbin service
-out=$(snip_configuring_ingress_using_an_istio_gateway_4 2>&1)
-#_verify_first_line "$out" "$snip_configuring_ingress_using_an_istio_gateway_4_out" "snip_configuring_ingress_using_an_istio_gateway_4"
-_verify_contains "$out" "HTTP/1.1 404 Not Found" "snip_configuring_ingress_using_an_istio_gateway_3"
+#_run_and_verify_first_line snip_configuring_ingress_using_an_istio_gateway_4 "$snip_configuring_ingress_using_an_istio_gateway_4_out"
+_run_and_verify_contains snip_configuring_ingress_using_an_istio_gateway_4 "HTTP/1.1 404 Not Found"
 
 # configure for web browser
 snip_accessing_ingress_services_using_a_browser_1

--- a/tests/trafficmanagement/ingress/scripts/secure_ingress.sh
+++ b/tests/trafficmanagement/ingress/scripts/secure_ingress.sh
@@ -67,8 +67,7 @@ _verify_contains "$out" "-=[ teapot ]=-" "snip_configure_a_tls_ingress_gateway_f
 set +e
 
 # verifying old httpbin credentials no longer work
-out=$(snip_configure_a_tls_ingress_gateway_for_a_single_host_8 2>&1)
-_verify_not_contains "$out" "HTTP/2 418" "snip_configure_a_tls_ingress_gateway_for_a_single_host_8"
+_run_and_verify_not_contains snip_configure_a_tls_ingress_gateway_for_a_single_host_8 "HTTP/2 418"
 
 # Restore error handling
 set -e
@@ -92,8 +91,7 @@ snip_configure_a_tls_ingress_gateway_for_multiple_hosts_6
 # waiting for configuration to propagate
 sleep 5s # TODO: call proper wait utility (e.g., istioctl wait)
 
-out=$(snip_configure_a_tls_ingress_gateway_for_multiple_hosts_7 2>&1)
-_verify_contains "$out" "$snip_configure_a_tls_ingress_gateway_for_multiple_hosts_7_out" "snip_configure_a_tls_ingress_gateway_for_multiple_hosts_7"
+_run_and_verify_contains snip_configure_a_tls_ingress_gateway_for_multiple_hosts_7 "$snip_configure_a_tls_ingress_gateway_for_multiple_hosts_7_out"
 
 out=$(snip_configure_a_tls_ingress_gateway_for_multiple_hosts_8 2>&1)
 _verify_contains "$out" "HTTP/2 418" "snip_configure_a_tls_ingress_gateway_for_multiple_hosts_8"
@@ -109,8 +107,7 @@ sleep 5s
 # The next command is expected to fail, but don't error the script.
 set +e
 
-out=$(snip_configure_a_mutual_tls_ingress_gateway_3 2>&1)
-_verify_not_contains "$out" "HTTP/2 418" "snip_configure_a_mutual_tls_ingress_gateway_3"
+_run_and_verify_not_contains snip_configure_a_mutual_tls_ingress_gateway_3 "HTTP/2 418"
 
 # Restore error handling
 set -e

--- a/tests/trafficmanagement/scripts/fault_injection.sh
+++ b/tests/trafficmanagement/scripts/fault_injection.sh
@@ -38,8 +38,7 @@ snip_injecting_an_http_delay_fault_1
 sleep 5s # TODO: call proper wait utility (e.g., istioctl wait)
 
 # confirm rules are set
-out=$(snip_injecting_an_http_delay_fault_2 2>&1)
-_verify_elided "$out" "$snip_injecting_an_http_delay_fault_2_out" "snip_injecting_an_http_delay_fault_2"
+_run_and_verify_elided snip_injecting_an_http_delay_fault_2 "$snip_injecting_an_http_delay_fault_2_out"
 
 # check that requests from user jason return error
 out=$(sample_http_request "/productpage" "jason")
@@ -52,8 +51,7 @@ snip_injecting_an_http_abort_fault_1
 sleep 5s # TODO: call proper wait utility (e.g., istioctl wait)
 
 # confirm rules are set
-out=$(snip_injecting_an_http_abort_fault_2 2>&1)
-_verify_elided "$out" "$snip_injecting_an_http_abort_fault_2_out" "snip_injecting_an_http_abort_fault_2"
+_run_and_verify_elided snip_injecting_an_http_abort_fault_2 "$snip_injecting_an_http_abort_fault_2_out"
 
 # check that requests from user jason return error and other request do not
 out=$(sample_http_request "/productpage" "jason")

--- a/tests/trafficmanagement/scripts/request_routing.sh
+++ b/tests/trafficmanagement/scripts/request_routing.sh
@@ -35,8 +35,7 @@ snip_apply_a_virtual_service_1
 sleep 5s # TODO: call proper wait utility (e.g., istioctl wait)
 
 # confirm route rules are set
-out=$(snip_apply_a_virtual_service_2 2>&1)
-_verify_elided "$out" "$snip_apply_a_virtual_service_2_out" "snip_apply_a_virtual_service_2"
+_run_and_verify_elided snip_apply_a_virtual_service_2 "$snip_apply_a_virtual_service_2_out"
 
 # check destination rules
 out=$(snip_apply_a_virtual_service_3 2>&1)
@@ -56,8 +55,7 @@ snip_route_based_on_user_identity_1
 sleep 5s # TODO: call proper wait utility (e.g., istioctl wait)
 
 # confirm route rules are set
-out=$(snip_route_based_on_user_identity_2 2>&1)
-_verify_elided "$out" "$snip_route_based_on_user_identity_2_out" "snip_route_based_on_user_identity_2"
+_run_and_verify_elided snip_route_based_on_user_identity_2 "$snip_route_based_on_user_identity_2_out"
 
 # check that requests from user jason return ratings and other requests do not
 out=$(sample_http_request "/productpage" "jason")

--- a/tests/trafficmanagement/scripts/tcp_trafficshifting.sh
+++ b/tests/trafficmanagement/scripts/tcp_trafficshifting.sh
@@ -61,8 +61,7 @@ snip_apply_weightbased_tcp_routing_3
 # wait for rules to propagate
 sleep 5s # TODO: call proper wait utility (e.g., istioctl wait)
 
-out=$(snip_apply_weightbased_tcp_routing_4 2>&1)
-_verify_elided "$out" "$snip_apply_weightbased_tcp_routing_4_out" "snip_apply_weightbased_tcp_routing_4"
+_run_and_verify_elided snip_apply_weightbased_tcp_routing_4 "$snip_apply_weightbased_tcp_routing_4_out"
 
 out=$(snip_apply_weightbased_tcp_routing_5 2>&1)
 _verify_contains "$out" "one" "snip_apply_weightbased_tcp_routing_5"

--- a/tests/trafficmanagement/scripts/traffic_shifting.txt
+++ b/tests/trafficmanagement/scripts/traffic_shifting.txt
@@ -80,12 +80,11 @@ function verify_traffic_shift() {
 
 # Step 1 configure all traffic to v1
 
-out=$(snip_config_all_v1 2>&1)
 expected="virtualservice.networking.istio.io/productpage created
 virtualservice.networking.istio.io/reviews created
 virtualservice.networking.istio.io/ratings created
 virtualservice.networking.istio.io/details created"
-_verify_same "$out" "$expected" "snip_config_all_v1"
+_run_and_verify_same snip_config_all_v1 "$expected"
 
 # Step 2: verify no rating stars visible, (reviews-v3 traffic=0%)
 
@@ -93,15 +92,13 @@ verify_traffic_shift 0
 
 # Step 3: switch 50% traffic to v3
 
-out=$(snip_config_50_v3 2>&1)
-_verify_same "$out" "virtualservice.networking.istio.io/reviews configured" "snip_config_50_v3"
+_run_and_verify_same snip_config_50_v3 "virtualservice.networking.istio.io/reviews configured"
 
 istioctl experimental wait --for=distribution VirtualService reviews.default
 
 # Step 4: Confirm the rule was replaced
 
-out=$(snip_verify_config_50_v3 2>&1)
-_verify_contains "$out" "subset: v3" "snip_verify_config_50_v3"
+_run_and_verify_contains snip_verify_config_50_v3 "subset: v3"
 
 # Step 5: verify rating stars visible 50% of the time
 

--- a/tests/util/verify.sh
+++ b/tests/util/verify.sh
@@ -14,56 +14,60 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-_err_exit() {
+__err_exit() {
     echo "VERIFY FAILED $1: $2";
     exit 1
 }
 
-# Verify that $out is the same as $expected.
-_verify_same() {
+# Returns 0 if $out and $expected are the same.  Otherwise, returns 1.
+__cmp_same() {
     local out=$1
     local expected=$2
-    local msg=$3
 
     if [[ "$out" != "$expected" ]]; then
-        _err_exit "$msg" "$out"
+        return 1
     fi
+
+    return 0
 }
 
-# Verify that $out contains the substring $expected.
-_verify_contains() {
+# Returns 0 if $out contains the substring $expected.  Otherwise, returns 1.
+__cmp_contains() {
     local out=$1
     local expected=$2
-    local msg=$3
 
     if [[ "$out" != *"$expected"* ]]; then
-        _err_exit "$msg" "$out"
+        echo "false"
+        return 1
     fi
+
+    return 0
 }
 
-# Verify that $out does not contains the substring $expected.
-_verify_not_contains() {
+# Returns 0 if $out does not contain the substring $expected.  Otherwise,
+# returns 1.
+__cmp_not_contains() {
     local out=$1
     local expected=$2
-    local msg=$3
 
     if [[ "$out" == *"$expected"* ]]; then
-        _err_exit "$msg" "$out"
+        return 1
     fi
+
+    return 0
 }
 
-# Verify that $out contains the lines in $expected where "..." on a line
-# matches one or more lines containing any text.
-_verify_elided() {
+# Returns 0 if $out contains the lines in $expected where "..." on a line
+# matches one or more lines containing any text.  Otherwise, returns 1.
+__cmp_elided() {
     local out=$1
     local expected=$2
-    local msg=$3
-    
+
     local contains=""
     while IFS=$'\n' read -r line; do
         if [[ "$line" =~ ^[[:space:]]*\.\.\.[[:space:]]*$ ]]; then
             if [[ "$contains" != "" && "$out" != *"$contains"* ]]; then
-                _err_exit "$msg" "$out"
+                return 1
             fi
             contains=""
         else
@@ -74,16 +78,18 @@ _verify_elided() {
         fi
     done <<< "$expected"
     if [[ "$contains" != "" && "$out" != *"$contains"* ]]; then
-        _err_exit "$msg" "$out"
+        return 1
     fi
+
+    return 0
 }
 
-# Verify that the first line of $out matches the first line in $expected.
+# Returns 0 if the first line of $out matches the first line in $expected.
+# Otherwise, returns 1.
 # TODO ???? flaky behavior, doesn't seem to work as expected
-_verify_first_line() {
+__cmp_first_line() {
     local out=$1
     local expected=$2
-    local msg=$3
 
     # TODO ???? the following seem to leave a trailing \n in some cases and then the following check fails
     IFS=$'\n' read -r out_first_line <<< "$out"
@@ -93,11 +99,13 @@ _verify_first_line() {
 
     # TODO ???? following fails because one or the other might have a \n at the end of the string, when the other does not
     if [[ "$out_first_line" != "$expected_first_line" ]]; then
-        _err_exit "$msg" "$out"
+        return 1
     fi
+
+    return 0
 }
 
-# Verify that $out is "like" $expected. Like implies:
+# Returns 0 if $out is "like" $expected. Like implies:
 #   1. Same number of lines
 #   2. Same number of whitespace-seperated tokens per line
 #   3. Tokens can only differ in the following ways:
@@ -105,10 +113,10 @@ _verify_first_line() {
 #        - different ip values
 #        - prefix match ending with a dash character
 #        - expected ... is a wildcard token, matches anything
-_verify_like() {
+# Otherwise, returns 1.
+__cmp_like() {
     local out=$1
     local expected=$2
-    local msg=$3
 
     if [[ "$out" != "$expected" ]]; then
         local olines=()
@@ -122,7 +130,7 @@ _verify_like() {
         done <<< "$expected"
 
         if [[ ${#olines[@]} -ne ${#elines[@]} ]]; then
-            _err_exit "$msg" "$out"
+            return 1
         fi
 
         for i in "${!olines[@]}"; do
@@ -137,7 +145,7 @@ _verify_like() {
             read -r -a etokens <<< "$eline"
 
             if [[ ${#otokens[@]} -ne ${#etokens[@]} ]]; then
-                _err_exit "$msg" "$out"
+                return 1
             fi
 
             for j in "${!otokens[@]}"; do
@@ -169,10 +177,185 @@ _verify_like() {
                         if [[ "$comm" =~ ^([a-zA-Z0-9_]+-)+ ]]; then
                             break
                         fi
-                        _err_exit "$msg" "$out"
+                        return 1
                     fi
                 done
             done
         done
+    fi
+
+    return 0
+}
+
+
+# Verify that $out is the same as $expected.  If they are not the same,
+# exponentially back off and try again.
+__verify_with_retry() {
+    local cmp_func=$1
+    local cmd=$2
+    local expected=$3
+    local max_attempts=$4
+    local attempt=0
+
+    while true; do
+      out=$($cmd 2>&1)
+
+      if $cmp_func "$out" "$expected"; then
+          return
+      fi
+
+      if (( attempt >= max_attempts )); then
+          __err_exit "$cmd" "$out"
+      fi
+
+      sleep $(( 2 ** attempt ))
+      attempt=$(( attempt + 1 ))
+    done
+}
+
+# Public Functions
+
+# Runs $func and compares the output with $expected.  If they are not the same,
+# will retry $max_attempts times with an exponential backoff.  If $max_attempts
+# is not set, a retry will not be attempted.
+_run_and_verify_same() {
+    local func=$1
+    local expected=$2
+    local max_attempts=${3:-0}
+    __verify_with_retry __cmp_same "$func" "$expected" "$max_attempts"
+}
+
+# Runs $func and compares the output with $expected.  If the output does not
+# contain the substring $expected, will retry $max_attempts times with an
+# exponential backoff.  If $max_attempts is not set, a retry will not be
+# attempted.
+_run_and_verify_contains() {
+    local func=$1
+    local expected=$2
+    local max_attempts=${3:-0}
+    __verify_with_retry __cmp_contains "$func" "$expected" "$max_attempts"
+}
+
+# Runs $func and compares the output with $expected.  If the output contains the
+# substring $expected, will retry $max_attempts times with an exponential
+# backoff.  If $max_attempts is not set, a retry will not be attempted.
+_run_and_verify_not_contains() {
+    local func=$1
+    local expected=$2
+    local max_attempts=${3:-0}
+    __verify_with_retry __cmp_not_contains "$func" "$expected" "$max_attempts"
+}
+
+# Runs $func and compares the output with $expected.  If the output does not
+# contain the lines in $expected where "..." on a line matches one or more lines
+# containing any text, will retry $max_attempts times with an exponential
+# backoff.  If $max_attempts is not set, a retry will not be attempted.
+_run_and_verify_elided() {
+    local func=$1
+    local expected=$2
+    local max_attempts=${3:-0}
+    __verify_with_retry __cmp_elided "$func" "$expected" "$max_attempts"
+}
+
+# Runs $func and compares the output with $expected.  If the first line of
+# output does not match the first line in $expected, will retry $max_attempts
+# times with an exponential backoff.  If $max_attempts is not set, a retry will
+# not be attempted.
+_run_and_verify_first_line() {
+    local func=$1
+    local expected=$2
+    local max_attempts=${3:-0}
+    __verify_with_retry __cmp_first_line "$func" "$expected" "$max_attempts"
+}
+
+# Runs $func and compares the output with $expected.  If the output is not
+# "like" $ecpted, will retry $max_attempts times with an exponential backoff.
+# Like implies:
+#   1. Same number of lines
+#   2. Same number of whitespace-seperated tokens per line
+#   3. Tokens can only differ in the following ways:
+#        - different elapsed time values
+#        - different ip values
+#        - prefix match ending with a dash character
+#        - expected ... is a wildcard token, matches anything
+# If $max_attempts is not set, a retry will not be attempted.
+_run_and_verify_like() {
+    local func=$1
+    local expected=$2
+    local max_attempts=${3:-0}
+    __verify_with_retry __cmp_like "$func" "$expected" "$max_attempts"
+}
+
+# Verify that $out is the same as $expected.
+_verify_same() {
+    local out=$1
+    local expected=$2
+    local msg=$3
+
+    if ! __cmp_same "$out" "$expected"; then
+        __err_exit "$msg" "$out"
+    fi
+}
+
+# Verify that $out contains the substring $expected.
+_verify_contains() {
+    local out=$1
+    local expected=$2
+    local msg=$3
+
+    if ! __cmp_contains "$out" "$expected"; then
+        __err_exit "$msg" "$out"
+    fi
+}
+
+# Verify that $out does not contain the substring $expected.
+_verify_not_contains() {
+    local out=$1
+    local expected=$2
+    local msg=$3
+
+    if ! __cmp_not_contains "$out" "$expected"; then
+        __err_exit "$msg" "$out"
+    fi
+}
+
+# Verify that $out contains the lines in $expected where "..." on a line
+# matches one or more lines containing any text.
+_verify_elided() {
+    local out=$1
+    local expected=$2
+    local msg=$3
+
+    if ! __cmp_elided "$out" "$expected"; then
+        __err_exit "$msg" "$out"
+    fi
+}
+
+# Verify that the first line of $out matches the first line in $expected.
+_verify_first_line() {
+    local out=$1
+    local expected=$2
+    local msg=$3
+
+    if ! __cmp_first_line "$out" "$expected"; then
+        __err_exit "$msg" "$out"
+    fi
+}
+
+# Verify that $out is "like" $expected. Like implies:
+#   1. Same number of lines
+#   2. Same number of whitespace-seperated tokens per line
+#   3. Tokens can only differ in the following ways:
+#        - different elapsed time values
+#        - different ip values
+#        - prefix match ending with a dash character
+#        - expected ... is a wildcard token, matches anything
+_verify_like() {
+    local out=$1
+    local expected=$2
+    local msg=$3
+
+    if ! __cmp_like "$out" "$expected"; then
+        __err_exit "$msg" "$out"
     fi
 }


### PR DESCRIPTION
This commit introduces new "_run_and_verify_*()" functions that run a function and verifies it against expected output.  An optional argument indicates the number of times a failed match should cause the function to be run again before giving up.  This is useful for tests that may take some time for the system to settle.  The second commit, which introduces an authz-deny test, makes use of this retry facility.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[X] Developer Infrastructure
