### PR TITLE
Misleading default namespace value 'istio'

### DIFF
--- a/content/en/blog/2018/aws-nlb/index.md
+++ b/content/en/blog/2018/aws-nlb/index.md
@@ -108,5 +108,5 @@ gateways:
 Generate a manifest with Helm:
 
 {{< text bash >}}
-$ helm template install/kubernetes/helm/istio --namespace istio -f override.yaml > $HOME/istio.yaml
+$ helm template install/kubernetes/helm/istio --namespace istio-system -f override.yaml > $HOME/istio.yaml
 {{< /text >}}


### PR DESCRIPTION
When generating the istio manifest, we should stick to the default namespace istio's installation uses which is **istio-system**. The way the text is written can mislead the user to a error because the namespace **istio** was never created or stated as custom in this context.