### PR TITLE
Remove IPv6 support for Kubernetes as a core supported feature

### DIFF
--- a/content/en/about/feature-stages/index.md
+++ b/content/en/about/feature-stages/index.md
@@ -100,6 +100,7 @@ Below is our list of existing features and their current phases. This informatio
 | [Custom Mixer Build Model](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide) | deprecated
 | [Out of Process Mixer Adapters (gRPC Adapters)](https://github.com/istio/istio/wiki/Mixer-Out-Of-Process-Adapter-Dev-Guide) | Beta
 | [Istio CNI plugin](/docs/setup/additional-setup/cni/) | Alpha
+ | IPv6 support for Kubernetes | Alpha. Dual-stack ipv4 and ipv6 is not supported.
 | [Distroless base images for Istio](/docs/ops/configuration/security/harden-docker-images/) | Alpha
 
 {{< idea >}}

--- a/content/en/about/feature-stages/index.md
+++ b/content/en/about/feature-stages/index.md
@@ -100,7 +100,7 @@ Below is our list of existing features and their current phases. This informatio
 | [Custom Mixer Build Model](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide) | deprecated
 | [Out of Process Mixer Adapters (gRPC Adapters)](https://github.com/istio/istio/wiki/Mixer-Out-Of-Process-Adapter-Dev-Guide) | Beta
 | [Istio CNI plugin](/docs/setup/additional-setup/cni/) | Alpha
- | IPv6 support for Kubernetes | Alpha. Dual-stack ipv4 and ipv6 is not supported.
+| IPv6 support for Kubernetes | Alpha. Dual-stack ipv4 and ipv6 is not supported.
 | [Distroless base images for Istio](/docs/ops/configuration/security/harden-docker-images/) | Alpha
 
 {{< idea >}}

--- a/content/en/about/feature-stages/index.md
+++ b/content/en/about/feature-stages/index.md
@@ -100,7 +100,7 @@ Below is our list of existing features and their current phases. This informatio
 | [Custom Mixer Build Model](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide) | deprecated
 | [Out of Process Mixer Adapters (gRPC Adapters)](https://github.com/istio/istio/wiki/Mixer-Out-Of-Process-Adapter-Dev-Guide) | Beta
 | [Istio CNI plugin](/docs/setup/additional-setup/cni/) | Alpha
-| IPv6 support for Kubernetes | Alpha. Dual-stack ipv4 and ipv6 is not supported.
+| IPv6 support for Kubernetes | Alpha. Dual-stack IPv4 and IPv6 is not supported.
 | [Distroless base images for Istio](/docs/ops/configuration/security/harden-docker-images/) | Alpha
 
 {{< idea >}}

--- a/content/en/about/feature-stages/index.md
+++ b/content/en/about/feature-stages/index.md
@@ -100,7 +100,6 @@ Below is our list of existing features and their current phases. This informatio
 | [Custom Mixer Build Model](https://github.com/istio/istio/wiki/Mixer-Compiled-In-Adapter-Dev-Guide) | deprecated
 | [Out of Process Mixer Adapters (gRPC Adapters)](https://github.com/istio/istio/wiki/Mixer-Out-Of-Process-Adapter-Dev-Guide) | Beta
 | [Istio CNI plugin](/docs/setup/additional-setup/cni/) | Alpha
-| IPv6 support for Kubernetes | Alpha
 | [Distroless base images for Istio](/docs/ops/configuration/security/harden-docker-images/) | Alpha
 
 {{< idea >}}


### PR DESCRIPTION
Fixes https://github.com/istio/istio.io/issues/7332