### PR TITLE
Remove para about application design goals

### DIFF
--- a/content/en/docs/ops/deployment/architecture/index.md
+++ b/content/en/docs/ops/deployment/architecture/index.md
@@ -104,13 +104,3 @@ to control who can access your services.
 
 Istiod maintains a CA and generates certificates to allow secure mTLS communication
 in the data plane.
-
-## Application design
-
-A design goal for Istio is that the developer can do minimum work
-to get real value from the system. Istio can automatically inject itself into
-the network paths between services and program the networking layer to
-securely route traffic and extract telemetry. If the application code
-uses TLS and uses its own policy and telemetry, Istio can only get minimal
-information from the encrypted communication between workloads.
-


### PR DESCRIPTION
Remove paragraph about application design goals. We typically avoid discussions of intention and goals, etc. in the end user docs. It's also unclear what the user is intended to do with this information in its current form.