### PR TITLE
Envoy Access Log link page returning 404

### DIFF
--- a/content/en/docs/tasks/observability/logs/access-log/index.md
+++ b/content/en/docs/tasks/observability/logs/access-log/index.md
@@ -9,7 +9,7 @@ aliases:
 ---
 
 The simplest kind of Istio logging is
-[Envoy's access logging](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log).
+[Envoy's access logging](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage).
 Envoy proxies print access information to their standard output.
 The standard output of Envoy's containers can then be printed by the `kubectl logs` command.
 


### PR DESCRIPTION

**Description**
This PR affects the doc's page for access logs of Envoy to format it accordingly.

**Changes**
Updated the envoy's access logging page with the latest link