### PR TITLE
changed fromRegistry to match MAIN_CLUSTER_NAME

### DIFF
--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -137,8 +137,7 @@ spec:
       meshNetworks:
         ${MAIN_CLUSTER_NETWORK}:
           endpoints:
-          # Always use Kubernetes as the registry name for the main cluster in the mesh network configuration
-          - fromRegistry: Kubernetes
+          - fromRegistry:  ${MAIN_CLUSTER_NAME}
           gateways:
           - registry_service_name: istio-ingressgateway.istio-system.svc.cluster.local
             port: 443
@@ -176,8 +175,7 @@ spec:
       meshNetworks:
         ${MAIN_CLUSTER_NETWORK}:
           endpoints:
-          # Always use Kubernetes as the registry name for the main cluster in the mesh network configuration
-          - fromRegistry: Kubernetes
+          - fromRegistry:  ${MAIN_CLUSTER_NAME}
           gateways:
           - registry_service_name: istio-ingressgateway.istio-system.svc.cluster.local
             port: 443


### PR DESCRIPTION
related to https://github.com/istio/istio/pull/23825, https://github.com/istio/istio/issues/22093, and https://github.com/istio/istio/issues/23495

Without this change, REMOTE_CLUSTER endpoints do not contain ingress gateway IP for endpoints in MAIN_CLUSTER.  Instead the MAIN_CLUSTER IPs are still their local 172.X.X.X addresses which results in REMOTE_CLUSTER calls from services to MAIN_CLUSTER to fail

With my change
```
kubectl --context=${REMOTE_CLUSTER_CTX} -n sample get pod -l app=sleep -o name | cut -f2 -d'/' | \
>     xargs -I{} istioctl --context=${REMOTE_CLUSTER_CTX} -n sample proxy-config endpoints {} --cluster "outbound|5000||helloworld.sample.svc.cluster.local"
ENDPOINT              STATUS      OUTLIER CHECK     CLUSTER
169.48.176.3:443      HEALTHY     OK                outbound|5000||helloworld.sample.svc.cluster.local
172.30.23.27:5000     HEALTHY     OK                outbound|5000||helloworld.sample.svc.cluster.local
```

Without:
```
kubectl --context=${REMOTE_CLUSTER_CTX} -n sample get pod -l app=sleep -o name | cut -f2 -d'/' | \
>     xargs -I{} istioctl --context=${REMOTE_CLUSTER_CTX} -n sample proxy-config endpoints {} --cluster "outbound|5000||helloworld.sample.svc.cluster.local"
ENDPOINT              STATUS      OUTLIER CHECK     CLUSTER
172.X.X.X:5000      HEALTHY     OK                outbound|5000||helloworld.sample.svc.cluster.local
172.30.23.27:5000     HEALTHY     OK                outbound|5000||helloworld.sample.svc.cluster.local
```