### PR TITLE
Bump istio/istio dependency

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -74,7 +74,7 @@ site:
 snips:
 	@scripts/gen_snips.sh
 
-gen: snips
+gen: snips tidy-go
 
 gen-check: gen check-clean-repo
 

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -61,5 +61,9 @@ cp -a "${ISTIO_GO}/tests/integration/iop-integration-test-defaults.yaml" "${ISTI
 cp -a "${ISTIO_GO}/manifests" "${ISTIOIO_GO}/manifests"
 
 # For generating junit.xml files
+function install-junit-report() {
+  (cd /tmp; go get github.com/jstemmer/go-junit-report)
+}
+
 echo "Installing go-junit-report..."
-unset GOOS && unset GOARCH && CGO_ENABLED=1 go get github.com/jstemmer/go-junit-report
+command -v go-junit-report || install-junit-report

--- a/go.mod
+++ b/go.mod
@@ -10,11 +10,7 @@ replace github.com/spf13/viper => github.com/istio/viper v1.3.3-0.20190515210538
 
 replace github.com/docker/docker => github.com/docker/engine v1.4.2-0.20191011211953-adfac697dc5b
 
-require (
-	github.com/Masterminds/semver v1.4.2
-	github.com/jstemmer/go-junit-report v0.9.1 // indirect
-	istio.io/istio v0.0.0-20200514170139-8aef23fd2265
-)
+require istio.io/istio v0.0.0-20200518170651-df8ea82bf434
 
 replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.0
 

--- a/go.sum
+++ b/go.sum
@@ -492,8 +492,6 @@ github.com/json-iterator/go v1.1.8/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/u
 github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
-github.com/jstemmer/go-junit-report v0.9.1 h1:6QPYqodiu3GuPL+7mfx+NwDdp2eTkp9IfEUpgAwUN0o=
-github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -1091,13 +1089,13 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 istio.io/api v0.0.0-20190515205759-982e5c3888c6/go.mod h1:hhLFQmpHia8zgaM37vb2ml9iS5NfNfqZGRt1pS9aVEo=
-istio.io/api v0.0.0-20200512133658-88979697a95e h1:JnVVAxwKtyL+dUMP1d6am82SYuhtF+7mY+e0+dmCSVg=
-istio.io/api v0.0.0-20200512133658-88979697a95e/go.mod h1:kyq3g5w42zl/AKlbzDGppYpGMQYMYMyZKeq0/eexML8=
+istio.io/api v0.0.0-20200518162646-2c1705ec4d0b h1:ENwp9Dqlta8fh8Zfn1jyYV12l2tg3jsAUCo8FBb+w6k=
+istio.io/api v0.0.0-20200518162646-2c1705ec4d0b/go.mod h1:kyq3g5w42zl/AKlbzDGppYpGMQYMYMyZKeq0/eexML8=
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
 istio.io/gogo-genproto v0.0.0-20200511213158-02f1fd1746e5 h1:+jL9OzDdbpqHghV6i1dDy2jV+FtC7wz+CuKi2UxZoSs=
 istio.io/gogo-genproto v0.0.0-20200511213158-02f1fd1746e5/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
-istio.io/istio v0.0.0-20200514170139-8aef23fd2265 h1:Cj7HDByROndwILZiBXje/DlAVPOOk1Y3uJY9L6GFPd8=
-istio.io/istio v0.0.0-20200514170139-8aef23fd2265/go.mod h1:yEmMt2JGGvBjQr17ON7BQLqWtnO7OS+KXyV4UTuf2t4=
+istio.io/istio v0.0.0-20200518170651-df8ea82bf434 h1:ReXbtIIh8lcF6ot8jbdSAeVlP+jgvcsH4k8ymfT5vI0=
+istio.io/istio v0.0.0-20200518170651-df8ea82bf434/go.mod h1:H05Mq3ZA3/FEy1d4MCA35NUePccrpIc0yBX3mFeTxQg=
 istio.io/pkg v0.0.0-20200511212725-7bfbbf968c23 h1:1GMOTQs9yVdNEBmVKxDlq6ios80gIAOMO1WfKYKYjZo=
 istio.io/pkg v0.0.0-20200511212725-7bfbbf968c23/go.mod h1:pwGaxLUDLobzL/WvWV94z72LvBbB1dr2UUUyPuasfIU=
 k8s.io/api v0.0.0-20190918155943-95b840bb6a1f/go.mod h1:uWuOHnjmNrtQomJrvEBg0c0HRNyQ+8KTEERVsK0PW48=


### PR DESCRIPTION
Also run go mod tidy. This made me notice we are installing the junit
reporter every time even when not needed and keeping it in go.mod
unexpectedly, so this is removed as well.
Blocker for https://github.com/istio/istio/issues/23899