### PR TITLE
fix Envoy Filter Reference:error converting YAML to JSON

### DIFF
--- a/content/en/docs/reference/config/networking/envoy-filter/index.html
+++ b/content/en/docs/reference/config/networking/envoy-filter/index.html
@@ -119,10 +119,10 @@ spec:
     patch:
       operation: INSERT_BEFORE
       value: # lua filter specification
-       name: envoy.lua
-       typed_config:
-         &quot;@type&quot;: &quot;type.googleapis.com/envoy.config.filter.http.lua.v2.Lua&quot;
-         inlineCode: |
+        name: envoy.lua
+        typed_config:
+          &quot;@type&quot;: &quot;type.googleapis.com/envoy.config.filter.http.lua.v2.Lua&quot;
+          inlineCode: |
            function envoy_on_request(request_handle)
              -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
              local headers, body = request_handle:httpCall(


### PR DESCRIPTION
Envoy Filter's the 2th yaml configure has a  indentation error:
```
error: error parsing lua.yaml: error converting YAML to JSON: yaml: line 27: did not find expected key
```
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
