### PR TITLE
verify.sh: Don't exit on error in _run_and_verify_*() funcs.

### DIFF
--- a/tests/util/verify.sh
+++ b/tests/util/verify.sh
@@ -191,18 +191,18 @@ __cmp_like() {
 }
 
 
-# Verify that $out is the same as $expected.  If they are not the same,
-# exponentially back off and try again.
+# Verify the output of $func is the same as $expected.  If they are not the
+# same, exponentially back off and try again.
 __verify_with_retry() {
     local cmp_func=$1
-    local cmd=$2
+    local func=$2
     local expected=$3
     local max_attempts=$4
     local attempt=1
 
     while true; do
       # Most tests include "set -e", which causes the script to exit if a
-      # statement returns a non-true return value.  In some cases, $cmd may
+      # statement returns a non-true return value.  In some cases, $func may
       # exit with a non-true return value, but we want to retry the command
       # later.  We want to temporarily disable that "errexit" behavior.
       local errexit_state
@@ -210,7 +210,7 @@ __verify_with_retry() {
       set +e
 
       # Run the command.
-      out=$($cmd 2>&1)
+      out=$($func 2>&1)
 
       # Restore the "errexit" state.
       eval "$errexit_state"
@@ -220,7 +220,7 @@ __verify_with_retry() {
       fi
 
       if (( attempt >= max_attempts )); then
-          __err_exit "$cmd" "$out" "$expected"
+          __err_exit "$func" "$out" "$expected"
       fi
 
       sleep $(( 2 ** attempt ))

--- a/tests/util/verify.sh
+++ b/tests/util/verify.sh
@@ -201,7 +201,19 @@ __verify_with_retry() {
     local attempt=1
 
     while true; do
+      # Most tests include "set -e", which causes the script to exit if a
+      # statement returns a non-true return value.  In some cases, $cmd may
+      # exit with a non-true return value, but we want to retry the command
+      # later.  We want to temporarily disable that "errexit" behavior.
+      local errexit_state
+      errexit_state="$(shopt -po errexit || true)"
+      set +e
+
+      # Run the command.
       out=$($cmd 2>&1)
+
+      # Restore the "errexit" state.
+      eval "$errexit_state"
 
       if $cmp_func "$out" "$expected"; then
           return


### PR DESCRIPTION
Most tests include "set -e", which causes the script to exit if a
statement returns a non-true return value.  In some cases, the command
may exit with a non-true return value, but we want to retry the command
later.  We want to temporarily disable that "errexit" behavior.