### PR TITLE
debug.sh: Add debugging to test runs.

### DIFF
--- a/tests/util/debug.sh
+++ b/tests/util/debug.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exec 5> "${TEST_DEBUG_FILE}"
+BASH_XTRACEFD="5"
+export PS4='+${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+set -x


### PR DESCRIPTION
When tests are run, shell script debugging is enabled and written to a
file called "<script_name>_debug.txt" in the same directory as the
"<script_name>_output.txt" file.