### PR TITLE
Added Envoy, Go and Istio matchings to Prometheus federation ServiceMonitors

### DIFF
--- a/content/en/docs/ops/best-practices/observability/index.md
+++ b/content/en/docs/ops/best-practices/observability/index.md
@@ -146,10 +146,6 @@ Add the following job to your configuration:
     'match[]':
     - '{__name__=~"workload:(.*)"}'
     - '{__name__=~"pilot(.*)"}'
-    - '{__name__=~"envoy(.*)"}'
-    - '{__name__=~"go(.*)"}'
-    - '{__name__=~"istio(.*)"}'
-
 {{< /text >}}
 
 If you are using the [Prometheus Operator](https://github.com/coreos/prometheus-operator), use the following configuration instead:
@@ -175,9 +171,6 @@ spec:
       'match[]':
       - '{__name__=~"workload:(.*)"}'
       - '{__name__=~"pilot(.*)"}'
-      - '{__name__=~"envoy(.*)"}'
-      - '{__name__=~"go(.*)"}'
-      - '{__name__=~"istio(.*)"}
     path: /federate
     targetPort: 9090
     honorLabels: true
@@ -193,6 +186,8 @@ The key to the federation configuration is matching on the job in the Istio-depl
 [Istio Standard Metrics](/docs/reference/config/telemetry/metrics/) and renaming any metrics collected by removing
 the prefix used in the workload-level recording rules (`workload:`). This will allow existing dashboards and
 queries to seamlessly continue working when pointed at the production Prometheus instance (and away from the Istio instance).
+
+You can also include additional metrics, e.g. envoy, go, etc. when setting up federation.
 
 Control plane metrics are also collected and federated up to the production Prometheus.
 {{< /tip >}}

--- a/content/en/docs/ops/best-practices/observability/index.md
+++ b/content/en/docs/ops/best-practices/observability/index.md
@@ -146,6 +146,10 @@ Add the following job to your configuration:
     'match[]':
     - '{__name__=~"workload:(.*)"}'
     - '{__name__=~"pilot(.*)"}'
+    - '{__name__=~"envoy(.*)"}'
+    - '{__name__=~"go(.*)"}'
+    - '{__name__=~"istio(.*)"}'
+
 {{< /text >}}
 
 If you are using the [Prometheus Operator](https://github.com/coreos/prometheus-operator), use the following configuration instead:
@@ -171,6 +175,9 @@ spec:
       'match[]':
       - '{__name__=~"workload:(.*)"}'
       - '{__name__=~"pilot(.*)"}'
+      - '{__name__=~"envoy(.*)"}'
+      - '{__name__=~"go(.*)"}'
+      - '{__name__=~"istio(.*)"}
     path: /federate
     targetPort: 9090
     honorLabels: true

--- a/content/en/docs/ops/best-practices/observability/index.md
+++ b/content/en/docs/ops/best-practices/observability/index.md
@@ -187,7 +187,7 @@ The key to the federation configuration is matching on the job in the Istio-depl
 the prefix used in the workload-level recording rules (`workload:`). This will allow existing dashboards and
 queries to seamlessly continue working when pointed at the production Prometheus instance (and away from the Istio instance).
 
-You can also include additional metrics, e.g. envoy, go, etc. when setting up federation.
+You can also include additional metrics (for example, envoy, go, etc.) when setting up federation.
 
 Control plane metrics are also collected and federated up to the production Prometheus.
 {{< /tip >}}


### PR DESCRIPTION

Wouldn't it make more sense to include cases for those metrics too? Or at least mention these somewhere.