### PR TITLE
update doc to use istioctl install

### DIFF
--- a/content/en/docs/examples/virtual-machines/multi-network/index.md
+++ b/content/en/docs/examples/virtual-machines/multi-network/index.md
@@ -42,7 +42,7 @@ following commands on a machine with cluster admin privileges:
    cluster and certificates with the change of how you deploy Istio control plane:
 
     {{< text bash >}}
-    $ istioctl manifest apply \
+    $ istioctl install \
        -f install/kubernetes/operator/examples/vm/values-istio-meshexpansion.yaml
     {{< /text >}}
 

--- a/content/en/docs/examples/virtual-machines/single-network/index.md
+++ b/content/en/docs/examples/virtual-machines/single-network/index.md
@@ -69,7 +69,7 @@ following commands on a machine with cluster admin privileges:
 1. For a simple setup, deploy Istio control plane into the cluster
 
         {{< text bash >}}
-        $ istioctl manifest apply
+        $ istioctl install
         {{< /text >}}
 
     For further details and customization options, refer to the

--- a/content/en/docs/ops/configuration/mesh/config-resource-ready/index.md
+++ b/content/en/docs/ops/configuration/mesh/config-resource-ready/index.md
@@ -31,7 +31,7 @@ installation using the following command. If you enable it after installation,
 you must re-deploy the control plane.
 
 {{< text bash >}}
-$ istioctl manifest apply --set values.pilot.env.PILOT_ENABLE_STATUS=true --set values.global.istiod.enableAnalysis=true
+$ istioctl install --set values.pilot.env.PILOT_ENABLE_STATUS=true --set values.global.istiod.enableAnalysis=true
 {{< /text >}}
 
 ## Wait for resource readiness

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -96,7 +96,7 @@ to understand how `X-Forwarded-For` headers and trusted client addresses are det
           gatewayTopology:
             numTrustedProxies: 2
     EOF
-    $ istioctl manifest apply -f topology.yaml
+    $ istioctl install -f topology.yaml
     {{< /text >}}
 
     {{< idea >}}

--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -149,7 +149,7 @@ status:
 You can enable this feature with:
 
 {{< text bash >}}
-$ istioctl manifest apply --set values.global.istiod.enableAnalysis=true
+$ istioctl install --set values.global.istiod.enableAnalysis=true
 {{< /text >}}
 
 ### Ignoring specific analyzer messages via CLI

--- a/content/en/docs/reference/config/config-status/index.md
+++ b/content/en/docs/reference/config/config-status/index.md
@@ -18,7 +18,7 @@ changes through the mesh, using the `status` field of the resource.
 Status is disabled by default, and can be enabled during install with:
 
 {{< text bash >}}
-$ istioctl manifest apply --set values.pilot.env.PILOT_ENABLE_STATUS=true --set values.global.istiod.enableAnalysis=true
+$ istioctl install --set values.pilot.env.PILOT_ENABLE_STATUS=true --set values.global.istiod.enableAnalysis=true
 {{< /text >}}
 
 The `status` field contains the state of a resource's configuration with various

--- a/content/en/docs/reference/config/telemetry/telemetry_v2_with_wasm/index.md
+++ b/content/en/docs/reference/config/telemetry/telemetry_v2_with_wasm/index.md
@@ -8,13 +8,13 @@ test: no
 Since Istio 1.5, by default Telemetry V2 is enabled as compiled in Istio proxy filters. The same filters are also compiled to WebAssembly (Wasm) modules and shipped with Istio proxy. To enable Telemetry V2 with Wasm runtime, install Istio with the `preview` profile:
 
 {{< text bash >}}
-$ istioctl manifest apply --set profile=preview
+$ istioctl install --set profile=preview
 {{< /text >}}
 
 Alternatively, set the following two values to enable Wasm based Telemetry v2 with the `default` profile:
 
 {{< text bash >}}
-$ istioctl manifest apply --set values.telemetry.v2.metadataExchange.wasmEnabled=true --set values.telemetry.v2.prometheus.wasmEnabled=true
+$ istioctl install --set values.telemetry.v2.metadataExchange.wasmEnabled=true --set values.telemetry.v2.prometheus.wasmEnabled=true
 {{< /text >}}
 
 {{< warning >}}

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -118,7 +118,7 @@ spec:
 {{< /text >}}
 
 {{< text bash >}}
-$ istioctl manifest apply -f cni.yaml
+$ istioctl install -f cni.yaml
 {{< /text >}}
 
 ### Hosted Kubernetes settings
@@ -167,7 +167,7 @@ EOF
 Then pass this file as an argument to `istioctl`, for example:
 
 {{< text bash >}}
-$ istioctl manifest apply -f cni-annotations.yaml
+$ istioctl install -f cni-annotations.yaml
 {{< /text >}}
 
 You can pass other command line arguments with `--set` if necessary.
@@ -189,7 +189,7 @@ In order to deploy Istio 1.4 on OpenShift with CNI you need to use at least Isti
     For example, the following `istioctl manifest` command sets the `values.cni.cniBinDir` value for a GKE cluster:
 
     {{< text bash >}}
-    $ istioctl manifest apply --set values.cni.cniBinDir=/home/kubernetes/bin \
+    $ istioctl install --set values.cni.cniBinDir=/home/kubernetes/bin \
         --set components.cni.enabled=true \
         --set components.cni.namespace=kube-system
     {{< /text >}}

--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -73,7 +73,7 @@ Follow these steps to get started with Istio:
     profiles for production or performance testing.
 
     {{< text bash >}}
-    $ istioctl manifest apply --set profile=demo
+    $ istioctl install --set profile=demo
     ✔ Istio core installed
     ✔ Istiod installed
     ✔ Egress gateways installed

--- a/content/en/docs/setup/install/multicluster/gateways/index.md
+++ b/content/en/docs/setup/install/multicluster/gateways/index.md
@@ -84,7 +84,7 @@ Cross-cluster communication occurs over the Istio gateways of the respective clu
     * Install Istio:
 
         {{< text bash >}}
-        $ istioctl manifest apply \
+        $ istioctl install \
             -f manifests/examples/multicluster/values-istio-multicluster-gateways.yaml
         {{< /text >}}
 

--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -208,7 +208,7 @@ EOF
 Apply the main cluster's configuration.
 
 {{< text bash >}}
-$ istioctl --context=${MAIN_CLUSTER_CTX} manifest apply -f istio-main-cluster.yaml
+$ istioctl install -f istio-main-cluster.yaml --context=${MAIN_CLUSTER_CTX}
 {{< /text >}}
 
 Wait for the control plane to be ready before proceeding.
@@ -279,7 +279,7 @@ EOF
 Apply the remote cluster configuration.
 
 {{< text bash >}}
-$ istioctl --context ${REMOTE_CLUSTER_CTX} manifest apply -f istio-remote0-cluster.yaml
+$ istioctl install -f istio-remote0-cluster.yaml --context ${REMOTE_CLUSTER_CTX}
 {{< /text >}}
 
 Wait for the remote cluster to be ready.

--- a/content/en/docs/setup/upgrade/index.md
+++ b/content/en/docs/setup/upgrade/index.md
@@ -143,7 +143,7 @@ can be found in the `bin/` subdirectory of the downloaded package.
 
     {{< warning >}}
     If you installed Istio using the `-f` flag, for example
-    `istioctl manifest apply -f <IstioControlPlane-custom-resource-definition-file>`,
+    `istioctl install -f <IstioControlPlane-custom-resource-definition-file>`,
     then you must provide the same `-f` flag value to the `istioctl upgrade` command.
     {{< /warning >}}
 
@@ -187,6 +187,6 @@ version (e.g., 1.4.4), and `upgrade` is experimental in 1.4. The process steps a
 identical to the upgrade process mentioned in the previous section. When completed,
 the process will restore Istio back to the Istio version that was installed before.
 
-`istioctl manifest apply` also installs the same Istio control plane, but does not
+`istioctl install` also installs the same Istio control plane, but does not
 perform any checks. For example, default values applied to the cluster for a configuration
 profile may change without warning.

--- a/content/en/docs/tasks/observability/distributed-tracing/lightstep/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/lightstep/index.md
@@ -44,7 +44,7 @@ This task uses the [Bookinfo](/docs/examples/bookinfo/) sample application as an
     when you run the install command. For example:
 
     {{< text bash >}}
-    $ istioctl manifest apply \
+    $ istioctl install \
         --set values.pilot.traceSampling=100 \
         --set values.global.proxy.tracer="lightstep" \
         --set values.global.tracer.lightstep.address="<satellite-address>" \

--- a/content/en/docs/tasks/observability/kiali/index.md
+++ b/content/en/docs/tasks/observability/kiali/index.md
@@ -90,7 +90,7 @@ Once you create the Kiali secret, follow
 For example:
 
 {{< text bash >}}
-$ istioctl manifest apply --set values.kiali.enabled=true
+$ istioctl install --set values.kiali.enabled=true
 {{< /text >}}
 
 {{< idea >}}
@@ -100,7 +100,7 @@ integrates with them, you must pass additional arguments to the
 `istioctl` command, for example:
 
 {{< text bash >}}
-$ istioctl manifest apply \
+$ istioctl install \
     --set values.kiali.enabled=true \
     --set "values.kiali.dashboard.jaegerURL=http://jaeger-query:16686" \
     --set "values.kiali.dashboard.grafanaURL=http://grafana:3000"

--- a/content/en/docs/tasks/observability/logs/access-log/index.md
+++ b/content/en/docs/tasks/observability/logs/access-log/index.md
@@ -27,7 +27,7 @@ In the example below, replace `demo` with the name of the profile you used when 
 {{< /tip >}}
 
 {{< text bash >}}
-$ istioctl manifest apply --set profile=demo --set meshConfig.accessLogFile="/dev/stdout"
+$ istioctl install --set profile=demo --set meshConfig.accessLogFile="/dev/stdout"
 - Applying manifest for component Base...
 ✔ Finished applying manifest for component Base.
 - Applying manifest for component Pilot...
@@ -118,7 +118,7 @@ In the example below, replace `demo` with the name of the profile you used when 
 {{< /tip >}}
 
 {{< text bash >}}
-$ istioctl manifest apply --set profile=demo
+$ istioctl install --set profile=demo
 - Applying manifest for component Base...
 ✔ Finished applying manifest for component Base.
 - Applying manifest for component Pilot...

--- a/content/en/docs/tasks/policy-enforcement/enabling-policy/index.md
+++ b/content/en/docs/tasks/policy-enforcement/enabling-policy/index.md
@@ -46,7 +46,7 @@ which enables policy checks by default.
     Execute the following command from the root Istio directory:
 
     {{< text bash >}}
-    $ istioctl manifest apply --set meshConfig.disablePolicyChecks=false --set values.pilot.policy.enabled=true
+    $ istioctl install --set meshConfig.disablePolicyChecks=false --set values.pilot.policy.enabled=true
     configuration "istio" replaced
     {{< /text >}}
 

--- a/content/en/docs/tasks/security/authentication/authn-policy/index.md
+++ b/content/en/docs/tasks/security/authentication/authn-policy/index.md
@@ -17,7 +17,12 @@ the underlying concepts in the [authentication overview](/docs/concepts/security
 * Understand Istio [authentication policy](/docs/concepts/security/#authentication-policies) and related
 [mutual TLS authentication](/docs/concepts/security/#mutual-tls-authentication) concepts.
 
-* Follow the [Istio installation guide](/docs/setup/install/istioctl/) to install Istio.
+* Install Istio on a Kubernetes cluster with the `default` configuration profile, as described in
+[installation steps](/docs/setup/getting-started).
+
+{{< text bash >}}
+$ istioctl install
+{{< /text >}}
 
 ### Setup
 

--- a/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
+++ b/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
@@ -20,6 +20,10 @@
 #          docs/tasks/security/authentication/authn-policy/index.md
 ####################################################################################################
 
+snip_before_you_begin_1() {
+istioctl install
+}
+
 snip_setup_1() {
 kubectl create ns foo
 kubectl apply -f <(istioctl kube-inject -f samples/httpbin/httpbin.yaml) -n foo

--- a/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
@@ -21,7 +21,7 @@ In Istio 1.4, we introduce an alpha feature to support {{< gloss >}}trust domain
 1. Install Istio with a custom trust domain and mutual TLS enabled.
 
     {{< text bash >}}
-    $ istioctl manifest apply --set profile=demo --set values.global.trustDomain=old-td
+    $ istioctl install --set profile=demo --set values.global.trustDomain=old-td
     {{< /text >}}
 
 1. Deploy the [httpbin]({{< github_tree >}}/samples/httpbin) sample in the `default` namespace
@@ -85,7 +85,7 @@ Notice that it may take tens of seconds for the authorization policy to be propa
 1. Install Istio with a new trust domain.
 
     {{< text bash >}}
-    $ istioctl manifest apply --set profile=demo --set values.global.trustDomain=new-td
+    $ istioctl install --set profile=demo --set values.global.trustDomain=new-td
     {{< /text >}}
 
     Istio mesh is now running with a new trust domain, `new-td`.
@@ -134,7 +134,7 @@ Notice that it may take tens of seconds for the authorization policy to be propa
           trustDomainAliases:
             - old-td
     EOF
-    $ istioctl manifest apply --set profile=demo -f td-installation.yaml
+    $ istioctl install --set profile=demo -f td-installation.yaml
     {{< /text >}}
 
 1. Without changing the authorization policy, verify that requests to `httpbin` from:

--- a/content/en/docs/tasks/security/cert-management/dns-cert/index.md
+++ b/content/en/docs/tasks/security/cert-management/dns-cert/index.md
@@ -35,7 +35,7 @@ spec:
         - secretName: dns.example2-service-account
           dnsNames: [example2.istio-system.svc, example2.istio-system]
 EOF
-$ istioctl manifest apply -f ./istio.yaml
+$ istioctl install -f ./istio.yaml
 {{< /text >}}
 
 ## DNS certificate provisioning and management
@@ -46,7 +46,7 @@ Istio also manages the lifecycle of the DNS certificates, including their rotati
 
 ## Configure DNS certificates
 
-The `IstioControlPlane` custom resource used to configure Istio in the `istioctl manifest apply` command, above,
+The `IstioControlPlane` custom resource used to configure Istio in the `istioctl install` command, above,
 contains an example DNS certificate configuration. Within, the `dnsNames` field specifies the DNS
 names in a certificate and the `secretName` field specifies the name of the Kubernetes secret used to
 store the certificate and the key.

--- a/content/en/docs/tasks/security/cert-management/dns-cert/snips.sh
+++ b/content/en/docs/tasks/security/cert-management/dns-cert/snips.sh
@@ -33,7 +33,7 @@ spec:
         - secretName: dns.example2-service-account
           dnsNames: [example2.istio-system.svc, example2.istio-system]
 EOF
-istioctl manifest apply -f ./istio.yaml
+istioctl install -f ./istio.yaml
 }
 
 snip_check_the_provisioning_of_dns_certificates_1() {

--- a/content/en/docs/tasks/security/cert-management/plugin-ca-cert/index.md
+++ b/content/en/docs/tasks/security/cert-management/plugin-ca-cert/index.md
@@ -54,7 +54,7 @@ which will be read by Istio's CA:
     Istio's CA will read certificates and key from the secret-mount files.
 
     {{< text bash >}}
-    $ istioctl manifest apply --set profile=demo
+    $ istioctl install --set profile=demo
     {{< /text >}}
 
 ## Deploying example services

--- a/content/en/docs/tasks/security/cert-management/plugin-ca-cert/snips.sh
+++ b/content/en/docs/tasks/security/cert-management/plugin-ca-cert/snips.sh
@@ -28,7 +28,7 @@ kubectl create secret generic cacerts -n istio-system --from-file=samples/certs/
 }
 
 snip_plugging_in_existing_certificates_and_key_2() {
-istioctl manifest apply --set profile=demo
+istioctl install --set profile=demo
 }
 
 snip_deploying_example_services_1() {

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -379,7 +379,7 @@ Update your `istio-sidecar-injector` configuration map using the IP ranges speci
 For example, if the range is 10.0.0.1&#47;24, use the following command:
 
 {{< text bash >}}
-$ istioctl manifest apply <the flags you used to install Istio> --set values.global.proxy.includeIPRanges="10.0.0.1/24"
+$ istioctl install <the flags you used to install Istio> --set values.global.proxy.includeIPRanges="10.0.0.1/24"
 {{< /text >}}
 
 Use the same command that you used to [install Istio](/docs/setup/install/istioctl) and
@@ -418,7 +418,7 @@ Update the `istio-sidecar-injector.configmap.yaml` configuration map to redirect
 proxies:
 
 {{< text bash >}}
-$ istioctl manifest apply <the flags you used to install Istio>
+$ istioctl install <the flags you used to install Istio>
 {{< /text >}}
 
 ## Understanding what happened

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -53,7 +53,7 @@ controlled way.
 1.  Run the following command:
 
     {{< text bash >}}
-    $ istioctl manifest apply --set values.global.istioNamespace=istio-system \
+    $ istioctl install --set values.global.istioNamespace=istio-system \
         --set values.gateways.istio-ingressgateway.enabled=false \
         --set values.gateways.istio-egressgateway.enabled=true
     {{< /text >}}


### PR DESCRIPTION

Based on https://github.com/istio/istio.io/pull/7336 and https://github.com/istio/istio/pull/22563, keeping consistency across docs for `istioctl install` instead of `istioctl manifest apply`. 

The `istioctl install` is already available for [Customizable Install with Istioctl](https://istio.io/docs/setup/install/istioctl/). Not sure when is the plan to deprecate `istioctl manifest apply`. 