### PR TITLE
auth: do not remove crd in upgrade note

### DIFF
--- a/content/en/news/releases/1.6.x/announcing-1.6/upgrade-notes/index.md
+++ b/content/en/news/releases/1.6.x/announcing-1.6/upgrade-notes/index.md
@@ -87,17 +87,6 @@ $ kubectl get servicerolebindings.rbac.istio.io --all-namespaces
 
 If there are any `v1alpha1` security policies in your clusters, migrate to the new APIs before upgrading.
 
-To ensure that `v1alpha1` security policies aren't applied in the future, delete the Custom Resource Definitions (CRDs) using the `v1alpha1` security policy APIs with the following commands:
-
-{{< text bash >}}
-$ kubectl delete crd policies.authentication.istio.io
-$ kubectl delete crd meshpolicies.authentication.istio.io
-$ kubectl delete crd rbacconfigs.rbac.istio.io
-$ kubectl delete crd clusterrbacconfigs.rbac.istio.io
-$ kubectl delete crd serviceroles.rbac.istio.io
-$ kubectl delete crd servicerolebindings.rbac.istio.io
-{{< /text >}}
-
 ## Istio configuration during installation
 
 Past Istio releases deployed configuration objects during installation. The presence of those objects caused the following issues:


### PR DESCRIPTION
1.6 doesn't support these CRDs but there are some left over code still trying to read them which is spamming the istiod logging. Keeping them should help avoid spamming istiod logs. We can recommend to delete the CRDs in 1.7 where we have cleaned the left over code.

Fixes https://github.com/istio/istio/issues/24035.