### PR TITLE
CORS Policy Example: Change allowOrigin block

### DIFF
--- a/content/en/docs/reference/config/networking/virtual-service/index.html
+++ b/content/en/docs/reference/config/networking/virtual-service/index.html
@@ -2263,8 +2263,8 @@ spec:
         host: ratings.prod.svc.cluster.local
         subset: v1
     corsPolicy:
-      allowOrigin:
-      - example.com
+      allowOrigins:
+      - exact: example.com
       allowMethods:
       - POST
       - GET
@@ -2291,8 +2291,8 @@ spec:
         host: ratings.prod.svc.cluster.local
         subset: v1
     corsPolicy:
-      allowOrigin:
-      - example.com
+      allowOrigins:
+      - exact: example.com
       allowMethods:
       - POST
       - GET

--- a/content/pt-br/docs/reference/config/networking/virtual-service/index.html
+++ b/content/pt-br/docs/reference/config/networking/virtual-service/index.html
@@ -121,8 +121,8 @@ spec:
         host: ratings.prod.svc.cluster.local
         subset: v1
     corsPolicy:
-      allowOrigin:
-      - example.com
+      allowOrigins:
+      - exact: example.com
       allowMethods:
       - POST
       - GET

--- a/content/zh/docs/reference/config/networking/virtual-service/index.html
+++ b/content/zh/docs/reference/config/networking/virtual-service/index.html
@@ -120,8 +120,8 @@ spec:
         host: ratings.prod.svc.cluster.local
         subset: v1
     corsPolicy:
-      allowOrigin:
-      - example.com
+      allowOrigins:
+      - exact: example.com
       allowMethods:
       - POST
       - GET


### PR DESCRIPTION
### Description
In this PR, we change the block of CORS Policy definition from `allowOrigin` to `allowOrigins` so not to be misleading for people who take this example as guide to setup their meshes.

After the upgrade to Istio 1.6 the block with deprecated `allowOrigin` is not respected thus not working.

### Addresses
https://github.com/istio/istio/issues/24145

### Checklist