### PR TITLE
Fix sudo command on VM doc

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -197,7 +197,7 @@ Run the following commands on the virtual machine you want to add to the Istio m
 1. Add the istiod host to `/etc/hosts`.
 
     {{< text bash >}}
-    $ sudo cat hosts-addendum >> /etc/hosts
+    $ sudo sh -c 'cat hosts-addendum >> /etc/hosts'
     {{< /text >}}
 
 1. Transfer ownership of the files in `/etc/certs/` and `/var/lib/istio/envoy/` to the Istio proxy.


### PR DESCRIPTION
If you are not running as root already, this will fail. The redirect part is not run as root previously



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure