### PR TITLE
Update min k8 supported version for istio 1.7

### DIFF
--- a/data/args.yml
+++ b/data/args.yml
@@ -29,7 +29,7 @@ source_branch_name: master
 doc_branch_name: master
 
 # The list of supported versions described by the docs
-supported_kubernetes_versions: ["1.15", "1.16", "1.17", "1.18"]
+supported_kubernetes_versions: ["1.16", "1.17", "1.18"]
 
 ####### Static values
 


### PR DESCRIPTION
Related: https://github.com/istio/istio/pull/24167

The minimum supported k8 version for Istio 1.7 is 1.16-1.18 (3 versions). Ref: https://github.com/istio/istio/pull/24134#issuecomment-634690848

Ref: https://deploy-preview-7422--preliminary-istio.netlify.app/docs/setup/platform-setup/

On Preliminary:
![version](https://user-images.githubusercontent.com/2920003/83110828-48f01200-a0e1-11ea-81dc-7b27c177742e.png)

