### PR TITLE
cache sidebar smartly when building site

### DIFF
--- a/layouts/partials/sidebar_level.html
+++ b/layouts/partials/sidebar_level.html
@@ -42,7 +42,11 @@
 
                     <button{{ if not $collapse }} class="show"{{ end }} aria-hidden="true"></button><a {{ if eq $current.Permalink .Permalink }}class="current"{{ end }} title="{{ $desc }}" href="{{ .Permalink }}">{{ .LinkTitle}}</a>
 
-                    {{ partial "sidebar_level.html" (dict "pages" $pages "parent" . "current" $current "collapse" $collapse "top" false "labelledby" "" ) }}
+                    {{ if (.CurrentSection.IsAncestor $current) }}
+                        {{ partial "sidebar_level.html" (dict "pages" $pages "parent" . "current" $current "collapse" $collapse "top" false "labelledby" "" ) }}
+                    {{- else -}}
+                        {{ partialCached "sidebar_level.html" (dict "pages" $pages "parent" . "current" $current "collapse" $collapse "top" false "labelledby" "" ) .CurrentSection }}
+                    {{- end -}}
                 </li>
             {{ else }}
                 <li role="none">

--- a/layouts/partials/sidebar_multicard.html
+++ b/layouts/partials/sidebar_multicard.html
@@ -18,7 +18,11 @@
                     </button>
 
                     <div class="body{{if .IsAncestor $current}} default{{end}}" aria-labelledby="{{ $id }}" role="region" id="{{ $id }}-body">
-                        {{ partial "sidebar_level.html" (dict "pages" $pages "parent" $page "current" $current "collapse" false "top" true "labelledby" $id ) }}
+                        {{ if ($page.IsAncestor $current) }}
+                            {{ partial "sidebar_level.html" (dict "pages" $pages "parent" $page "current" $current "collapse" false "top" true "labelledby" $id ) }}
+                        {{ else }}
+                            {{ partialCached "sidebar_level.html" (dict "pages" $pages "parent" $page "current" $current "collapse" false "top" true "labelledby" $id ) $page.CurrentSection }}
+                        {{ end }}
                     </div>
                 </div>
             {{ end }}


### PR DESCRIPTION
Hugo now will cache the sidebar intelligently when building the site. This increases hugo build times from ~100s to ~10s, a 10x improvement (on my laptop).

[ ] Configuration Infrastructure
[ X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
