### PR TITLE
Fix heading for bookinfo sample app in release notes for 1.6.1

### DIFF
--- a/content/en/news/releases/1.6.x/announcing-1.6.1/index.md
+++ b/content/en/news/releases/1.6.x/announcing-1.6.1/index.md
@@ -48,7 +48,7 @@ what’s different between Istio 1.6.0 and Istio 1.6.1.
 - **Fixed** a proxy sidecar segfault when the response to HTTP calls by WASM filters are empty ([Issue 23890](https://github.com/istio/istio/issues/23890))
 - **Fixed** a proxy sidecar segfault while parsing CEL expressions ([Issue 497](https://github.com/envoyproxy/envoy-wasm/issues/497))
 
-# Bookinfo sample application security fixes
+## Bookinfo sample application security fixes
 
 We've updated the versions of Node.js and jQuery used in the Bookinfo sample application. Node.js has been upgraded from
 version 12.9 to 12.18. jQuery has been updated from version 2.1.4 to version 3.5.0. The highest rated vulnerability fixed:


### PR DESCRIPTION
Incorrect header for Bookinfo notice

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
