### PR TITLE
Add missing cleanup for VirtualService nginx

### DIFF
--- a/content/pt-br/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/pt-br/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -812,6 +812,7 @@ to hold the configuration of the NGINX server:
     $ kubectl delete deployment my-nginx -n mesh-external
     $ kubectl delete namespace mesh-external
     $ kubectl delete gateway istio-egressgateway
+    $ kubectl delete virtualservice nginx
     $ kubectl delete serviceentry nginx
     $ kubectl delete virtualservice direct-nginx-through-egress-gateway
     $ kubectl delete destinationrule originate-mtls-for-nginx


### PR DESCRIPTION
Cleanup for deleting VirtualService nginx is missing.


[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure