### PR TITLE
replace deprecated policy configuration with peerAuthentication

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/istioctl-describe/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-describe/index.md
@@ -239,16 +239,16 @@ instructions, you can enable strict mutual TLS for the `ratings` service:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
-  name: "ratings-strict"
+  name: ratings-strict
 spec:
-  targets:
-  - name: ratings
-  peers:
-  - mtls:
-      mode: STRICT
+  selector:
+    matchLabels:
+      app: ratings
+  mtls:
+    mode: STRICT
 EOF
 {{< /text >}}
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

`policy` and `meshpolicy` are removed since istio 1.6.0, see: #22602
we need to update the troubleshooting doc for the example configuration.

resolve: https://github.com/istio/istio/issues/24502

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ X ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
