### PR TITLE
add steering as blog approval

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 *                @istio/wg-docs-maintainers-infra
 /.spelling       @istio/wg-docs-maintainers-english
 /content/en/     @istio/wg-docs-maintainers-english
-/content/en/blog @istio/steering-committee 
+/content/en/blog @istio/steering-committee
 /content/zh/     @istio/wg-docs-maintainers-chinese
 /i18n/en.toml    @istio/wg-docs-maintainers-english
 /i18n/zh.toml    @istio/wg-docs-maintainers-chinese

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 *                @istio/wg-docs-maintainers-infra
 /.spelling       @istio/wg-docs-maintainers-english
 /content/en/     @istio/wg-docs-maintainers-english
-/content/en/blog @istio/steering-committee-maintainers @istio/steering-committee-members
+/content/en/blog @istio/steering-committee 
 /content/zh/     @istio/wg-docs-maintainers-chinese
 /i18n/en.toml    @istio/wg-docs-maintainers-english
 /i18n/zh.toml    @istio/wg-docs-maintainers-chinese

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 *                @istio/wg-docs-maintainers-infra
 /.spelling       @istio/wg-docs-maintainers-english
 /content/en/     @istio/wg-docs-maintainers-english
+/content/en/blog @istio/steering-committee-maintainers @istio/steering-committee-members
 /content/zh/     @istio/wg-docs-maintainers-chinese
 /i18n/en.toml    @istio/wg-docs-maintainers-english
 /i18n/zh.toml    @istio/wg-docs-maintainers-chinese


### PR DESCRIPTION
fixes: https://github.com/istio/istio.io/issues/7535

Not sure how to do require 2 approvers for this `/content/en/blog` folder only.  I can configure the istio.io repo to require 2 approvals, but that is not really what we wanted.  @howardjohn do you know?



[ ] Configuration Infrastructure
[ x ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure