### PR TITLE
Add a clause indicating that CNI works OOB

### DIFF
--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -43,7 +43,32 @@ replaces the functionality provided by the `istio-init` container.
     *  The Kubernetes documentation highly recommends this for all Kubernetes installations
        where `ServiceAccounts` are utilized.
 
-## Installation
+## Basic Installation
+
+For most environments, CNI works correctly by installing with this `IstioOperator`:
+
+{{< text yaml >}}
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    cni:
+      enabled: true
+  values:
+    cni:
+      excludeNamespaces:
+       - istio-system
+       - kube-system
+      logLevel: info
+{{< /text >}}
+
+Then to install Istio, apply the `IstioOperator`:
+
+{{< text bash >}}
+$ istioctl install -f istio-cni.yaml
+{{< /text >}}
+
+## Advanced Installation
 
 1.  Determine the Kubernetes environment's CNI plugin `--cni-bin-dir` and `--cni-conf-dir` settings.
     Refer to [Hosted Kubernetes settings](#hosted-kubernetes-settings) for any non-default settings required.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -45,9 +45,10 @@ replaces the functionality provided by the `istio-init` container.
 
 ## Basic Installation
 
-For most environments, CNI works correctly by installing with this `IstioOperator`:
+In most environments, a basic Istio cluster with CNI enabled can be installed using the following command:
 
-{{< text yaml >}}
+{{< text bash >}}
+$ cat <<EOF > istio-cni.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
@@ -60,11 +61,7 @@ spec:
        - istio-system
        - kube-system
       logLevel: info
-{{< /text >}}
-
-Then to install Istio, apply the `IstioOperator`:
-
-{{< text bash >}}
+EOF
 $ istioctl install -f istio-cni.yaml
 {{< /text >}}
 


### PR DESCRIPTION
CNI should work nearly everywhere out of the box. If someone or
something provides a nonstandard configuration, the existing documentation
can help them get moving.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure