### PR TITLE
fixed minor typos in security/request_authentication documentation

### DIFF
--- a/content/en/docs/reference/config/security/request_authentication/index.html
+++ b/content/en/docs/reference/config/security/request_authentication/index.html
@@ -53,7 +53,7 @@ spec:
 
 <ul>
 <li>The next example shows how to set a different JWT requirement for a different <code>host</code>. The <code>RequestAuthentication</code>
-declares it can accpet JWTs issuer by either <code>issuer-foo</code> or <code>issuer-bar</code> (the public key set is implicitly
+declares it can accept JWTs issued by either <code>issuer-foo</code> or <code>issuer-bar</code> (the public key set is implicitly
 set from the OpenID Connect spec).</li>
 </ul>
 

--- a/content/zh/docs/reference/config/security/request_authentication/index.html
+++ b/content/zh/docs/reference/config/security/request_authentication/index.html
@@ -53,7 +53,7 @@ spec:
 
 <ul>
 <li>The next example shows how to set a different JWT requirement for a different <code>host</code>. The <code>RequestAuthentication</code>
-declares it can accpet JWTs issuer by either <code>issuer-foo</code> or <code>issuer-bar</code> (the public key set is implicitly
+declares it can accept JWTs issued by either <code>issuer-foo</code> or <code>issuer-bar</code> (the public key set is implicitly
 set from the OpenID Connect spec).
 &ldquo;`yaml
 apiVersion: security.istio.io/v1beta1


### PR DESCRIPTION
* fixed minor typo
* Also changed `issuer` to `issued` because I think it is also a typo


[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure