### PR TITLE
Fix description of Shared control plane

### DIFF
--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -482,7 +482,7 @@ ENDPOINT             STATUS      OUTLIER CHECK     CLUSTER
 {{< /text >}}
 
 In the remote cluster, the endpoints are the gateway IP of the main cluster (`192.168.1.246:443`) and
-the pod IP in the main cluster (`10.32.0.9:5000`).
+the pod IP in the remote cluster (`10.32.0.9:5000`).
 
 **Congratulations!**
 


### PR DESCRIPTION
From the remote cluster, one of the endpoints should be the IP of the Pod in the remote cluster not in the main cluster.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
