### PR TITLE
fix: kubectl exec command error

### DIFF
--- a/content/zh/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/zh/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -93,7 +93,7 @@ keywords: [traffic-management,circuit-breaking]
 
     {{< text bash >}}
     $ FORTIO_POD=$(kubectl get pod | grep fortio | awk '{ print $1 }')
-    $ kubectl exec -it $FORTIO_POD  -c fortio /usr/bin/fortio -- load -curl  http://httpbin:8000/get
+    $ kubectl exec -it $FORTIO_POD  -c fortio -- /usr/bin/fortio load -curl  http://httpbin:8000/get
     HTTP/1.1 200 OK
     server: envoy
     date: Tue, 16 Jan 2018 23:47:00 GMT


### PR DESCRIPTION
This is an error in the Chinese version of [circuit-breaking](https://istio.io/latest/zh/docs/tasks/traffic-management/circuit-breaking/)

[X] Docs
