### PR TITLE
Add kiali integrations page

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -170,6 +170,7 @@ CRDs
 CSRs
 Ctrl
 Customizable
+customizable
 CVE
 CVE-2019-12243
 CVE-2019-12995

--- a/content/en/docs/ops/integrations/kiali/index.md
+++ b/content/en/docs/ops/integrations/kiali/index.md
@@ -6,8 +6,8 @@ keywords: [integration,kiali]
 test: no
 ---
 
-[Kiali](https://kiali.io/) is an observability console for Istio with service mesh configuration capabilities.
-It helps you to understand the structure of your service mesh by inferring the topology, and also provides the health of your mesh.
+[Kiali](https://kiali.io/) is an observability console for Istio with service mesh configuration and validation capabilities.
+It helps you understand the structure and health of your service mesh by monitoring traffic flow to infer the topology and report errors.
 Kiali provides detailed metrics, and a basic [Grafana](/docs/ops/integrations/grafana) integration is available for advanced queries.
 Distributed tracing is provided by integrating [Jaeger](/docs/ops/integrations/jaeger).
 

--- a/content/en/docs/ops/integrations/kiali/index.md
+++ b/content/en/docs/ops/integrations/kiali/index.md
@@ -8,20 +8,20 @@ test: no
 
 [Kiali](https://kiali.io/) is an observability console for Istio with service mesh configuration and validation capabilities.
 It helps you understand the structure and health of your service mesh by monitoring traffic flow to infer the topology and report errors.
-Kiali provides detailed metrics, and a basic [Grafana](/docs/ops/integrations/grafana) integration is available for advanced queries.
-Distributed tracing is provided by integrating [Jaeger](/docs/ops/integrations/jaeger).
+Kiali provides detailed metrics and a basic [Grafana](/docs/ops/integrations/grafana) integration, which can be used for advanced queries.
+Distributed tracing is provided by integration with [Jaeger](/docs/ops/integrations/jaeger).
 
 ## Configuration
 
 ### Option 1: Quick start
 
-To get quickly up and running with Kiali, Istio provides a basic sample installation:
+Istio provides a basic sample installation to quickly get Kiali up and running:
 
 {{< text bash >}}
 $ kubectl apply {{< github_tree >}}/samples/addons/kiali.yaml -n istio-system
 {{< /text >}}
 
-This will deploy Kiali into your cluster
+This will deploy Kiali into your cluster.
 
 ### Option 2: Customizable install
 

--- a/content/en/docs/ops/integrations/kiali/index.md
+++ b/content/en/docs/ops/integrations/kiali/index.md
@@ -1,0 +1,32 @@
+---
+title: Kiali
+description: Information on how to integrate with Kiali.
+weight: 29
+keywords: [integration,kiali]
+test: no
+---
+
+[Kiali](https://kiali.io/) is an observability console for Istio with service mesh configuration capabilities.
+It helps you to understand the structure of your service mesh by inferring the topology, and also provides the health of your mesh.
+Kiali provides detailed metrics, and a basic [Grafana](/docs/ops/integrations/grafana) integration is available for advanced queries.
+Distributed tracing is provided by integrating [Jaeger](/docs/ops/integrations/jaeger).
+
+## Configuration
+
+### Option 1: Quick start
+
+To get quickly up and running with Kiali, Istio provides a basic sample installation:
+
+{{< text bash >}}
+$ kubectl apply {{< github_tree >}}/samples/addons/kiali.yaml -n istio-system
+{{< /text >}}
+
+This will deploy Kiali into your cluster
+
+### Option 2: Customizable install
+
+The Kiali project offers its own [customizable installation methods](https://kiali.io/documentation/latest/getting-started). We recommend production users follow these instructions to ensure they stay up to date with the latest versions and best practices.
+
+## Usage
+
+For more information about using Kiali, see the [Visualizing Your Mesh](/docs/tasks/observability/kiali/) task.

--- a/content/en/docs/ops/integrations/prometheus/index.md
+++ b/content/en/docs/ops/integrations/prometheus/index.md
@@ -1,7 +1,7 @@
 ---
 title: Prometheus
 description: How to integrate with Prometheus.
-weight: 29
+weight: 30
 keywords: [integration,prometheus]
 test: n/a
 ---

--- a/content/en/docs/ops/integrations/zipkin/index.md
+++ b/content/en/docs/ops/integrations/zipkin/index.md
@@ -1,7 +1,7 @@
 ---
 title: Zipkin
 description: How to integrate with Zipkin.
-weight: 30
+weight: 31
 keywords: [integration,zipkin,tracing]
 test: n/a
 ---

--- a/content/en/docs/tasks/observability/kiali/index.md
+++ b/content/en/docs/tasks/observability/kiali/index.md
@@ -27,7 +27,7 @@ This task uses the [Bookinfo](/docs/examples/bookinfo/) sample application as th
 
 {{< tip >}}
 The following instructions assume you have installed `istioctl` and will use it to install Kiali.
-To install Kiali without `istioctl`, follow the [Kiali installation instructions](https://www.kiali.io/documentation/getting-started/).
+To install Kiali without `istioctl`, follow the [Kiali installation instructions](https://kiali.io/documentation/latest/getting-started/).
 {{< /tip >}}
 
 ### Create a secret


### PR DESCRIPTION
The primary purpose for this is to just have a page here for consistency
with other addons, most of the content still lives in the other doc I
link to here. That may change in the future but for now I think it makes
sense to just get something here and we can refactor in the future.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure