### PR TITLE
Fix invalid link for workselector

### DIFF
--- a/content/en/docs/reference/config/security/authorization-policy/index.html
+++ b/content/en/docs/reference/config/security/authorization-policy/index.html
@@ -183,7 +183,7 @@ spec:
 <tbody>
 <tr id="AuthorizationPolicy-selector">
 <td><code>selector</code></td>
-<td><code><a href="/docs/reference/config/type/v1beta1/workload-selector/#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>Optional. Workload selector decides where to apply the authorization policy.
 If not set, the authorization policy will be applied to all workloads in the

--- a/content/en/docs/reference/config/security/peer_authentication/index.html
+++ b/content/en/docs/reference/config/security/peer_authentication/index.html
@@ -105,7 +105,7 @@ spec:
 <tbody>
 <tr id="PeerAuthentication-selector">
 <td><code>selector</code></td>
-<td><code><a href="/docs/reference/config/type/v1beta1/workload-selector/#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>The selector determines the workloads to apply the ChannelAuthentication on.
 If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>

--- a/content/en/docs/reference/config/security/request_authentication/index.html
+++ b/content/en/docs/reference/config/security/request_authentication/index.html
@@ -128,7 +128,7 @@ spec:
 <tbody>
 <tr id="RequestAuthentication-selector">
 <td><code>selector</code></td>
-<td><code><a href="/docs/reference/config/type/v1beta1/workload-selector/#WorkloadSelector">WorkloadSelector</a></code></td>
+<td><code><a href="/docs/reference/config/networking/sidecar/#WorkloadSelector">WorkloadSelector</a></code></td>
 <td>
 <p>The selector determines the workloads to apply the RequestAuthentication on.
 If not set, the policy will be applied to all workloads in the same namespace as the policy.</p>


### PR DESCRIPTION
[X] Security

This patch fixes invalid link for workselector. It gets Page Not Found error now. You can see it from here https://istio.io/latest/docs/reference/config/security/peer_authentication/ for example.