### PR TITLE
Replace deprecated api versions in EN docs

### DIFF
--- a/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
+++ b/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
@@ -120,7 +120,7 @@ service/productpage patched
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:
       name: bookinfo

--- a/content/en/docs/examples/microservices-istio/setup-kubernetes-cluster/index.md
+++ b/content/en/docs/examples/microservices-istio/setup-kubernetes-cluster/index.md
@@ -63,7 +63,7 @@ proceed to [setting up your local computer](/docs/examples/microservices-istio/s
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1beta1
     kind: Ingress
     metadata:
       name: istio-system

--- a/content/en/docs/ops/integrations/certmanager/index.md
+++ b/content/en/docs/ops/integrations/certmanager/index.md
@@ -64,8 +64,8 @@ cert-manager provides direct integration with Kubernetes Ingress by configuring 
 Alternatively, a `Certificate` can be created as described in [Istio Gateway](#istio-gateway), then referenced in the `Ingress` object:
 
 {{< text yaml >}}
-apiVersion: extensions/v1beta1
-kind: Ingress
+apiVersion: networking.k8s.io/v1beta1
+Kind: Ingress
 metadata:
   name: ingress
   annotations:

--- a/content/en/docs/reference/config/policy-and-telemetry/attribute-vocabulary/index.md
+++ b/content/en/docs/reference/config/policy-and-telemetry/attribute-vocabulary/index.md
@@ -26,7 +26,7 @@ deployments will have agents (Envoy or Mixer adapters) that produce these attrib
 | `source.name`               | string | Source workload instance name. | `redis-master-2353460263-1ecey` |
 | `source.namespace`          | string | Source workload instance namespace. | `my-namespace` |
 | `source.principal`          | string | Authority under which the source workload instance is running. | `service-account-foo` |
-| `source.owner`              | string | Reference to the workload controlling the source workload instance. | `kubernetes://apis/extensions/v1beta1/namespaces/istio-system/deployments/istio-policy` |
+| `source.owner`              | string | Reference to the workload controlling the source workload instance. | `kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-policy` |
 | `source.workload.uid`       | string | Unique identifier of the source workload. | `istio://istio-system/workloads/istio-policy` |
 | `source.workload.name`      | string | Source workload name. | `istio-policy` |
 | `source.workload.namespace` | string | Source workload namespace.  | `istio-system` |
@@ -37,7 +37,7 @@ deployments will have agents (Envoy or Mixer adapters) that produce these attrib
 | `destination.name`              | string | Destination workload instance name. | `istio-telemetry-2359333` |
 | `destination.namespace`         | string | Destination workload instance namespace. | `istio-system` |
 | `destination.principal`         | string | Authority under which the destination workload instance is running. | `service-account` |
-| `destination.owner`             | string | Reference to the workload controlling the destination workload instance.| `kubernetes://apis/extensions/v1beta1/namespaces/istio-system/deployments/istio-telemetry` |
+| `destination.owner`             | string | Reference to the workload controlling the destination workload instance.| `kubernetes://apis/apps/v1/namespaces/istio-system/deployments/istio-telemetry` |
 | `destination.workload.uid`      | string | Unique identifier of the destination workload. | `istio://istio-system/workloads/istio-telemetry` |
 | `destination.workload.name`     | string | Destination workload name. | `istio-telemetry` |
 | `destination.workload.namespace` | string | Destination workload namespace. | `istio-system` |

--- a/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
@@ -111,7 +111,7 @@ dimensions.
     {{< /tip >}}
 
     {{< text yaml >}}
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     spec:
     template:


### PR DESCRIPTION

Update API version for Ingress and Deployments in content/docs me files


[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure