### PR TITLE
add junit report to build

### DIFF
--- a/tests/tests.mk
+++ b/tests/tests.mk
@@ -2,9 +2,13 @@ export TIMEOUT ?= 30m
 
 # gocache disabled by -count=1
 # tests in different packages forced to be sequential by -p=1
-doc.test: init
-	@${GO} test ${REPO_ROOT}/tests/setup/... -v -timeout=${TIMEOUT} -count=1 -p=1 \
-		-istio.test.env=kube -istio.test.hub=$(HUB) -istio.test.tag=$(TAG)
+doc.test: init | $(JUNIT_REPORT)
+	@${GO} test ${REPO_ROOT}/tests/setup/... \
+		-v -timeout=${TIMEOUT} -count=1 -p=1 \
+		-istio.test.env=kube \
+		-istio.test.hub=$(HUB) \
+		-istio.test.tag=$(TAG) \
+		2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 doc.test.help:
 	@echo "The command \"make doc.test\" accepts three optional environment variables."

--- a/tests/tests.mk
+++ b/tests/tests.mk
@@ -5,7 +5,6 @@ export TIMEOUT ?= 30m
 doc.test: init | $(JUNIT_REPORT)
 	@${GO} test ${REPO_ROOT}/tests/setup/... \
 		-v -timeout=${TIMEOUT} -count=1 -p=1 \
-		-istio.test.env=kube \
 		-istio.test.hub=$(HUB) \
 		-istio.test.tag=$(TAG) \
 		2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))


### PR DESCRIPTION
This PR tries to add junit report to present doc test results in build.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure