### PR TITLE
Fix identation of extra tags annotation

### DIFF
--- a/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
@@ -109,9 +109,9 @@ dimensions.
     apiVersion: extensions/v1beta1
     kind: Deployment
     spec:
-    template:
+      template: # pod template
         metadata:
-        annotations:
+          annotations:
             sidecar.istio.io/extraStatTags: destination_port,request_host
     {{< /text >}}
 


### PR DESCRIPTION
fix misleading indentation of extra annotation tags. Context: https://github.com/istio/istio/issues/24844


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure