### PR TITLE
Update Istio ref

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ replace github.com/docker/docker => github.com/docker/engine v1.4.2-0.2019101121
 
 require (
 	istio.io/gogo-genproto v0.0.0-20200511213158-02f1fd1746e5 // indirect
-	istio.io/istio v0.0.0-20200619163927-99b67ebd0881
+	istio.io/istio v0.0.0-20200622140019-5d0ba6bf14a4
 	istio.io/pkg v0.0.0-20200511212725-7bfbbf968c23
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1107,8 +1107,8 @@ istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZc
 istio.io/gogo-genproto v0.0.0-20200422223746-8166b73efbae/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
 istio.io/gogo-genproto v0.0.0-20200511213158-02f1fd1746e5 h1:+jL9OzDdbpqHghV6i1dDy2jV+FtC7wz+CuKi2UxZoSs=
 istio.io/gogo-genproto v0.0.0-20200511213158-02f1fd1746e5/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
-istio.io/istio v0.0.0-20200619163927-99b67ebd0881 h1:QmbSpNguFYVuwKi2l3mNni7z2pnmRvmaGT33FtDPcg0=
-istio.io/istio v0.0.0-20200619163927-99b67ebd0881/go.mod h1:S2VJ2OMf/wyMRud9QOAXkkwc3BBFx1qPdSYMsfPe/2k=
+istio.io/istio v0.0.0-20200622140019-5d0ba6bf14a4 h1:E1/TgxPbGgtgEPY6wrinExFXJE+Y472pycn57cUcpJc=
+istio.io/istio v0.0.0-20200622140019-5d0ba6bf14a4/go.mod h1:S2VJ2OMf/wyMRud9QOAXkkwc3BBFx1qPdSYMsfPe/2k=
 istio.io/pkg v0.0.0-20200504224939-261164cc57da/go.mod h1:EwvmercDF5DLCg5qUQlkM40xHwCxGoY1H/2LhI1p2YU=
 istio.io/pkg v0.0.0-20200511212725-7bfbbf968c23 h1:1GMOTQs9yVdNEBmVKxDlq6ios80gIAOMO1WfKYKYjZo=
 istio.io/pkg v0.0.0-20200511212725-7bfbbf968c23/go.mod h1:pwGaxLUDLobzL/WvWV94z72LvBbB1dr2UUUyPuasfIU=


### PR DESCRIPTION
Update the base istio.io/istio version to remove the extraneous error messages in the test output.