### PR TITLE
copy all root files over to root of public folder

### DIFF
--- a/scripts/include_archive_site.sh
+++ b/scripts/include_archive_site.sh
@@ -23,4 +23,4 @@ mkdir ./public/latest
 cp -r "${TMP}"/* ./public/latest/
 
 #copy top level pages, such as landing page, redirects, headers, robots.txt, etc
-find ${TMP} -maxdepth 1 -type f -exec cp -t ./public/ {} +
+find "${TMP}" -maxdepth 1 -type f -exec cp -t ./public/ {} +

--- a/scripts/include_archive_site.sh
+++ b/scripts/include_archive_site.sh
@@ -22,7 +22,5 @@ cp -r ./archive/* ./public/
 mkdir ./public/latest
 cp -r "${TMP}"/* ./public/latest/
 
-#copy home page
-cp "${TMP}"/index.html ./public/
-
-mv "${TMP}"/_redirects ./public/
+#copy top level pages, such as landing page, redirects, headers, robots.txt, etc
+find ${TMP} -maxdepth 1 -type f -exec cp -t ./public/ {} +


### PR DESCRIPTION
This copies files that we didn't copy before, such as robots.txt

[ ] Configuration Infrastructure
[ X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
