### PR TITLE
"consecutiveErrors" is replaced with "repconsecutive5xxErrors"

### DIFF
--- a/content/en/docs/reference/config/networking/destination-rule/index.html
+++ b/content/en/docs/reference/config/networking/destination-rule/index.html
@@ -694,7 +694,7 @@ spec:
         http2MaxRequests: 1000
         maxRequestsPerConnection: 10
     outlierDetection:
-      consecutiveErrors: 7
+      consecutive5xxErrors: 7
       interval: 5m
       baseEjectionTime: 15m
 </code></pre>
@@ -717,7 +717,7 @@ spec:
         http2MaxRequests: 1000
         maxRequestsPerConnection: 10
     outlierDetection:
-      consecutiveErrors: 7
+      consecutive5xxErrors: 7
       interval: 5m
       baseEjectionTime: 15m
 </code></pre>


### PR DESCRIPTION
"consecutiveErrors" is replaced with "consecutive5xxErrors".

Reference:

https://github.com/istio/istio/blob/b1ab3068092bb858dda4d97cf47f796ff9d62b7a/pkg/config/validation/validation.go

| outlier detection consecutive errors is deprecated, use consecutiveGatewayErrors or consecutive5xxErrors instead



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure