### PR TITLE
[release-1.6] Change makefile target to fix postsubmit test

### DIFF
--- a/tests/tests.mk
+++ b/tests/tests.mk
@@ -40,7 +40,7 @@ test.kube.presubmit: init | $(JUNIT_REPORT)
 
 test.kube.postsubmit: test.kube.presubmit
 
-test.kube.%: init | $(JUNIT_REPORT)
+test.kube.directory.%: init | $(JUNIT_REPORT)
 	$(eval INTEGRATION_TEST_FLAGS += --istio.test.tag=$(TAG))
 	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ./tests/$(subst .,/,$*)/... -timeout 30m \
 	--istio.test.select -postsubmit,-flaky \

--- a/tests/tests.mk
+++ b/tests/tests.mk
@@ -39,12 +39,3 @@ test.kube.presubmit: init | $(JUNIT_REPORT)
 	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
 
 test.kube.postsubmit: test.kube.presubmit
-
-test.kube.directory.%: init | $(JUNIT_REPORT)
-	$(eval INTEGRATION_TEST_FLAGS += --istio.test.tag=$(TAG))
-	PATH=${PATH}:${ISTIO_OUT} $(GO) test -p 1 ${T} ./tests/$(subst .,/,$*)/... -timeout 30m \
-	--istio.test.select -postsubmit,-flaky \
-	--istio.test.env kube \
-	${_INTEGRATION_TEST_FLAGS} \
-	2>&1 | tee >($(JUNIT_REPORT) > $(JUNIT_OUT))
-


### PR DESCRIPTION

Fixes #7621 

The current makefile target to run individual directories overlaps with the post-submit test name so it is executed incorrectly during post submit and fails (there is no post-submit directory).

In master, we don't have a way to run individual targets, so this could possibly have been removed in 1.6. For now, I just renamed the target (added directory) so one can still run a subset of the tests (by changing the target name to include directory.).


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure