### PR TITLE
Update community page to update Slack URL

### DIFF
--- a/content/en/about/community/join/index.md
+++ b/content/en/about/community/join/index.md
@@ -21,9 +21,7 @@ on deploying, configuring, and using Istio.
 
 {{< community_item logo="./slack.svg" alt="Slack" >}}
 If you'd like to have live interactions with members of our community, you can join us on
-[Istio's Slack](https://istio.slack.com) workspace.
-Fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSfdsupDfOWBtNVvVvXED6ULxtR4UIsYGCH_cQcRr0VcG1ZqQQ/viewform)
-to join.
+[Istio's Slack](https://slack.istio.io) workspace.
 {{< /community_item >}}
 
 {{< community_item logo="./gcal.svg" alt="Community Calendar" >}}


### PR DESCRIPTION
Slack invite machine is now at slack.istio.io, and will forward you through if you're a signed-in user. 

Please cherrypick this back to the current branch ASAP, as the old form will not be maintained going forward.

Closes [community/251](https://github.com/istio/community/issues/251).

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

