### PR TITLE
Implement new terminology for multicluster

### DIFF
--- a/content/en/docs/ops/deployment/deployment-models/index.md
+++ b/content/en/docs/ops/deployment/deployment-models/index.md
@@ -20,17 +20,21 @@ owner: istio/wg-environments-maintainers
 test: n/a
 ---
 
-When configuring a production deployment of Istio, you need to answer a number of questions.
-Will the mesh be confined to a single {{< gloss >}}cluster{{< /gloss >}} or distributed across
-multiple clusters? Will all the services be located in a single fully connected network, or will
-gateways be required to connect services across multiple networks? Is there a single
-{{< gloss >}}control plane{{< /gloss >}}, potentially shared across clusters,
-or are there multiple control planes deployed to ensure high availability (HA)?
-If there is more than one cluster being deployed, and more specifically in isolated networks,
-are they going to be connected into a single {{< gloss >}}multicluster{{< /gloss >}}
-service mesh or will they be federated into a {{< gloss >}}multi-mesh{{< /gloss >}} deployment?
+When configuring a production deployment of Istio, you need to answer a number
+of questions. Will the mesh be confined to a single
+{{< gloss >}}cluster{{< /gloss >}} or distributed across multiple clusters? Will
+all the services be located in a single fully connected network, or will
+gateways be required to connect services across multiple networks? Is there a
+single {{< gloss >}}control plane{{< /gloss >}}, potentially shared across
+{{< gloss "remote cluster" >}}remote clusters{{< /gloss >}}, or are there
+multiple {{< gloss "primary cluster" >}}primary clusters{{< /gloss >}} deployed
+to ensure high availability (HA)? If there is more than one cluster being
+deployed, and more specifically in isolated networks, are they going to be
+connected into a single {{< gloss >}}multicluster{{< /gloss >}} service mesh or
+will they be federated into a {{< gloss >}}multi-mesh{{< /gloss >}} deployment?
 
-All of these questions, among others, represent independent dimensions of configuration for an Istio deployment.
+All of these questions, among others, represent independent dimensions of
+configuration for an Istio deployment.
 
 1. single or multiple cluster
 1. single or multiple network
@@ -42,11 +46,14 @@ some are clearly not very interesting (for example, multiple mesh in a single cl
 
 In a production deployment involving multiple clusters, the deployment may use a
 mix of patterns. For example, having more than one control plane is recommended for HA,
-but you could achieve this for a 3 cluster deployment by deploying 2 clusters with
-a single shared control plane and then adding the third cluster with a second
-control plane in a different network. All three clusters could then be configured
-to share both control planes so that all the clusters have 2 sources of control
-to ensure HA.
+and you can achieve this for a 3 cluster deployment with the following steps:
+
+1. Deploy a {{< gloss >}}primary cluster{{< /gloss >}}
+1. Deploy a {{< gloss >}}remote cluster{{< /gloss >}} on the same network
+1. Deploy a primary cluster in a different network.
+
+All three clusters could then be configured to share both control planes so that
+all the clusters have 2 sources of control to ensure HA.
 
 Choosing the right deployment model depends on the isolation, performance,
 and HA requirements for your use case. This guide describes the various options and
@@ -191,14 +198,17 @@ cluster.
     caption="A service mesh with a control plane"
     >}}
 
-Multicluster deployments can also share control plane instances. In this case,
-the control plane instances can reside in one or more clusters.
+{{< gloss "remote cluster" >}}Remote clusters{{< /gloss >}} in multicluster
+deployments can share control plane instances. In this case, the control plane
+instances can reside in one or more
+{{< gloss "primary cluster" >}}primary clusters{{< /gloss >}} or be
+{{< gloss "managed control plane" >}}managed control planes{{< /gloss >}}.
 
 {{< image width="75%"
     link="shared-control.svg"
-    alt="A service mesh with two clusters sharing a control plane"
-    title="Shared control plane"
-    caption="A service mesh with two clusters sharing a control plane"
+    alt="A service mesh with a primary and a remote cluster"
+    title="Primary and remote clusters"
+    caption="A service mesh with a primary and a remote cluster"
     >}}
 
 For high availability, you should deploy a control plane across multiple

--- a/content/en/docs/ops/deployment/deployment-models/index.md
+++ b/content/en/docs/ops/deployment/deployment-models/index.md
@@ -26,13 +26,12 @@ of questions. Will the mesh be confined to a single
 all the services be located in a single fully connected network, or will
 gateways be required to connect services across multiple networks? Is there a
 single {{< gloss >}}control plane{{< /gloss >}} or multiple control planes in
-your mesh? Is the control plane shared across
-{{< gloss "remote cluster" >}}remote clusters{{< /gloss >}}, or are there
-multiple {{< gloss "primary cluster" >}}primary clusters{{< /gloss >}} to ensure
-high availability (HA)? If there is more than one cluster being deployed, and
-more specifically in isolated networks, are they going to be connected into a
-single {{< gloss >}}multicluster{{< /gloss >}} service mesh or will they be
-federated into a {{< gloss >}}multi-mesh{{< /gloss >}} deployment?
+your mesh? Do {{< gloss "remote cluster" >}}remote clusters{{< /gloss >}} share
+a control plane, or are there multiple {{< gloss "primary cluster" >}}primary clusters{{< /gloss >}}
+to ensure high availability (HA)? If there is more than one cluster,
+specifically in isolated networks, are they going to be connected into a
+{{< gloss >}}multicluster{{< /gloss >}} single service mesh or will they be federated
+into a {{< gloss >}}multi-mesh{{< /gloss >}} deployment?
 
 All of these questions, among others, represent independent dimensions of
 configuration for an Istio deployment.
@@ -49,8 +48,8 @@ In a production environment involving multiple clusters, you can use a mix
 of deployment models. For example, having more than one control plane is
 recommended for HA.
 
-All three clusters could then be configured to share both control planes so that
-all the clusters have 2 sources of control to ensure HA.
+Multiple clusters in the same region can share a control plane in a zonal or
+regional cluster.
 
 Choosing the right deployment model depends on the isolation, performance,
 and HA requirements for your use case. This guide describes the various options and
@@ -195,10 +194,11 @@ cluster.
     caption="A service mesh with a control plane"
     >}}
 
-{{< gloss "remote cluster" >}}Remote clusters{{< /gloss >}} in multicluster
-deployments can share control plane instances. In this case, the control plane
-instances can reside in one or more
-{{< gloss "primary cluster" >}}primary clusters{{< /gloss >}} or be
+A {{< gloss >}}remote cluster{{< /gloss >}} in a multicluster
+deployment can use a control plane outside the cluster. In this case, the
+control plane instances can reside in one or more
+{{< gloss "primary cluster" >}}primary clusters{{< /gloss >}}, or be managed
+independently of your clusters if it is a cloud vendor's
 {{< gloss "managed control plane" >}}managed control planes{{< /gloss >}}.
 
 {{< image width="75%"

--- a/content/en/docs/ops/deployment/deployment-models/index.md
+++ b/content/en/docs/ops/deployment/deployment-models/index.md
@@ -25,13 +25,14 @@ of questions. Will the mesh be confined to a single
 {{< gloss >}}cluster{{< /gloss >}} or distributed across multiple clusters? Will
 all the services be located in a single fully connected network, or will
 gateways be required to connect services across multiple networks? Is there a
-single {{< gloss >}}control plane{{< /gloss >}}, potentially shared across
+single {{< gloss >}}control plane{{< /gloss >}} or multiple control planes in
+your mesh? Is the control plane shared across
 {{< gloss "remote cluster" >}}remote clusters{{< /gloss >}}, or are there
-multiple {{< gloss "primary cluster" >}}primary clusters{{< /gloss >}} deployed
-to ensure high availability (HA)? If there is more than one cluster being
-deployed, and more specifically in isolated networks, are they going to be
-connected into a single {{< gloss >}}multicluster{{< /gloss >}} service mesh or
-will they be federated into a {{< gloss >}}multi-mesh{{< /gloss >}} deployment?
+multiple {{< gloss "primary cluster" >}}primary clusters{{< /gloss >}} to ensure
+high availability (HA)? If there is more than one cluster being deployed, and
+more specifically in isolated networks, are they going to be connected into a
+single {{< gloss >}}multicluster{{< /gloss >}} service mesh or will they be
+federated into a {{< gloss >}}multi-mesh{{< /gloss >}} deployment?
 
 All of these questions, among others, represent independent dimensions of
 configuration for an Istio deployment.
@@ -44,13 +45,9 @@ configuration for an Istio deployment.
 All combinations are possible, although some are more common than others and
 some are clearly not very interesting (for example, multiple mesh in a single cluster).
 
-In a production deployment involving multiple clusters, the deployment may use a
-mix of patterns. For example, having more than one control plane is recommended for HA,
-and you can achieve this for a 3 cluster deployment with the following steps:
-
-1. Deploy a {{< gloss >}}primary cluster{{< /gloss >}}
-1. Deploy a {{< gloss >}}remote cluster{{< /gloss >}} on the same network
-1. Deploy a primary cluster in a different network.
+In a production environment involving multiple clusters, the you can use a mix
+of deployment models. For example, having more than one control plane is
+recommended for HA.
 
 All three clusters could then be configured to share both control planes so that
 all the clusters have 2 sources of control to ensure HA.

--- a/content/en/docs/ops/deployment/deployment-models/index.md
+++ b/content/en/docs/ops/deployment/deployment-models/index.md
@@ -45,7 +45,7 @@ configuration for an Istio deployment.
 All combinations are possible, although some are more common than others and
 some are clearly not very interesting (for example, multiple mesh in a single cluster).
 
-In a production environment involving multiple clusters, the you can use a mix
+In a production environment involving multiple clusters, you can use a mix
 of deployment models. For example, having more than one control plane is
 recommended for HA.
 

--- a/content/en/docs/setup/additional-setup/config-profiles/index.md
+++ b/content/en/docs/setup/additional-setup/config-profiles/index.md
@@ -10,10 +10,11 @@ test: n/a
 ---
 
 This page describes the built-in configuration profiles that can be used when
-[installing Istio](/docs/setup/install/istioctl/).
-The profiles provide customization of the Istio control plane and of the sidecars for the Istio data plane.
-You can start with one of Istio’s built-in configuration profiles and then further customize the configuration for
-your specific needs. The following built-in configuration profiles are currently available:
+[installing Istio](/docs/setup/install/istioctl/). The profiles provide
+customization of the Istio control plane and of the sidecars for the Istio data
+plane. You can start with one of Istio’s built-in configuration profiles and
+then further customize the configuration for your specific needs. The following
+built-in configuration profiles are currently available:
 
 1. **default**: enables components according to the default settings of the
     [`IstioOperator` API](/docs/reference/config/istio.operator.v1alpha1/)
@@ -32,7 +33,8 @@ your specific needs. The following built-in configuration profiles are currently
 
 1. **minimal**: the minimal set of components necessary to use Istio's [traffic management](/docs/tasks/traffic-management/) features.
 
-1. **remote**: used for configuring remote clusters of a
+1. **remote**: used for configuring
+    {{< gloss "remote cluster" >}}remote clusters{{< /gloss >}} of a
     [multicluster mesh](/docs/ops/deployment/deployment-models/#multiple-clusters) with a
     [shared control plane](/docs/setup/install/multicluster/shared/) configuration.
 

--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -19,9 +19,10 @@ across multiple {{< gloss "remote cluster" >}}remote clusters{{< /gloss >}} that
 share a control plane. In this configuration, multiple Kubernetes clusters
 running a remote configuration connect to a shared Istio [control plane](/docs/ops/deployment/deployment-models/#control-plane-models)
 running in a {{< gloss >}}primary cluster{{< /gloss >}}. Remote clusters can be
-in the same network or on a different network as the primary clusters. After one
-or more remote clusters are connected, the control plane manages the service
-mesh across all endpoints.
+in the same network or on a different network than the primary cluster. After
+one or more remote clusters are connected, the {{< gloss >}}control plane{{< /gloss >}}
+of the primary cluster manages the service mesh across all
+{{< gloss "service endpoint" >}}endpoints{{< /gloss >}}.
 
 {{< image width="80%" link="./multicluster-with-vpn.svg" caption="Istio mesh spanning multiple Kubernetes clusters with direct network access to remote pods over VPN" >}}
 

--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -18,10 +18,10 @@ Setup a [multicluster Istio service mesh](/docs/ops/deployment/deployment-models
 across multiple {{< gloss "remote cluster" >}}remote clusters{{< /gloss >}} that
 share a control plane. In this configuration, multiple Kubernetes clusters
 running a remote configuration connect to a shared Istio [control plane](/docs/ops/deployment/deployment-models/#control-plane-models)
-running in a {{< gloss >}}primary cluster{{< /gloss >}}. The remote clusters can
-share the same network or be in other networks. After one or more remote
-clusters are connected to the Istio control plane in the primary cluster, Envoy
-can then form a mesh.
+running in a {{< gloss >}}primary cluster{{< /gloss >}}. Remote clusters can be
+in the same network or on a different network as the primary clusters. After one
+or more remote clusters are connected, the control plane manages the service
+mesh across all endpoints.
 
 {{< image width="80%" link="./multicluster-with-vpn.svg" caption="Istio mesh spanning multiple Kubernetes clusters with direct network access to remote pods over VPN" >}}
 

--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -1,6 +1,6 @@
 ---
-title: Shared control plane (single and multiple networks)
-description: Install an Istio mesh across multiple Kubernetes clusters with a shared control plane.
+title: Deploy Remote Clusters on Single and Multiple networks
+description: Install an Istio mesh across remote clusters.
 weight: 5
 keywords: [kubernetes,multicluster,federation,vpn,gateway]
 aliases:
@@ -15,11 +15,14 @@ test: no
 ---
 
 Setup a [multicluster Istio service mesh](/docs/ops/deployment/deployment-models/#multiple-clusters)
-across multiple clusters with a shared control plane. In this configuration, multiple Kubernetes clusters running
-a remote configuration connect to a shared Istio [control plane](/docs/ops/deployment/deployment-models/#control-plane-models)
-running in a main cluster. Clusters may be on the same network or different networks than other
-clusters in the mesh. Once one or more remote Kubernetes clusters are connected to the Istio control plane,
-Envoy can then form a mesh.
+
+across multiple {{< gloss "remote cluster" >}}remote clusters{{< /gloss >}} that
+share a control plane. In this configuration, multiple Kubernetes clusters
+running a remote configuration connect to a shared Istio [control plane](/docs/ops/deployment/deployment-models/#control-plane-models)
+running in a {{< gloss >}}primary cluster{{< /gloss >}}. The remote clusters can
+share the same network or be in other networks. After one or more remote
+clusters are connected to the Istio control plane in the primary cluster, Envoy
+can then form a mesh.
 
 {{< image width="80%" link="./multicluster-with-vpn.svg" caption="Istio mesh spanning multiple Kubernetes clusters with direct network access to remote pods over VPN" >}}
 

--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -1,6 +1,6 @@
 ---
-title: Deploy Remote Clusters on Single and Multiple networks
-description: Install an Istio mesh across remote clusters.
+title: Configure Clusters for Multicluster Deployments
+description: Install an Istio mesh across multiple clusters.
 weight: 5
 keywords: [kubernetes,multicluster,federation,vpn,gateway]
 aliases:
@@ -15,7 +15,6 @@ test: no
 ---
 
 Setup a [multicluster Istio service mesh](/docs/ops/deployment/deployment-models/#multiple-clusters)
-
 across multiple {{< gloss "remote cluster" >}}remote clusters{{< /gloss >}} that
 share a control plane. In this configuration, multiple Kubernetes clusters
 running a remote configuration connect to a shared Istio [control plane](/docs/ops/deployment/deployment-models/#control-plane-models)


### PR DESCRIPTION
This change modifies existing content to reference the new terminology.
Primary cluster and remote cluster help explain shared control planes.
Previous content referencing the shared control plane was revisited
to use the new terms.

Signed-off-by: Rigs Caballero <grca@google.com>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ X ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
