### PR TITLE
Add selector on the squid deployment manifest

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -72,6 +72,9 @@ This example uses [Squid](http://www.squid-cache.org) but you can use any HTTPS 
       namespace: external
     spec:
       replicas: 1
+      selector:
+        matchLabels:
+          app: squid
       template:
         metadata:
           labels:

--- a/content/zh/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -59,6 +59,9 @@ aliases:
       namespace: external
     spec:
       replicas: 1
+      selector:
+        matchLabels:
+          app: squid
       template:
         metadata:
           labels:


### PR DESCRIPTION
On https://istio.io/latest/docs/tasks/traffic-management/egress/http-proxy/, the manifest to create the squid deployment is missing a "selector" field making Kubernetes complain:
```
error: error validating "STDIN": error validating data: ValidationError(Deployment.spec): missing required field "selector" in io.k8s.api.apps.v1.DeploymentSpec; if you choose to ignore these errors, turn validation off with --validate=false
```
This PR just adds the missing selector field.

Version used:
Istio: 1.6.3
Kubernetes: 1.18.2
Minikube: 1.10.1

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
