### PR TITLE
Add IBM Cloud Kubernetes Service specific instructions for node port Ingress Host

### DIFF
--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -293,7 +293,14 @@ _Docker For Desktop:_
 $ export INGRESS_HOST=127.0.0.1
 {{< /text >}}
 
-_Other environments (e.g., IBM Cloud Private, etc.):_
+_IBM Cloud Kubernetes Service:_
+
+{{< text bash >}}
+$ ibmcloud ks workers --cluster <cluster-name or id>
+$ export INGRESS_HOST= <public IP of one of the worker nodes>
+{{< /text >}}
+
+_Other environments:_
 
 {{< text bash >}}
 $ export INGRESS_HOST=$(kubectl get po -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].status.hostIP}')

--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -297,7 +297,7 @@ _IBM Cloud Kubernetes Service:_
 
 {{< text bash >}}
 $ ibmcloud ks workers --cluster <cluster-name or id>
-$ export INGRESS_HOST= <public IP of one of the worker nodes>
+$ export INGRESS_HOST=<public IP of one of the worker nodes>
 {{< /text >}}
 
 _Other environments:_

--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -287,17 +287,17 @@ $ gcloud compute firewall-rules create allow-gateway-http --allow tcp:$INGRESS_P
 $ gcloud compute firewall-rules create allow-gateway-https --allow tcp:$SECURE_INGRESS_PORT
 {{< /text >}}
 
-_Docker For Desktop:_
-
-{{< text bash >}}
-$ export INGRESS_HOST=127.0.0.1
-{{< /text >}}
-
 _IBM Cloud Kubernetes Service:_
 
 {{< text bash >}}
 $ ibmcloud ks workers --cluster <cluster-name or id>
 $ export INGRESS_HOST=<public IP of one of the worker nodes>
+{{< /text >}}
+
+_Docker For Desktop:_
+
+{{< text bash >}}
+$ export INGRESS_HOST=127.0.0.1
 {{< /text >}}
 
 _Other environments:_

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -103,6 +103,7 @@ Setting the ingress IP depends on the cluster provider:
     $ ibmcloud ks workers --cluster cluster-name-or-id
     $ export INGRESS_HOST=public-IP-of-one-of-the-worker-nodes
     {{< /text >}}
+
 1.  _Minikube:_
 
     {{< text bash >}}

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -103,13 +103,20 @@ Setting the ingress IP depends on the cluster provider:
     $ export INGRESS_HOST=$(minikube ip)
     {{< /text >}}
 
+1.  _IBM Cloud Kubernetes Service:_
+
+    {{< text bash >}}
+    $ ibmcloud ks workers --cluster <cluster-name or id>
+    $ export INGRESS_HOST=<public IP of one of the worker nodes>
+    {{< /text >}}
+
 1.  _Docker For Desktop:_
 
     {{< text bash >}}
     $ export INGRESS_HOST=127.0.0.1
     {{< /text >}}
 
-1.  _Other environments (e.g., IBM Cloud Private etc):_
+1.  _Other environments:_
 
     {{< text bash >}}
     $ export INGRESS_HOST=$(kubectl get po -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].status.hostIP}')

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -103,7 +103,6 @@ Setting the ingress IP depends on the cluster provider:
     $ ibmcloud ks workers --cluster cluster-name-or-id
     $ export INGRESS_HOST=public-IP-of-one-of-the-worker-nodes
     {{< /text >}}
-    
 1.  _Minikube:_
 
     {{< text bash >}}

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -97,7 +97,6 @@ Setting the ingress IP depends on the cluster provider:
     $ gcloud compute firewall-rules create allow-gateway-https --allow "tcp:$SECURE_INGRESS_PORT"
     {{< /text >}}
 
-
 1.  _IBM Cloud Kubernetes Service:_
 
     {{< text bash >}}

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -106,8 +106,8 @@ Setting the ingress IP depends on the cluster provider:
 1.  _IBM Cloud Kubernetes Service:_
 
     {{< text bash >}}
-    $ ibmcloud ks workers --cluster <cluster-name or id>
-    $ export INGRESS_HOST=<public IP of one of the worker nodes>
+    $ ibmcloud ks workers --cluster cluster-name-or-id
+    $ export INGRESS_HOST=public-IP-of-one-of-the-worker-nodes
     {{< /text >}}
 
 1.  _Docker For Desktop:_

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -97,17 +97,18 @@ Setting the ingress IP depends on the cluster provider:
     $ gcloud compute firewall-rules create allow-gateway-https --allow "tcp:$SECURE_INGRESS_PORT"
     {{< /text >}}
 
-1.  _Minikube:_
-
-    {{< text bash >}}
-    $ export INGRESS_HOST=$(minikube ip)
-    {{< /text >}}
 
 1.  _IBM Cloud Kubernetes Service:_
 
     {{< text bash >}}
     $ ibmcloud ks workers --cluster cluster-name-or-id
     $ export INGRESS_HOST=public-IP-of-one-of-the-worker-nodes
+    {{< /text >}}
+    
+1.  _Minikube:_
+
+    {{< text bash >}}
+    $ export INGRESS_HOST=$(minikube ip)
     {{< /text >}}
 
 1.  _Docker For Desktop:_

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -60,10 +60,15 @@ export INGRESS_HOST=$(minikube ip)
 }
 
 snip_determining_the_ingress_ip_and_ports_8() {
-export INGRESS_HOST=127.0.0.1
+ibmcloud ks workers --cluster <cluster-name or id>
+export INGRESS_HOST=<public IP of one of the worker nodes>
 }
 
 snip_determining_the_ingress_ip_and_ports_9() {
+export INGRESS_HOST=127.0.0.1
+}
+
+snip_determining_the_ingress_ip_and_ports_10() {
 export INGRESS_HOST=$(kubectl get po -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].status.hostIP}')
 }
 

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -56,12 +56,12 @@ gcloud compute firewall-rules create allow-gateway-https --allow "tcp:$SECURE_IN
 }
 
 snip_determining_the_ingress_ip_and_ports_7() {
-export INGRESS_HOST=$(minikube ip)
+ibmcloud ks workers --cluster cluster-name-or-id
+export INGRESS_HOST=public-IP-of-one-of-the-worker-nodes
 }
 
 snip_determining_the_ingress_ip_and_ports_8() {
-ibmcloud ks workers --cluster <cluster-name or id>
-export INGRESS_HOST=<public IP of one of the worker nodes>
+export INGRESS_HOST=$(minikube ip)
 }
 
 snip_determining_the_ingress_ip_and_ports_9() {

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
@@ -38,7 +38,7 @@ if [[ "$out" != *"<none>"* && "$out" != *"<pending>"* ]]; then
 else
     # node port
     snip_determining_the_ingress_ip_and_ports_4
-    snip_determining_the_ingress_ip_and_ports_9
+    snip_determining_the_ingress_ip_and_ports_10
 fi
 
 # create the gateway and routes


### PR DESCRIPTION
The previous instruction put IBM cloud under other environments, and the command set the Ingress Host to the wrong address.



[ ] Configuration Infrastructure
[x ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure