### PR TITLE
do not prune ingress-gateway when deploying egress-gateway.

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -54,7 +54,6 @@ controlled way.
 
     {{< text bash >}}
     $ istioctl install --set values.global.istioNamespace=istio-system \
-        --set values.gateways.istio-ingressgateway.enabled=false \
         --set values.gateways.istio-egressgateway.enabled=true
     {{< /text >}}
 


### PR DESCRIPTION

Currently the istio operator will prune ingressgateway when deploying egressgateway, see install logs:
```
✔ Istio core installed
✔ Istiod installed
✔ Egress gateways installed
- Pruning removed resources                                                                                                                                                                                                                   Removed HorizontalPodAutoscaler:istio-system:istio-ingressgateway.
  Removed PodDisruptionBudget:istio-system:istio-ingressgateway.
  Removed Deployment:istio-system:istio-ingressgateway.
  Removed Service:istio-system:istio-ingressgateway.
  Removed ServiceAccount:istio-system:istio-ingressgateway-service-account.
  Removed RoleBinding:istio-system:istio-ingressgateway-sds.
  Removed Role:istio-system:istio-ingressgateway-sds.
✔ Installation complete
```

This PR is to keep ingressgateway when deploying egressgateway.


[ ] Configuration Infrastructure
[ X ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure