### PR TITLE
Fixed link to Prometheus example application

### DIFF
--- a/content/en/blog/2020/proxy-cert/index.md
+++ b/content/en/blog/2020/proxy-cert/index.md
@@ -47,4 +47,4 @@ The output from the above command should include non-empty key and certificate f
 
 If you want to use this mechanism to provision a certificate
 for your own application, take a look at our
-[Prometheus example application]({{< github_blob >}}/manifests/istio-telemetry/prometheus/templates/deployment.yaml) and simply follow the same pattern.
+[Prometheus example application]({{< github_blob >}}/manifests/charts/istio-telemetry/prometheus/templates/deployment.yaml) and simply follow the same pattern.


### PR DESCRIPTION
The blog article talking about how to deploy a sidecar for certificate provisioning has a link to an example in the main Istio repo. The link was incorrect; I've updated it so it's not 404.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
