### PR TITLE
[release-1.6] Update reference docs for 1.6.5

### DIFF
--- a/content/en/docs/reference/config/istio.mesh.v1alpha1/index.html
+++ b/content/en/docs/reference/config/istio.mesh.v1alpha1/index.html
@@ -901,7 +901,7 @@ No
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#boolvalue">BoolValue</a></code></td>
 <td>
 <p>This flag is used to enable mutual TLS automatically for service to service communication
-within the mesh, default false.
+within the mesh, default true.
 If set to true, and a given service does not have a corresponding DestinationRule configured,
 or its DestinationRule does not have ClientTLSSettings specified, Istio configures client side
 TLS configuration appropriately. More specifically,

--- a/content/en/docs/reference/config/networking/virtual-service/index.html
+++ b/content/en/docs/reference/config/networking/virtual-service/index.html
@@ -928,6 +928,78 @@ No
 </section>
 <h2 id="Headers">Headers</h2>
 <section>
+<p>Message headers can be manipulated when Envoy forwards requests to,
+or responses from, a destination service. Header manipulation rules can
+be specified for a specific route destination or for all destinations.
+The following VirtualService adds a <code>test</code> header with the value <code>true</code>
+to requests that are routed to any <code>reviews</code> service destination.
+It also romoves the <code>foo</code> response header, but only from responses
+coming from the <code>v1</code> subset (version) of the <code>reviews</code> service.</p>
+
+<p>{{<tabset category-name="example">}}
+{{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
+
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - headers:
+      request:
+        set:
+          test: true
+    route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v2
+      weight: 25
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v1
+      headers:
+        response:
+          remove:
+          - foo
+      weight: 75
+</code></pre>
+
+<p>{{</tab>}}</p>
+
+<p>{{<tab name="v1beta1" category-value="v1beta1">}}</p>
+
+<pre><code class="language-yaml">apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: reviews-route
+spec:
+  hosts:
+  - reviews.prod.svc.cluster.local
+  http:
+  - headers:
+      request:
+        set:
+          test: true
+    route:
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v2
+      weight: 25
+    - destination:
+        host: reviews.prod.svc.cluster.local
+        subset: v1
+      headers:
+        response:
+          remove:
+          - foo
+      weight: 75
+</code></pre>
+
+<p>{{</tab>}}
+{{</tabset>}}</p>
+
 <table class="message-fields">
 <thead>
 <tr>

--- a/content/en/docs/reference/config/policy-and-telemetry/adapters/wavefront/index.html
+++ b/content/en/docs/reference/config/policy-and-telemetry/adapters/wavefront/index.html
@@ -10,9 +10,9 @@ provider: VMware, Inc.
 contact_email: veniln@vmware.com
 support_link:
 source_link: https://github.com/vmware/wavefront-adapter-for-istio
-latest_release_link: https://github.com/vmware/wavefront-adapter-for-istio/releases/tag/0.1.1
+latest_release_link: https://github.com/vmware/wavefront-adapter-for-istio/releases/tag/0.1.4
 helm_chart_link:
-istio_versions: "1.0.3, 1.0.4"
+istio_versions: "1.4.9, 1.5.6, 1.6.2"
 supported_templates: metric
 logo_link: https://github.com/vmware/wavefront-adapter-for-istio/raw/master/docs/images/logo.png
 number_of_entries: 9


### PR DESCRIPTION

I ran make update_ref_docs to get the changes.

One issue I ran into was a large change was shown for: `content/en/docs/reference/config/istio.mesh.v1alpha1/index.html`
I did some investigation and found there are 2 files in istio/api that update the same file and depending on ordering, either file could be used. I created an PR for istio/api to remove the extraneous file: https://github.com/istio/api/pull/1509 which will have a release-1.6 cherry pick.
I manually grabbed the changed from the non-extraneous (by that PR) file.



[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure