### PR TITLE
Print proxy status when debug fails for root cause

### DIFF
--- a/tests/util/helpers.sh
+++ b/tests/util/helpers.sh
@@ -57,6 +57,7 @@ _wait_for_istio() {
     local name="$3"
     if ! istioctl experimental wait --for=distribution --timeout=5m "$kind" "$name.$namespace"; then
         echo "Failed distribution of $kind $name in namespace $namespace"
+        istioctl ps
         exit 1
     fi
 }


### PR DESCRIPTION
This will help us understand if the distribution really has failed, or if there is a bug in wait..