### PR TITLE
kiali: fix a broken link.

### DIFF
--- a/content/en/docs/tasks/observability/kiali/index.md
+++ b/content/en/docs/tasks/observability/kiali/index.md
@@ -19,7 +19,7 @@ Public API to generate graph data in the form of consumable JSON.
 {{< idea >}}
 This task does not cover all of the features provided by Kiali.
 To learn about the full set of features it supports,
-see the [Kiali website](http://kiali.io/documentation/features/).
+see the [Kiali website](http://kiali.io/documentation/latest/features/).
 {{< /idea >}}
 
 This task uses the [Bookinfo](/docs/examples/bookinfo/) sample application as the example throughout.

--- a/content/zh/docs/tasks/observability/kiali/index.md
+++ b/content/zh/docs/tasks/observability/kiali/index.md
@@ -13,7 +13,7 @@ aliases:
 最后，您使用 Kiali Public API 返回的 JSON 数据生成图形数据。
 
 {{< idea >}}
-这个任务并不包括 Kiali 提供的所有特性。要了解它所支持的全部功能，请查看 [Kiali 官网](http://kiali.io/documentation/features/)。
+这个任务并不包括 Kiali 提供的所有特性。要了解它所支持的全部功能，请查看 [Kiali 官网](http://kiali.io/documentation/latest/features/)。
 {{< /idea >}}
 
 此任务始终将 [Bookinfo](/zh/docs/examples/bookinfo/) 示例应用程序作为示例。


### PR DESCRIPTION
Fix a broken link on the web page. The path to kiali features page appears to be `documentation/latest/features` instead of `documentation/features`.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
