### PR TITLE
Capitalize 'istio' in VM doc

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -1,6 +1,6 @@
 ---
 title: Virtual Machine Installation
-description: Deploy istio and connect a workload running within a virtual machine to it.
+description: Deploy Istio and connect a workload running within a virtual machine to it.
 weight: 40
 keywords:
 - kubernetes


### PR DESCRIPTION
The proper noun "Istio" is not capitalized in https://preliminary.istio.io/latest/docs/setup/install/

```
Virtual Machine Installation
Deploy istio and connect a workload running within a virtual machine to it.
```

We don't want to dilute Open Usage Commons (OUC)'s valuable trademark.

I did `find . -name "*.md" -exec grep "^description.*istio" \{\} \; -print` and didn't find any other lower case "istio" except cases referring to the "istioctl" command.