### PR TITLE
Update grab_reference_docs to also strip `latest` from url

### DIFF
--- a/content/en/docs/reference/config/policy-and-telemetry/istio.mixer.v1.config.client/index.html
+++ b/content/en/docs/reference/config/policy-and-telemetry/istio.mixer.v1.config.client/index.html
@@ -776,7 +776,7 @@ specialized Mixer adapters and services can also generate attributes.</p>
 <a href="/docs/reference/config/policy-and-telemetry/attribute-vocabulary/">here</a>.</p>
 
 <p>Attributes are strongly typed. The supported attribute types are defined by
-<a href="https://github.com/istio/api/blob/master/policy/v1beta1/value_type.proto">ValueType</a>.
+<a href="https://github.com/istio/api/blob/release-1.7/policy/v1beta1/value_type.proto">ValueType</a>.
 Each type of value is encoded into one of the so-called transport types present
 in this message.</p>
 

--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -85,8 +85,7 @@ locate_file() {
     FN=${FN%.html}
     PP=$(echo "${FNP}" | rev | cut -d'/' -f2- | rev)
     mkdir -p "${ROOTDIR}/content/en/docs${PP}/${FN}"
-    sed -e 's/href="https:\/\/istio.io/href="/g' "${FILENAME}" >"${ROOTDIR}/content/en/docs${PP}/${FN}/index.html"
-    sed -E -e 's/(href="https:\/\/istio.io.*)\.html/\1\//' -e 's/href="https:\/\/istio.io/href="/g' "${FILENAME}" >"${ROOTDIR}/content/en/docs${PP}/${FN}/index.html"
+    sed -E -e 's/(href="https:\/\/istio.io.*)\.html/\1\//' -e 's/href="https:\/\/istio.io/href="/g' -e 's/href="https:\/\/istio.io/href="/g' -e 's/href="\/latest\//href="\//g' "${FILENAME}" >"${ROOTDIR}/content/en/docs${PP}/${FN}/index.html"
 
     LEN=${#WORK_DIR}
 

--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -85,7 +85,7 @@ locate_file() {
     FN=${FN%.html}
     PP=$(echo "${FNP}" | rev | cut -d'/' -f2- | rev)
     mkdir -p "${ROOTDIR}/content/en/docs${PP}/${FN}"
-    sed -E -e 's/(href="https:\/\/istio.io.*)\.html/\1\//' -e 's/href="https:\/\/istio.io/href="/g' -e 's/href="https:\/\/istio.io/href="/g' -e 's/href="\/latest\//href="\//g' "${FILENAME}" >"${ROOTDIR}/content/en/docs${PP}/${FN}/index.html"
+    sed -E -e 's/(href="https:\/\/istio.io.*)\.html/\1\//' -e 's/href="https:\/\/istio.io/href="/g' -e 's/href="\/latest\//href="\//g' "${FILENAME}" >"${ROOTDIR}/content/en/docs${PP}/${FN}/index.html"
 
     LEN=${#WORK_DIR}
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

Remove the `latest` from the href if it exists. 

Not that the link is a correct link in istio.api: example: `https://istio.io/latest/docs/reference/config/networking/sidecar/` 

We currently strip the _https://istio.io_ off of it in our gathering process. It makes sense we should strip the _latest_ as well if it exists. This allows correct URLs and older now incorrect URLs which don’t have _latest_ in the gathered docs.

Also the one file change from running with the new script

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
