### PR TITLE
Update min k8 supported version for istio 1.8

### DIFF
--- a/data/args.yml
+++ b/data/args.yml
@@ -29,7 +29,7 @@ source_branch_name: release-1.7
 doc_branch_name: master
 
 # The list of supported versions described by the docs
-supported_kubernetes_versions: ["1.16", "1.17", "1.18"]
+supported_kubernetes_versions: ["1.17", "1.18", "1.19"]
 
 ####### Static values
 


### PR DESCRIPTION
The minimum supported k8 version for `Istio 1.8` is `1.17-1.19` (3 versions). Ref: https://github.com/istio/istio/pull/24134#issuecomment-634690848

Related:
https://github.com/istio/istio/pull/25793

For `1.7` support.
https://github.com/istio/istio/pull/24167
https://github.com/istio/istio.io/pull/7422
