### PR TITLE
Revert "Update min k8 supported version for istio 1.8 (#7776)"

### DIFF
--- a/data/args.yml
+++ b/data/args.yml
@@ -29,7 +29,7 @@ source_branch_name: release-1.7
 doc_branch_name: master
 
 # The list of supported versions described by the docs
-supported_kubernetes_versions: ["1.17", "1.18", "1.19"]
+supported_kubernetes_versions: ["1.16", "1.17", "1.18"]
 
 ####### Static values
 


### PR DESCRIPTION
This reverts commit a72ac48739922ea926436a9c3196abf068b412e1.

Reverting #7776 because it is targetted for 1.8, and we have not cut the 1.7 branch yet.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
