### PR TITLE
fix secret name

### DIFF
--- a/content/en/docs/examples/virtual-machines/single-network/index.md
+++ b/content/en/docs/examples/virtual-machines/single-network/index.md
@@ -60,7 +60,7 @@ following commands on a machine with cluster admin privileges:
 
     {{< text bash >}}
     $ kubectl create namespace istio-system
-    $ kubectl create secret generic cacerts -n istio-system \
+    $ kubectl create secret generic istio-ca-cert -n istio-system \
         --from-file=@samples/certs/ca-cert.pem@ \
         --from-file=@samples/certs/ca-key.pem@ \
         --from-file=@samples/certs/root-cert.pem@ \


### PR DESCRIPTION
Currently, the docs tell you to create secret named `cacerts`, but the generate_cert tool looks for `istio-ca-secret`.  It is possible that the tool is the one that is wrong, in which case I can submit a second PR.