### PR TITLE
Add warning about regression in 1.6.6

### DIFF
--- a/content/en/news/releases/1.6.x/announcing-1.6.6/index.md
+++ b/content/en/news/releases/1.6.x/announcing-1.6.6/index.md
@@ -11,7 +11,7 @@ aliases:
 
 
 {{< warning >}}
-This release contains a regression from 1.6.5. Please upgrade to 1.6.7 instead. 
+This release contains a regression from 1.6.5 that prevents endpoints that are not associated with pods from working. Please upgrade to 1.6.7 instead. 
 {{< /warning >}}
 
 This release contains bug fixes to improve robustness. This release note describes

--- a/content/en/news/releases/1.6.x/announcing-1.6.6/index.md
+++ b/content/en/news/releases/1.6.x/announcing-1.6.6/index.md
@@ -9,9 +9,8 @@ aliases:
     - /news/announcing-1.6.6
 ---
 
-
 {{< warning >}}
-This release contains a regression from 1.6.5 that prevents endpoints that are not associated with pods from working. Please upgrade to 1.6.7 instead. 
+This release contains a regression from 1.6.5 that prevents endpoints that are not associated with pods from working. Please upgrade to 1.6.7 instead.
 {{< /warning >}}
 
 This release contains bug fixes to improve robustness. This release note describes

--- a/content/en/news/releases/1.6.x/announcing-1.6.6/index.md
+++ b/content/en/news/releases/1.6.x/announcing-1.6.6/index.md
@@ -10,7 +10,7 @@ aliases:
 ---
 
 {{< warning >}}
-This release contains a regression from 1.6.5 that prevents endpoints that are not associated with pods from working. Please upgrade to 1.6.7 instead.
+This release contains a regression from 1.6.5 that prevents endpoints not associated with pods from working. Please upgrade to 1.6.7 instead.
 {{< /warning >}}
 
 This release contains bug fixes to improve robustness. This release note describes

--- a/content/en/news/releases/1.6.x/announcing-1.6.6/index.md
+++ b/content/en/news/releases/1.6.x/announcing-1.6.6/index.md
@@ -9,6 +9,11 @@ aliases:
     - /news/announcing-1.6.6
 ---
 
+
+{{< warning >}}
+This release contains a regression from 1.6.5. Please upgrade to 1.6.7 instead. 
+{{< /warning >}}
+
 This release contains bug fixes to improve robustness. This release note describes
 what’s different between Istio 1.6.5 and Istio 1.6.6.
 

--- a/content/en/news/releases/1.6.x/announcing-1.6.6/index.md
+++ b/content/en/news/releases/1.6.x/announcing-1.6.6/index.md
@@ -10,7 +10,7 @@ aliases:
 ---
 
 {{< warning >}}
-This release contains a regression from 1.6.5 that prevents endpoints not associated with pods from working. Please upgrade to 1.6.7 instead.
+This release contains a regression from 1.6.5 that prevents endpoints not associated with pods from working. Please upgrade to 1.6.7 when it is available.
 {{< /warning >}}
 
 This release contains bug fixes to improve robustness. This release note describes


### PR DESCRIPTION
1.6.6 contains a regression (see: https://github.com/istio/istio/issues/25974). This prevents endpoints that are not associated with pods from working. This adds a warning. 
