### PR TITLE
replace deprecated policy configuration with peerAuthentication in zh

### DIFF
--- a/content/zh/docs/ops/diagnostic-tools/istioctl-describe/index.md
+++ b/content/zh/docs/ops/diagnostic-tools/istioctl-describe/index.md
@@ -204,16 +204,16 @@ VirtualService: reviews
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
 metadata:
   name: "ratings-strict"
 spec:
-  targets:
-  - name: ratings
-  peers:
-  - mtls:
-      mode: STRICT
+  selector:
+    matchLabels:
+      app: ratings
+  mtls:
+    mode: STRICT
 EOF
 {{< /text >}}
 

--- a/content/zh/docs/tasks/security/authentication/mtls-migration/index.md
+++ b/content/zh/docs/tasks/security/authentication/mtls-migration/index.md
@@ -102,17 +102,13 @@ sleep.legacy to httpbin.foo: 200
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n foo -f -
-apiVersion: "authentication.istio.io/v1alpha1"
-kind: "Policy"
+apiVersion: "security.istio.io/v1beta1"
+kind: "PeerAuthentication"
 metadata:
-  name: "example-httpbin-strict"
-  namespace: foo
+  name: "default"
 spec:
-  targets:
-  - name: httpbin
-  peers:
-  - mtls:
-      mode: STRICT
+  ntls:
+    mode: STRICT
 EOF
 {{< /text >}}
 

--- a/content/zh/docs/tasks/security/authentication/mtls-migration/index.md
+++ b/content/zh/docs/tasks/security/authentication/mtls-migration/index.md
@@ -107,7 +107,7 @@ kind: "PeerAuthentication"
 metadata:
   name: "default"
 spec:
-  ntls:
+  mtls:
     mode: STRICT
 EOF
 {{< /text >}}


### PR DESCRIPTION
`policy` and `meshpolicy` are removed since istio 1.6.0, see: [#22602](https://github.com/istio/istio/issues/22602)
we need to update the troubleshooting doc for the example configuration.

resolve: [istio/istio#24502](https://github.com/istio/istio/issues/24502)

[ ] Configuration Infrastructure
[X ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
