### PR TITLE
Replace usage of meshExpansion flag with istiod gateway code sample

### DIFF
--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -212,7 +212,7 @@ Apply the primary cluster's configuration.
 $ istioctl install -f istio-main-cluster.yaml --context=${MAIN_CLUSTER_CTX}
 {{< /text >}}
 
-If you're using the `istio-ingressgateway` option, expose the control plane by using the provided sample configuration.
+If you selected the `istio-ingressgateway` option, expose the control plane using the provided sample configuration.
 
 {{< text bash >}}
 $ kubectl apply -f @samples/istiod-gateway/istiod-gateway.yaml@

--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -154,10 +154,6 @@ spec:
           gateways:
           - registry_service_name: istio-ingressgateway.istio-system.svc.cluster.local
             port: 443
-
-      # Use the existing istio-ingressgateway.
-      meshExpansion:
-        enabled: true
 EOF
 {{< /text >}}
 
@@ -214,6 +210,12 @@ Apply the primary cluster's configuration.
 
 {{< text bash >}}
 $ istioctl install -f istio-main-cluster.yaml --context=${MAIN_CLUSTER_CTX}
+{{< /text >}}
+
+If you're using the `istio-ingressgateway` option, expose the control plane by using the provided sample configuration.
+
+{{< text bash >}}
+$ kubectl apply -f @samples/istiod-gateway/istiod-gateway.yaml@
 {{< /text >}}
 
 Wait for the control plane to be ready before proceeding.
@@ -533,6 +535,7 @@ $ rm istio-remote0-cluster.yaml
 To uninstall the primary cluster, run the following command:
 
 {{< text bash >}}
+$ kubectl delete --ignore-not-found=true -f @samples/istiod-gateway/istiod-gateway.yaml@
 $ istioctl manifest generate -f istio-main-cluster.yaml --context=${MAIN_CLUSTER_CTX} | \
     kubectl delete -f - --context=${MAIN_CLUSTER_CTX}
 $ kubectl delete namespace sample --context=${MAIN_CLUSTER_CTX}

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -54,7 +54,7 @@ Install Istio and expose the control plane so that virtual machines can reach it
     $ istioctl install
     {{< /text >}}
 
-1. Expose the control plane by using the provided code sample.
+1. Expose the control plane using the provided sample configuration.
 
     {{< text bash >}}
     $ kubectl apply -f @samples/istiod-gateway/istiod-gateway.yaml@

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -46,26 +46,18 @@ and `SERVICE_ACCOUNT`
 
 ## Install the Istio control plane
 
-Install Istio with the installation setting `values.global.meshExpansion.enabled: true`.
+Install Istio and expose the control plane so that virtual machines can reach it.
 
-1. Create the `IstioOperator` custom resource:
+1. Install Istio.
 
     {{< text bash >}}
-    $ cat <<EOF> "${WORK_DIR}"/vmintegration.yaml
-    apiVersion: install.istio.io/v1alpha1
-    kind: IstioOperator
-    spec:
-      values:
-        global:
-          meshExpansion:
-            enabled: true
-    EOF
+    $ istioctl install
     {{< /text >}}
 
-1. Install or upgrade Istio with virtual machine integration features enabled.
+1. Expose the control plane by using the provided code sample.
 
     {{< text bash >}}
-    $ istioctl install -f "${WORK_DIR}"/vmintegration.yaml
+    $ kubectl apply -f @samples/istiod-gateway/istiod-gateway.yaml@
     {{< /text >}}
 
 ## Configure the VM namespace
@@ -257,7 +249,8 @@ Then, remove the Istio-sidecar package:
 To uninstall Istio, run the following command:
 
 {{< text bash >}}
-$ istioctl manifest generate -f "${WORK_DIR}"/vmintegration.yaml | kubectl delete -f -
+$ kubectl delete -f @samples/istiod-gateway/istiod-gateway.yaml@
+$ istioctl manifest generate | kubectl delete -f -
 {{< /text >}}
 
 The control plane namespace (e.g., `istio-system`) is not removed by default.

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -46,7 +46,7 @@ and `SERVICE_ACCOUNT`
 
 ## Install the Istio control plane
 
-Install Istio and expose the control plane so that virtual machines can reach it.
+Install Istio and expose the control plane so that your virtual machine can access it.
 
 1. Install Istio.
 


### PR DESCRIPTION
As described in https://github.com/istio/istio/issues/25933, the meshExpansion flag is being deprecated in favor of user config that can be added post-installation. This updates docs accordingly

/hold
Note that this isn't ready to be merged for the 1.7 release because https://github.com/istio/istio/pull/26091 is past the cutoff

Also, for this to fully work, either I need to finish https://github.com/istio/istio/issues/25933 by adding more ports to the ingress Service by default, or these docs would need to be further modified to instruct users to patch in port 15012. I prefer the former, but first wanted feedback on this, in case it would be better to make a new Example or Task just for exposing Istiod and such a page should be linked in the release notes/deprecation warning

[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure