### PR TITLE
Fix Prometheus and Grafana svc not found during observability

### DIFF
--- a/content/en/docs/tasks/observability/metrics/querying-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/querying-metrics/index.md
@@ -18,8 +18,9 @@ the example application throughout this task.
 
 ## Before you begin
 
-[Install Istio](/docs/setup/) in your cluster and deploy an
-application.
+* [Install Istio](/docs/setup) in your cluster.
+* Deploy [Bookinfo](/docs/examples/bookinfo/) application.
+* Add [Prometheus Addon](/docs/ops/integrations/prometheus/#option-1-quick-start) in your cluster.
 
 ## Querying Istio metrics
 
@@ -76,13 +77,13 @@ You can also see the query results graphically by selecting the Graph tab undern
 
 Other queries to try:
 
--   Total count of all requests to the `productpage` service:
+*   Total count of all requests to the `productpage` service:
 
     {{< text plain >}}
     istio_requests_total{destination_service="productpage.default.svc.cluster.local"}
     {{< /text >}}
 
-- Total count of all requests to `v3` of the `reviews` service:
+*   Total count of all requests to `v3` of the `reviews` service:
 
     {{< text plain >}}
     istio_requests_total{destination_service="reviews.default.svc.cluster.local", destination_version="v3"}
@@ -90,7 +91,7 @@ Other queries to try:
 
     This query returns the current total count of all requests to the v3 of the `reviews` service.
 
--   Rate of requests over the past 5 minutes to all instances of the `productpage` service:
+*   Rate of requests over the past 5 minutes to all instances of the `productpage` service:
 
     {{< text plain >}}
     rate(istio_requests_total{destination_service=~"productpage.*", response_code="200"}[5m])
@@ -107,12 +108,12 @@ docs](https://prometheus.io/docs/querying/basics/).
 
 ## Cleanup
 
--   Remove any `istioctl` processes that may still be running using control-C or:
+*   Remove any `istioctl` processes that may still be running using control-C or:
 
     {{< text bash >}}
     $ killall istioctl
     {{< /text >}}
 
--   If you are not planning to explore any follow-on tasks, refer to the
+*   If you are not planning to explore any follow-on tasks, refer to the
     [Bookinfo cleanup](/docs/examples/bookinfo/#cleanup) instructions
     to shutdown the application.

--- a/content/en/docs/tasks/observability/metrics/querying-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/querying-metrics/index.md
@@ -19,8 +19,8 @@ the example application throughout this task.
 ## Before you begin
 
 * [Install Istio](/docs/setup) in your cluster.
-* Deploy [Bookinfo](/docs/examples/bookinfo/) application.
-* Add [Prometheus Addon](/docs/ops/integrations/prometheus/#option-1-quick-start) in your cluster.
+* Install the [Prometheus Addon](/docs/ops/integrations/prometheus/#option-1-quick-start).
+* Deploy the [Bookinfo](/docs/examples/bookinfo/) application.
 
 ## Querying Istio metrics
 

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
@@ -20,9 +20,9 @@ the example application throughout this task.
 ## Before you begin
 
 * [Install Istio](/docs/setup) in your cluster.
-* Deploy [Bookinfo](/docs/examples/bookinfo/) application.
-* Add [Grafana Addon](/docs/ops/integrations/grafana/#option-1-quick-start) in your cluster.
-* Add [Prometheus Addon](/docs/ops/integrations/prometheus/#option-1-quick-start) in your cluster.
+* Install the [Grafana Addon](/docs/ops/integrations/grafana/#option-1-quick-start).
+* Install the [Prometheus Addon](/docs/ops/integrations/prometheus/#option-1-quick-start).
+* Deploy the [Bookinfo](/docs/examples/bookinfo/) application.
 
 ## Viewing the Istio dashboard
 

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
@@ -20,8 +20,9 @@ the example application throughout this task.
 ## Before you begin
 
 * [Install Istio](/docs/setup) in your cluster.
-* Follow the [Grafana installation](/docs/ops/integrations/grafana/#configuration) documentation to deploy Grafana into your cluster.
 * Deploy [Bookinfo](/docs/examples/bookinfo/) application.
+* Add [Grafana Addon](/docs/ops/integrations/grafana/#option-1-quick-start) in your cluster.
+* Add [Prometheus Addon](/docs/ops/integrations/prometheus/#option-1-quick-start) in your cluster.
 
 ## Viewing the Istio dashboard
 
@@ -31,8 +32,8 @@ the example application throughout this task.
 
     {{< text bash >}}
     $ kubectl -n istio-system get svc prometheus
-    NAME         CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
-    prometheus   10.59.241.54   <none>        9090/TCP   2m
+    NAME         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+    prometheus   ClusterIP   10.100.250.202   <none>        9090/TCP   103s
     {{< /text >}}
 
 1.  Verify that the Grafana service is running in your cluster.
@@ -41,8 +42,8 @@ the example application throughout this task.
 
     {{< text bash >}}
     $ kubectl -n istio-system get svc grafana
-    NAME      CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
-    grafana   10.59.247.103   <none>        3000/TCP   2m
+    NAME      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+    grafana   ClusterIP   10.103.244.103   <none>        3000/TCP   2m25s
     {{< /text >}}
 
 1.  Open the Istio Dashboard via the Grafana UI.
@@ -50,7 +51,7 @@ the example application throughout this task.
     In Kubernetes environments, execute the following command:
 
     {{< text bash >}}
-    $ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=grafana -o jsonpath='{.items[0].metadata.name}') 3000:3000 &
+    $ istioctl dashboard grafana
     {{< /text >}}
 
     Visit [http://localhost:3000/dashboard/db/istio-mesh-dashboard](http://localhost:3000/dashboard/db/istio-mesh-dashboard) in your web browser.


### PR DESCRIPTION
To fix https://github.com/istio/istio.io/issues/7877

Prometheus and Grafana are now available as an addon integration. Users must manually install these before proceeding with the observability task.