### PR TITLE
Remove deprecated addonComponents

### DIFF
--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -138,8 +138,8 @@ spec:
 EOF
 {{< /text >}}
 
-You can also enable or disable components and modify resource settings.
-For example, to enable the `Grafana` component and increase pilot memory requests:
+You can also modify resource settings.
+For example, to increase pilot memory requests:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -156,9 +156,6 @@ spec:
         resources:
           requests:
             memory: 3072Mi
-  addonComponents:
-    grafana:
-      enabled: true
 EOF
 {{< /text >}}
 

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -138,8 +138,8 @@ spec:
 EOF
 {{< /text >}}
 
-You can also modify resource settings.
-For example, to increase pilot memory requests:
+You can also enable or disable components and modify resource settings.
+For example, to enable the `egressGateways` component and increase pilot memory requests:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -156,6 +156,9 @@ spec:
         resources:
           requests:
             memory: 3072Mi
+    egressGateways:
+    - name: istio-egressgateway
+      enabled: true
 EOF
 {{< /text >}}
 

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -139,7 +139,7 @@ EOF
 {{< /text >}}
 
 You can also enable or disable components and modify resource settings.
-For example, to enable the `egressGateways` component and increase pilot memory requests:
+For example, to enable the `istio-egressgateway` component and increase pilot memory requests:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF


### PR DESCRIPTION
Based on https://github.com/istio/istio/pull/24567

`Grafana` is now available as an addon and can be [installed independently](https://preliminary.istio.io/latest/docs/ops/integrations/grafana/).
 