### PR TITLE
update wording on bookinfo destination rules differences

### DIFF
--- a/content/en/docs/examples/bookinfo/index.md
+++ b/content/en/docs/examples/bookinfo/index.md
@@ -192,22 +192,16 @@ versions, called *subsets*, in [destination rules](/docs/concepts/traffic-manage
 
 Run the following command to create default destination rules for the Bookinfo services:
 
-* If you did **not** enable mutual TLS, execute this command:
+{{< text bash >}}
+$ kubectl apply -f @samples/bookinfo/networking/destination-rule-all.yaml@
+{{< /text >}}
 
-    {{< tip >}}
-    Choose this option if you are new to Istio and are using the `demo`
-    [configuration profile](/docs/setup/additional-setup/config-profiles/).
-    {{< /tip >}}
-
-    {{< text bash >}}
-    $ kubectl apply -f @samples/bookinfo/networking/destination-rule-all.yaml@
-    {{< /text >}}
-
-* If you **did** enable mutual TLS, execute this command:
-
-    {{< text bash >}}
-    $ kubectl apply -f @samples/bookinfo/networking/destination-rule-all-mtls.yaml@
-    {{< /text >}}
+{{< tip >}}
+You can enforce mutual TLS using the `samples/bookinfo/networking/destination-rule-all-mtls.yaml`
+destination rule.  However, the `default` and `demo` [configuration profiles](/docs/setup/additional-setup/config-profiles/) have [auto mutual TLS](/docs/tasks/security/authentication/authn-policy/#auto-mutual-tls) enabled by default.  If a TLS context is not provided in a
+destination rule, Istio configures client proxies to send mutual TLS traffic to injected proxies
+automatically.
+{{< /tip >}}
 
 Wait a few seconds for the destination rules to propagate.
 

--- a/content/en/docs/examples/bookinfo/index.md
+++ b/content/en/docs/examples/bookinfo/index.md
@@ -197,10 +197,8 @@ $ kubectl apply -f @samples/bookinfo/networking/destination-rule-all.yaml@
 {{< /text >}}
 
 {{< tip >}}
-You can enforce mutual TLS using the `samples/bookinfo/networking/destination-rule-all-mtls.yaml`
-destination rule.  However, the `default` and `demo` [configuration profiles](/docs/setup/additional-setup/config-profiles/) have [auto mutual TLS](/docs/tasks/security/authentication/authn-policy/#auto-mutual-tls) enabled by default.  If a TLS context is not provided in a
-destination rule, Istio configures client proxies to send mutual TLS traffic to injected proxies
-automatically.
+The `default` and `demo` [configuration profiles](/docs/setup/additional-setup/config-profiles/) have [auto mutual TLS](/docs/tasks/security/authentication/authn-policy/#auto-mutual-tls) enabled by default.
+To enforce mutual TLS, use the destination rules in `samples/bookinfo/networking/destination-rule-all-mtls.yaml`.
 {{< /tip >}}
 
 Wait a few seconds for the destination rules to propagate.

--- a/content/en/docs/examples/bookinfo/snips.sh
+++ b/content/en/docs/examples/bookinfo/snips.sh
@@ -97,10 +97,6 @@ kubectl apply -f samples/bookinfo/networking/destination-rule-all.yaml
 }
 
 snip_apply_default_destination_rules_2() {
-kubectl apply -f samples/bookinfo/networking/destination-rule-all-mtls.yaml
-}
-
-snip_apply_default_destination_rules_3() {
 kubectl get destinationrules -o yaml
 }
 

--- a/content/en/docs/examples/bookinfo/test.sh
+++ b/content/en/docs/examples/bookinfo/test.sh
@@ -57,7 +57,7 @@ _verify_contains snip_confirm_the_app_is_accessible_from_outside_the_cluster_1 "
 
 snip_apply_default_destination_rules_1
 
-_verify_lines snip_apply_default_destination_rules_3 "
+_verify_lines snip_apply_default_destination_rules_2 "
 + productpage
 + reviews
 + ratings


### PR DESCRIPTION

Some missed conditional logic that was required prior to Istio auto mTLS

Resolves https://github.com/istio/istio.io/issues/7915


[ ] Configuration Infrastructure
[ X ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure