### PR TITLE
Add docs for target_arch

### DIFF
--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -44,7 +44,11 @@ Follow these steps to get started with Istio:
     The command above downloads the latest release (numerically) of Istio.
     To download a specific version, you can add a variable on the command line.
     For example to download Istio 1.4.3, you would run
-      `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.4.3 sh -`
+      `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 sh -`. 
+      
+    The processor architecture will be detected automatically, but can alternatively
+    be overridden with the `TARGET_ARCH` environment variable. For example: 
+    `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 TARGET_ARCH=x86_64 sh -`. 
     {{< /tip >}}
 
 1.  Move to the Istio package directory. For example, if the package is

--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -44,11 +44,10 @@ Follow these steps to get started with Istio:
     The command above downloads the latest release (numerically) of Istio.
     To download a specific version, you can add a variable on the command line.
     For example to download Istio 1.4.3, you would run
-      `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 sh -`. 
-      
-    The processor architecture will be detected automatically, but can alternatively
-    be overridden with the `TARGET_ARCH` environment variable. For example: 
-    `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 TARGET_ARCH=x86_64 sh -`. 
+    `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 sh -`. The
+    processor architecture can be overridden with the `TARGET_ARCH` environment
+    variable. For example, to download the x86_64, architecture, you would run
+    `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 TARGET_ARCH=x86_64 sh -`.
     {{< /tip >}}
 
 1.  Move to the Istio package directory. For example, if the package is

--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -43,7 +43,7 @@ Follow these steps to get started with Istio:
     {{< tip >}}
     The command above downloads the latest release (numerically) of Istio.
     To download a specific version, you can add a variable on the command line.
-    For example to download Istio 1.4.3, you would run
+    For example to download Istio 1.6.8, you would run
     `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 sh -`. The
     processor architecture can be overridden with the `TARGET_ARCH` environment
     variable. For example, to download the x86_64, architecture, you would run

--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -42,12 +42,10 @@ Follow these steps to get started with Istio:
 
     {{< tip >}}
     The command above downloads the latest release (numerically) of Istio.
-    To download a specific version, you can add a variable on the command line.
-    For example to download Istio 1.6.8, you would run
-    `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 sh -`. The
-    processor architecture can be overridden with the `TARGET_ARCH` environment
-    variable. For example, to download the x86_64, architecture, you would run
-    `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 TARGET_ARCH=x86_64 sh -`.
+    You can pass variables on the command line to download a specific version
+    or to override the processor architecture.
+    For example, to download Istio 1.6.8 for the x86_64 architecture,
+    run `curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.6.8 TARGET_ARCH=x86_64 sh -`.
     {{< /tip >}}
 
 1.  Move to the Istio package directory. For example, if the package is


### PR DESCRIPTION
The TARGET_ARCH option for downloading Istio is currently not documented. This updates the example to point at a more recent version of Istio and documents the TARGET_ARCH.

ref: https://github.com/istio/istio/issues/24577

