### PR TITLE
Remove retired command manifest versions

### DIFF
--- a/content/en/docs/setup/upgrade/index.md
+++ b/content/en/docs/setup/upgrade/index.md
@@ -145,13 +145,6 @@ can be found in the `bin/` subdirectory of the downloaded package.
 1. [Download the new Istio release](/docs/setup/getting-started/#download)
    and change directory to the new release directory.
 
-1. Verify that `istoctl` supports upgrading from your current Istio version by
-   viewing the supported versions list:
-
-    {{< text bash >}}
-    $ istioctl manifest versions
-    {{< /text >}}
-
 1. Ensure that your Kubernetes configuration points to the cluster to upgrade:
 
     {{< text bash >}}


### PR DESCRIPTION
`istioctl manifest versions` was removed as part of https://github.com/istio/istio/pull/23512/.
The validation of version is done during istioctl upgrade now.

Fix: https://github.com/istio/istio.io/issues/7925

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure