### PR TITLE
add warning about uninstall with filename

### DIFF
--- a/content/en/docs/setup/upgrade/index.md
+++ b/content/en/docs/setup/upgrade/index.md
@@ -102,15 +102,15 @@ To uninstall a control plane of revision `istio-1-6-5`, run:
 $ istioctl x uninstall --revision istio-1-6-5
 {{< /text >}}
 
+{{< warning >}}
+This command will also remove gateway deployments for specified revision. If you want to remove the canary revision, please reinstall the gateway(s) with previous revision first to avoid down time.
+{{< /warning >}}
+
 If the old control plane does not have a revision label, uninstall it using its original installation options, for example:
 
 {{< text bash >}}
 $ istioctl x uninstall -f manifests/profiles/default.yaml
 {{< /text >}}
-
-{{< warning >}}
-Note that this command would also remove gateway deployments, use it with caution. The issue would be fixed in release `1.7.1`
-{{< /warning >}}
 
 Confirm that the old control plane has been removed and only the new one still exists in the cluster:
 

--- a/content/en/docs/setup/upgrade/index.md
+++ b/content/en/docs/setup/upgrade/index.md
@@ -108,6 +108,10 @@ If the old control plane does not have a revision label, uninstall it using its 
 $ istioctl x uninstall -f manifests/profiles/default.yaml
 {{< /text >}}
 
+{{< warning >}}
+Note that this command would also remove gateway deployments, use it with caution. The issue would be fixed in release `1.7.1`
+{{< /warning >}}
+
 Confirm that the old control plane has been removed and only the new one still exists in the cluster:
 
 {{< text bash >}}


### PR DESCRIPTION
This is applicable to `istioctl x uninstall` with filename flag. Resolves: https://github.com/istio/istio.io/issues/7927. The actual fix is: https://github.com/istio/istio/pull/26449
