### PR TITLE
Workaround code regression

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -67,15 +67,12 @@ deployment you place into production.
 
     {{< text bash >}}
     $ cd "${WORK_DIR}"
-    $ make -f "${ISTIO_DIR}"/tools/certs/Makefile NAME="${CLUSTER_NAME}" NAMESPACE="${SERVICE_NAMESPACE}" "${CLUSTER_NAME}"-cacerts-selfSigned
+    $ make -f "${ISTIO_DIR}"/tools/certs/Makefile.vm NAME="${CLUSTER_NAME}" NAMESPACE="${SERVICE_NAMESPACE}" "${CLUSTER_NAME}"-certs-wl
     {{< /text >}}
 
-1. Execute the following commands to create certificates for use on the virtual machine.
-
-    {{< text bash >}}
-    $ cd "${WORK_DIR}"
-    $ make -f "${ISTIO_DIR}"/tools/certs/Makefile NAME="${CLUSTER_NAME}" NAMESPACE="${SERVICE_NAMESPACE}" "${NAMESPACE}"-certs-selfSigned
-    {{< /text >}}
+    {{< warning >}}
+    In Istio 1.6.0, the above Makefile is located in `"${ISTIO_DIR}"/samples/certs/Makefile`.
+    {{< /warning >}}
 
 ## Install the Istio control plane
 
@@ -86,10 +83,10 @@ The Istio control plane must be installed with virtual machine integration enabl
     {{< text bash >}}
     $ kubectl create namespace istio-system
     $ kubectl create secret generic cacerts -n istio-system \
-        --from-file=ca-cert.pem="${WORK_DIR}"/"${CLUSTER_NAME}"/selfSigned-ca-cert.pem \
-        --from-file=ca-key.pem="${WORK_DIR}"/"${CLUSTER_NAME}"/selfSigned-ca-key.pem \
-        --from-file=root-cert.pem="${WORK_DIR}"/"${CLUSTER_NAME}"/root-cert.pem \
-        --from-file=cert-chain.pem="${WORK_DIR}"/"${CLUSTER_NAME}"/selfSigned-ca-cert-chain.pem
+        --from-file="${WORK_DIR}"/"${CLUSTER_NAME}"/ca-cert.pem \
+        --from-file="${WORK_DIR}"/"${CLUSTER_NAME}"/ca-key.pem \
+        --from-file="${WORK_DIR}"/"${CLUSTER_NAME}"/root-cert.pem \
+        --from-file="${WORK_DIR}"/"${CLUSTER_NAME}"/cert-chain.pem
     {{< /text >}}
 
 1. Create the install `IstioOperator` custom resource:
@@ -120,9 +117,10 @@ The Istio control plane must be installed with virtual machine integration enabl
 1. Make a copy of files to copy to the virtual machine
 
     {{< text bash >}}
-    $ cp -a "${WORK_DIR}"/"${SERVICE_NAMESPACE}"/key.pem "${WORK_DIR}"/"${CLUSTER_NAME}"/"${SERVICE_NAMESPACE}"/
-    $ cp -a "${WORK_DIR}"/"${SERVICE_NAMESPACE}"/root-cert.pem "${WORK_DIR}"/"${CLUSTER_NAME}"/"${SERVICE_NAMESPACE}"/
-    $ cp -a "${WORK_DIR}"/"${SERVICE_NAMESPACE}"/selfSigned-workload-cert-chain.pem "${WORK_DIR}"/"${CLUSTER_NAME}"/"${SERVICE_NAMESPACE}"/cert-chain.pem
+    $ cp -a "${WORK_DIR}"/"${CLUSTER_NAME}"/ca-cert.pem "${WORK_DIR}"/"${CLUSTER_NAME}"/"${SERVICE_NAMESPACE}"/
+    $ cp -a "${WORK_DIR}"/"${CLUSTER_NAME}"/key.pem "${WORK_DIR}"/"${CLUSTER_NAME}"/"${SERVICE_NAMESPACE}"/
+    $ cp -a "${WORK_DIR}"/"${CLUSTER_NAME}"/root-cert.pem "${WORK_DIR}"/"${CLUSTER_NAME}"/"${SERVICE_NAMESPACE}"/
+    $ cp -a "${WORK_DIR}"/"${CLUSTER_NAME}"/workload-cert-chain.pem "${WORK_DIR}"/"${CLUSTER_NAME}"/"${SERVICE_NAMESPACE}"/cert-chain.pem
     {{< /text >}}
 
 1. Generate a `cluster.env` configuration file that informs the virtual machine


### PR DESCRIPTION
The project does not want to rebuild Istio with a change but also
does not want to ship a regression. This small workaround provides
a suitable solution until the next-generation documentation is ready
or [Ed's PR](https://github.com/istio/istio/pull/26452) merges.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure