### PR TITLE
Fix invalid inline code

### DIFF
--- a/content/en/docs/tasks/observability/metrics/tcp-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/tcp-metrics/index.md
@@ -146,7 +146,7 @@ In this task, you used Istio configuration to
 automatically generate and report metrics for all traffic to a TCP service
 within the mesh.
 TCP Metrics for all active connections are recorded every `15s` by default and this timer is configurable
-via [`tcpReportingDurationconfig`](/docs/reference/config/proxy_extensions/stats/#PluginConfig).
+via [`tcpReportingDuration`](/docs/reference/config/proxy_extensions/stats/#PluginConfig).
 Metrics for a connection are also recorded at the end of the connection.
 
 ### TCP attributes

--- a/content/en/docs/tasks/observability/metrics/tcp-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/tcp-metrics/index.md
@@ -146,7 +146,7 @@ In this task, you used Istio configuration to
 automatically generate and report metrics for all traffic to a TCP service
 within the mesh.
 TCP Metrics for all active connections are recorded every `15s` by default and this timer is configurable
-via `[tcpReportingDurationconfig](/docs/reference/config/proxy_extensions/stats/#PluginConfig)`.
+via [`tcpReportingDurationconfig`](/docs/reference/config/proxy_extensions/stats/#PluginConfig).
 Metrics for a connection are also recorded at the end of the connection.
 
 ### TCP attributes


### PR DESCRIPTION
[X] Docs

This patch fixes a small invalid inline code.

In https://istio.io/latest/docs/tasks/observability/metrics/tcp-metrics/#understanding-tcp-telemetry-collection,
the inline code for `tcpReportingDurationconfig` is wrong.

tobe
```
 [`tcpReportingDurationconfig`](/docs/reference/config/proxy_extensions/stats/#PluginConfig)
```

current
```
`[tcpReportingDurationconfig](/docs/reference/config/proxy_extensions/stats/#PluginConfig)`
```

