### PR TITLE
clarify request timeout default

### DIFF
--- a/content/en/docs/tasks/traffic-management/request-timeouts/index.md
+++ b/content/en/docs/tasks/traffic-management/request-timeouts/index.md
@@ -28,7 +28,7 @@ This task shows you how to setup request timeouts in Envoy using Istio.
 ## Request timeouts
 
 A timeout for http requests can be specified using the *timeout* field of the [route rule](/docs/reference/config/networking/virtual-service/#HTTPRoute).
-By default, the timeout is 15 seconds, but in this task you override the `reviews` service
+By default, the request timeout is diabled, but in this task you override the `reviews` service
 timeout to 1 second.
 To see its effect, however, you also introduce an artificial 2 second delay in calls
 to the `ratings` service.


### PR DESCRIPTION
cc @GregHanson @rvennam 
Note: in the doc below, it also said ```In this task, you used Istio to set the request timeout for calls to the reviews microservice to half a second. By default the request timeout is disabled.```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
