### PR TITLE
add extra alias for 1.7.0

### DIFF
--- a/content/en/news/releases/1.7.x/announcing-1.7/_index.md
+++ b/content/en/news/releases/1.7.x/announcing-1.7/_index.md
@@ -8,6 +8,7 @@ release: 1.7.0
 skip_list: true
 aliases:
     - /news/announcing-1.7
+    - /news/announcing-1.7.0
 ---
 
 We are pleased to announce the release of Istio 1.7!


### PR DESCRIPTION
this fixes the defaultly generated release builder link for any
that find that


[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
