### PR TITLE
Add blog post for Steering changes

### DIFF
--- a/content/en/blog/2020/steering-changes/index.md
+++ b/content/en/blog/2020/steering-changes/index.md
@@ -15,9 +15,9 @@ The new Steering Committee consists of 13 seats: 9 proportionally allocated **Co
 
 ## Contribution Seats
 
-The direction of a project is set by the people who contribute to it. We've designed our committee to reflect that, with 9 seats to be attributed in proportion to contributions made to Istio in the previous 12 months. In Kubernetes, the mantra was “chop wood, carry water,” and we similarly want to reward companies who are fueling the growth of the project with contributions.
+The direction of a project is set by the people who contribute to it. We've designed our committee to reflect that, with 9 seats to be attributed in proportion to contributions made to Istio in the previous 12 months. In Kubernetes, the mantra was "chop wood, carry water," and we similarly want to reward companies who are fueling the growth of the project with contributions.
 
-This year, we've chosen to use **merged pull requests** as our [proxy for proportional contribution](https://github.com/istio/community/blob/master/steering/CONTRIBUTION-FORMULA.md). We know that no measure of contribution is perfect, and as such we will explicitly reconsider the formula every year. (Other measures we considered, including commits, comments, and actions, gave the same results for this period.)  
+This year, we've chosen to use **merged pull requests** as our [proxy for proportional contribution](https://github.com/istio/community/blob/master/steering/CONTRIBUTION-FORMULA.md). We know that no measure of contribution is perfect, and as such we will explicitly reconsider the formula every year. (Other measures we considered, including commits, comments, and actions, gave the same results for this period.)
 
 In order to ensure corporate diversity, there will always be a minimum of three companies represented in Contribution Seats.
 
@@ -39,4 +39,4 @@ We also want to make it clear that no single vendor, no matter how large their c
 
 According to our [seat allocation process](https://docs.google.com/spreadsheets/d/1Dt-h9s8G7Wyt4r16ZVqcmdWXDuCaPC0kPS21BuAfCL8/edit#gid=0), this year Google will be allocated 5 seats and IBM/Red Hat will be allocated 3. As the third largest contributor to Istio in the last 12 months, we are pleased to announce that Salesforce has earned a Contribution Seat.
 
-The first [election for Community Seats](https://github.com/istio/community/tree/master/steering/elections/2020) begins today.  Members have two weeks to nominate themselves, and voting will run from 14 to 27 September. You can learn all about the election in the istio/community repo on GitHub.  We're also hosting a special [community meeting](http://bit.ly/istiocommunitymeet) this Thursday at 10am to discuss the changes and the election process. We'd love to see you there!
+The first [election for Community Seats](https://github.com/istio/community/tree/master/steering/elections/2020) begins today.  Members have two weeks to nominate themselves, and voting will run from 14 to 27 September. You can learn all about the election in the `istio/community` repository on GitHub.  We're also hosting a special [community meeting](http://bit.ly/istiocommunitymeet) this Thursday at 10:00 Pacific to discuss the changes and the election process. We'd love to see you there!

--- a/content/en/blog/2020/steering-changes/index.md
+++ b/content/en/blog/2020/steering-changes/index.md
@@ -1,0 +1,42 @@
+---
+title: "Introducing the new Istio steering committee"
+subtitle: A new charter opens up governance roles to more contributors and community members
+description: The Istio Steering Committee is now in part proportionally allocated to companies based on contribution, and in part elected by community members.
+publishdate: 2020-08-24
+attribution: "Istio Steering Committee"
+keywords: [istio,steering,governance,community,election]
+---
+
+Today, the Istio project is pleased to announce a new revision to its steering charter, which opens up governance roles to more contributors and community members.  This revision solidifies our commitment to open governance, ensuring that the community around the project will always be able to steer its direction, and that no one company has majority voting control over the project.
+
+The Istio Steering Committee oversees the administrative aspects of the project and sets the marketing direction. From the earliest days of the project, it was bootstrapped with members from Google and IBM, the two founders and largest contributors, with the explicit intention that other seats would be added. We are very happy to deliver on that promise today, with a new charter designed to reward contribution and community.
+
+The new Steering Committee consists of 13 seats: 9 proportionally allocated **Contribution Seats**, and 4 elected **Community Seats**.
+
+## Contribution Seats
+
+The direction of a project is set by the people who contribute to it. We've designed our committee to reflect that, with 9 seats to be attributed in proportion to contributions made to Istio in the previous 12 months. In Kubernetes, the mantra was “chop wood, carry water,” and we similarly want to reward companies who are fueling the growth of the project with contributions.
+
+This year, we've chosen to use **merged pull requests** as our [proxy for proportional contribution](https://github.com/istio/community/blob/master/steering/CONTRIBUTION-FORMULA.md). We know that no measure of contribution is perfect, and as such we will explicitly reconsider the formula every year. (Other measures we considered, including commits, comments, and actions, gave the same results for this period.)  
+
+In order to ensure corporate diversity, there will always be a minimum of three companies represented in Contribution Seats.
+
+## Community Seats
+
+There are many wonderful contributors to the Istio community, including developers, SREs and mesh admins, working for companies large and small. We wanted to ensure that their voices were included, both in terms of representation and selection.
+
+We have added 4 seats for representatives from 4 different organizations, who are not represented in the Contribution Seat allocation. These seats will be voted on by the Istio community in an [annual election](https://github.com/istio/community/tree/master/steering/elections).
+
+Any [project member](https://github.com/istio/community/blob/master/ROLES.md#member) can stand for election; all Istio members who have been active in the last 12 months are eligible to vote.
+
+## Corporate diversification is the goal
+
+Our goal is that the governance of Istio reflects the diverse set of contributors. Both Google and IBM/Red Hat will have fewer seats than previously, and the new model is designed to ensure representation from at least 7 different organizations.
+
+We also want to make it clear that no single vendor, no matter how large their contribution, has majority voting control over the Istio project. We've implemented a cap on the number of seats a company can hold, such that they can neither unanimously win a vote, or veto a decision of the rest of the committee.
+
+## The 2020 committee and election
+
+According to our [seat allocation process](https://docs.google.com/spreadsheets/d/1Dt-h9s8G7Wyt4r16ZVqcmdWXDuCaPC0kPS21BuAfCL8/edit#gid=0), this year Google will be allocated 5 seats and IBM/Red Hat will be allocated 3. As the third largest contributor to Istio in the last 12 months, we are pleased to announce that Salesforce has earned a Contribution Seat.
+
+The first [election for Community Seats](https://github.com/istio/community/tree/master/steering/elections/2020) begins today.  Members have two weeks to nominate themselves, and voting will run from 14 to 27 September. You can learn all about the election in the istio/community repo on GitHub.  We're also hosting a special [community meeting](http://bit.ly/istiocommunitymeet) this Thursday at 10am to discuss the changes and the election process. We'd love to see you there!


### PR DESCRIPTION
Publish a blog post announcing the new Steering Committee charter and elections.

[X] Docs