### PR TITLE
remove test:no/yes from index.md for zipkin, jaeger, lightstep, tracing overview and kiali

### DIFF
--- a/content/en/docs/tasks/observability/distributed-tracing/jaeger/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/jaeger/index.md
@@ -6,7 +6,6 @@ keywords: [telemetry,tracing,jaeger,span,port-forwarding]
 aliases:
  - /docs/tasks/telemetry/distributed-tracing/jaeger/
 owner: istio/wg-policies-and-telemetry-maintainers
-test: no
 ---
 
 After completing this task, you understand how to have your application participate in tracing with [Jaeger](https://www.jaegertracing.io/),

--- a/content/en/docs/tasks/observability/distributed-tracing/lightstep/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/lightstep/index.md
@@ -6,7 +6,6 @@ keywords: [telemetry,tracing,lightstep]
 aliases:
  - /docs/tasks/telemetry/distributed-tracing/lightstep/
 owner: istio/wg-policies-and-telemetry-maintainers
-test: no
 ---
 
 This task shows you how to configure Istio to collect trace spans and send them to [Lightstep](https://lightstep.com).

--- a/content/en/docs/tasks/observability/distributed-tracing/overview/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/overview/index.md
@@ -6,7 +6,6 @@ keywords: [telemetry,tracing]
 aliases:
  - /docs/tasks/telemetry/distributed-tracing/overview/
 owner: istio/wg-policies-and-telemetry-maintainers
-test: no
 ---
 
 Distributed tracing enables users to track a request through mesh that is distributed across multiple services.

--- a/content/en/docs/tasks/observability/distributed-tracing/zipkin/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/zipkin/index.md
@@ -6,7 +6,6 @@ keywords: [telemetry,tracing,zipkin,span,port-forwarding]
 aliases:
     - /docs/tasks/zipkin-tracing.html
 owner: istio/wg-policies-and-telemetry-maintainers
-test: no
 ---
 
 After completing this task, you understand how to have your application participate in tracing with [Zipkin](https://zipkin.io/),

--- a/content/en/docs/tasks/observability/kiali/index.md
+++ b/content/en/docs/tasks/observability/kiali/index.md
@@ -6,7 +6,6 @@ keywords: [telemetry,visualization]
 aliases:
  - /docs/tasks/telemetry/kiali/
 owner: istio/wg-policies-and-telemetry-maintainers
-test: no
 ---
 
 This task shows you how to visualize different aspects of your Istio mesh.


### PR DESCRIPTION
As per review in https://github.com/istio/istio.io/pull/8003#pullrequestreview-473052262 , tracing is covered by integration test in istio/istio or mesh visualization is more about testing Kiali's functionality than Istio. So `test:yes/no` can be removed as doc test is not necessary.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
