### PR TITLE
Add upgrade note for EnvoyFilter changes

### DIFF
--- a/content/en/news/releases/1.7.x/announcing-1.7/upgrade-notes/index.md
+++ b/content/en/news/releases/1.7.x/announcing-1.7/upgrade-notes/index.md
@@ -67,7 +67,7 @@ If you need to run as root, this option can be enabled with `--set values.gatewa
 
 EnvoyFilter using the legacy `config` syntax will need to be migrated to the new `typed_config`. This is due to [underlying changes](https://github.com/istio/istio/issues/19885) in Envoy's API.
 
-As EnvoyFilter is a [break glass API](docs/reference/config/networking/envoy-filter/) without backwards compatibility guarantees, we recommend users explicitly bind EnvoyFilters to specific versions and appropriately test them prior to upgrading.
+As EnvoyFilter is a [break glass API](/docs/reference/config/networking/envoy-filter/) without backwards compatibility guarantees, we recommend users explicitly bind EnvoyFilters to specific versions and appropriately test them prior to upgrading.
 
 For example, a configuration for Istio 1.6, using the legacy `config` syntax:
 

--- a/content/en/news/releases/1.7.x/announcing-1.7/upgrade-notes/index.md
+++ b/content/en/news/releases/1.7.x/announcing-1.7/upgrade-notes/index.md
@@ -63,11 +63,11 @@ Note: the `targetPort` only modifies which port the gateway binds to. Clients wi
 
 If you need to run as root, this option can be enabled with `--set values.gateways.istio-ingressgateway.runAsRoot=true`.
 
-## EnvoyFilter syntax change
+## `EnvoyFilter` syntax change
 
-EnvoyFilter using the legacy `config` syntax will need to be migrated to the new `typed_config`. This is due to [underlying changes](https://github.com/istio/istio/issues/19885) in Envoy's API.
+`EnvoyFilter`s using the legacy `config` syntax will need to be migrated to the new `typed_config`. This is due to [underlying changes](https://github.com/istio/istio/issues/19885) in Envoy's API.
 
-As EnvoyFilter is a [break glass API](/docs/reference/config/networking/envoy-filter/) without backwards compatibility guarantees, we recommend users explicitly bind EnvoyFilters to specific versions and appropriately test them prior to upgrading.
+As `EnvoyFilter` is a [break glass API](/docs/reference/config/networking/envoy-filter/) without backwards compatibility guarantees, we recommend users explicitly bind `EnvoyFilter`s to specific versions and appropriately test them prior to upgrading.
 
 For example, a configuration for Istio 1.6, using the legacy `config` syntax:
 

--- a/content/en/news/releases/1.7.x/announcing-1.7/upgrade-notes/index.md
+++ b/content/en/news/releases/1.7.x/announcing-1.7/upgrade-notes/index.md
@@ -62,3 +62,68 @@ It should be changed to specify a valid `targetPort` that can be bound to:
 Note: the `targetPort` only modifies which port the gateway binds to. Clients will still connect to the port defined by `port` (generally 80 and 443), so this change should be transparent.
 
 If you need to run as root, this option can be enabled with `--set values.gateways.istio-ingressgateway.runAsRoot=true`.
+
+## EnvoyFilter syntax change
+
+EnvoyFilter using the legacy `config` syntax will need to be migrated to the new `typed_config`. This is due to [underlying changes](https://github.com/istio/istio/issues/19885) in Envoy's API.
+
+As EnvoyFilter is a [break glass API](docs/reference/config/networking/envoy-filter/) without backwards compatibility guarantees, we recommend users explicitly bind EnvoyFilters to specific versions and appropriately test them prior to upgrading.
+
+For example, a configuration for Istio 1.6, using the legacy `config` syntax:
+
+{{< text yaml >}}
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: lua-1.6
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: ANY
+        listener:
+          filterChain:
+            filter:
+              name: envoy.http_connection_manager
+        proxy:
+          proxyVersion: ^1\.6.*
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.lua
+          config:
+            inlineCode: |
+              function envoy_on_request(handle)
+                request_handle:headers():add("foo", "bar")
+              end
+{{< /text >}}
+
+When upgrading to Istio 1.7, a new filter should be added:
+
+{{< text yaml >}}
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: lua-1.7
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: ANY
+        listener:
+          filterChain:
+            filter:
+              name: envoy.http_connection_manager
+        proxy:
+          proxyVersion: ^1\.6.*
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.lua
+          typed_config:
+            '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+            inlineCode: |
+              function envoy_on_request(handle)
+                request_handle:headers():add("foo", "bar")
+              end
+{{< /text >}}


### PR DESCRIPTION
Courtesy of
https://banzaicloud.com/blog/istio-1.7/#envoyfilter-syntax-for-lua-filter-is-changed
which this is large inspired/copied by. I have verified with Zsolt from
their team that they are ok with their example being reused here



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure