### PR TITLE
Remove mention of "pilot agent"

### DIFF
--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -28,8 +28,8 @@ which does not have an Istio issued certificate. Therefore when mutual TLS is en
 the health check requests will fail.
 
 Istio solves this problem by rewriting the application `PodSpec` readiness/liveness probe,
-so that the probe request is sent to [Pilot agent](/docs/reference/commands/pilot-agent/).
-Pilot agent then redirects the request to the application, strips the response body, only returning the response code.
+so that the probe request is sent to the [sidecar agent](/docs/reference/commands/pilot-agent/).
+The sidecar agent then redirects the request to the application, strips the response body, only returning the response code.
 
 This feature is enabled by default in all built-in Istio [configuration profiles](/docs/setup/additional-setup/config-profiles/)
 but can be disabled as described below.


### PR DESCRIPTION
I have heard 5+ cases of folks thinking this means it going through the
control plane. https://github.com/istio/istio/issues/26737 for example.

We should not call it "pilot agent". We are callnig it istio-agent
internally, not sure if we want to make that in the docs or something
else -- anything but "pilot" agent.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure