### PR TITLE
Fix duplicate period (..) on end of paragraphs

### DIFF
--- a/content/en/docs/concepts/traffic-management/index.md
+++ b/content/en/docs/concepts/traffic-management/index.md
@@ -804,4 +804,4 @@ availability of services in the mesh, applications must handle the failure
 or errors and take appropriate fallback actions. For example, when all
 instances in a load balancing pool have failed, Envoy returns an `HTTP 503`
 code. The application must implement any fallback logic needed to handle the
-`HTTP 503` error code..
+`HTTP 503` error code.


### PR DESCRIPTION

This PR fixes duplicate periods (..) that existed in the final paragraph of `content/en/docs/concepts/traffic-management/index.md` and in all the related HTML files.


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure