### PR TITLE
Updating incorrect information in the glossary

### DIFF
--- a/content/en/docs/reference/glossary/control-plane.md
+++ b/content/en/docs/reference/glossary/control-plane.md
@@ -5,4 +5,3 @@ test: n/a
 
 A control plane is a set of system services that configure the mesh or a subset of
 the mesh to manage the communication between the workload instances within.
-All instances of a control plane in a single mesh share the same configuration source.

--- a/content/en/docs/reference/glossary/identity.md
+++ b/content/en/docs/reference/glossary/identity.md
@@ -40,5 +40,3 @@ Istio supports the following service identities on different platforms:
   account refers to the existing service account just like the identities that
   the customer’s Identity Directory manages.
 
-Typically, the [trust domain](/docs/reference/glossary/#trust-domain) specifies
-the mesh the identity belongs to.

--- a/content/en/docs/reference/glossary/trust-domain.md
+++ b/content/en/docs/reference/glossary/trust-domain.md
@@ -6,9 +6,9 @@ test: n/a
 [Trust domain](https://spiffe.io/spiffe/concepts/#trust-domain) corresponds to the trust root of a system and is part of a workload identity
 
 Istio uses a trust domain to create all
-[identities](/docs/reference/glossary/#identity) within a mesh. Every mesh has
-an exclusive trust domain.
+[identities](/docs/reference/glossary/#identity) within a mesh. 
 
-For example in `spiffe://mytrustdomain.com/ns/default/sa/myname` the substring
-identifying the mesh is: `mytrustdomain.com`. This substring is the trust
-domain of the mesh.
+For example in `spiffe://mytrustdomain.com/ns/default/sa/myname` the substring `mytrustdomain.com`
+specifies that the workload is from a trust domain called `mytrustdomain.com`.
+
+Depending upon your configuration, you can choose to have a single trust domain for the entire mesh across clusters or a trust domain for each cluster, as long as the clusters share the same root of trust.

--- a/content/en/docs/reference/glossary/trust-domain.md
+++ b/content/en/docs/reference/glossary/trust-domain.md
@@ -8,4 +8,4 @@ test: n/a
 Istio uses a trust domain to create all [identities](/docs/reference/glossary/#identity) within a mesh.
 For example in `spiffe://mytrustdomain.com/ns/default/sa/myname` the substring `mytrustdomain.com` specifies that the workload is from a trust domain called `mytrustdomain.com`.
 
-Depending upon your configuration, you can choose to have a single trust domain for the entire mesh across clusters or a trust domain for each cluster, as long as the clusters share the same root of trust.
+You can have one or more trust domains in a multicluster mesh, as long as the clusters share the same root of trust.

--- a/content/en/docs/reference/glossary/trust-domain.md
+++ b/content/en/docs/reference/glossary/trust-domain.md
@@ -6,7 +6,6 @@ test: n/a
 [Trust domain](https://spiffe.io/spiffe/concepts/#trust-domain) corresponds to the trust root of a system and is part of a workload identity.
 
 Istio uses a trust domain to create all [identities](/docs/reference/glossary/#identity) within a mesh.
-
 For example in `spiffe://mytrustdomain.com/ns/default/sa/myname` the substring `mytrustdomain.com` specifies that the workload is from a trust domain called `mytrustdomain.com`.
 
 Depending upon your configuration, you can choose to have a single trust domain for the entire mesh across clusters or a trust domain for each cluster, as long as the clusters share the same root of trust.

--- a/content/en/docs/reference/glossary/trust-domain.md
+++ b/content/en/docs/reference/glossary/trust-domain.md
@@ -3,12 +3,10 @@ title: Trust Domain
 test: n/a
 ---
 
-[Trust domain](https://spiffe.io/spiffe/concepts/#trust-domain) corresponds to the trust root of a system and is part of a workload identity
+[Trust domain](https://spiffe.io/spiffe/concepts/#trust-domain) corresponds to the trust root of a system and is part of a workload identity.
 
-Istio uses a trust domain to create all
-[identities](/docs/reference/glossary/#identity) within a mesh. 
+Istio uses a trust domain to create all [identities](/docs/reference/glossary/#identity) within a mesh.
 
-For example in `spiffe://mytrustdomain.com/ns/default/sa/myname` the substring `mytrustdomain.com`
-specifies that the workload is from a trust domain called `mytrustdomain.com`.
+For example in `spiffe://mytrustdomain.com/ns/default/sa/myname` the substring `mytrustdomain.com` specifies that the workload is from a trust domain called `mytrustdomain.com`.
 
 Depending upon your configuration, you can choose to have a single trust domain for the entire mesh across clusters or a trust domain for each cluster, as long as the clusters share the same root of trust.


### PR DESCRIPTION
There is a whole lot of misinformation in our glossary.  It seems to imply that a trust domain is for the entire mesh when we have tons of people having a shared root CA with different trust domains for different clusters. We also seem to imply that there can be only one service of a given name in a given namespace across the entire mesh when the entire replicated control plane multicluster model indicates that the name/namespace thing is irrelevant as the two clusters communicate via gateways.



[ ] Configuration Infrastructure
[x ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure