### PR TITLE
Docs: monitoring-multicluster-prometheus fixes

### DIFF
--- a/content/en/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/index.md
+++ b/content/en/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/index.md
@@ -125,7 +125,7 @@ $ kubectl -n istio-system edit cm prometheus -o yaml
 
 Then add configurations for the *remote* clusters (replacing the ingress domain and cluster name for each cluster) and
 add one configuration for the *local* cluster:
-
+# Trigger recheck
 {{< text yaml >}}
 scrape_configs:
 - job_name: 'federate-{{REMOTE_CLUSTER_NAME}}'

--- a/content/en/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/index.md
+++ b/content/en/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/index.md
@@ -73,22 +73,22 @@ like the following (replacing the ingress domain and cluster name):
 
 {{< text yaml >}}
 scrape_configs:
-  - job_name: 'federate-{{CLUSTER_NAME}}'
-    scrape_interval: 15s
+- job_name: 'federate-{{CLUSTER_NAME}}'
+  scrape_interval: 15s
 
-    honor_labels: true
-    metrics_path: '/federate'
+  honor_labels: true
+  metrics_path: '/federate'
 
-    params:
-      'match[]':
-        - '{job="pilot"}'
-        - '{job="envoy-stats"}'
+  params:
+    'match[]':
+      - '{job="pilot"}'
+      - '{job="envoy-stats"}'
 
-    static_configs:
-      - targets:
-        - 'prometheus.{{INGRESS_DOMAIN}}'
-        labels:
-          cluster: '{{CLUSTER_NAME}}'
+  static_configs:
+    - targets:
+      - 'prometheus.{{INGRESS_DOMAIN}}'
+      labels:
+        cluster: '{{CLUSTER_NAME}}'
 {{< /text >}}
 
 Notes:
@@ -128,38 +128,38 @@ add one configuration for the *local* cluster:
 
 {{< text yaml >}}
 scrape_configs:
-  - job_name: 'federate-{{REMOTE_CLUSTER_NAME}}'
-    scrape_interval: 15s
+- job_name: 'federate-{{REMOTE_CLUSTER_NAME}}'
+  scrape_interval: 15s
 
-    honor_labels: true
-    metrics_path: '/federate'
+  honor_labels: true
+  metrics_path: '/federate'
 
-    params:
-      'match[]':
-        - '{job="pilot"}'
-        - '{job="envoy-stats"}'
+  params:
+    'match[]':
+      - '{job="pilot"}'
+      - '{job="envoy-stats"}'
 
-    static_configs:
-      - targets:
-        - 'prometheus.{{REMOTE_INGRESS_DOMAIN}}'
-        labels:
-          cluster: '{{REMOTE_CLUSTER_NAME}}'
+  static_configs:
+    - targets:
+      - 'prometheus.{{REMOTE_INGRESS_DOMAIN}}'
+      labels:
+        cluster: '{{REMOTE_CLUSTER_NAME}}'
 
-  - job_name: 'federate-local'
+- job_name: 'federate-local'
 
-    honor_labels: true
-    metrics_path: '/federate'
+  honor_labels: true
+  metrics_path: '/federate'
 
-    metric_relabel_configs:
-    - replacement: '{{CLUSTER_NAME}}'
-      target_label: cluster
+  metric_relabel_configs:
+  - replacement: '{{CLUSTER_NAME}}'
+    target_label: cluster
 
-    kubernetes_sd_configs:
-    - role: pod
-      namespaces:
-        names: ['istio-system']
-    params:
-      'match[]':
-      - '{__name__=~"istio_(.*)"}'
-      - '{__name__=~"pilot(.*)"}'
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names: ['istio-system']
+  params:
+    'match[]':
+    - '{__name__=~"istio_(.*)"}'
+    - '{__name__=~"pilot(.*)"}'
 {{< /text >}}

--- a/content/en/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/index.md
+++ b/content/en/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/index.md
@@ -125,7 +125,7 @@ $ kubectl -n istio-system edit cm prometheus -o yaml
 
 Then add configurations for the *remote* clusters (replacing the ingress domain and cluster name for each cluster) and
 add one configuration for the *local* cluster:
-# Trigger recheck
+
 {{< text yaml >}}
 scrape_configs:
 - job_name: 'federate-{{REMOTE_CLUSTER_NAME}}'

--- a/content/en/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/index.md
+++ b/content/en/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/index.md
@@ -150,9 +150,9 @@ scrape_configs:
     honor_labels: true
     metrics_path: '/federate'
 
-    metrics_relabel_configs:
+    metric_relabel_configs:
     - replacement: '{{CLUSTER_NAME}}'
-      targetLabel: cluster
+      target_label: cluster
 
     kubernetes_sd_configs:
     - role: pod


### PR DESCRIPTION


[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

I was following the documentations here:
https://istio.io/latest/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/

Prometheus throws an error using the scrape_configs in the "Production Prometheus on an in-mesh cluster" section.

Reading the Prometheus documentations:
https://prometheus.io/docs/prometheus/latest/configuration/configuration/

Fields `metrics_relabel_configs` and `targetLabel` should be `metric_relabel_configs` and `target_label`.

The indentation of the scrape config jobs was also slightly off with the scrape_configs field.

Errors from Prometheus:

When applying the config as is in the documentations:
`level=error ts=2020-08-31T10:51:42.113Z caller=main.go:727 err="error loading config from \"/etc/prometheus/prometheus.yml\": couldn't load configuration (--config.file=\"/etc/prometheus/prometheus.yml\"): parsing YAML file /etc/prometheus/prometheus.yml: yaml: line 38: did not find expected key"`

When only fixing the indentation:
`level=error ts=2020-08-31T10:55:29.079Z caller=main.go:727 err="error loading config from \"/etc/prometheus/prometheus.yml\": couldn't load configuration (--config.file=\"/etc/prometheus/prometheus.yml\"): parsing YAML file /etc/prometheus/prometheus.yml: yaml: unmarshal errors:\n  line 26: field metrics_relabel_configs not found in type config.plain"`

Fixing the metrics_relabel_configs field as well:
`level=error ts=2020-08-31T11:14:57.719Z caller=main.go:727 err="error loading config from \"/etc/prometheus/prometheus.yml\": couldn't load configuration (--config.file=\"/etc/prometheus/prometheus.yml\"): parsing YAML file /etc/prometheus/prometheus.yml: yaml: unmarshal errors:\n  line 28: field targetLabel not found in type relabel.plain"`

Using the configurations in this pull request, Prometheus parses the yaml without error.