### PR TITLE
Doc test for accessing Jaeger and Grafana dashboards by port-forwarding

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -20,4 +20,4 @@ BUILD_WITH_CONTAINER ?= 1
 
 # The release branching scripts use git commands so mount the global .gitconfig into the container
 CONDITIONAL_HOST_MOUNTS = --mount type=bind,source=${HOME}/.gitconfig,destination=/config/.gitconfig,readonly \
-													--mount type=bind,source=/tmp,destination=/tmp ${}
+                          --mount type=bind,source=/tmp,destination=/tmp ${}

--- a/content/en/docs/tasks/observability/distributed-tracing/jaeger/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/jaeger/index.md
@@ -6,7 +6,7 @@ keywords: [telemetry,tracing,jaeger,span,port-forwarding]
 aliases:
  - /docs/tasks/telemetry/distributed-tracing/jaeger/
 owner: istio/wg-policies-and-telemetry-maintainers
-test: no
+test: yes
 ---
 
 After completing this task, you understand how to have your application participate in tracing with [Jaeger](https://www.jaegertracing.io/),

--- a/content/en/docs/tasks/observability/distributed-tracing/jaeger/snips.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/jaeger/snips.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2153,SC2155,SC2164
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          docs/tasks/observability/distributed-tracing/jaeger/index.md
+####################################################################################################
+source "content/en/boilerplates/snips/trace-generation.sh"
+
+snip_accessing_the_dashboard_1() {
+istioctl dashboard jaeger
+}
+
+snip_cleanup_1() {
+killall istioctl
+}

--- a/content/en/docs/tasks/observability/distributed-tracing/jaeger/test.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/jaeger/test.sh
@@ -39,7 +39,7 @@ snip_accessing_the_dashboard_1 &
 # Although test says, take a look at traces, we don't have to do that in this task
 # as it is covered by an integration test in istio/istio.
 function access_jaeger_by_port_forward() {
-  curl -s -o /dev/null -w '%{http_code}' http://localhost:16686/jaeger
+  curl -s -o /dev/null -w '%{http_code}' "http://localhost:16686/jaeger/api/traces?service=productpage.default&limit=20"
 }
 
 _verify_same access_jaeger_by_port_forward "200"

--- a/content/en/docs/tasks/observability/distributed-tracing/jaeger/test.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/jaeger/test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC2154,SC2155,SC2034
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+
+source "tests/util/helpers.sh"
+source "tests/util/samples.sh"
+source "tests/util/addons.sh"
+
+# @setup profile=default
+
+# NOTE: This test is very similar to the one for zipkin.
+_deploy_and_wait_for_addons jaeger
+
+kubectl label namespace default istio-injection=enabled --overwrite
+startup_bookinfo_sample
+_set_ingress_environment_variables
+GATEWAY_URL="$INGRESS_HOST:$INGRESS_PORT"
+bpsnip_trace_generation__1
+
+snip_accessing_the_dashboard_1 &
+
+# Although test says, take a look at traces, we don't have to do that in this task
+# as it is covered by an integration test in istio/istio.
+function access_jaeger_by_port_forward() {
+  curl -s -o /dev/null -w '%{http_code}' http://localhost:16686/jaeger
+}
+
+_verify_same access_jaeger_by_port_forward "200"
+pgrep istioctl | xargs kill
+
+# @cleanup
+set +e
+
+# TODO: Fix issue of killing twice (https://github.com/istio/istio.io/issues/8014)
+pgrep istioctl | xargs kill
+cleanup_bookinfo_sample
+_undeploy_addons jaeger

--- a/content/en/docs/tasks/observability/distributed-tracing/jaeger/test.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/jaeger/test.sh
@@ -39,7 +39,7 @@ snip_accessing_the_dashboard_1 &
 # Although test says, take a look at traces, we don't have to do that in this task
 # as it is covered by an integration test in istio/istio.
 function access_jaeger_by_port_forward() {
-  curl -s -o /dev/null -w '%{http_code}' "http://localhost:16686/jaeger/api/traces?service=productpage.default&limit=20"
+  curl -s -o /dev/null -w '%{http_code}' "http://localhost:16686/jaeger/api/traces?service=productpage.default"
 }
 
 _verify_same access_jaeger_by_port_forward "200"

--- a/content/en/docs/tasks/observability/distributed-tracing/zipkin/test.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/zipkin/test.sh
@@ -20,6 +20,7 @@ set -u
 set -o pipefail
 
 source "tests/util/samples.sh"
+source "tests/util/addons.sh"
 
 # @setup profile=demo
 
@@ -27,8 +28,7 @@ source "tests/util/samples.sh"
 # Set to known setting of sidecar injection
 kubectl label namespace default istio-injection=enabled --overwrite
 
-kubectl apply -f "https://raw.githubusercontent.com/istio/istio/release-1.7/samples/addons/extras/zipkin.yaml"
-_wait_for_deployment istio-system zipkin
+_deploy_and_wait_for_addons zipkin
 
 # Install Bookinfo application
 startup_bookinfo_sample
@@ -55,7 +55,4 @@ cleanup_bookinfo_sample
 
 # TODO: Fix issue with using killall. Also why do we need to do this in setup and cleanup?
 pgrep istioctl | xargs kill
-
-# Had to repeat again, as setup and cleanup are split into separate scripts
-# and are invoked separately by istio.io docs test framework
-kubectl delete -f "https://raw.githubusercontent.com/istio/istio/release-1.7/samples/addons/extras/zipkin.yaml"
+_undeploy_addons zipkin

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
@@ -65,9 +65,7 @@ the example application throughout this task.
     For the Bookinfo sample, visit `http://$GATEWAY_URL/productpage` in your web
     browser or issue the following command:
 
-    {{< text bash >}}
-    $ curl "http://$GATEWAY_URL/productpage"
-    {{< /text >}}
+    {{< boilerplate trace-generation >}}
 
     {{< tip >}}
     `$GATEWAY_URL` is the value set in the [Bookinfo](/docs/examples/bookinfo/) example.

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
@@ -7,7 +7,7 @@ aliases:
     - /docs/tasks/telemetry/using-istio-dashboard/
     - /docs/tasks/telemetry/metrics/using-istio-dashboard/
 owner: istio/wg-policies-and-telemetry-maintainers
-test: no
+test: yes
 ---
 
 This task shows you how to setup and use the Istio Dashboard to monitor mesh

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
@@ -66,7 +66,7 @@ the example application throughout this task.
     browser or issue the following command:
 
     {{< text bash >}}
-    $ curl http://$GATEWAY_URL/productpage
+    $ curl "http://$GATEWAY_URL/productpage"
     {{< /text >}}
 
     {{< tip >}}

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/snips.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2153,SC2155,SC2164
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          docs/tasks/observability/metrics/using-istio-dashboard/index.md
+####################################################################################################
+
+snip_viewing_the_istio_dashboard_1() {
+kubectl -n istio-system get svc prometheus
+}
+
+! read -r -d '' snip_viewing_the_istio_dashboard_1_out <<\ENDSNIP
+NAME         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+prometheus   ClusterIP   10.100.250.202   <none>        9090/TCP   103s
+ENDSNIP
+
+snip_viewing_the_istio_dashboard_2() {
+kubectl -n istio-system get svc grafana
+}
+
+! read -r -d '' snip_viewing_the_istio_dashboard_2_out <<\ENDSNIP
+NAME      TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+grafana   ClusterIP   10.103.244.103   <none>        3000/TCP   2m25s
+ENDSNIP
+
+snip_viewing_the_istio_dashboard_3() {
+istioctl dashboard grafana
+}
+
+snip_viewing_the_istio_dashboard_4() {
+curl http://$GATEWAY_URL/productpage
+}
+
+snip_cleanup_1() {
+killall kubectl
+}

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/snips.sh
@@ -43,7 +43,7 @@ istioctl dashboard grafana
 }
 
 snip_viewing_the_istio_dashboard_4() {
-curl http://$GATEWAY_URL/productpage
+curl "http://$GATEWAY_URL/productpage"
 }
 
 snip_cleanup_1() {

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/snips.sh
@@ -19,6 +19,7 @@
 # WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
 #          docs/tasks/observability/metrics/using-istio-dashboard/index.md
 ####################################################################################################
+source "content/en/boilerplates/snips/trace-generation.sh"
 
 snip_viewing_the_istio_dashboard_1() {
 kubectl -n istio-system get svc prometheus
@@ -40,10 +41,6 @@ ENDSNIP
 
 snip_viewing_the_istio_dashboard_3() {
 istioctl dashboard grafana
-}
-
-snip_viewing_the_istio_dashboard_4() {
-curl "http://$GATEWAY_URL/productpage"
 }
 
 snip_cleanup_1() {

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/test.sh
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/test.sh
@@ -56,39 +56,39 @@ function access_grafana_istio_workload_dashboard() {
 # Grafana calls this behind the scenes. It sends a query to prometheus
 # The long and scary query is copied straight from requests page in browser
 # and some parameters are edited. Basically it is a URL-encoded prometheus query
-function query_request_count_to_productpage() {
-  curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=%20sum(istio_requests_total%7Breporter%3D%22destination%22%2C%20destination_service%3D~%22productpage.default.svc.cluster.local%22%2C%20source_workload_namespace%3D~%22istio-system%22%7D)%20by%20(source_workload)%20or%20sum(istio_tcp_sent_bytes_total%7Breporter%3D%22destination%22%2C%20destination_service%3D~%22productpage.default.svc.cluster.local%22%2C%20source_workload_namespace%3D~%22istio-system%22%7D)%20by%20(source_workload)' | jq -r '.status' 
-}
+# function query_request_count_to_productpage() {
+#   curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=%20sum(istio_requests_total%7Breporter%3D%22destination%22%2C%20destination_service%3D~%22productpage.default.svc.cluster.local%22%2C%20source_workload_namespace%3D~%22istio-system%22%7D)%20by%20(source_workload)%20or%20sum(istio_tcp_sent_bytes_total%7Breporter%3D%22destination%22%2C%20destination_service%3D~%22productpage.default.svc.cluster.local%22%2C%20source_workload_namespace%3D~%22istio-system%22%7D)%20by%20(source_workload)' | jq -r '.status' 
+# }
 
-# This Prometheus query is from Mesh dashboard
-function query_request_for_all_workloads() {
-  curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=label_join(sum(rate(istio_requests_total%7Breporter%3D%22destination%22%2C%20response_code%3D%22200%22%7D%5B1m%5D))%20by%20(destination_workload%2C%20destination_workload_namespace%2C%20destination_service)%2C%20%22destination_workload_var%22%2C%20%22.%22%2C%20%22destination_workload%22%2C%20%22destination_workload_namespace%22)' \
-  | jq -r '.data.result[].metric.destination_workload_var' | sort
-}
+# # This Prometheus query is from Mesh dashboard
+# function query_request_for_all_workloads() {
+#   curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=label_join(sum(rate(istio_requests_total%7Breporter%3D%22destination%22%2C%20response_code%3D%22200%22%7D%5B1m%5D))%20by%20(destination_workload%2C%20destination_workload_namespace%2C%20destination_service)%2C%20%22destination_workload_var%22%2C%20%22.%22%2C%20%22destination_workload%22%2C%20%22destination_workload_namespace%22)' \
+#   | jq -r '.data.result[].metric.destination_workload_var' | sort
+# }
 
-function query_request_from_productpage_workload() {
-  curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=%20sum(istio_requests_total%7Breporter%3D%22source%22%2C%20source_workload%3D~%22productpage-v1%22%2C%20source_workload_namespace%3D~%22default%22%7D)%20by%20(destination_service)%20or%20sum(istio_tcp_sent_bytes_total%7Breporter%3D%22source%22%2C%20source_workload%3D~%22productpage-v1%22%2C%20source_workload_namespace%3D~%22default%22%7D)%20by%20(destination_service)' \
-  | jq -r '.data.result[].metric.destination_service' | sort
-}
+# function query_request_from_productpage_workload() {
+#   curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=%20sum(istio_requests_total%7Breporter%3D%22source%22%2C%20source_workload%3D~%22productpage-v1%22%2C%20source_workload_namespace%3D~%22default%22%7D)%20by%20(destination_service)%20or%20sum(istio_tcp_sent_bytes_total%7Breporter%3D%22source%22%2C%20source_workload%3D~%22productpage-v1%22%2C%20source_workload_namespace%3D~%22default%22%7D)%20by%20(destination_service)' \
+#   | jq -r '.data.result[].metric.destination_service' | sort
+# }
 
 _verify_same access_grafana_istio_mesh_dashboard "200"
-_verify_lines query_request_for_all_workloads "
-+ details-v1.default
-+ productpage-v1.default
-+ ratings-v1.default
-+ reviews-v1.default
-+ reviews-v2.default
-+ reviews-v3.default
-"
+# _verify_lines query_request_for_all_workloads "
+# + details-v1.default
+# + productpage-v1.default
+# + ratings-v1.default
+# + reviews-v1.default
+# + reviews-v2.default
+# + reviews-v3.default
+# "
 
 _verify_same access_grafana_istio_service_dashboard "200"
-_verify_same query_request_count_to_productpage "success"
+# _verify_same query_request_count_to_productpage "success"
 
 _verify_same access_grafana_istio_workload_dashboard "200"
-_verify_lines query_request_from_productpage_workload "
-+ details.default.svc.cluster.local
-+ reviews.default.svc.cluster.local
-"
+# _verify_lines query_request_from_productpage_workload "
+# + details.default.svc.cluster.local
+# + reviews.default.svc.cluster.local
+# "
 
 pgrep istioctl | xargs kill
 

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/test.sh
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/test.sh
@@ -42,11 +42,11 @@ snip_viewing_the_istio_dashboard_3 &
 # For verification, we only check if the dashboards are accessible, but not its actual contents
 # TODO: Is it worth checking API calls and output for Grafana case? 
 function access_grafana_istio_mesh_dashboard() {
-  curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/dashboard/db/istio-mesh-dashboard
+  curl -L -s -o /dev/null -w '%{http_code}' "http://localhost:3000/dashboard/db/istio-mesh-dashboard"
 }
 
 function access_grafana_istio_service_dashboard() {
-  curl -s -o /dev/null -w '%{http_code}'http://localhost:3000/dashboard/db/istio-service-dashboard
+  curl -L -s -o /dev/null -w '%{http_code}' "http://localhost:3000/dashboard/db/istio-service-dashboard"
 }
 
 _verify_same access_grafana_istio_mesh_dashboard "200"

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/test.sh
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/test.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC2154,SC2155,SC2034
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+set -o pipefail
+
+source "tests/util/helpers.sh"
+source "tests/util/samples.sh"
+source "tests/util/addons.sh"
+
+# @setup profile=default
+
+_deploy_and_wait_for_addons prometheus grafana
+_verify_like snip_viewing_the_istio_dashboard_1 "$snip_viewing_the_istio_dashboard_1_out"
+_verify_like snip_viewing_the_istio_dashboard_2 "$snip_viewing_the_istio_dashboard_2_out"
+
+# TODO: Deploying bookinfo and sending requests through ingress gateway
+# seems like a common pattern for many tests. Should be moved to tests/util. 
+kubectl label namespace default istio-injection=enabled --overwrite
+startup_bookinfo_sample
+_set_ingress_environment_variables
+GATEWAY_URL="$INGRESS_HOST:$INGRESS_PORT"
+bpsnip_trace_generation__1
+
+snip_viewing_the_istio_dashboard_3 &
+
+# For verification, we only check if the dashboards are accessible, but not its actual contents
+# TODO: Is it worth checking API calls and output for Grafana case? 
+function access_grafana_istio_mesh_dashboard() {
+  curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/dashboard/db/istio-mesh-dashboard
+}
+
+function access_grafana_istio_service_dashboard() {
+  curl -s -o /dev/null -w '%{http_code}'http://localhost:3000/dashboard/db/istio-service-dashboard
+}
+
+_verify_same access_grafana_istio_mesh_dashboard "200"
+_verify_same access_grafana_istio_service_dashboard "200"
+pgrep istioctl | xargs kill
+
+# @cleanup
+set +e
+
+# TODO: Fix issue of killing twice (https://github.com/istio/istio.io/issues/8014)
+pgrep istioctl | xargs kill
+cleanup_bookinfo_sample
+_undeploy_addons prometheus grafana

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/test.sh
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/test.sh
@@ -35,6 +35,7 @@ kubectl label namespace default istio-injection=enabled --overwrite
 startup_bookinfo_sample
 _set_ingress_environment_variables
 GATEWAY_URL="$INGRESS_HOST:$INGRESS_PORT"
+
 bpsnip_trace_generation__1
 
 snip_viewing_the_istio_dashboard_3 &
@@ -56,39 +57,39 @@ function access_grafana_istio_workload_dashboard() {
 # Grafana calls this behind the scenes. It sends a query to prometheus
 # The long and scary query is copied straight from requests page in browser
 # and some parameters are edited. Basically it is a URL-encoded prometheus query
-# function query_request_count_to_productpage() {
-#   curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=%20sum(istio_requests_total%7Breporter%3D%22destination%22%2C%20destination_service%3D~%22productpage.default.svc.cluster.local%22%2C%20source_workload_namespace%3D~%22istio-system%22%7D)%20by%20(source_workload)%20or%20sum(istio_tcp_sent_bytes_total%7Breporter%3D%22destination%22%2C%20destination_service%3D~%22productpage.default.svc.cluster.local%22%2C%20source_workload_namespace%3D~%22istio-system%22%7D)%20by%20(source_workload)' | jq -r '.status' 
-# }
+function query_request_count_to_productpage() {
+  curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=%20sum(istio_requests_total%7Breporter%3D%22destination%22%2C%20destination_service%3D~%22productpage.default.svc.cluster.local%22%2C%20source_workload_namespace%3D~%22istio-system%22%7D)%20by%20(source_workload)%20or%20sum(istio_tcp_sent_bytes_total%7Breporter%3D%22destination%22%2C%20destination_service%3D~%22productpage.default.svc.cluster.local%22%2C%20source_workload_namespace%3D~%22istio-system%22%7D)%20by%20(source_workload)' | jq -r '.status' 
+}
 
-# # This Prometheus query is from Mesh dashboard
-# function query_request_for_all_workloads() {
-#   curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=label_join(sum(rate(istio_requests_total%7Breporter%3D%22destination%22%2C%20response_code%3D%22200%22%7D%5B1m%5D))%20by%20(destination_workload%2C%20destination_workload_namespace%2C%20destination_service)%2C%20%22destination_workload_var%22%2C%20%22.%22%2C%20%22destination_workload%22%2C%20%22destination_workload_namespace%22)' \
-#   | jq -r '.data.result[].metric.destination_workload_var' | sort
-# }
+# This Prometheus query is from Mesh dashboard
+function query_request_for_all_workloads() {
+  curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=label_join(sum(rate(istio_requests_total%7Breporter%3D%22destination%22%2C%20response_code%3D%22200%22%7D%5B1m%5D))%20by%20(destination_workload%2C%20destination_workload_namespace%2C%20destination_service)%2C%20%22destination_workload_var%22%2C%20%22.%22%2C%20%22destination_workload%22%2C%20%22destination_workload_namespace%22)' \
+  | jq -r '.data.result[].metric.destination_workload_var' | sort
+}
 
-# function query_request_from_productpage_workload() {
-#   curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=%20sum(istio_requests_total%7Breporter%3D%22source%22%2C%20source_workload%3D~%22productpage-v1%22%2C%20source_workload_namespace%3D~%22default%22%7D)%20by%20(destination_service)%20or%20sum(istio_tcp_sent_bytes_total%7Breporter%3D%22source%22%2C%20source_workload%3D~%22productpage-v1%22%2C%20source_workload_namespace%3D~%22default%22%7D)%20by%20(destination_service)' \
-#   | jq -r '.data.result[].metric.destination_service' | sort
-# }
+function query_request_from_productpage_workload() {
+  curl -L -s 'http://localhost:3000/api/datasources/proxy/1/api/v1/query?query=%20sum(istio_requests_total%7Breporter%3D%22source%22%2C%20source_workload%3D~%22productpage-v1%22%2C%20source_workload_namespace%3D~%22default%22%7D)%20by%20(destination_service)%20or%20sum(istio_tcp_sent_bytes_total%7Breporter%3D%22source%22%2C%20source_workload%3D~%22productpage-v1%22%2C%20source_workload_namespace%3D~%22default%22%7D)%20by%20(destination_service)' \
+  | jq -r '.data.result[].metric.destination_service' | sort
+}
 
 _verify_same access_grafana_istio_mesh_dashboard "200"
-# _verify_lines query_request_for_all_workloads "
-# + details-v1.default
-# + productpage-v1.default
-# + ratings-v1.default
-# + reviews-v1.default
-# + reviews-v2.default
-# + reviews-v3.default
-# "
+_verify_lines query_request_for_all_workloads "
++ details-v1.default
++ productpage-v1.default
++ ratings-v1.default
++ reviews-v1.default
++ reviews-v2.default
++ reviews-v3.default
+"
 
 _verify_same access_grafana_istio_service_dashboard "200"
-# _verify_same query_request_count_to_productpage "success"
+_verify_same query_request_count_to_productpage "success"
 
 _verify_same access_grafana_istio_workload_dashboard "200"
-# _verify_lines query_request_from_productpage_workload "
-# + details.default.svc.cluster.local
-# + reviews.default.svc.cluster.local
-# "
+_verify_lines query_request_from_productpage_workload "
++ details.default.svc.cluster.local
++ reviews.default.svc.cluster.local
+"
 
 pgrep istioctl | xargs kill
 


### PR DESCRIPTION
Very similar to Zipkin - https://preliminary.istio.io/latest/docs/tasks/observability/distributed-tracing/jaeger/
Accessing Grafana dashboards (mesh and service) - https://preliminary.istio.io/latest/docs/tasks/observability/metrics/using-istio-dashboard/

**NOTE**: We cannot verify screenshots (but still possible to verify API calls and results. But not sure, if that needs to be done, or is covered in some integration test in istio.io/istio repo)

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
