### PR TITLE
Add note regarding current operator merge behaviour

### DIFF
--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -123,6 +123,12 @@ Now, with the controller running, you can change the Istio configuration by edit
 the `IstioOperator` resource. The controller will detect the change and respond by updating
 the Istio installation correspondingly.
 
+{{< warning >}}
+The current behavior of the Istio operator is to _merge_ configuration of some components rather than to _override_
+configuration. This applies to components that have immutable fields such as the Kubernetes `Service` object's
+`clusterIP` field. This can cause Istio components to display a mix of current configuration and previous configuration.
+{{< /warning >}}
+
 For example, you can switch the installation to the `default`
 profile with the following command:
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

Closes #8090.

Questions for reviewers:

* Does this need an example? The example that lead me to this was adding different affinity settings (required, then preferred) and both of them ending up in the gateway pod spec. However perhaps a simpler example would be better.
* Does this need info on when it will be fixed? It will be fixed when Istio no long supports K8s <1.16 (because then we can use server-side apply)
* Should this provide an alternative e.g. 'If this behaviour is incompatible with your desired Istio installation, consider using X installation method instead'?

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
