### PR TITLE
Fix typo for root-cert generation in VM Install Doc

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -86,7 +86,7 @@ Install Istio and expose the control plane so that your virtual machine can acce
 1. Get the root certificate:
 
     {{< text bash >}}
-    $ kubectl -n "${VM_NAMESPACE}" get configmaps istio-ca-root-cert -o json | jq -j '."data"."root-cert.pem"' > "${WORK_DIR}"/root-cert
+    $ kubectl -n "${VM_NAMESPACE}" get configmaps istio-ca-root-cert -o json | jq -j '."data"."root-cert.pem"' > "${WORK_DIR}"/root-cert.pem
     {{< /text >}}
 
 1. Generate a `cluster.env` configuration file that informs the virtual machine


### PR DESCRIPTION
This PR adds a missing file extension (`.pem`) in the command that generates the root certificate artifact in the VM installation documentation. The file extension didn't exist on the generation step, but is referenced in later steps which made the instruction invalid without modification. This should line things up and not require user deviation from the doc to complete the task.

[ ] Configuration Infrastructure
[X ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
