### PR TITLE
No need to pass additional -c for Istiod logs

### DIFF
--- a/content/en/about/bugs/index.md
+++ b/content/en/about/bugs/index.md
@@ -66,10 +66,10 @@ containing:
 
 * Current and previous logs from all Istio components and sidecar
 
-* Pilot logs:
+* Istiod logs:
 
     {{< text bash >}}
-    $ kubectl logs -n istio-system -l istio=pilot -c discovery
+    $ kubectl logs -n istio-system -l app=istiod
     {{< /text >}}
 
 * All Istio configuration artifacts:


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/27013.

As Istiod only have one container, we don't need to pass `-c discovery`.

Related: https://github.com/istio/istio.io/pull/8083