### PR TITLE
fix: update root cert file name, add the suffix

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -94,7 +94,7 @@ Install Istio with the installation setting `values.global.meshExpansion.enabled
 1. Get the root certificate:
 
     {{< text bash >}}
-    $ kubectl -n "${VM_NAMESPACE}" get configmaps istio-ca-root-cert -o json | jq -j '."data"."root-cert.pem"' > "${WORK_DIR}"/root-cert
+    $ kubectl -n "${VM_NAMESPACE}" get configmaps istio-ca-root-cert -o json | jq -j '."data"."root-cert.pem"' > "${WORK_DIR}"/root-cert.pem
     {{< /text >}}
 
 1. Generate a `cluster.env` configuration file that informs the virtual machine


### PR DESCRIPTION
In the latter part of this article, the commands executed in the virtual machine reference this file. The name of the file is root-cert.pem @SecurityInsanity 

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure