### PR TITLE
Change deprecated tracingSampling to (...).tracing.sampling

### DIFF
--- a/content/en/docs/tasks/observability/distributed-tracing/jaeger/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/jaeger/index.md
@@ -20,7 +20,7 @@ To learn how Istio handles tracing, visit this task's [overview](../overview/).
 
 1.  Follow the [Jaeger installation](/docs/ops/integrations/jaeger/#installation) documentation to deploy Jaeger into your cluster.
 
-1.  When you enable tracing, you can set the sampling rate that Istio uses for tracing. Use the `values.pilot.traceSampling` option during installation to set the sampling rate. The default sampling rate is 1%.
+1.  When you enable tracing, you can set the sampling rate that Istio uses for tracing. Use the [`values.meshConfig.defaultConfig.tracing.sampling`](/docs/tasks/observability/distributed-tracing/configurability/#customizing-trace-sampling) option during installation to set the sampling rate. The default sampling rate is 1%.
 
 1.  Deploy the [Bookinfo](/docs/examples/bookinfo/#deploying-the-application) sample application.
 


### PR DESCRIPTION
tracingSampling is deprecated, this reference confused me slightly. I've also added a link to the relevant documentation.



[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure