### PR TITLE
add ingress gateway annotation docs

### DIFF
--- a/content/en/docs/ops/common-problems/network-issues/index.md
+++ b/content/en/docs/ops/common-problems/network-issues/index.md
@@ -261,6 +261,8 @@ Then, simply bind both `VirtualServices` to it like this:
 - `VirtualService` configuration `vs1` with host `service1.test.com` and gateway `gw`
 - `VirtualService` configuration `vs2` with host `service2.test.com` and gateway `gw`
 
+When using `Kubernetes Ingress` with `Istio Ingress Controller`, `Istio Pilot` generates `gateway` per `ingress` automatically. When TLS is configured such problem might occur as well. In this case, it is possible to avoid this problem by configuring a single `gateway` manually, using the [istio-gateway annotation](/docs/tasks/traffic-management/ingress/kubernetes-ingress/).
+
 ## Port conflict when configuring multiple TLS hosts in a gateway
 
 If you apply a `Gateway` configuration that has the same `selector` labels as another

--- a/content/en/docs/ops/common-problems/network-issues/index.md
+++ b/content/en/docs/ops/common-problems/network-issues/index.md
@@ -261,7 +261,7 @@ Then, simply bind both `VirtualServices` to it like this:
 - `VirtualService` configuration `vs1` with host `service1.test.com` and gateway `gw`
 - `VirtualService` configuration `vs2` with host `service2.test.com` and gateway `gw`
 
-When using `Kubernetes Ingress` with `Istio Ingress Controller`, `Istio Pilot` generates `gateway` per `ingress` automatically. When TLS is configured such problem might occur as well. In this case, it is possible to avoid this problem by configuring a single `gateway` manually, using the [istio-gateway annotation](/docs/tasks/traffic-management/ingress/kubernetes-ingress/).
+When using `Kubernetes Ingress` with `Istio Ingress Controller`, `Istio Pilot` generates `gateway` per `ingress` automatically. When TLS is configured such problem might occur as well. In this case, it is possible to avoid this problem by configuring a single `gateway` manually, using the [istio-gateway annotation](/docs/tasks/traffic-management/ingress/kubernetes-ingress/#specifying-istio-gateway).
 
 ## Port conflict when configuring multiple TLS hosts in a gateway
 

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
@@ -70,6 +70,24 @@ Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
 
 ## Next Steps
 
+### Specify an existing Istio Gateway via annotation
+
+When using `Kubernetes Ingress` with `Istio Ingress Controller`, `Istio Pilot` generates a `gateway` per `ingress` automatically. To specify an existing gateway instead, you can use the `ingress.kubernetes.io/istio-gateway: {namespace}/{existing-gateway-name}` annotation.
+
+    {{< text bash >}}
+    $ kubectl apply -f - <<EOF
+    apiVersion: networking.k8s.io/v1beta1
+    kind: Ingress
+    metadata:
+      annotations:
+        kubernetes.io/ingress.class: istio
+        ingress.kubernetes.io/istio-gateway: "istio-system/my-existing-gateway"
+      name: ingress
+    spec:
+      ...
+    EOF
+    {{< /text >}}
+
 ### TLS
 
 `Ingress` supports [specifying TLS settings](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls). This is supported by Istio, but the referenced `Secret` must exist in the namespace of the `istio-ingressgateway` deployment (typically `istio-system`). [cert-manager](/docs/ops/integrations/certmanager/) can be used to generate these certificates.

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
@@ -72,7 +72,7 @@ Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
 
 ### Specifying Istio Gateway
 
-When using `Kubernetes Ingress` with `Istio Ingress Controller`, `Istio Pilot` generates a `gateway` per `ingress` automatically. To specify an existing gateway instead, you can use the `ingress.kubernetes.io/istio-gateway: {namespace}/{existing-gateway-name}` annotation.
+When using `Kubernetes Ingress` with `Istio Ingress Controller`, `Istio Pilot` will generate a `gateway` and `VirtualService` per `ingress` automatically. Sometimes we want to specify an existing gateway instead. To do so, you can use the `ingress.kubernetes.io/istio-gateway: {namespace}/{existing-gateway-name}` annotation. `VirtualService` will still be generated automatically, together with the pre-defined `gateway`.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
@@ -70,7 +70,7 @@ Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
 
 ## Next Steps
 
-### Specify an existing Istio Gateway via annotation
+### Specifying Istio Gateway
 
 When using `Kubernetes Ingress` with `Istio Ingress Controller`, `Istio Pilot` generates a `gateway` per `ingress` automatically. To specify an existing gateway instead, you can use the `ingress.kubernetes.io/istio-gateway: {namespace}/{existing-gateway-name}` annotation.
 

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
@@ -72,7 +72,7 @@ Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
 
 ### Specifying Istio Gateway
 
-When using `Kubernetes Ingress` with `Istio Ingress Controller`, `Istio Pilot` will generate a `gateway` and `VirtualService` per `ingress` automatically. Sometimes we want to specify an existing gateway instead. To do so, you can use the `ingress.kubernetes.io/istio-gateway: {namespace}/{existing-gateway-name}` annotation. `VirtualService` will still be generated automatically, together with the pre-defined `gateway`.
+When using `Kubernetes Ingress` with `Istio Ingress Controller`, `Istio Pilot` will generate a `gateway` and `VirtualService` per `ingress` automatically. Sometimes we want to specify an existing gateway instead. To do so, you can use the `ingress.kubernetes.io/istio-gateway: {namespace}/{existing-gateway-name}` annotation. `VirtualService` will still be generated automatically, and its `gateway` will be set accordingly as pre-defined.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF


### PR DESCRIPTION
This is the relevant docs of Kubernetes Ingress - Allow specifying an existing gateway via annotation. 
The changes introduced in https://github.com/istio/istio/pull/27326

[ ] Configuration Infrastructure
[ x ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
