### PR TITLE
Update TestRef for 1.6.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ replace github.com/spf13/viper => github.com/istio/viper v1.3.3-0.20190515210538
 
 replace github.com/docker/docker => github.com/docker/engine v1.4.2-0.20191011211953-adfac697dc5b
 
-require istio.io/istio v0.0.0-20200903024532-6b4199d7f133
+require istio.io/istio v0.0.0-20200916183711-d57a92bf78e6
 
 replace github.com/Azure/go-autorest/autorest => github.com/Azure/go-autorest/autorest v0.9.0
 

--- a/go.sum
+++ b/go.sum
@@ -1096,8 +1096,8 @@ istio.io/api v0.0.0-20200813195615-8ab1a23cc673/go.mod h1:kyq3g5w42zl/AKlbzDGppY
 istio.io/gogo-genproto v0.0.0-20190930162913-45029607206a/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
 istio.io/gogo-genproto v0.0.0-20200709220749-8607e17318e8 h1:41vUsZxxi7Kq9pyxmk7xjSKrYEYyXCQsTvP4mWOXzoI=
 istio.io/gogo-genproto v0.0.0-20200709220749-8607e17318e8/go.mod h1:OzpAts7jljZceG4Vqi5/zXy/pOg1b209T3jb7Nv5wIs=
-istio.io/istio v0.0.0-20200903024532-6b4199d7f133 h1:sdZ+GMzuu3rR9C29HaRdn2EhgLBiZ7u/yYY2za3gLkc=
-istio.io/istio v0.0.0-20200903024532-6b4199d7f133/go.mod h1:6qSy5DUl2S9RLEwpypDcbLPS481kbc6769OgnnCYxB0=
+istio.io/istio v0.0.0-20200916183711-d57a92bf78e6 h1:Uk2+QrzGcsOgU9YafEEu0hSZpZzDFNiZni3M3v5Zc+k=
+istio.io/istio v0.0.0-20200916183711-d57a92bf78e6/go.mod h1:6qSy5DUl2S9RLEwpypDcbLPS481kbc6769OgnnCYxB0=
 istio.io/pkg v0.0.0-20200709220414-14d5de656564 h1:iaOIWnzUh6T7O2ViQL9EDY6TtnPgDkNSohIcpJ92bHw=
 istio.io/pkg v0.0.0-20200709220414-14d5de656564/go.mod h1:pwGaxLUDLobzL/WvWV94z72LvBbB1dr2UUUyPuasfIU=
 k8s.io/api v0.0.0-20190918155943-95b840bb6a1f/go.mod h1:uWuOHnjmNrtQomJrvEBg0c0HRNyQ+8KTEERVsK0PW48=


### PR DESCRIPTION

As prep for the 1.6.10 release, update the test to run against the build.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure