### PR TITLE
egress-gateway-tls-origination - Additional secrets need cleaning

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -605,7 +605,7 @@ to hold the configuration of the NGINX server:
 
     {{< text bash >}}
     $ kubectl delete secret nginx-server-certs nginx-ca-certs -n mesh-external
-    $ kubectl delete secret istio-egressgateway-certs istio-egressgateway-ca-certs -n istio-system
+    $ kubectl delete secret istio-egressgateway-certs istio-egressgateway-ca-certs nginx-client-certs nginx-ca-certs -n istio-system
     $ kubectl delete configmap nginx-configmap -n mesh-external
     $ kubectl delete service my-nginx -n mesh-external
     $ kubectl delete deployment my-nginx -n mesh-external

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/snips.sh
@@ -472,7 +472,7 @@ kubectl logs -l istio=egressgateway -n istio-system | grep 'my-nginx.mesh-extern
 
 snip_cleanup_the_mutual_tls_origination_example_1() {
 kubectl delete secret nginx-server-certs nginx-ca-certs -n mesh-external
-kubectl delete secret istio-egressgateway-certs istio-egressgateway-ca-certs -n istio-system
+kubectl delete secret istio-egressgateway-certs istio-egressgateway-ca-certs nginx-client-certs nginx-ca-certs -n istio-system
 kubectl delete configmap nginx-configmap -n mesh-external
 kubectl delete service my-nginx -n mesh-external
 kubectl delete deployment my-nginx -n mesh-external


### PR DESCRIPTION

Trying to run the test twice in succession yielded two secrets that weren't getting cleanup up (failed because secret already existed).

Can now run the test multiple times with getting the message and failing.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure