### PR TITLE
Test flake - increase timeout and echo actual wait duration.

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-control/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/test.sh
@@ -62,7 +62,9 @@ _wait_for_deployment istio-system istiod
 # Restart the sleep service
 snip_cleanup_1
 snip_before_you_begin_1
-kubectl wait --for=delete "pod/$SOURCE_POD" --timeout=60s
+start=$(date +%s)
+kubectl wait --for=delete "pod/$SOURCE_POD" --timeout=180s
+echo "Wait for termination duration: $(($(date +%s)-start)) seconds"
 
 kubectl get po
 


### PR DESCRIPTION
This is an attempt to fix the problem noted here: https://github.com/istio/istio.io/pull/8180#issuecomment-697960306

For now, extend the timeout (the termination takes nearly 60s when running locally by the new duration being echoed) to something longer.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure