### PR TITLE
Test Flake - Fix flaky failure

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh
@@ -27,6 +27,7 @@ _wait_for_deployment istio-system istiod
 kubectl label namespace default istio-injection=enabled --overwrite
 
 snip_before_you_begin_2
+_wait_for_deployment default sleep
 snip_before_you_begin_4
 
 confirm_blocking() {


### PR DESCRIPTION

Failure: https://prow.istio.io/view/gs/istio-prow/logs/doc.test.profile_none_istio.io_postsubmit/37

```
        ✔ Installation completedeployment "istiod" successfully rolled out
600
        namespace/default labeled
601
        serviceaccount/sleep created
602
        service/sleep created
603
        deployment.apps/sleep created
604
        VERIFY FAILED confirm_blocking: received: "error: pod or type/name must be specified
605
        error: pod or type/name must be specified", expected: "command terminated with exit code 35"
```

There should be a delay to wait for the sleep deployment to finish before trying to retrieve the pods.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure