### PR TITLE
Increase retry count for test flakiness

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-ingress/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/test.sh
@@ -21,6 +21,9 @@ set -o pipefail
 
 # @setup profile=default
 
+# Set retries to a higher value because config update is slow.
+export VERIFY_RETRIES=10
+
 export CLIENT_IP
 
 snip_before_you_begin_1


### PR DESCRIPTION

https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio.io/8204/doc.test.profile_default_istio.io/143 had a test flake in TestDocs/tasks/security/authorization/authz-ingress/test.sh. Running locally, I only need two retries in this verify, but may need more in the CI pipeline (similar to the authz-jwt test).


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure