### PR TITLE
Add warning on egress gw instructions

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -289,12 +289,10 @@ You need to specify port 443 with protocol `TLS` in a corresponding `ServiceEntr
 1.  Create an egress `Gateway` for _edition.cnn.com_, a destination rule and a virtual service
     to direct the traffic through the egress gateway and from the egress gateway to the external service.
 
-    {{< warning >}}
-    When following these steps for additional hosts, do not create the `Gateway` and `DestinationRule` resources again.
-    Instead modify these two resources to work with multiple hosts. The `Gateway` resource accepts a list of hosts, or
-    use `'*'` to match all. The `subset` in the `DestinationRule` can be reused for additional hosts. Adding an additional
-    `DestinationRule` targetting the same Egress Gateway may result in undefined behavior.
-    {{< /warning >}}
+    {{< tip >}}
+    To direct multiple hosts through an egress gateway, you can include a list of hosts, or use `*` to match all, in the `Gateway`.
+    The `subset` field in the `DestinationRule` should be reused for the additional hosts.
+    {{< /tip >}}
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -136,7 +136,7 @@ First create a `ServiceEntry` to allow direct traffic to an external service.
     traffic directed to the egress gateway.
 
     {{< warning >}}
-    When following these steps for additional hosts, do not create these resources again. In stead modify the resources
+    When following these steps for additional hosts, do not create these resources again. Instead modify the resources
     to work with multiple hosts. The `Gateway` resource accepts a list of hosts, or use `'*'` to match all. The `subset`
     in the `DestinationRule` can be reused for additional hosts. Adding an additional `DestinationRule` targetting the
     same Egress Gateway may result in undefined behavior.
@@ -293,7 +293,7 @@ You need to specify port 443 with protocol `TLS` in a corresponding `ServiceEntr
 
     {{< warning >}}
     When following these steps for additional hosts, do not create the `Gateway` and `DestinationRule` resources again.
-    In stead modify these two resources to work with multiple hosts. The `Gateway` resource accepts a list of hosts, or
+    Instead modify these two resources to work with multiple hosts. The `Gateway` resource accepts a list of hosts, or
     use `'*'` to match all. The `subset` in the `DestinationRule` can be reused for additional hosts. Adding an additional
     `DestinationRule` targetting the same Egress Gateway may result in undefined behavior.
     {{< /warning >}}

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -135,6 +135,13 @@ First create a `ServiceEntry` to allow direct traffic to an external service.
 1.  Create an egress `Gateway` for _edition.cnn.com_, port 80, and a destination rule for
     traffic directed to the egress gateway.
 
+    {{< warning >}}
+    When following these steps for additional hosts, do not create these resources again. In stead modify the resources
+    to work with multiple hosts. The `Gateway` resource accepts a list of hosts, or use `'*'` to match all. The `subset`
+    in the `DestinationRule` can be reused for additional hosts. Adding an additional `DestinationRule` targetting the
+    same Egress Gateway may result in undefined behavior.
+    {{< /warning >}}
+
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1alpha3
@@ -283,6 +290,13 @@ You need to specify port 443 with protocol `TLS` in a corresponding `ServiceEntr
 
 1.  Create an egress `Gateway` for _edition.cnn.com_, a destination rule and a virtual service
     to direct the traffic through the egress gateway and from the egress gateway to the external service.
+
+    {{< warning >}}
+    When following these steps for additional hosts, do not create the `Gateway` and `DestinationRule` resources again.
+    In stead modify these two resources to work with multiple hosts. The `Gateway` resource accepts a list of hosts, or
+    use `'*'` to match all. The `subset` in the `DestinationRule` can be reused for additional hosts. Adding an additional
+    `DestinationRule` targetting the same Egress Gateway may result in undefined behavior.
+    {{< /warning >}}
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -135,12 +135,10 @@ First create a `ServiceEntry` to allow direct traffic to an external service.
 1.  Create an egress `Gateway` for _edition.cnn.com_, port 80, and a destination rule for
     traffic directed to the egress gateway.
 
-    {{< warning >}}
-    When following these steps for additional hosts, do not create these resources again. Instead modify the resources
-    to work with multiple hosts. The `Gateway` resource accepts a list of hosts, or use `'*'` to match all. The `subset`
-    in the `DestinationRule` can be reused for additional hosts. Adding an additional `DestinationRule` targetting the
-    same Egress Gateway may result in undefined behavior.
-    {{< /warning >}}
+    {{< tip >}}
+    To direct multiple hosts through an egress gateway, you can include a list of hosts, or use `*` to match all, in the `Gateway`.
+    The `subset` field in the `DestinationRule` should be reused for the additional hosts.
+    {{< /tip >}}
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF


### PR DESCRIPTION
Documentation is misleading when repeating the steps for multiple
hosts. The example breaks down. Add a warning describing how to
configuration should look like when additional hosts are configured.



[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure