### PR TITLE
Removal of the -it argument in the kubectl command for several example pages.

### DIFF
--- a/content/en/docs/examples/microservices-istio/add-new-microservice-version/index.md
+++ b/content/en/docs/examples/microservices-istio/add-new-microservice-version/index.md
@@ -44,14 +44,14 @@ tests, end-to-end tests and tests in a staging environment.
     1.  Send a request to the pod and see that it returns the correct result:
 
         {{< text bash >}}
-        $ kubectl exec -it $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -- curl $REVIEWS_V2_POD_IP:9080/reviews/7
+        $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -- curl "$REVIEWS_V2_POD_IP:9080/reviews/7"
         {"id": "7","reviews": [{  "reviewer": "Reviewer1",  "text": "An extremely entertaining play by Shakespeare. The slapstick humour is refreshing!", "rating": {"stars": 5, "color": "black"}},{  "reviewer": "Reviewer2",  "text": "Absolutely fun and entertaining. The play lacks thematic depth when compared to other plays by Shakespeare.", "rating": {"stars": 4, "color": "black"}}]}
         {{< /text >}}
 
     1.  Perform primitive load testing by sending a request 10 times in a row:
 
         {{< text bash >}}
-        $ kubectl exec -it $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -- sh -c "for i in 1 2 3 4 5 6 7 8 9 10; do curl -o /dev/null -s -w '%{http_code}\n' $REVIEWS_V2_POD_IP:9080/reviews/7; done"
+        $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -- sh -c "for i in 1 2 3 4 5 6 7 8 9 10; do curl -o /dev/null -s -w '%{http_code}\n' $REVIEWS_V2_POD_IP:9080/reviews/7; done"
         200
         200
         ...

--- a/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
+++ b/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
@@ -95,7 +95,7 @@ microservice.
     with a curl command from your testing pod:
 
     {{< text bash >}}
-    $ kubectl exec -it $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -c sleep -- curl productpage:9080/productpage | grep -o "<title>.*</title>"
+    $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -c sleep -- curl productpage:9080/productpage | grep -o "<title>.*</title>"
     <title>Simple Bookstore App</title>
     {{< /text >}}
 

--- a/content/en/docs/examples/microservices-istio/production-testing/index.md
+++ b/content/en/docs/examples/microservices-istio/production-testing/index.md
@@ -17,7 +17,7 @@ Test your microservice, in production!
 1.  Issue an HTTP request from the testing pod to one of your services:
 
     {{< text bash >}}
-    $ kubectl exec -it $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -- curl http://ratings:9080/ratings/7
+    $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -- curl http://ratings:9080/ratings/7
     {{< /text >}}
 
 ## Chaos testing
@@ -30,7 +30,7 @@ the pods' status with `kubectl get pods`.
 1.  Terminate the `details` service in one pod.
 
     {{< text bash >}}
-    $ kubectl exec -it $(kubectl get pods -l app=details -o jsonpath='{.items[0].metadata.name}') -- pkill ruby
+    $ kubectl exec $(kubectl get pods -l app=details -o jsonpath='{.items[0].metadata.name}') -- pkill ruby
     {{< /text >}}
 
 1.  Check the pods status:
@@ -58,7 +58,7 @@ the pods' status with `kubectl get pods`.
 1.  Terminate the `details` service in all its pods:
 
     {{< text bash >}}
-    $ for pod in $(kubectl get pods -l app=details -o jsonpath='{.items[*].metadata.name}'); do echo terminating $pod; kubectl exec -it $pod -- pkill ruby; done
+    $ for pod in $(kubectl get pods -l app=details -o jsonpath='{.items[*].metadata.name}'); do echo terminating "$pod"; kubectl exec "$pod" -- pkill ruby; done
     {{< /text >}}
 
 1.  Check the webpage of the application:


### PR DESCRIPTION
The documentation in the following pages contained a reference to `kubectl exec -it`:
* `docs/examples/microservices-istio/add-new-microservice-version`
* `docs/examples/microservices-istio/bookinfo-kubernetes`
* `docs/examples/microservices-istio/production-testing`

While this works for users that follow these examples, upcoming work that aims to create automated tests for these pages will not due to the `-it` arguments. As a result, this PR removes removes the `-it` from the `kubectl exec` command.

This PR addresses the following areas:
[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
