### PR TITLE
Add health check using TCP socket

### DIFF
--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -17,8 +17,9 @@ test: yes
 [Kubernetes liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
 describes several ways to configure liveness and readiness probes including:
 
-1. Command
-1. HTTP request
+1. [Command](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-command)
+1. [HTTP request](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request)
+1. [TCP Probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-tcp-liveness-probe)
 
 The command approach works with Istio regardless of whether or not mutual TLS is enabled.
 
@@ -86,6 +87,7 @@ to disable the probe rewrite option. Make sure you add the annotation to the
 anywhere else (for example, on an enclosing deployment resource).
 
 {{< text yaml >}}
+kubectl apply -f - <<EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -114,6 +116,7 @@ spec:
             port: 8001
           initialDelaySeconds: 5
           periodSeconds: 5
+EOF
 {{< /text >}}
 
 This approach allows you to disable the health check probe rewrite gradually on individual deployments,
@@ -126,6 +129,40 @@ to disable the probe rewrite globally. **Alternatively**, update the configurati
 
 {{< text bash >}}
 $ kubectl get cm istio-sidecar-injector -n istio-system -o yaml | sed -e 's/"rewriteAppHTTPProbe": true/"rewriteAppHTTPProbe": false/' | kubectl apply -f -
+{{< /text >}}
+
+## Liveness probes using the TCP socket
+
+A third type of liveness probe uses a TCP socket.
+
+{{< text yaml >}}
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: liveness-tcp
+spec:
+  selector:
+    matchLabels:
+      app: liveness-tcp
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: liveness-tcp
+        version: v1
+    spec:
+      containers:
+      - name: liveness-tcp
+        image: docker.io/istio/health:example
+        ports:
+        - containerPort: 8001
+        livenessProbe:
+          tcpSocket:
+            port: 8001
+          initialDelaySeconds: 5
+          periodSeconds: 5
+EOF
 {{< /text >}}
 
 ## Cleanup

--- a/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
@@ -51,6 +51,7 @@ liveness-6857c8775f-zdv9r        2/2       Running   0           4m
 ENDSNIP
 
 ! read -r -d '' snip_disable_the_http_probe_rewrite_for_a_pod_1 <<\ENDSNIP
+kubectl apply -f - <<EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -79,11 +80,42 @@ spec:
             port: 8001
           initialDelaySeconds: 5
           periodSeconds: 5
+EOF
 ENDSNIP
 
 snip_disable_the_probe_rewrite_globally_1() {
 kubectl get cm istio-sidecar-injector -n istio-system -o yaml | sed -e 's/"rewriteAppHTTPProbe": true/"rewriteAppHTTPProbe": false/' | kubectl apply -f -
 }
+
+! read -r -d '' snip_liveness_probes_using_the_tcp_socket_1 <<\ENDSNIP
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: liveness-tcp
+spec:
+  selector:
+    matchLabels:
+      app: liveness-tcp
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: liveness-tcp
+        version: v1
+    spec:
+      containers:
+      - name: liveness-tcp
+        image: docker.io/istio/health:example
+        ports:
+        - containerPort: 8001
+        livenessProbe:
+          tcpSocket:
+            port: 8001
+          initialDelaySeconds: 5
+          periodSeconds: 5
+EOF
+ENDSNIP
 
 snip_cleanup_1() {
 kubectl delete ns istio-io-health


### PR DESCRIPTION
To fix https://github.com/istio/istio.io/issues/8245


```
$ kubectl get pods
NAME                             READY   STATUS    RESTARTS   AGE
liveness-http-86c7cc8f45-s4h7m   1/1     Running   0          2m
liveness-tcp-59f6d56f7-69f7k     1/1     Running   0          2m3s
```
Using the HTTP probe
```
$ kubectl describe pod liveness-http-86c7cc8f45-s4h7m
...
Liveness:       http-get http://:8001/foo delay=5s timeout=1s period=5s #success=1 #failure=3
```

Using TCP probe
```
$ kubectl describe pod liveness-tcp-59f6d56f7-69f7k
...
Liveness:       tcp-socket :8001 delay=5s timeout=1s period=5s #success=1 #failure=3
```
