### PR TITLE
add pod securitycontext to k8s settings for operator api.

### DIFF
--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -467,6 +467,7 @@ which allows the following settings to be changed. Use this list to identify the
 1. [Toleration](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
 1. [Strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
 1. [Env](https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/)
+1. [Pod security context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
 
 All of these Kubernetes settings use the Kubernetes API definitions, so [Kubernetes documentation](https://kubernetes.io/docs/concepts/) can be used for reference.
 


### PR DESCRIPTION
pod securitycontext was added to k8s settings of operator api in https://github.com/istio/istio/pull/26456
this PR tries to sync latest k8s settings of operator api.


[ ] Configuration Infrastructure
[ X ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure