### PR TITLE
typo  istop/io -> istio.io

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -85,7 +85,7 @@ to understand how `X-Forwarded-For` headers and trusted client addresses are det
 
 #### Example using X-Forwarded-For capability with httpbin
 
-1. Specify `numTrustedProxies` as 2 either using `MeshConfig` or an `proxy.istop/io/config` annotation. If you are using `MeshConfig`, run the following command to create a file named `topology.yaml` and apply it to your cluster:
+1. Specify `numTrustedProxies` as 2 either using `MeshConfig` or an `proxy.istio.io/config` annotation. If you are using `MeshConfig`, run the following command to create a file named `topology.yaml` and apply it to your cluster:
 
     {{< text bash >}}
     $ cat <<EOF > topology.yaml


### PR DESCRIPTION
Small typo. istop/io -> istio.io


[ ] Configuration Infrastructure
[ X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure