### PR TITLE
Global trustDomain setting is deprecated in favour of meshConfig.trustDomain

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
@@ -22,7 +22,7 @@ In Istio 1.4, we introduce an alpha feature to support {{< gloss >}}trust domain
 1. Install Istio with a custom trust domain and mutual TLS enabled.
 
     {{< text bash >}}
-    $ istioctl install --set profile=demo --set values.global.trustDomain=old-td
+    $ istioctl install --set profile=demo --set meshConfig.trustDomain=old-td
     {{< /text >}}
 
 1. Deploy the [httpbin]({{< github_tree >}}/samples/httpbin) sample in the `default` namespace
@@ -86,7 +86,7 @@ Notice that it may take tens of seconds for the authorization policy to be propa
 1. Install Istio with a new trust domain.
 
     {{< text bash >}}
-    $ istioctl install --set profile=demo --set values.global.trustDomain=new-td
+    $ istioctl install --set profile=demo --set meshConfig.trustDomain=new-td
     {{< /text >}}
 
     Istio mesh is now running with a new trust domain, `new-td`.

--- a/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
@@ -83,7 +83,7 @@ Notice that it may take tens of seconds for the authorization policy to be propa
 
 ## Migrate trust domain without trust domain aliases
 
-1. Install Istio with a new trust domain and trust domain aliases.
+1. Install Istio with a new trust domain.
 
     {{< text bash >}}
     $ istioctl install --set profile=demo --set meshConfig.trustDomain=new-td
@@ -129,11 +129,10 @@ Notice that it may take tens of seconds for the authorization policy to be propa
     apiVersion: install.istio.io/v1alpha1
     kind: IstioOperator
     spec:
-      values:
-        global:
-          trustDomain: new-td
-          trustDomainAliases:
-            - old-td
+      meshConfig:
+        trustDomain: new-td
+        trustDomainAliases:
+          - old-td
     EOF
     $ istioctl install --set profile=demo -f td-installation.yaml -y
     {{< /text >}}

--- a/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
@@ -83,7 +83,7 @@ Notice that it may take tens of seconds for the authorization policy to be propa
 
 ## Migrate trust domain without trust domain aliases
 
-1. Install Istio with a new trust domain.
+1. Install Istio with a new trust domain and trust domain aliases.
 
     {{< text bash >}}
     $ istioctl install --set profile=demo --set meshConfig.trustDomain=new-td

--- a/content/en/docs/tasks/security/authorization/authz-td-migration/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/snips.sh
@@ -21,7 +21,7 @@
 ####################################################################################################
 
 snip_before_you_begin_1() {
-istioctl install --set profile=demo --set values.global.trustDomain=old-td
+istioctl install --set profile=demo --set meshConfig.trustDomain=old-td
 }
 
 snip_before_you_begin_2() {
@@ -74,7 +74,7 @@ kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items.
 ENDSNIP
 
 snip_migrate_trust_domain_without_trust_domain_aliases_1() {
-istioctl install --set profile=demo --set values.global.trustDomain=new-td
+istioctl install --set profile=demo --set meshConfig.trustDomain=new-td
 }
 
 snip_migrate_trust_domain_without_trust_domain_aliases_2() {

--- a/content/en/docs/tasks/security/authorization/authz-td-migration/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/snips.sh
@@ -106,11 +106,10 @@ cat <<EOF > ./td-installation.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
-  values:
-    global:
-      trustDomain: new-td
-      trustDomainAliases:
-        - old-td
+  meshConfig:
+    trustDomain: new-td
+    trustDomainAliases:
+      - old-td
 EOF
 istioctl install --set profile=demo -f td-installation.yaml -y
 }


### PR DESCRIPTION
Part of https://github.com/istio/istio/issues/27734

Related: https://github.com/istio/istio/pull/27806