### PR TITLE
zh_translation: fix a link error

### DIFF
--- a/content/zh/docs/concepts/traffic-management/index.md
+++ b/content/zh/docs/concepts/traffic-management/index.md
@@ -319,7 +319,7 @@ spec:
 -   为外部目标 redirect 和转发请求，例如来自 web 端的 API 调用，或者流向遗留老系统的服务。
 -   为外部目标定义[重试](#retries)、[超时](#timeouts)和[故障注入](#fault-injection)策略。
 -   添加一个运行在虚拟机的服务来[扩展您的网格](/zh/docs/examples/virtual-machines/single-network/#running-services-on-the-added-VM)。
--   从逻辑上添加来自不同集群的服务到网格，在 Kubernetes 上实现一个[多集群 Istio 网格](/zh/docs/setup/install/multicluster/gateways/#configure-the-example-services)。
+-   从逻辑上添加来自不同集群的服务到网格，在 Kubernetes 上实现一个[多集群 Istio 网格](/zh/docs/setup/install/multicluster)。
 
 您不需要为网格服务要使用的每个外部服务都添加服务入口。默认情况下，Istio 配置 Envoy 代理将请求传递给未知服务。但是，您不能使用 Istio 的特性来控制没有在网格中注册的目标流量。
 


### PR DESCRIPTION
[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

The English version of this docs has been updated [commits from PR #8180 ](https://github.com/istio/istio.io/pull/8180/commits/16dc93014be48cb88a658410d8941272a6cd9575#diff-e4e9e2ab753066efb664791ebc4e5014ba9fea0d88f0fbfd324a3f78cb5a3a02).
The PR corrected the link, so I update it in zh version.