### PR TITLE
Fix '/home/.gitconfig' error message when using build container

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -18,6 +18,4 @@ CONTAINER_OPTIONS = -p 1313:1313 ${ADDITIONAL_CONTAINER_OPTIONS}
 # this repo is on the container plan by default
 BUILD_WITH_CONTAINER ?= 1
 
-# The release branching scripts use git commands so mount the global .gitconfig into the container
-CONDITIONAL_HOST_MOUNTS = --mount type=bind,source=${HOME}/.gitconfig,destination=/config/.gitconfig,readonly \
-                          --mount type=bind,source=/tmp,destination=/tmp ${}
+CONDITIONAL_HOST_MOUNTS = --mount type=bind,source=/tmp,destination=/tmp ${}


### PR DESCRIPTION
Error message:
```
> make shell
cp: cannot create regular file '/home/.gitconfig': Read-only file system
build-tools:/work$ 

```

The mount point was added to common-files so remove from this repo.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure