### PR TITLE
prepare for release-1.8 as istio source is already branched

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -72,7 +72,7 @@ baseurl := "$(URL)"
 endif
 
 # Which branch of the Istio source code do we fetch stuff from
-SOURCE_BRANCH_NAME ?= master
+SOURCE_BRANCH_NAME ?= release-1.8
 
 site:
 	@scripts/gen_site.sh

--- a/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
+++ b/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
@@ -373,7 +373,7 @@ spec:
       istio: ingressgateway
   jwtRules:
   - issuer: "testing@secure.istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/jwks.json"
+    jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.8/security/tools/jwt/samples/jwks.json"
 EOF
 }
 
@@ -394,7 +394,7 @@ curl --header "Authorization: Bearer deadbeef" "$INGRESS_HOST:$INGRESS_PORT/head
 ENDSNIP
 
 snip_enduser_authentication_7() {
-TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt -s)
+TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/release-1.8/security/tools/jwt/samples/demo.jwt -s)
 curl --header "Authorization: Bearer $TOKEN" "$INGRESS_HOST:$INGRESS_PORT/headers" -s -o /dev/null -w "%{http_code}\n"
 }
 
@@ -403,11 +403,11 @@ curl --header "Authorization: Bearer $TOKEN" "$INGRESS_HOST:$INGRESS_PORT/header
 ENDSNIP
 
 snip_enduser_authentication_8() {
-wget --no-verbose https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/gen-jwt.py
+wget --no-verbose https://raw.githubusercontent.com/istio/istio/release-1.8/security/tools/jwt/samples/gen-jwt.py
 }
 
 snip_enduser_authentication_9() {
-wget --no-verbose https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/key.pem
+wget --no-verbose https://raw.githubusercontent.com/istio/istio/release-1.8/security/tools/jwt/samples/key.pem
 }
 
 snip_enduser_authentication_10() {

--- a/content/en/docs/tasks/security/authorization/authz-jwt/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-jwt/snips.sh
@@ -47,7 +47,7 @@ spec:
       app: httpbin
   jwtRules:
   - issuer: "testing@secure.istio.io"
-    jwksUri: "https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/jwks.json"
+    jwksUri: "https://raw.githubusercontent.com/istio/istio/release-1.8/security/tools/jwt/samples/jwks.json"
 EOF
 }
 
@@ -87,7 +87,7 @@ EOF
 }
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_5() {
-TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt -s) && echo "$TOKEN" | cut -d '.' -f2 - | base64 --decode -
+TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/release-1.8/security/tools/jwt/samples/demo.jwt -s) && echo "$TOKEN" | cut -d '.' -f2 - | base64 --decode -
 }
 
 ! read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_5_out <<\ENDSNIP
@@ -133,7 +133,7 @@ EOF
 }
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_9() {
-TOKEN_GROUP=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/groups-scope.jwt -s) && echo "$TOKEN_GROUP" | cut -d '.' -f2 - | base64 --decode -
+TOKEN_GROUP=$(curl https://raw.githubusercontent.com/istio/istio/release-1.8/security/tools/jwt/samples/groups-scope.jwt -s) && echo "$TOKEN_GROUP" | cut -d '.' -f2 - | base64 --decode -
 }
 
 ! read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_9_out <<\ENDSNIP

--- a/data/args.yml
+++ b/data/args.yml
@@ -25,7 +25,7 @@ archive_date: YYYY-MM-DD
 archive_search_refinement: "V1.1"
 
 # GitHub branch names used when the docs have links to GitHub
-source_branch_name: master
+source_branch_name: release-1.8
 doc_branch_name: master
 
 # The list of supported versions described by the docs


### PR DESCRIPTION
Ran the `make prepare-1.8.0`. I needed to comment out the git commands and then do them manually to create the commit ,push, and then create the PR. I might work on the script to get it working based on what I learned in automating the release-builder branching.