### PR TITLE
Add regex matching semantics documentation

### DIFF
--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -656,6 +656,9 @@ schemas:
    that a field must be present, use the `fieldname: ["*"]`format. This is
    different from leaving a field unspecified, which means match anything,
    including empty.
+- Regex match: `"regex:"` is used as special prefix. Anything after "regex:" is 
+   interpreted as regular expression. For example, `'regex:abc.com\/[0-9]?'`
+   matches `"abc.com/"`, `"abc.com/0"`, etc.
 
 There are a few exceptions. For example, the following fields only support exact
 match:
@@ -665,7 +668,7 @@ match:
 - The `ports` field under the `to` section
 
 The following example policy allows access at paths with the `/test/*` prefix
-or the `*/info` suffix.
+or the `*/info` suffix, or paths that match regex expression `abc.com\/[0-9]?`.
 
 {{< text yaml >}}
 apiVersion: security.istio.io/v1beta1
@@ -681,7 +684,7 @@ spec:
   rules:
   - to:
     - operation:
-        paths: ["/test/*", "*/info"]
+        paths: ["/test/*", "*/info", 'regex:abc.com\/[0-9]?']
 {{< /text >}}
 
 #### Exclusion matching


### PR DESCRIPTION
Add regex matching semantics documentation in Security Value Matching section. 
- code change https://github.com/istio/istio/pull/27984

istio.io website change:
- istio/istio.io    https://github.com/istio/istio.io/pull/8340
- istio/api          https://github.com/istio/api/pull/1707

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[X] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure