### PR TITLE
step 10 is duplicated with step 4

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -193,12 +193,6 @@ Run the following commands on the virtual machine you want to add to the Istio m
     $ sudo sh -c 'cat $(eval echo ~$SUDO_USER)/hosts-addendum >> /etc/hosts'
     {{< /text >}}
 
-1. Install the root certificate in the directory `/var/run/secrets/istio`
-
-    {{< text bash >}}
-    $ sudo cp "${HOME}"/root-cert.pem /var/run/secrets/istio/root-cert.pem
-    {{< /text >}}
-
 1. Transfer ownership of the files in `/etc/certs/` and `/var/lib/istio/envoy/` to the Istio proxy:
 
     {{< text bash >}}


### PR DESCRIPTION
In the document, the operation of step 4 is the same with step 10:

```
4. Install the root certificate at /var/run/secrets/istio:

$ sudo mkdir -p /var/run/secrets/istio
$ sudo cp "${HOME}"/root-cert.pem /var/run/secrets/istio/root-cert.pem

10. Install the root certificate in the directory /var/run/secrets/istio

$ sudo cp "${HOME}"/root-cert.pem /var/run/secrets/istio/root-cert.pem
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
