### PR TITLE
Add wait for gateway to multicluster tests

### DIFF
--- a/content/en/docs/setup/install/multicluster/_index.md
+++ b/content/en/docs/setup/install/multicluster/_index.md
@@ -27,3 +27,11 @@ This guide covers some of the most common concerns when creating a
 - [Control plane topologies](/docs/ops/deployment/deployment-models#control-plane-models):
   multiple {{< gloss "primary cluster" >}}primary clusters{{< /gloss >}},
   a primary and {{< gloss >}}remote cluster{{< /gloss >}}
+
+{{< tip >}}
+For meshes that span more than two clusters, you can extend the steps in this
+guide to configure more complex topologies.
+
+See [deployment models](/docs/ops/deployment/deployment-models) for more
+information.
+{{< /tip >}}

--- a/content/en/docs/setup/install/multicluster/before-you-begin/index.md
+++ b/content/en/docs/setup/install/multicluster/before-you-begin/index.md
@@ -27,7 +27,7 @@ mesh. Many cloud providers make API Servers publicly accessible via network
 load balancers (NLB). If the API Server is not directly accessible, you will
 have to modify the installation procedure to enable access. For example, the
 [east-west](https://en.wikipedia.org/wiki/East-west_traffic) gateway used in
-the multi-network and primary-remote configurations below could also be used
+the multi-network and primary-remote configurations could also be used
 to enable access to the API Server.
 
 ## Environment Variables
@@ -79,6 +79,14 @@ control plane topology.
 
 Choose the installation that best fits your needs:
 
+- [Install Multi-Primary](/docs/setup/install/multicluster/multi-primary)
+
+- [Install Primary-Remote](/docs/setup/install/multicluster/primary-remote)
+
+- [Install Multi-Primary on Different Networks](/docs/setup/install/multicluster/multi-primary_multi-network)
+
+- [Install Primary-Remote on Different Networks](/docs/setup/install/multicluster/primary-remote_multi-network)
+
 {{< tip >}}
 For meshes that span more than two clusters, you may need to use more than
 one of these options. For example, you may have a primary cluster per region
@@ -88,11 +96,3 @@ control plane in the regional primary (i.e. primary-remote).
 See [deployment models](/docs/ops/deployment/deployment-models) for more
 information.
 {{< /tip >}}
-
-- [Install Multi-Primary](/docs/setup/install/multicluster/multi-primary)
-
-- [Install Primary-Remote](/docs/setup/install/multicluster/primary-remote)
-
-- [Install Multi-Primary on Different Networks](/docs/setup/install/multicluster/multi-primary_multi-network)
-
-- [Install Primary-Remote on Different Networks](/docs/setup/install/multicluster/primary-remote_multi-network)

--- a/content/en/docs/setup/install/multicluster/common.sh
+++ b/content/en/docs/setup/install/multicluster/common.sh
@@ -120,7 +120,7 @@ function verify_load_balancing
   _wait_for_deployment sample sleep "${CTX_CLUSTER2}"
 
   # Verify everything is deployed as expected.
-  VERIFY_RETRIES=0 # Don't retry.
+  VERIFY_TIMEOUT=0 # Don't retry.
   echo "Verifying helloworld v1 deployment"
   _verify_like snip_deploy_helloworld_v1_2 "$snip_deploy_helloworld_v1_2_out"
   echo "Verifying helloworld v2 deployment"
@@ -129,7 +129,7 @@ function verify_load_balancing
   _verify_like snip_deploy_sleep_2 "$snip_deploy_sleep_2_out"
   echo "Verifying sleep deployment in ${CTX_CLUSTER2}"
   _verify_like snip_deploy_sleep_3 "$snip_deploy_sleep_3_out"
-  unset VERIFY_RETRIES # Restore default
+  unset VERIFY_TIMEOUT # Restore default
 
   local EXPECTED_RESPONSE_FROM_CLUSTER1="Hello version: v1, instance:"
   local EXPECTED_RESPONSE_FROM_CLUSTER2="Hello version: v2, instance:"

--- a/content/en/docs/setup/install/multicluster/multi-primary/test.sh
+++ b/content/en/docs/setup/install/multicluster/multi-primary/test.sh
@@ -61,5 +61,5 @@ set_single_network_vars
 time cleanup
 
 # Everything should be removed once cleanup completes. Use a small
-# number of retries for comparing cluster snapshots before/after the test.
-export VERIFY_RETRIES=1
+# timeout for comparing cluster snapshots before/after the test.
+export VERIFY_TIMEOUT=20

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -68,6 +68,14 @@ $ MESH=mesh1 CLUSTER=cluster1 NETWORK=network1 \
     kubectl apply --context="${CTX_CLUSTER1}" -f -
 {{< /text >}}
 
+Wait for the east-west gateway to be assigned an external IP address:
+
+{{< text bash >}}
+$ kubectl --context="${CTX_CLUSTER1}" get svc istio-eastwestgateway -n istio-system
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.80.6.124   34.75.71.237   ...       51s
+{{< /text >}}
+
 ## Expose services in `cluster1`
 
 Since the clusters are on separate networks, we need to expose all services
@@ -115,6 +123,14 @@ $ MESH=mesh1 CLUSTER=cluster2 NETWORK=network2 \
     @samples/multicluster/gen-eastwest-gateway.sh@ | \
     istioctl manifest generate -f - | \
     kubectl apply --context="${CTX_CLUSTER2}" -f -
+{{< /text >}}
+
+Wait for the east-west gateway to be assigned an external IP address:
+
+{{< text bash >}}
+$ kubectl --context="${CTX_CLUSTER2}" get svc istio-eastwestgateway -n istio-system
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.0.12.121   34.122.91.98   ...       51s
 {{< /text >}}
 
 ## Expose services in `cluster2`

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/snips.sh
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/snips.sh
@@ -45,6 +45,15 @@ MESH=mesh1 CLUSTER=cluster1 NETWORK=network1 \
     kubectl apply --context="${CTX_CLUSTER1}" -f -
 }
 
+snip_install_the_eastwest_gateway_in_cluster1_2() {
+kubectl --context="${CTX_CLUSTER1}" get svc istio-eastwestgateway -n istio-system
+}
+
+! read -r -d '' snip_install_the_eastwest_gateway_in_cluster1_2_out <<\ENDSNIP
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.80.6.124   34.75.71.237   ...       51s
+ENDSNIP
+
 snip_expose_services_in_cluster1_1() {
 kubectl --context="${CTX_CLUSTER1}" apply -n istio-system -f \
     samples/multicluster/expose-services.yaml
@@ -74,6 +83,15 @@ MESH=mesh1 CLUSTER=cluster2 NETWORK=network2 \
     istioctl manifest generate -f - | \
     kubectl apply --context="${CTX_CLUSTER2}" -f -
 }
+
+snip_install_the_eastwest_gateway_in_cluster2_2() {
+kubectl --context="${CTX_CLUSTER2}" get svc istio-eastwestgateway -n istio-system
+}
+
+! read -r -d '' snip_install_the_eastwest_gateway_in_cluster2_2_out <<\ENDSNIP
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.0.12.121   34.122.91.98   ...       51s
+ENDSNIP
 
 snip_expose_services_in_cluster2_1() {
 kubectl --context="${CTX_CLUSTER2}" apply -n istio-system -f \

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/test.sh
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/test.sh
@@ -34,7 +34,7 @@ function install_istio_on_cluster1 {
     snip_install_the_eastwest_gateway_in_cluster1_1
 
     echo "Waiting for the east-west gateway to have an external IP"
-    _wait_for_gateway_ip istio-system istio-eastwestgateway "${CTX_CLUSTER1}"
+    _verify_like snip_install_the_eastwest_gateway_in_cluster1_2 "$snip_install_the_eastwest_gateway_in_cluster1_2_out"
 
     echo "Exposing services via the east-west gateway"
     snip_expose_services_in_cluster1_1
@@ -50,7 +50,7 @@ function install_istio_on_cluster2 {
     snip_install_the_eastwest_gateway_in_cluster2_1
 
     echo "Waiting for the east-west gateway to have an external IP"
-    _wait_for_gateway_ip istio-system istio-eastwestgateway "${CTX_CLUSTER2}"
+    _verify_like snip_install_the_eastwest_gateway_in_cluster2_2 "$snip_install_the_eastwest_gateway_in_cluster2_2_out"
 
     echo "Exposing services via the east-west gateway"
     snip_expose_services_in_cluster2_1
@@ -81,5 +81,5 @@ set_multi_network_vars
 time cleanup
 
 # Everything should be removed once cleanup completes. Use a small
-# number of retries for comparing cluster snapshots before/after the test.
-export VERIFY_RETRIES=1
+# timeout for comparing cluster snapshots before/after the test.
+export VERIFY_TIMEOUT=20

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -81,6 +81,14 @@ $ MESH=mesh1 CLUSTER=cluster1 NETWORK=network1 \
     kubectl apply --context="${CTX_CLUSTER1}" -f -
 {{< /text >}}
 
+Wait for the east-west gateway to be assigned an external IP address:
+
+{{< text bash >}}
+$ kubectl --context="${CTX_CLUSTER1}" get svc istio-eastwestgateway -n istio-system
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.80.6.124   34.75.71.237   ...       51s
+{{< /text >}}
+
 ## Expose the control plane in `cluster1`
 
 Before we can install on `cluster2`, we need to first expose the control plane in

--- a/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
@@ -45,6 +45,15 @@ MESH=mesh1 CLUSTER=cluster1 NETWORK=network1 \
     kubectl apply --context="${CTX_CLUSTER1}" -f -
 }
 
+snip_install_the_eastwest_gateway_in_cluster1_2() {
+kubectl --context="${CTX_CLUSTER1}" get svc istio-eastwestgateway -n istio-system
+}
+
+! read -r -d '' snip_install_the_eastwest_gateway_in_cluster1_2_out <<\ENDSNIP
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.80.6.124   34.75.71.237   ...       51s
+ENDSNIP
+
 snip_expose_the_control_plane_in_cluster1_1() {
 kubectl apply --context="${CTX_CLUSTER1}" -f \
     samples/multicluster/expose-istiod.yaml

--- a/content/en/docs/setup/install/multicluster/primary-remote/test.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote/test.sh
@@ -33,7 +33,8 @@ function install_istio_on_cluster1 {
     snip_install_the_eastwest_gateway_in_cluster1_1
 
     echo "Waiting for the east-west gateway to have an external IP"
-    _wait_for_gateway_ip istio-system istio-eastwestgateway "${CTX_CLUSTER1}"
+    _verify_like snip_install_the_eastwest_gateway_in_cluster1_2 "$snip_install_the_eastwest_gateway_in_cluster1_2_out"
+    snip_install_the_eastwest_gateway_in_cluster1_2
 
     echo "Exposing istiod via the east-west gateway"
     snip_expose_the_control_plane_in_cluster1_1
@@ -63,5 +64,5 @@ set_single_network_vars
 time cleanup
 
 # Everything should be removed once cleanup completes. Use a small
-# number of retries for comparing cluster snapshots before/after the test.
-export VERIFY_RETRIES=1
+# timeout for comparing cluster snapshots before/after the test.
+export VERIFY_TIMEOUT=20

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -82,6 +82,14 @@ $ MESH=mesh1 CLUSTER=cluster1 NETWORK=network1 \
     kubectl apply --context="${CTX_CLUSTER1}" -f -
 {{< /text >}}
 
+Wait for the east-west gateway to be assigned an external IP address:
+
+{{< text bash >}}
+$ kubectl --context="${CTX_CLUSTER1}" get svc istio-eastwestgateway -n istio-system
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.80.6.124   34.75.71.237   ...       51s
+{{< /text >}}
+
 ## Expose the control plane in `cluster1`
 
 Before we can install on `cluster2`, we need to first expose the control plane in
@@ -172,6 +180,14 @@ $ MESH=mesh1 CLUSTER=cluster2 NETWORK=network2 \
     @samples/multicluster/gen-eastwest-gateway.sh@ | \
     istioctl manifest generate -f - | \
     kubectl apply --context="${CTX_CLUSTER2}" -f -
+{{< /text >}}
+
+Wait for the east-west gateway to be assigned an external IP address:
+
+{{< text bash >}}
+$ kubectl --context="${CTX_CLUSTER2}" get svc istio-eastwestgateway -n istio-system
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.0.12.121   34.122.91.98   ...       51s
 {{< /text >}}
 
 ## Expose services in `cluster2`

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
@@ -45,6 +45,15 @@ MESH=mesh1 CLUSTER=cluster1 NETWORK=network1 \
     kubectl apply --context="${CTX_CLUSTER1}" -f -
 }
 
+snip_install_the_eastwest_gateway_in_cluster1_2() {
+kubectl --context="${CTX_CLUSTER1}" get svc istio-eastwestgateway -n istio-system
+}
+
+! read -r -d '' snip_install_the_eastwest_gateway_in_cluster1_2_out <<\ENDSNIP
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.80.6.124   34.75.71.237   ...       51s
+ENDSNIP
+
 snip_expose_the_control_plane_in_cluster1_1() {
 kubectl apply --context="${CTX_CLUSTER1}" -f \
     samples/multicluster/expose-istiod.yaml
@@ -95,6 +104,15 @@ MESH=mesh1 CLUSTER=cluster2 NETWORK=network2 \
     istioctl manifest generate -f - | \
     kubectl apply --context="${CTX_CLUSTER2}" -f -
 }
+
+snip_install_the_eastwest_gateway_in_cluster2_2() {
+kubectl --context="${CTX_CLUSTER2}" get svc istio-eastwestgateway -n istio-system
+}
+
+! read -r -d '' snip_install_the_eastwest_gateway_in_cluster2_2_out <<\ENDSNIP
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.0.12.121   34.122.91.98   ...       51s
+ENDSNIP
 
 snip_expose_services_in_cluster2_1() {
 kubectl --context="${CTX_CLUSTER2}" apply -n istio-system -f \

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/test.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/test.sh
@@ -33,7 +33,7 @@ function install_istio_on_cluster1 {
     snip_install_the_eastwest_gateway_in_cluster1_1
 
     echo "Waiting for the east-west gateway to have an external IP"
-    _wait_for_gateway_ip istio-system istio-eastwestgateway "${CTX_CLUSTER1}"
+    _verify_like snip_install_the_eastwest_gateway_in_cluster1_2 "$snip_install_the_eastwest_gateway_in_cluster1_2_out"
 
     echo "Exposing istiod via the east-west gateway"
     snip_expose_the_control_plane_in_cluster1_1
@@ -56,7 +56,7 @@ function install_istio_on_cluster2 {
     snip_install_the_eastwest_gateway_in_cluster2_1
 
     echo "Waiting for the east-west gateway to have an external IP"
-    _wait_for_gateway_ip istio-system istio-eastwestgateway "${CTX_CLUSTER2}"
+    _verify_like snip_install_the_eastwest_gateway_in_cluster2_2 "$snip_install_the_eastwest_gateway_in_cluster2_2_out"
 
     echo "Exposing services via the east-west gateway"
     snip_expose_services_in_cluster2_1
@@ -75,5 +75,5 @@ set_multi_network_vars
 time cleanup
 
 # Everything should be removed once cleanup completes. Use a small
-# number of retries for comparing cluster snapshots before/after the test.
-export VERIFY_RETRIES=1
+# timeout for comparing cluster snapshots before/after the test.
+export VERIFY_TIMEOUT=20

--- a/content/en/docs/tasks/security/authorization/authz-deny/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-deny/test.sh
@@ -23,7 +23,7 @@ set -o pipefail
 
 # Set retries to a higher value for some flakiness.
 # TODO: remove this when istioctl wait calls are added
-export VERIFY_RETRIES=10
+export VERIFY_TIMEOUT=300
 
 snip_before_you_begin_1
 

--- a/content/en/docs/tasks/security/authorization/authz-ingress/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/test.sh
@@ -22,7 +22,7 @@ set -o pipefail
 # @setup profile=default
 
 # Set retries to a higher value because config update is slow.
-export VERIFY_RETRIES=10
+export VERIFY_TIMEOUT=300
 
 export CLIENT_IP
 

--- a/content/en/docs/tasks/security/authorization/authz-jwt/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-jwt/test.sh
@@ -22,7 +22,7 @@ set -o pipefail
 # @setup profile=default
 
 # Set retries to a higher value because config update is slow.
-export VERIFY_RETRIES=10
+export VERIFY_TIMEOUT=300
 
 snip_before_you_begin_1
 

--- a/content/en/docs/tasks/security/authorization/authz-td-migration/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/test.sh
@@ -21,7 +21,7 @@ set -e
 set -u
 set -o pipefail
 
-#export VERIFY_RETRIES=10
+#export VERIFY_TIMEOUT=300
 
 echo y | snip_before_you_begin_1
 

--- a/content/en/docs/tasks/security/cert-management/dns-cert/test.sh
+++ b/content/en/docs/tasks/security/cert-management/dns-cert/test.sh
@@ -23,7 +23,7 @@ set -o pipefail
 
 # @setup profile=none
 
-export VERIFY_RETRIES=10
+export VERIFY_TIMEOUT=300
 
 echo y | snip_before_you_begin_1
 _wait_for_deployment istio-system istiod

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1090,SC2154
+# shellcheck disable=SC1090,SC2034,SC2154
 
 # Copyright Istio Authors
 #
@@ -29,7 +29,9 @@ kubectl label namespace default istio-injection=enabled --overwrite
 startup_httpbin_sample
 
 # check for external load balancer
+CMP_MATCH_IP_PENDING=true # TODO(https://github.com/istio/istio.io/issues/8353)
 _verify_like snip_determining_the_ingress_ip_and_ports_1 "$snip_determining_the_ingress_ip_and_ports_1_out"
+unset CMP_MATCH_IP_PENDING
 
 # set INGRESS_HOST, INGRESS_PORT, SECURE_INGRESS_PORT, and TCP_INGRESS_PORT environment variables
 if [[ "$out" != *"<none>"* && "$out" != *"<pending>"* ]]; then

--- a/tests/README.md
+++ b/tests/README.md
@@ -182,36 +182,42 @@ expected output. The framework includes the following built-in verify functions:
 1. **`_verify_same`** `func` `expected`
 
    Runs `func` and compares the output with `expected`. If they are not the same,
-   exponentially back off and try again, 7 times by default. The number of retries
-   can be changed by setting the `VERIFY_RETRIES` environment variable.
+   wait a second and try again, up to two minutes by default. The retry behavior
+   can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+   variables.
 
 1. **`_verify_contains`** `func` `expected`
 
    Runs `func` and compares the output with `expected`. If the output does not
-   contain the substring `expected`, exponentially back off and try again, 7 times
-   by default. The number of retries can be changed by setting the `VERIFY_RETRIES`
-   environment variable.
+   contain the substring `expected`,
+   wait a second and try again, up to two minutes by default. The retry behavior
+   can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+   variables.
 
 1. **`_verify_not_contains`** `func` `expected`
 
    Runs `func` and compares the output with `expected`. If the command execution fails
    or the output contains the substring `expected`,
-   exponentially back off and try again, 7 times by default. The number of retries
-   can be changed by setting the `VERIFY_RETRIES` environment variable.
+   wait a second and try again, up to two minutes by default. The retry behavior
+   can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+   variables.
 
 1. **`_verify_elided`** `func` `expected`
 
    Runs `func` and compares the output with `expected`. If the output does not
    contain the lines in `expected` where "..." on a line matches one or more lines
-   containing any text, exponentially back off and try again, 7 times by default.
-   The number of retries can be changed by setting the `VERIFY_RETRIES` environment
-   variable.
+   containing any text,
+   wait a second and try again, up to two minutes by default. The retry behavior
+   can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+   variables.
 
 1. **`_verify_like`** `func` `expected`
 
    Runs `func` and compares the output with `expected`. If the output is not
-   "like" `expected`, exponentially back off and try again, 7 times by default. The number
-   of retries can be changed by setting the `VERIFY_RETRIES` environment variable.
+   "like" `expected`,
+   wait a second and try again, up to two minutes by default. The retry behavior
+   can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+   variables.
    Like implies:
 
    - Same number of lines
@@ -219,7 +225,10 @@ expected output. The framework includes the following built-in verify functions:
    - Tokens can only differ in the following ways:
 
      1. different elapsed time values (e.g., `30s` is like `5m`)
-     1. different ip values (e.g., `172.21.0.1` is like `10.0.0.31`)
+     1. different ip values (e.g., `172.21.0.1` is like `10.0.0.31`). Disallows
+         `<none>` and `<pending>` by default. This can be customized by setting
+         the `ALLOW_NONE_IP` and `ALLOW_PENDING_IP` environment variables,
+         respectively.
      1. prefix match ending with a dash character (e.g., `reviews-v1-12345...` is like `reviews-v1-67890...`)
      1. expected `...` is a wildcard token, matches anything
 
@@ -230,8 +239,9 @@ expected output. The framework includes the following built-in verify functions:
 
    Runs `func` and compares the output with `expected`. If the output does not
    "conform to" the specification in `expected`,
-   exponentially back off and try again, 7 times by default. The number of retries
-   can be changed by setting the `VERIFY_RETRIES` environment variable.
+   wait a second and try again, up to two minutes by default. The retry behavior
+   can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+   variables.
    Conformance implies:
 
    1. For each line in `expected` with the prefix "+ " there must be at least one

--- a/tests/util/helpers.sh
+++ b/tests/util/helpers.sh
@@ -81,39 +81,6 @@ _wait_for_deployment() {
     fi
 }
 
-# Wait for the given gateway to be allocated an external IP.
-# usage: _wait_for_gateway_ip <namespace> <service name> <optional: context>
-_wait_for_gateway_ip() {
-    local namespace="$1"
-    local service="$2"
-    local context="${3:-}"
-
-    local max_time=${MAX_SECONDS:-300} # Default to 5 min.
-    local delay=5
-
-    local start_time=$(date +%s)
-    local current_time=$start_time
-    local end_time=$((start_time + max_time))
-
-    while true; do
-        local ip=$(kubectl --context="${context}" get svc "${service}" -n "${namespace}" -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-
-        # Verify that the IP is set.
-        if [[ -n "${ip}" ]]; then
-            echo "IP Assigned for $service.$namespace: ${ip}"
-            return
-        fi
-
-        current_time=$(date +%s)
-        if (( current_time > end_time )); then
-            echo "Failed waiting for $service.$namespace: ${ip}"
-            exit 1
-        fi
-
-        sleep "${delay}"
-    done
-}
-
 # Wait for Istio config to propagate
 # usage: _wait_for_istio <kind> <namespace> <name>
 _wait_for_istio() {

--- a/tests/util/verify.sh
+++ b/tests/util/verify.sh
@@ -108,7 +108,10 @@ __cmp_first_line() {
 #   2. Same number of whitespace-seperated tokens per line
 #   3. Tokens can only differ in the following ways:
 #        - different elapsed time values
-#        - different ip values
+#        - different ip values. Disallows <none> and <pending> by
+#          default. This can be customized by setting the
+#          CMP_MATCH_IP_NONE and CMP_MATCH_IP_PENDING environment
+#          variables, respectively.
 #        - prefix match ending with a dash character
 #        - expected ... is a wildcard token, matches anything
 # Otherwise, returns 1.
@@ -163,8 +166,22 @@ __cmp_like() {
                     continue
                 fi
 
-                if [[ ("$otok" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ || "$otok" == "<none>" || "$otok" == "<pending>") && "$etok" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                    continue
+                if [[ "$etok" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    # We're expecting an IP address...
+                    if [[ "$otok" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                      # We got an IP address. It's a match.
+                      continue
+                    fi
+
+                    if [[ "$otok" == "<pending>" && "${CMP_MATCH_IP_PENDING:-false}" == "true" ]]; then
+                      # We're configured to allow <pending>. Consider this a match.
+                      continue
+                    fi
+
+                    if [[ "$otok" == "<none>" && "${CMP_MATCH_IP_NONE:-false}" == "true" ]]; then
+                      # We're configured to allow <none>. Consider this a match.
+                      continue
+                    fi
                 fi
 
                 local comm=""
@@ -213,16 +230,23 @@ __cmp_lines() {
 }
 
 # Verify the output of $func is the same as $expected.  If they are not the same,
-# exponentially back off and try again, 7 times (~2m total) by default. The number
-# of retries can be changed by setting the VERIFY_RETRIES environment variable.
+# retry every second, up to 2 minutes by default. The delay between retries as
+# well as the timeout can be configured by setting the VERIFY_DELAY and
+# VERIFY_TIMEOUT environment variables, respectively.
 __verify_with_retry() {
     local cmp_func=$1
     local func=$2
     local expected=$3
     local failonerr=${4:-}
 
-    local max_attempts=${VERIFY_RETRIES:-7}
-    local attempt=1
+    local max_time=${VERIFY_TIMEOUT:-120} # Default to 2 min.
+    local delay=${VERIFY_DELAY:-1} # Default time between retries.
+
+    local start_time
+    start_time=$(date +%s)
+    local end_time
+    end_time=$((start_time + max_time))
+    local current_time=$start_time
 
     # Most tests include "set -e", which causes the script to exit if a
     # statement returns a non-true return value.  In some cases, $func may
@@ -251,14 +275,14 @@ __verify_with_retry() {
             fi
         fi
 
-        if (( attempt >= max_attempts )); then
+        current_time=$(date +%s)
+        if (( current_time > end_time )); then
             # Restore the "errexit" state.
             eval "$errexit_state"
-            __err_exit "$func" "$out" "$expected"
+            __err_exit "$func (timeout after ${max_time}s)" "$out" "$expected"
         fi
 
-        sleep $(( 2 ** attempt ))
-        attempt=$(( attempt + 1 ))
+        sleep "${delay}"
     done
 }
 
@@ -313,7 +337,7 @@ __create_cluster_snapshots() {
 }
 
 __cluster_cleanup_check() {
-    VERIFY_RETRIES=${VERIFY_RETRIES:-9}
+    VERIFY_TIMEOUT=${VERIFY_TIMEOUT:-300}
 
     # Get the list of KUBECONFIG files as an array.
     IFS=':' read -r -a KFILES <<< "${KUBECONFIG}"
@@ -342,8 +366,9 @@ __cluster_cleanup_check() {
 
 
 # Runs $func and compares the output with $expected.  If they are not the same,
-# exponentially back off and try again, 7 times by default. The number of retries
-# can be changed by setting the VERIFY_RETRIES environment variable.
+# wait a second and try again, up to two minutes by default. The retry behavior
+# can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+# variables.
 _verify_same() {
     local func=$1
     local expected=$2
@@ -352,8 +377,9 @@ _verify_same() {
 
 # Runs $func and compares the output with $expected.  If the output does not
 # contain the substring $expected,
-# exponentially back off and try again, 7 times by default. The number of retries
-# can be changed by setting the VERIFY_RETRIES environment variable.
+# wait a second and try again, up to two minutes by default. The retry behavior
+# can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+# variables.
 _verify_contains() {
     local func=$1
     local expected=$2
@@ -362,8 +388,9 @@ _verify_contains() {
 
 # Runs $func and compares the output with $expected.  If the output contains the
 # substring $expected,
-# exponentially back off and try again, 7 times by default. The number of retries
-# can be changed by setting the VERIFY_RETRIES environment variable.
+# wait a second and try again, up to two minutes by default. The retry behavior
+# can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+# variables.
 _verify_not_contains() {
     local func=$1
     local expected=$2
@@ -375,8 +402,9 @@ _verify_not_contains() {
 # Runs $func and compares the output with $expected.  If the output does not
 # contain the lines in $expected where "..." on a line matches one or more lines
 # containing any text,
-# exponentially back off and try again, 7 times by default. The number of retries
-# can be changed by setting the VERIFY_RETRIES environment variable.
+# wait a second and try again, up to two minutes by default. The retry behavior
+# can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+# variables.
 _verify_elided() {
     local func=$1
     local expected=$2
@@ -385,8 +413,9 @@ _verify_elided() {
 
 # Runs $func and compares the output with $expected.  If the first line of
 # output does not match the first line in $expected,
-# exponentially back off and try again, 7 times by default. The number of retries
-# can be changed by setting the VERIFY_RETRIES environment variable.
+# wait a second and try again, up to two minutes by default. The retry behavior
+# can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+# variables.
 _verify_first_line() {
     local func=$1
     local expected=$2
@@ -395,14 +424,18 @@ _verify_first_line() {
 
 # Runs $func and compares the output with $expected.  If the output is not
 # "like" $expected,
-# exponentially back off and try again, 7 times by default. The number of retries
-# can be changed by setting the VERIFY_RETRIES environment variable.
+# wait a second and try again, up to two minutes by default. The retry behavior
+# can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+# variables.
 # Like implies:
 #   1. Same number of lines
 #   2. Same number of whitespace-seperated tokens per line
 #   3. Tokens can only differ in the following ways:
 #        - different elapsed time values
-#        - different ip values
+#        - different ip values. Disallows <none> and <pending> by
+#          default. This can be customized by setting the
+#          CMP_MATCH_IP_NONE and CMP_MATCH_IP_PENDING environment
+#          variables, respectively.
 #        - prefix match ending with a dash character
 #        - expected ... is a wildcard token, matches anything
 _verify_like() {
@@ -413,8 +446,9 @@ _verify_like() {
 
 # Runs $func and compares the output with $expected.  If the output does not
 # "conform to" the specification in $expected,
-# exponentially back off and try again, 7 times by default. The number of retries
-# can be changed by setting the VERIFY_RETRIES environment variable.
+# wait a second and try again, up to two minutes by default. The retry behavior
+# can be changed by setting the `VERIFY_TIMEOUT` and `VERIFY_DELAY` environment
+# variables.
 # Conformance implies:
 #   1. For each line in $expected with the prefix "+ " there must be at least one
 #      line in the output containing the following string.


### PR DESCRIPTION
This required some other changes WRT verification:

- Change __cmp_like to allow for not accepting <pending> for an IP address.

- Change __verify_with_retry to use a timeout rathan than number of retries. This is a more intuitive interface and aligns with the way we do retries in istio/istio. I also got rid of exponential backoff and allow both the timeout and delay between retries to be configured.



[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[x] Test and Release
[ ] User Experience
[ ] Developer Infrastructure