### PR TITLE
Fix markdown section number issue

### DIFF
--- a/content/en/docs/tasks/observability/gateways/index.md
+++ b/content/en/docs/tasks/observability/gateways/index.md
@@ -54,14 +54,14 @@ This example uses self-signed certificates, which may not be appropriate for pro
 
 1. Setup the certificates. This example uses `openssl` to self sign.
 
-{{< text bash >}}
-$ CERT_DIR=/tmp/certs
-$ mkdir -p ${CERT_DIR}
-$ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj "/O=example Inc./CN=*.${INGRESS_DOMAIN}" -keyout ${CERT_DIR}/ca.key -out ${CERT_DIR}/ca.crt
-$ openssl req -out ${CERT_DIR}/cert.csr -newkey rsa:2048 -nodes -keyout ${CERT_DIR}/tls.key -subj "/CN=*.${INGRESS_DOMAIN}/O=example organization"
-$ openssl x509 -req -days 365 -CA ${CERT_DIR}/ca.crt -CAkey ${CERT_DIR}/ca.key -set_serial 0 -in ${CERT_DIR}/cert.csr -out ${CERT_DIR}/tls.crt
-$ kubectl create -n istio-system secret tls telemetry-gw-cert --key=${CERT_DIR}/tls.key --cert=${CERT_DIR}/tls.crt
-{{< /text >}}
+    {{< text bash >}}
+    $ CERT_DIR=/tmp/certs
+    $ mkdir -p ${CERT_DIR}
+    $ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj "/O=example Inc./CN=*.${INGRESS_DOMAIN}" -keyout ${CERT_DIR}/ca.key -out ${CERT_DIR}/ca.crt
+    $ openssl req -out ${CERT_DIR}/cert.csr -newkey rsa:2048 -nodes -keyout ${CERT_DIR}/tls.key -subj "/CN=*.${INGRESS_DOMAIN}/O=example organization"
+    $ openssl x509 -req -days 365 -CA ${CERT_DIR}/ca.crt -CAkey ${CERT_DIR}/ca.key -set_serial 0 -in ${CERT_DIR}/cert.csr -out ${CERT_DIR}/tls.crt
+    $ kubectl create -n istio-system secret tls telemetry-gw-cert --key=${CERT_DIR}/tls.key --cert=${CERT_DIR}/tls.crt
+    {{< /text >}}
 
 1. Apply networking configuration for the telemetry addons.
 


### PR DESCRIPTION
Fix markdown section number issue for this page:
https://preliminary.istio.io/latest/docs/tasks/observability/gateways/
<img width="406" alt="Screen Shot 2020-10-26 at 8 39 49 AM" src="https://user-images.githubusercontent.com/29208297/97194066-f2a5fe80-1766-11eb-815c-a50b6d60a930.png">

`Apply networking configuration` should start with number `2`.