### PR TITLE
Remove ICP from IBM Cloud platform setup page

### DIFF
--- a/content/en/docs/setup/platform-setup/ibm/index.md
+++ b/content/en/docs/setup/platform-setup/ibm/index.md
@@ -13,9 +13,6 @@ test: no
 
 Follow these instructions to prepare a cluster for Istio using the
 [IBM Cloud Kubernetes Service](https://cloud.ibm.com/docs/containers?topic=containers-getting-started).
-To install Istio on IBM Cloud Private, refer to
-[Istio on IBM Cloud Private](https://www.ibm.com/support/knowledgecenter/en/SSBS6K_3.2.1/manage_cluster/istio.html)
-instead.
 
 {{< tip >}}
 IBM offers a {{< gloss >}}managed control plane{{< /gloss >}} add-on for the IBM Cloud Kubernetes Service,


### PR DESCRIPTION
Fixes #8359, removing IBM Cloud Private from the IBM Cloud platform setup page.