### PR TITLE
Add TOC links to website

### DIFF
--- a/content/en/about/community/toc/index.md
+++ b/content/en/about/community/toc/index.md
@@ -5,4 +5,5 @@ weight: 12
 keywords: [community]
 icon: community
 ---
-Istio's Technical Oversight Community's [charter](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#charter) and [membership](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#committee-members).
+- Istio's Technical Oversight Committee [charter](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#charter).
+- Istio's Technical OverSight Committee [membership](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#committee-members).

--- a/content/en/about/community/toc/index.md
+++ b/content/en/about/community/toc/index.md
@@ -5,4 +5,4 @@ weight: 12
 keywords: [community]
 icon: community
 ---
-Istio's Technical Oversight Community's [charter](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#charter) and [membership](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#committee-members). 
+Istio's Technical Oversight Community's [charter](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#charter) and [membership](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#committee-members).

--- a/content/en/about/community/toc/index.md
+++ b/content/en/about/community/toc/index.md
@@ -1,0 +1,8 @@
+---
+title: Technical Oversight Committee
+description: Information describing the technical oversight committee within the Istio Community
+weight: 10
+keywords: [community]
+icon: community
+---
+Istio's Technical Oversight Community's [charter](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#charter) and [membership](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#committee-members). 

--- a/content/en/about/community/toc/index.md
+++ b/content/en/about/community/toc/index.md
@@ -1,6 +1,6 @@
 ---
 title: Technical Oversight Committee
-description: Information describing the technical oversight committee within the Istio Community
+description: Information describing the Istio technical oversight committee.
 weight: 12
 keywords: [community]
 icon: community

--- a/content/en/about/community/toc/index.md
+++ b/content/en/about/community/toc/index.md
@@ -1,9 +1,9 @@
 ---
 title: Technical Oversight Committee
-description: Information describing the Istio technical oversight committee.
+description: Information describing the Istio Technical Oversight Committee.
 weight: 12
 keywords: [community]
 icon: community
 ---
 - Istio's Technical Oversight Committee [charter](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#charter).
-- Istio's Technical OverSight Committee [membership](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#committee-members).
+- Istio's Technical Oversight Committee [membership](https://github.com/istio/community/blob/master/TECH-OVERSIGHT-COMMITTEE.md#committee-members).

--- a/content/en/about/community/toc/index.md
+++ b/content/en/about/community/toc/index.md
@@ -1,7 +1,7 @@
 ---
 title: Technical Oversight Committee
 description: Information describing the technical oversight committee within the Istio Community
-weight: 10
+weight: 12
 keywords: [community]
 icon: community
 ---


### PR DESCRIPTION
The TOC governance material is very hard to find. Call it out clearly as
a top level item in the about pages. In the future, it may make sense to
transfer this document from istio/community directly to the website for
publishing after some post-processing.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
