### PR TITLE
grant mysql root access to other IPs

### DIFF
--- a/content/en/docs/examples/virtual-machines/bookinfo/index.md
+++ b/content/en/docs/examples/virtual-machines/bookinfo/index.md
@@ -49,9 +49,14 @@ On the VM:
 
 {{< text bash >}}
 $ sudo apt-get update && sudo apt-get install -y mariadb-server
+$ sudo sed -i '/bind-address/c\bind-address  = 0.0.0.0' /etc/mysql/mariadb.conf.d/50-server.cnf
 $ sudo mysql
 # Grant access to root
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' IDENTIFIED BY 'password' WITH GRANT OPTION;
+# Grant root access to other IPs
+CREATE USER 'root'@'%' IDENTIFIED BY 'password';
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' WITH GRANT OPTION;
+FLUSH PRIVILEGES;
 quit;
 {{< /text >}}
 


### PR DESCRIPTION

The current mysql configuration only allow localhost connection, but usually , the ratings deployment is not the deployed on the same host with the mysql server, this pull request fix 2 problems to solve the  issue:

1. By default, mysql bind to localhost, when connecting from another hosts (which a not localhost ip is required), error `ERROR 2003 (HY000): Can't connect to MySQL server on '192.168.7.3' (111 "Connection refused")` occurs,
To solve the problem, the mysql server should be bind to other IPs, for the purpose of generally applicable, 0.0.0.0 is used here.

2. The current granted privileges only allow `mysql -u root -ppassword` connecting, if accessing from other hosts using `mysql -u root -ppassword -h x.x.x.x`, it gets refused with error `host 'y.y.y.y' is not allowed to connect to this mariadb server`. To solve the problem, `root$%` privilege should be granted so that the mysql server can be visited from any other hosts.



[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure