### PR TITLE
Update the `Learn Microservices Using Kubernetes and Istio` example

### DIFF
--- a/content/en/docs/examples/microservices-istio/add-istio/index.md
+++ b/content/en/docs/examples/microservices-istio/add-istio/index.md
@@ -32,7 +32,7 @@ disrupt your application, it continues to run and serve user requests.
 
     {{< text bash >}}
     $ curl -s {{< github_file >}}/samples/bookinfo/platform/kube/bookinfo.yaml | istioctl kube-inject -f - | sed 's/replicas: 1/replicas: 3/g' | kubectl apply -l app=productpage,version=v1 -f -
-    deployment "productpage-v1" configured
+    deployment.apps/productpage-v1 configured
     {{< /text >}}
 
 1.  Access the application's webpage and verify that the application continues

--- a/content/en/docs/examples/microservices-istio/add-new-microservice-version/index.md
+++ b/content/en/docs/examples/microservices-istio/add-new-microservice-version/index.md
@@ -22,7 +22,7 @@ tests, end-to-end tests and tests in a staging environment.
 
     {{< text bash >}}
     $ curl -s {{< github_file >}}/samples/bookinfo/platform/kube/bookinfo.yaml | sed 's/app: reviews/app: reviews_test/' | kubectl apply -l app=reviews_test,version=v2 -f -
-    deployment "reviews-v2" created
+    deployment.apps/reviews-v2 created
     {{< /text >}}
 
 1.  Access your application to ensure the deployed microservice did not disrupt
@@ -89,7 +89,7 @@ tests, end-to-end tests and tests in a staging environment.
     {{< text bash >}}
     $ kubectl delete deployment reviews-v2
     $ kubectl delete pod -l app=reviews,version=v2
-    deployment "reviews-v2" deleted
+    deployment.apps "reviews-v2" deleted
     pod "reviews-v2-79c8c8c7c5-4p4mn" deleted
     {{< /text >}}
 
@@ -101,7 +101,7 @@ tests, end-to-end tests and tests in a staging environment.
 
     {{< text bash >}}
     $ kubectl apply -l app=reviews,version=v2 -f {{< github_file >}}/samples/bookinfo/platform/kube/bookinfo.yaml
-    deployment "reviews-v2" created
+    deployment.apps/reviews-v2 created
     {{< /text >}}
 
     Access your application's webpage several times and see that now the black
@@ -112,7 +112,7 @@ tests, end-to-end tests and tests in a staging environment.
 
     {{< text bash >}}
     $ kubectl scale deployment reviews-v2 --replicas=3
-    deployment "reviews-v2" scaled
+    deployment.apps/reviews-v2 scaled
     {{< /text >}}
 
     Now, access your application's webpage several times and see that the black
@@ -122,7 +122,7 @@ tests, end-to-end tests and tests in a staging environment.
 
     {{< text bash >}}
     $ kubectl delete deployment reviews-v1
-    deployment "reviews-v1" deleted
+    deployment.apps "reviews-v1" deleted
     {{< /text >}}
 
     Accessing the web page of the application will return reviews with black

--- a/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
+++ b/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
@@ -31,14 +31,18 @@ microservice.
 
     {{< text bash >}}
     $ kubectl apply -l version!=v2,version!=v3 -f {{< github_file >}}/samples/bookinfo/platform/kube/bookinfo.yaml
-    service "details" created
-    deployment "details-v1" created
-    service "ratings" created
-    deployment "ratings-v1" created
-    service "reviews" created
-    deployment "reviews-v1" created
-    service "productpage" created
-    deployment "productpage-v1" created
+    service/details created
+    serviceaccount/bookinfo-details created
+    deployment.apps/details-v1 created
+    service/ratings created
+    serviceaccount/bookinfo-ratings created
+    deployment.apps/ratings-v1 created
+    service/reviews created
+    serviceaccount/bookinfo-reviews created
+    deployment.apps/reviews-v1 created
+    service/productpage created
+    serviceaccount/bookinfo-productpage created
+    deployment.apps/productpage-v1 created
     {{< /text >}}
 
 1.  Check the status of the pods:
@@ -56,12 +60,10 @@ microservice.
 
     {{< text bash >}}
     $ kubectl scale deployments --all --replicas 3
-    deployment "details-v1" scaled
-    deployment "productpage-v1" scaled
-    deployment "ratings-v1" scaled
-    deployment "reviews-v1" scaled
-    deployment "reviews-v2" scaled
-    deployment "reviews-v3" scaled
+    deployment.apps/details-v1 scaled
+    deployment.apps/productpage-v1 scaled
+    deployment.apps/ratings-v1 scaled
+    deployment.apps/reviews-v1 scaled
     {{< /text >}}
 
 1.  Check the pods status. Notice that each microservice has three pods:
@@ -125,6 +127,8 @@ service/productpage patched
     kind: Ingress
     metadata:
       name: bookinfo
+      annotations:
+        kubernetes.io/ingress.class: istio
     spec:
       rules:
       - host: $MYHOST

--- a/content/en/docs/examples/microservices-istio/enable-istio-all-microservices/index.md
+++ b/content/en/docs/examples/microservices-istio/enable-istio-all-microservices/index.md
@@ -26,13 +26,17 @@ enable Istio on all the remaining microservices in one step.
     {{< text bash >}}
     $ curl -s {{< github_file >}}/samples/bookinfo/platform/kube/bookinfo.yaml | istioctl kube-inject -f - | kubectl apply -l app!=reviews -f -
     $ curl -s {{< github_file >}}/samples/bookinfo/platform/kube/bookinfo.yaml | istioctl kube-inject -f - | kubectl apply -l app=reviews,version=v2 -f -
-    service "details" unchanged
-    deployment "details-v1" configured
-    service "ratings" unchanged
-    deployment "ratings-v1" configured
-    service "productpage" unchanged
-    deployment "productpage-v1" configured
-    deployment "reviews-v2" configured
+    service/details unchanged
+    serviceaccount/bookinfo-details unchanged
+    deployment.apps/details-v1 configured
+    service/ratings unchanged
+    serviceaccount/bookinfo-ratings unchanged
+    deployment.apps/ratings-v1 configured
+    serviceaccount/bookinfo-reviews unchanged
+    service/productpage unchanged
+    serviceaccount/bookinfo-productpage unchanged
+    deployment.apps/productpage-v1 configured
+    deployment.apps/reviews-v2 configured
     {{< /text >}}
 
 1.  Access the application's webpage several times. Note that Istio was added

--- a/content/en/docs/examples/microservices-istio/logs-istio/index.md
+++ b/content/en/docs/examples/microservices-istio/logs-istio/index.md
@@ -6,7 +6,7 @@ owner: istio/wg-docs-maintainers
 test: no
 ---
 
-Monitoring is crucial to support transitioning to the microservices architecture style. Other requirements include rapid provisioning and rapid deployment, according to [this article](https://aadrake.com/posts/2017-05-20-enough-with-the-microservices.html).
+Monitoring is crucial to support transitioning to the microservices architecture style.
 
 With Istio, you gain monitoring of the traffic between microservices by default.
 You can use the Istio Dashboard for monitoring your microservices in real time.

--- a/content/en/docs/examples/microservices-istio/package-service/index.md
+++ b/content/en/docs/examples/microservices-istio/package-service/index.md
@@ -28,6 +28,13 @@ This module shows how you create a [Docker](https://www.docker.com) image and ru
     into the container's filesystem and then runs the `npm install` command you ran in the previous module.
     The `CMD` command instructs Docker to run the `ratings` service on port `9080`.
 
+1.  Create an environment variable to store your user id which will be used to tag the docker image for `ratings` service.
+    For example, `user`.
+
+    {{< text bash >}}
+    $ export USER=user
+    {{< /text >}}
+
 1.  Build a Docker image from the `Dockerfile`:
 
     {{< text bash >}}
@@ -45,7 +52,7 @@ This module shows how you create a [Docker](https://www.docker.com) image and ru
     `ratings` microservice on port `9081`.
 
     {{< text bash >}}
-    $ docker run --rm -d -p 9081:9080 $USER/ratings
+    $ docker run --name my-ratings  --rm -d -p 9081:9080 $USER/ratings
     {{< /text >}}
 
 1.  Access [http://localhost:9081/ratings/7](http://localhost:9081/ratings/7) in your browser or use the following `curl` command:
@@ -68,7 +75,7 @@ This module shows how you create a [Docker](https://www.docker.com) image and ru
 1.  Stop the running container:
 
     {{< text bash >}}
-    $ docker stop <the container ID from the output of docker ps>
+    $ docker stop my-ratings
     {{< /text >}}
 
 You have learned how to package a single service into a container. The next step is to learn how to [deploy the whole application to a Kubernetes cluster](/docs/examples/microservices-istio/bookinfo-kubernetes).

--- a/content/en/docs/examples/microservices-istio/production-testing/index.md
+++ b/content/en/docs/examples/microservices-istio/production-testing/index.md
@@ -94,6 +94,8 @@ the pods' status with `kubectl get pods`.
     restarted once. You may experience the `Error` and the
     `CrashLoopBackOff` statuses until the pods reach `Running` status.
 
+1. Use Ctrl-C in the terminal to stop the infinite loop that is running to simulate traffic.
+
 In both cases, the application did not crash. The crash in the `details`
 microservice did not cause other microservices to fail. This behavior means you
 did not have a **cascading failure** in this situation. Instead, you had

--- a/content/en/docs/examples/microservices-istio/setup-kubernetes-cluster/index.md
+++ b/content/en/docs/examples/microservices-istio/setup-kubernetes-cluster/index.md
@@ -56,11 +56,6 @@ proceed to [setting up your local computer](/docs/examples/microservices-istio/s
     be some timing issues which will be resolved when the command is run again.
     {{< /tip >}}
 
-1.  Next, enable Envoy's access logging as described in
-    [Enable Envoy's access logging](/docs/tasks/observability/logs/access-log/#before-you-begin).
-    Skip the clean up and delete steps, because you need the sleep
-    application for later tutorial modules.
-
 1.  Create a Kubernetes Ingress resource for these common Istio services using
     the `kubectl` command shown. It is not necessary to be familiar with each of
     these services at this point in the tutorial.
@@ -80,6 +75,8 @@ proceed to [setting up your local computer](/docs/examples/microservices-istio/s
     metadata:
       name: istio-system
       namespace: istio-system
+      annotations:
+        kubernetes.io/ingress.class: istio
     spec:
       rules:
       - host: my-istio-dashboard.io

--- a/content/en/docs/examples/microservices-istio/setup-local-computer/index.md
+++ b/content/en/docs/examples/microservices-istio/setup-local-computer/index.md
@@ -22,7 +22,7 @@ In this module you prepare your local computer for the tutorial.
     created yourself in the previous module.
 
     {{< text bash >}}
-    $ export KUBECONFIG=<the file you recieved or created in the previous module>
+    $ export KUBECONFIG=<the file you received or created in the previous module>
     {{< /text >}}
 
 1.  Verify that the configuration took effect by printing the current namespace:


### PR DESCRIPTION
Update this example in the Istio docs as part of writing automated test cases(#7989). The updates
include:

1. Setup a Kubernetes Cluster
- Remove Step-6 since we are installing Istio using the demo profile, access logging is enabled by default
- Step 7 - Updated command for Ingress resource to use Istio's Ingress controller
2. Setup a local computer - fix a small typo
3. Run ratings in docker
 - export USER variable
 - name the ratings container 'my-ratings' so that we can later stop it easily using this name
4.Run Bookinfo with Kubernetes
 - Configure Kubernetes Ingress resources and access your application's webpage (add annotation to use Istio's ingress controller)
 - Fixed output of some commands
5. Monitoring with Istio
 - Remove link to an old blog that is not working.
6. Fixed output of some commands



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure