### PR TITLE
Fix invalid operator sample

### DIFF
--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -268,7 +268,7 @@ customized install using these commands:
 
 {{< text bash >}}
 $ istioctl manifest generate > 1.yaml
-$ istioctl manifest generate -f samples/operator/pilot-k8s.yaml > 2.yaml
+$ istioctl manifest generate -f operator/samples/pilot-k8s.yaml > 2.yaml
 $ istioctl manifest diff 1.yaml 2.yaml
 Differences of manifests are:
 
@@ -332,7 +332,7 @@ Alternatively, the `IstioOperator` configuration can be specified in a YAML file
 `istioctl` using the `-f` option:
 
 {{< text bash >}}
-$ istioctl install -f samples/operator/pilot-k8s.yaml
+$ istioctl install -f operator/samples/pilot-k8s.yaml
 {{< /text >}}
 
 {{< tip >}}
@@ -523,7 +523,7 @@ spec:
 Use `istioctl install` to apply the modified settings to the cluster:
 
 {{< text syntax="bash" repo="operator" >}}
-$ istioctl install -f samples/operator/pilot-k8s.yaml
+$ istioctl install -f operator/samples/pilot-k8s.yaml
 {{< /text >}}
 
 ### Customize Istio settings using the Helm API


### PR DESCRIPTION
https://istio.io/latest/docs/setup/install/istioctl explains that the `pilot-k8s.yaml` exists in `samples/operator/`,
but it does not. It should be [operator/samples/pilot-k8s.yaml](https://github.com/istio/istio/blob/master/operator/samples/pilot-k8s.yaml).

[X] Docs
