### PR TITLE
Supported versions for 1.8 from TOC

### DIFF
--- a/data/args.yml
+++ b/data/args.yml
@@ -29,7 +29,7 @@ source_branch_name: release-1.8
 doc_branch_name: master
 
 # The list of supported versions described by the docs
-supported_kubernetes_versions: ["1.17", "1.18", "1.19"]
+supported_kubernetes_versions: ["1.16", "1.17", "1.18", "1.19"]
 
 ####### Static values
 


### PR DESCRIPTION

Fixes #8361 

From TOC meeting, support for 1.8 is 1.16->1.19.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure