### PR TITLE
Add profile item: remote

### DIFF
--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -170,6 +170,7 @@ cat <<EOF> istio-main-cluster.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
+  profile: remote
   values:
     global:
       multiCluster:


### PR DESCRIPTION
if not write this profile，it's install default profile resulting in the remote ingressgateway not running.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure