### PR TITLE
Fix waiting for Kiali deployment to be ready

### DIFF
--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -353,7 +353,9 @@ Use the following instructions to deploy the [Kiali](/docs/ops/integrations/kial
 
     {{< text bash >}}
     $ kubectl apply -f @samples/addons@
-    $ while ! kubectl wait --for=condition=available --timeout=600s deployment/kiali -n istio-system; do sleep 1; done
+    $ kubectl rollout status deployment/kiali -n istio-system
+    Waiting for deployment "kiali" rollout to finish: 0 of 1 updated replicas are available...
+    deployment "kiali" successfully rolled out
     {{< /text >}}
 
     {{< tip >}}

--- a/content/en/docs/setup/getting-started/snips.sh
+++ b/content/en/docs/setup/getting-started/snips.sh
@@ -226,8 +226,13 @@ echo "http://$GATEWAY_URL/productpage"
 
 snip_view_the_dashboard_dashboard_1() {
 kubectl apply -f samples/addons
-while ! kubectl wait --for=condition=available --timeout=600s deployment/kiali -n istio-system; do sleep 1; done
+kubectl rollout status deployment/kiali -n istio-system
 }
+
+! read -r -d '' snip_view_the_dashboard_dashboard_1_out <<\ENDSNIP
+Waiting for deployment "kiali" rollout to finish: 0 of 1 updated replicas are available...
+deployment "kiali" successfully rolled out
+ENDSNIP
 
 snip_view_the_dashboard_dashboard_2() {
 istioctl dashboard kiali

--- a/content/en/docs/setup/getting-started/test.sh
+++ b/content/en/docs/setup/getting-started/test.sh
@@ -75,9 +75,8 @@ get_bookinfo_productpage() {
 }
 _verify_contains get_bookinfo_productpage "<title>Simple Bookstore App</title>"
 
-# Install addons
-# TODO Fix this. For now Kiali has a problem being cleaned up: https://github.com/istio/istio/pull/25886
-snip_view_the_dashboard_dashboard_1
+# verify Kiali deployment
+_verify_contains snip_view_the_dashboard_dashboard_1 'deployment "kiali" successfully rolled out'
 
 # Verify Kiala dashboard
 # TODO Verify the browser output


### PR DESCRIPTION
To fix https://github.com/istio/istio.io/issues/8397

`kubectl wait` is not consistent and has some issues. Using rollout status works fine.

Always returns immediately. 
```
while ! kubectl wait --for=condition=available --timeout=600s deployment/kiali -n istio-system; do sleep 1; done
deployment.apps/kiali condition met
```

with `condition=ready` get stuck and never finish.
```
while ! kubectl wait --for=condition=ready --timeout=600s deployment/kiali -n istio-system; do sleep 1; done

```

Using rollout status:
```
$ kubectl rollout status deployment/kiali -n istio-system
Waiting for deployment "kiali" rollout to finish: 0 of 1 updated replicas are available...
deployment "kiali" successfully rolled out
```