### PR TITLE
Add profile item: remote

### DIFF
--- a/content/en/docs/setup/install/multicluster/shared/index.md
+++ b/content/en/docs/setup/install/multicluster/shared/index.md
@@ -261,6 +261,7 @@ cat <<EOF> istio-remote0-cluster.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
+  profile: remote
   values:
     global:
       # The remote cluster's name and network name must match the values specified in the


### PR DESCRIPTION
Sorry，last PR write the wrong place.
if not write this profile，it's install default profile resulting in the remote ingressgateway not running.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure