### PR TITLE
Remove rbac instruction for GKE

### DIFF
--- a/content/en/docs/setup/platform-setup/gke/index.md
+++ b/content/en/docs/setup/platform-setup/gke/index.md
@@ -69,13 +69,3 @@ Follow these instructions to prepare a GKE cluster for Istio.
         --zone $ZONE \
         --project $PROJECT_ID
     {{< /text >}}
-
-1. Grant cluster administrator (admin) permissions to the current user. To
-   create the necessary RBAC rules for Istio, the current user requires admin
-   permissions.
-
-    {{< text bash >}}
-    $ kubectl create clusterrolebinding cluster-admin-binding \
-        --clusterrole=cluster-admin \
-        --user=$(gcloud config get-value core/account)
-    {{< /text >}}


### PR DESCRIPTION
I removed the RBAC step from GKE because this is no longer an issue for k8s version 1.11+.

https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-control


[ ] Configuration Infrastructure
[ ] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure