### PR TITLE
upgrade support --set flag

### DIFF
--- a/content/en/docs/setup/upgrade/in-place/index.md
+++ b/content/en/docs/setup/upgrade/in-place/index.md
@@ -59,9 +59,9 @@ can be found in the `bin/` subdirectory of the downloaded package.
     then you must provide the same `-f` flag value to the `istioctl upgrade` command.
     {{< /warning >}}
 
-    If you installed Istio using the `--set` command, create a configuration file with
-    the equivalent configuration options and pass it to the `istioctl upgrade`
-    command using the `-f` flag instead.
+    If you installed Istio using `--set` flags, ensure that you pass the same `--set` flags to upgrade,
+    otherwise the customizations done with `--set` will be reverted. For production use, the use of a
+    configuration file instead of `--set` is recommended.
 
     If you omit the `-f` flag, Istio upgrades using the default profile.
 

--- a/content/en/docs/setup/upgrade/in-place/index.md
+++ b/content/en/docs/setup/upgrade/in-place/index.md
@@ -59,8 +59,7 @@ can be found in the `bin/` subdirectory of the downloaded package.
     then you must provide the same `-f` flag value to the `istioctl upgrade` command.
     {{< /warning >}}
 
-    `istioctl upgrade` does not support the `--set` flag. Therefore, if you
-    installed Istio using the `--set` command, create a configuration file with
+    If you installed Istio using the `--set` command, create a configuration file with
     the equivalent configuration options and pass it to the `istioctl upgrade`
     command using the `-f` flag instead.
 


### PR DESCRIPTION
Ref: https://preliminary.istio.io/latest/docs/setup/upgrade/in-place/#upgrade-steps

```
[1.8.0-alpha.2] $ istioctl upgrade -h
The upgrade command checks for upgrade version eligibility and, if eligible, upgrades the Istio control plane components in-place. Warning: traffic may be disrupted during upgrade. Please ensure PodDisruptionBudgets are defined to maintain service continuity.

Usage:
  istioctl upgrade [flags]

  -s, --set stringArray              Override an IstioOperator value, e.g. to choose a profile
                                     (--set profile=demo), enable or disable components (--set components.policy.enabled=true), or override Istio
                                     settings (--set meshConfig.enableTracing=true). See documentation for more info:
```
