### PR TITLE
Make proxy protocol EnvoyFilter consistent with Network Topology doc

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -51,7 +51,7 @@ git checkout "$ISTIO_SHA"
 ISTIOCTL_ARTIFACT="${ISTIO_OUT}/release/"
 case "$GOOS_LOCAL" in
   linux)
-    ISTIOCTL_ARTIFACT+="istioctl-${GOOS_LOCAL}-${GOARCH_LOCAL}"
+    ISTIOCTL_ARTIFACT+="istioctl-${GOOS_LOCAL}-amd64"
     ;;
   darwin)
     ISTIOCTL_ARTIFACT+="istioctl-osx"

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -51,7 +51,7 @@ git checkout "$ISTIO_SHA"
 ISTIOCTL_ARTIFACT="${ISTIO_OUT}/release/"
 case "$GOOS_LOCAL" in
   linux)
-    ISTIOCTL_ARTIFACT+="istioctl-${GOOS_LOCAL}-amd64"
+    ISTIOCTL_ARTIFACT+="istioctl-${GOOS_LOCAL}-${GOARCH_LOCAL}"
     ;;
   darwin)
     ISTIOCTL_ARTIFACT+="istioctl-osx"

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -75,9 +75,6 @@ metadata:
   name: proxy-protocol
   namespace: istio-system
 spec:
-  workloadSelector:
-    labels:
-      istio: ingressgateway
   configPatches:
   - applyTo: LISTENER
     patch:
@@ -85,6 +82,10 @@ spec:
       value:
         listener_filters:
         - name: envoy.listener.proxy_protocol
+        - name: envoy.listener.tls_inspector
+  workloadSelector:
+    labels:
+      istio: ingressgateway
 {{< /text >}}
 
 Here is a sample of the `IstioOperator` that shows how to configure the Istio ingress gateway on AWS EKS to support the Proxy Protocol:

--- a/content/en/docs/tasks/security/authorization/authz-ingress/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/snips.sh
@@ -45,9 +45,6 @@ metadata:
   name: proxy-protocol
   namespace: istio-system
 spec:
-  workloadSelector:
-    labels:
-      istio: ingressgateway
   configPatches:
   - applyTo: LISTENER
     patch:
@@ -55,6 +52,10 @@ spec:
       value:
         listener_filters:
         - name: envoy.listener.proxy_protocol
+        - name: envoy.listener.tls_inspector
+  workloadSelector:
+    labels:
+      istio: ingressgateway
 ENDSNIP
 
 ! read -r -d '' snip_source_ip_address_of_the_original_client_2 <<\ENDSNIP


### PR DESCRIPTION
Make the proxy protocol EnvoyFilter identical to the one in
docs/ops/configuration/traffic-management/network-topologies/


[ ] Configuration Infrastructure
[ x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
