### PR TITLE
No need to create ns up front

### DIFF
--- a/content/en/docs/setup/upgrade/gateways/index.md
+++ b/content/en/docs/setup/upgrade/gateways/index.md
@@ -34,12 +34,6 @@ the control plane.
 
 ### Installation with `istioctl`
 
-1. Create a namespace to install Istio into if one doesn't already exist:
-
-    {{< text bash >}}
-    $ kubectl create ns istio-system
-    {{< /text >}}
-
 1.  Ensure that the main `IstioOperator` CR has a name and does not install a gateway:
 
     {{< text yaml >}}


### PR DESCRIPTION
istioctl install cmd covers it, see https://github.com/istio/istio/blob/master/operator/cmd/mesh/install.go#L190

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
