### PR TITLE
Update root transition operation page

### DIFF
--- a/content/en/docs/ops/configuration/security/root-transition/index.md
+++ b/content/en/docs/ops/configuration/security/root-transition/index.md
@@ -43,9 +43,6 @@ and how to transition to a new root certificate with a 10 year lifetime.
 
 1. Execute a root certificate transition:
 
-    Starting with Istio version 1.5, Envoy can automatically load the new root certificate when it refreshes its
-    certificate.
-
     {{< text bash>}}
     $ ./root-transition.sh root-transition
     Create new ca cert, with trust domain as cluster.local
@@ -53,10 +50,10 @@ and how to transition to a new root certificate with a 10 year lifetime.
     secret "istio-ca-secret" deleted
     Wed Jun  5 19:11:15 PDT 2019 create new ca secret
     secret/istio-ca-secret created
-    pod "istio-citadel-8574b88bcd-j7v2d" deleted
+    pod "istiod-86f88b6f6-d8hjt" deleted
     Wed Jun  5 19:11:18 PDT 2019 restarted Citadel, checking status
-    NAME                             READY     STATUS    RESTARTS   AGE
-    istio-citadel-8574b88bcd-l2g74   1/1       Running   0          3s
+    NAME                                   READY   STATUS    RESTARTS   AGE
+    istiod-5d4798c786-w782z                1/1     Running   0          3s
     New root certificate:
     Certificate:
         Data:
@@ -99,3 +96,5 @@ and how to transition to a new root certificate with a 10 year lifetime.
     Inspect the `valid_from` value of `ca_cert`.
     If it matches the `_Not_ _Before_` value in the new certificate as shown in Step 2,
     your Envoy has loaded the new root certificate.
+    If you see your Envoy is not able to load the new certificate, check the health of Istiod.
+    You may also manually restart the workloads.

--- a/content/en/docs/ops/configuration/security/root-transition/index.md
+++ b/content/en/docs/ops/configuration/security/root-transition/index.md
@@ -71,9 +71,9 @@ and how to transition to a new root certificate with a 10 year lifetime.
 
     Envoy proxies will retrieve the new root certificate when they rotate the workload key and certificates.
     Because the rotation is triggered based on the remaining lifetime of the existing certificate,
-    with the default 24-hour workload certificate lifetime,
+    with the default 24 hour workload certificate lifetime,
     expect the root transition to happen within the next 12 hours
-    (within the 12-hour window, all workloads should rotate their keys and certificates). 
+    (within the 12 hour window, all workloads should rotate their keys and certificates).
     You can verify whether an Envoy has received the new certificates.
     The following command shows an example to check the Envoy’s certificate for a pod.
 

--- a/content/en/docs/ops/configuration/security/root-transition/index.md
+++ b/content/en/docs/ops/configuration/security/root-transition/index.md
@@ -20,21 +20,16 @@ To evaluate the lifetime remaining for your root certificate, please refer to th
 
 The steps below show you how to transition to a new root certificate.
 After the transition, the new root certificate has a 10 year lifetime.
-Note that the Envoy instances will be hot restarted to reload the new root certificates, which may impact long-lived connections.
-For details about the impact and how Envoy hot restart works, please refer to
-[here](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/hot_restart) and
-[here](https://blog.envoyproxy.io/envoy-hot-restart-1d16b14555b5).
+From Istio V1.5, Envoy can automatically load the new root certificate when it refreshes its
+certificate.
 
 ## Scenarios
 
 If you are not currently using the mutual TLS feature in Istio and will not use it in the future,
 you are not affected and no action is required.
 
-If you may use the mutual TLS feature in the future, you should
-follow the procedure below to perform a root certificate transition.
-
-If you are currently using the mutual TLS feature in Istio with self-signed certificates,
-please follow the procedure and check whether you will be affected.
+If your cluster started using Istio from V1.3 or later versions,
+you are not affected and no action is required.
 
 ## Root transition procedure
 
@@ -53,43 +48,10 @@ please follow the procedure and check whether you will be affected.
 
     Execute the remainder of the steps prior to root certificate expiration to avoid system outages.
 
-1. Check the version of your sidecars and upgrade if needed:
-
-    Some early versions of Istio sidecar could not automatically reload the new root certificate.
-    Please run the following command to check the version of your Istio sidecars.
-
-    {{< text bash>}}
-    $ ./root-transition.sh check-version
-    Checking namespace: default
-    Istio proxy version: 1.3.5
-    Checking namespace: istio-system
-    Istio proxy version: 1.3.5
-    Istio proxy version: 1.3.5
-    ...
-    {{< /text >}}
-
-    If your sidecars are using versions lower than 1.0.8 and 1.1.8,
-    please upgrade the Istio control plane and sidecars to versions no lower than 1.0.8 and 1.1.8.
-    To upgrade, follow the Istio [upgrade procedure](/docs/setup/upgrade/)
-    or the procedure provided by your cloud service provider.
-
 1. Execute a root certificate transition:
 
-    During the transition, the Envoy sidecars may be hot-restarted to reload the new certificates.
-    This may have some impact on your traffic. Please refer to
-    [Envoy hot restart](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/hot_restart)
-    and read [this](https://blog.envoyproxy.io/envoy-hot-restart-1d16b14555b5)
-    blog post for more details.
-
-    {{< warning >}}
-    If your Pilot does not have an Envoy sidecar, consider installing one.
-    Pilot has issues using the old root certificate to verify the new workload certificates, which
-    may cause disconnection between Pilot and Envoy.
-    Please see [here](#how-can-i-check-if-pilot-has-a-sidecar) for how to check for this
-    condition.
-    The [Istio upgrade guide](/docs/setup/upgrade/)
-    by default installs Pilot with a sidecar.
-    {{< /warning >}}
+    From Istio V1.5, Envoy can automatically load the new root certificate when it refreshes its
+    certificate.
 
     {{< text bash>}}
     $ ./root-transition.sh root-transition
@@ -115,29 +77,10 @@ please follow the procedure and check whether you will be affected.
     Please save them safely and privately.
     {{< /text >}}
 
-1. Verify the new workload certificates are generated:
-
-    {{< text bash>}}
-    $ ./root-transition.sh verify-certs
-    ...
-    Checking the current root CA certificate is propagated to all the Istio-managed workload secrets in the cluster.
-    Root cert MD5 is 8fa8229ab89122edba73706e49a55e4c
-    Checking namespace: default
-      Secret default.istio.default matches current root.
-      Secret default.istio.sleep matches current root.
-    Checking namespace: istio-system
-      Secret istio-system.istio.default matches current root.
-      ...
-
-    =====All Istio mutual TLS keys and certificates match the current root!=====
-
-    {{< /text >}}
-
-    If this command fails, wait a minute and run the command again.
-    It takes some time for Citadel to propagate the certificates.
-
 1. Verify the new workload certificates are loaded by Envoy:
 
+    Envoy in the mesh will retrieve the new root certificate when they rotate the workload key and
+    certificates.
     You can verify whether an Envoy has received the new certificates.
     The following command shows an example to check the Envoy’s certificate for a pod.
 
@@ -161,47 +104,3 @@ please follow the procedure and check whether you will be affected.
     If it matches the `_Not_ _Before_` value in the new certificate as shown in Step 3,
     your Envoy has loaded the new root certificate.
 
-## Troubleshooting
-
-### Why aren't workloads picking up the new certificates (in Step 5)?
-
-Please make sure you have updated to 1.0.8, 1.1.8 or later for the `istio-proxy` sidecars in Step 2.
-
-{{< warning >}}
-If you are using Istio releases 1.1.3 - 1.1.7, the Envoy may not be hot-restarted
-after the new certificates are generated.
-{{< /warning >}}
-
-### Why does Pilot not work and log "handshake error"?
-
-This may because Pilot is
-[not using an Envoy sidecar](#how-can-i-check-if-pilot-has-a-sidecar),
-while the `controlPlaneSecurity` is enabled.
-In this case, restart both Galley and Pilot to ensure they load the new certificates.
-As an example, the following commands redeploy a pod for Galley / Pilot by removing a pod.
-
-{{< text bash>}}
-$ kubectl delete po <galley-pod> -n istio-system
-$ kubectl delete po <pilot-pod> -n istio-system
-{{< /text >}}
-
-### How can I check if Pilot has a sidecar?
-
-If the following command shows `1/1`, that means your Pilot does not have an Envoy sidecar,
-otherwise, if it is showing `2/2`, your Pilot is using an Envoy sidecar.
-
-{{< text bash>}}
-$ kubectl get po -l istio=pilot -n istio-system
-istio-pilot-569bc6d9c-tfwjr   1/1     Running   0          11m
-{{< /text >}}
-
-### Why can't I deploy new workloads with the sidecar-injector?
-
-This may happen if you did not upgrade to 1.0.8, 1.1.8 or later.
-Try to restart the sidecar injector.
-The sidecar injector will reload the certificate after the restart:
-
-{{< text bash>}}
-$ kubectl delete po -l istio=sidecar-injector -n istio-system
-pod "istio-sidecar-injector-788bd8fc48-x9gdc" deleted
-{{< /text >}}

--- a/content/en/docs/ops/configuration/security/root-transition/index.md
+++ b/content/en/docs/ops/configuration/security/root-transition/index.md
@@ -11,12 +11,12 @@ test: n/a
 ---
 
 {{< tip >}}
-You can skip this guide if your cluster started with Istio V1.3 or later versions,
+You can skip this guide if your cluster was started with Istio version 1.3 or later,
 or if you do not use the Istio self-signed certificates.
 {{< /tip >}}
 
-Before Istio V1.3, the Istio self-signed certificates had a 1 year default lifetime.
-If your cluster started with Istio V1.2 or earlier version,
+Before version 1.3, Istio self-signed certificates had a 1 year default lifetime.
+If your cluster started with Istio version 1.2 or earlier,
 and it is using Istio self-signed certificates,
 you need to be mindful about the expiration date of the root certificate.
 The expiration of a root certificate may lead to an unexpected cluster-wide outage.
@@ -24,7 +24,7 @@ The expiration of a root certificate may lead to an unexpected cluster-wide outa
 To evaluate the lifetime remaining for your root certificate, please refer to the first step in the
 [procedure below](#root-transition-procedure).
 
-The steps below show you how to examine the remaining lifetime for your root certificate,
+The following steps show you how to examine the remaining lifetime for your root certificate,
 and how to transition to a new root certificate with a 10 year lifetime.
 
 ## Root transition procedure
@@ -46,7 +46,7 @@ and how to transition to a new root certificate with a 10 year lifetime.
 
 1. Execute a root certificate transition:
 
-    From Istio V1.5, Envoy can automatically load the new root certificate when it refreshes its
+    Starting with Istio version 1.5, Envoy can automatically load the new root certificate when it refreshes its
     certificate.
 
     {{< text bash>}}
@@ -99,7 +99,6 @@ and how to transition to a new root certificate with a 10 year lifetime.
         }
     {{< /text >}}
 
-    Please inspect the `valid_from` value of `ca_cert`.
+    Inspect the `valid_from` value of `ca_cert`.
     If it matches the `_Not_ _Before_` value in the new certificate as shown in Step 2,
     your Envoy has loaded the new root certificate.
-

--- a/content/en/docs/ops/configuration/security/root-transition/index.md
+++ b/content/en/docs/ops/configuration/security/root-transition/index.md
@@ -10,26 +10,22 @@ owner: istio/wg-security-maintainers
 test: n/a
 ---
 
-Istio self-signed certificates have historically had a 1 year default lifetime.
-If you are using Istio self-signed certificates,
+{{< tip >}}
+You can skip this guide if your cluster started with Istio V1.3 or later versions,
+or if you do not use the Istio self-signed certificates.
+{{< /tip >}}
+
+Before Istio V1.3, the Istio self-signed certificates had a 1 year default lifetime.
+If your cluster started with Istio V1.2 or earlier version,
+and it is using Istio self-signed certificates,
 you need to be mindful about the expiration date of the root certificate.
 The expiration of a root certificate may lead to an unexpected cluster-wide outage.
 
 To evaluate the lifetime remaining for your root certificate, please refer to the first step in the
 [procedure below](#root-transition-procedure).
 
-The steps below show you how to transition to a new root certificate.
-After the transition, the new root certificate has a 10 year lifetime.
-From Istio V1.5, Envoy can automatically load the new root certificate when it refreshes its
-certificate.
-
-## Scenarios
-
-If you are not currently using the mutual TLS feature in Istio and will not use it in the future,
-you are not affected and no action is required.
-
-If your cluster started using Istio from V1.3 or later versions,
-you are not affected and no action is required.
+The steps below show you how to examine the remaining lifetime for your root certificate,
+and how to transition to a new root certificate with a 10 year lifetime.
 
 ## Root transition procedure
 
@@ -79,8 +75,11 @@ you are not affected and no action is required.
 
 1. Verify the new workload certificates are loaded by Envoy:
 
-    Envoy in the mesh will retrieve the new root certificate when they rotate the workload key and
-    certificates.
+    Envoy proxies will retrieve the new root certificate when they rotate the workload key and certificates.
+    Because the rotation is triggered based on the remaining lifetime of the existing certificate,
+    with the default 24-hour workload certificate lifetime,
+    expect the root transition to happen within the next 12 hours
+    (within the 12-hour window, all workloads should rotate their keys and certificates). 
     You can verify whether an Envoy has received the new certificates.
     The following command shows an example to check the Envoy’s certificate for a pod.
 
@@ -100,7 +99,7 @@ you are not affected and no action is required.
         }
     {{< /text >}}
 
-    Please inspect the `valid\_from` value of the `ca\_cert`.
-    If it matches the `_Not_ _Before_` value in the new certificate as shown in Step 3,
+    Please inspect the `valid_from` value of `ca_cert`.
+    If it matches the `_Not_ _Before_` value in the new certificate as shown in Step 2,
     your Envoy has loaded the new root certificate.
 

--- a/content/en/docs/ops/configuration/security/root-transition/index.md
+++ b/content/en/docs/ops/configuration/security/root-transition/index.md
@@ -21,9 +21,6 @@ and it is using Istio self-signed certificates,
 you need to be mindful about the expiration date of the root certificate.
 The expiration of a root certificate may lead to an unexpected cluster-wide outage.
 
-To evaluate the lifetime remaining for your root certificate, please refer to the first step in the
-[procedure below](#root-transition-procedure).
-
 The following steps show you how to examine the remaining lifetime for your root certificate,
 and how to transition to a new root certificate with a 10 year lifetime.
 


### PR DESCRIPTION
A lot of content in this page are stale and need to be cleaned up:
https://preliminary.istio.io/latest/docs/ops/configuration/security/root-transition/

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ X ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure