### PR TITLE
Small update to clarify the mirror flow

### DIFF
--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -235,7 +235,7 @@ log entries for `v1` and none for `v2`:
     EOF
     {{< /text >}}
 
-    This route rule sends 100% of the traffic to `v1`. The last stanza specifies
+    This route rule sends 100% of the traffic from `v1` to `v2`. The last stanza specifies
     that you want to mirror to the `httpbin:v2` service. When traffic gets mirrored,
     the requests are sent to the mirrored service with their Host/Authority headers
     appended with `-shadow`. For example, `cluster-1` becomes `cluster-1-shadow`.

--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -235,8 +235,8 @@ log entries for `v1` and none for `v2`:
     EOF
     {{< /text >}}
 
-    This route rule sends 100% of the traffic from `v1` to `v2`. The last stanza specifies
-    that you want to mirror to the `httpbin:v2` service. When traffic gets mirrored,
+    This route rule sends 100% of the traffic to `v1`. The last stanza specifies
+    that you want to mirror 100% of traffic from `httpbin:v1` to the `httpbin:v2` service. When traffic gets mirrored,
     the requests are sent to the mirrored service with their Host/Authority headers
     appended with `-shadow`. For example, `cluster-1` becomes `cluster-1-shadow`.
 

--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -236,7 +236,8 @@ log entries for `v1` and none for `v2`:
     {{< /text >}}
 
     This route rule sends 100% of the traffic to `v1`. The last stanza specifies
-    that you want to mirror 100% of traffic from `httpbin:v1` to the `httpbin:v2` service. When traffic gets mirrored,
+    that you want to mirror (i.e., also send) 100% of the same traffic to the
+    `httpbin:v2` service. When traffic gets mirrored,
     the requests are sent to the mirrored service with their Host/Authority headers
     appended with `-shadow`. For example, `cluster-1` becomes `cluster-1-shadow`.
 


### PR DESCRIPTION
Small clarification - This route rule sends 100% of the traffic from `v1` to `v2`



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure