### PR TITLE
fix jsonpath typo on in-place upgrade section

### DIFF
--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -185,14 +185,14 @@ You should see that the `istio-operator` pod has restarted and its version has c
 
 {{< text bash >}}
 $ kubectl get pods --namespace istio-operator \
-  -o=jsonpath='{range .items[*'{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}'
+  -o=jsonpath='{range .items[*]}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{"\n"}{end}'
 {{< /text >}}
 
 After a minute or two, the Istio control plane components should also be restarted at the new version:
 
 {{< text bash >}}
 $ kubectl get pods --namespace istio-system \
-  -o=jsonpath='{range .items[*'{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}'
+  -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{"\n"}{end}'
 {{< /text >}}
 
 ## Canary Upgrade


### PR DESCRIPTION
move {"\n"} to the end, `.{range items[*]}` will make the command runs

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
