### PR TITLE
Update supported releases page

### DIFF
--- a/content/en/about/supported-releases/index.md
+++ b/content/en/about/supported-releases/index.md
@@ -11,18 +11,19 @@ changes. For more information refer to the [Istio support policy](../release-cad
 
 ## Support status of Istio releases
 
-| Version         | Currently Supported   | Release Date    | End of Life       | Supported Kubernetes Versions |
-|-----------------|-----------------------|-----------------|-------------------|-------------------------------|
-| master          | No, development only  |                 |                   |                               |
-| 1.8             |                       | TBD             |                   | 1.16, 1.17, 1.18, 1.19        |
-| 1.7             | Yes                   | August 21, 2020 |                   | 1.16, 1.17, 1.18              |
-| 1.6             | Yes                   | May 21, 2020    | November 21, 2020 | 1.15, 1.16, 1.17, 1.18        |
-| 1.5 and earlier | No                    |                 |                   |                               |
+| Version         | Currently Supported   | Release Date      | End of Life       | Supported Kubernetes Versions |
+|-----------------|-----------------------|-------------------|-------------------|-------------------------------|
+| master          | No, development only  |                   |                   |                               |
+| 1.8             | Yes                   | November 10, 2020 |                   | 1.16, 1.17, 1.18, 1.19        |
+| 1.7             | Yes                   | August 21, 2020   |                   | 1.16, 1.17, 1.18              |
+| 1.6             | No                    | May 21, 2020      | November 23, 2020 | 1.15, 1.16, 1.17, 1.18        |
+| 1.5 and earlier | No                    |                   |                   |                               |
 
 ## Releases without known Common Vulnerabilities and Exposures (CVEs)
 
 | LTS Release                | Patched versions with no known CVEs  |
 |----------------------------|--------------------------------------|
-| 1.7.x                      | 1.7.3, 1.7.4                         |
-| 1.6.x                      | 1.6.11, 1.6.12, 1.6.13               |
+| 1.8.x                      | 1.8.0                                |
+| 1.7.x                      | 1.7.3, 1.7.4, 1.7.5                  |
+| 1.6.x                      | 1.6.11, 1.6.12, 1.6.13, 1.6.14       |
 | 1.5 and earlier            | None                                 |


### PR DESCRIPTION
Update to https://istio.io/latest/about/supported-releases/

* Include release of 1.8
* EOL 1.6
* Update patches without any known CVEs


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure