### PR TITLE
update command to check connected istiod.

### DIFF
--- a/content/en/docs/setup/upgrade/canary/index.md
+++ b/content/en/docs/setup/upgrade/canary/index.md
@@ -62,8 +62,8 @@ Unlike istiod, Istio gateways do not run revision-specific instances, but are in
 You can verify that the `istio-ingress` gateway is using the `canary` revision by running the following command:
 
 {{< text bash >}}
-$ istioctl proxy-config endpoints $(kubectl -n istio-system get pod -l app=istio-ingressgateway -o jsonpath='{.items..metadata.name}').istio-system --cluster xds-grpc -ojson | grep hostname
-"hostname": "istiod-canary.istio-system.svc"
+$ istioctl proxy-status | grep $(kubectl -n istio-system get pod -l app=istio-ingressgateway -o jsonpath='{.items..metadata.name}') | awk '{print $8}'
+istiod-canary-6956db645c-vwhsk
 {{< /text >}}
 
 However, simply installing the new revision has no impact on the existing sidecar proxies. To upgrade these,
@@ -94,8 +94,8 @@ $ kubectl get pods -n test-ns -l istio.io/rev=canary
 To verify that the new pods in the `test-ns` namespace are using the `istiod-canary` service corresponding to the `canary` revision, select one newly created pod and use the `pod_name` in the following command:
 
 {{< text bash >}}
-$ istioctl proxy-config endpoints ${pod_name}.test-ns --cluster xds-grpc -ojson | grep hostname
-"hostname": "istiod-canary.istio-system.svc"
+$ istioctl proxy-status | grep ${pod_name} | awk '{print $8}'
+istiod-canary-6956db645c-vwhsk
 {{< /text >}}
 
 The output confirms that the pod is using `istiod-canary` revision of the control plane.


### PR DESCRIPTION

**For istio-1.8.x and later, the endpoint from `istioctl proxy-config` for `xds-grpc` doesn't contain explicative connected istiod svc, we have to switch `istioctl proxy-status` command to get the current connected istiod instance, see:**
```
istioctl proxy-config endpoints $(kubectl -n istio-system get pod -l app=istio-ingressgateway -o jsonpath='{.items..metadata.name}').istio-system --cluster xds-grpc -ojson
[
    {
        "name": "xds-grpc",
        "hostStatuses": [
            {
                "address": {
                    "pipe": {
                        "path": "./etc/istio/proxy/XDS"
                    }
                },
                "stats": [
                    {
                        "name": "cx_connect_fail"
                    },
                    {
                        "value": "1",
                        "name": "cx_total"
                    },
                    {
                        "name": "rq_error"
                    },
                    {
                        "name": "rq_success"
                    },
                    {
                        "name": "rq_timeout"
                    },
                    {
                        "value": "1",
                        "name": "rq_total"
                    },
                    {
                        "type": "GAUGE",
                        "value": "1",
                        "name": "cx_active"
                    },
                    {
                        "type": "GAUGE",
                        "value": "1",
                        "name": "rq_active"
                    }
                ],
                "healthStatus": {
                    "edsHealthStatus": "HEALTHY"
                },
                "weight": 1,
                "locality": {}
            }
        ],
        "circuitBreakers": {
            "thresholds": [
                {
                    "maxConnections": 100000,
                    "maxPendingRequests": 100000,
                    "maxRequests": 100000,
                    "maxRetries": 3
                },
                {
                    "priority": "HIGH",
                    "maxConnections": 100000,
                    "maxPendingRequests": 100000,
                    "maxRequests": 100000,
                    "maxRetries": 3
                }
            ]
        }
    }
]
```


[ ] Configuration Infrastructure
[ X ] Docs
[ X ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure