### PR TITLE
[Helm] move warning before installing base helm chart

### DIFF
--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -44,13 +44,6 @@ follow the instructions below.
     $ kubectl create namespace istio-system
     {{< /text >}}
 
-1. Install the Istio base chart which contains cluster-wide resources used by
-   the Istio control plane:
-
-    {{< text bash >}}
-    $ helm install --namespace istio-system istio-base manifests/charts/base
-    {{< /text >}}
-
     {{< warning >}}
     The default chart configuration uses the secure third party tokens for service
     account token projections used by Istio proxies to authenticate with the Istio
@@ -63,6 +56,13 @@ follow the instructions below.
     gateways or workloads with injected Envoy proxies will not get deployed due
     to the missing `istio-token` volume.
     {{< /warning >}}
+
+1. Install the Istio base chart which contains cluster-wide resources used by
+   the Istio control plane:
+
+    {{< text bash >}}
+    $ helm install -n istio-system istio-base manifests/charts/base
+    {{< /text >}}
 
 1. Install the Istio discovery chart which deploys the `istiod` service:
 

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -38,24 +38,24 @@ The commands in this guide use the Helm charts that are included in the Istio re
 Change directory to the root of the release package and then
 follow the instructions below.
 
+{{< warning >}}
+The default chart configuration uses the secure third party tokens for the service
+account token projections used by Istio proxies to authenticate with the Istio
+control plane. Before proceeding to install any of the charts below, you should
+verify if third party tokens are enabled in your cluster by following the steps
+describe [here](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens).
+If third party tokens are not enabled, you should add the option
+`--set global.jwtPolicy=first-party-jwt` to the Helm install commands.
+If the `jwtPolicy` is not set correctly, pods associated with `istiod`,
+gateways or workloads with injected Envoy proxies will not get deployed due
+to the missing `istio-token` volume.
+{{< /warning >}}
+
 1. Create a namespace `istio-system` for Istio components:
 
     {{< text bash >}}
     $ kubectl create namespace istio-system
     {{< /text >}}
-
-    {{< warning >}}
-    The default chart configuration uses the secure third party tokens for service
-    account token projections used by Istio proxies to authenticate with the Istio
-    control plane. Before proceeding to install any of the charts below, you should
-    verify if third party tokens are enabled in your cluster by following the steps
-    describe [here](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens).
-    If third party tokens are not enabled, you should add the option
-    `--set global.jwtPolicy=first-party-jwt` to the Helm install commands.
-    If the `jwtPolicy` is not set correctly, pods associated with `istiod`,
-    gateways or workloads with injected Envoy proxies will not get deployed due
-    to the missing `istio-token` volume.
-    {{< /warning >}}
 
 1. Install the Istio base chart which contains cluster-wide resources used by
    the Istio control plane:


### PR DESCRIPTION
Ref: https://istio.io/latest/docs/setup/install/helm/#installation-steps

The warning for setting `jwtPolicy` should be displayed before the user installs the base helm chart. If the user reads a warning after installing base charts, the container will always be in `ContainerCreating` due to the missing `istio-token` volume.

```
$ kubectl get pods -n istio-system
NAME                                    READY   STATUS              RESTARTS   AGE
istio-ingressgateway-69ff8bff7b-64bck   0/1     ContainerCreating   0          9s
istiod-76d6d69564-dh75c                 0/1     ContainerCreating   0          21s
```