### PR TITLE
Added Gateway creation to kubernetes-ingress page

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
@@ -23,6 +23,28 @@ A [Kubernetes Ingress Resources](https://kubernetes.io/docs/concepts/services-ne
 
 Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
 
+1.  Create a `Gateway` to handle requests for port 80
+    {{< text bash >}}
+    $ kubectl apply -f - <<EOF
+    apiVersion: networking.istio.io/v1alpha3
+    kind: Gateway
+    metadata:
+      namespace: istio-system
+      name: gateway
+    spec:
+      selector:
+        istio: ingressgateway
+      servers:
+      - port:
+          number: 80
+          name: http
+          protocol: HTTP
+        hosts:
+        - httpbin.example.com
+    EOF
+    {{< /text >}}
+
+
 1.  Create an `Ingress` resource:
 
     {{< text bash >}}


### PR DESCRIPTION
I think it's required to have a gateway listening in order for istio to serve requests to kubernetes ingress resources. Correct me if I'm wrong and/or missing something!

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
