### PR TITLE
Use minimal profile instead of default

### DIFF
--- a/content/en/docs/setup/additional-setup/config-profiles/index.md
+++ b/content/en/docs/setup/additional-setup/config-profiles/index.md
@@ -32,7 +32,8 @@ for your specific needs. The following built-in configuration profiles are curre
     This profile enables high levels of tracing and access logging so it is not suitable for performance tests.
     {{< /warning >}}
 
-1. **minimal**: the minimal set of components necessary to use Istio's [traffic management](/docs/tasks/traffic-management/) features.
+1. **minimal**: same as the default profile, but only the control plane components are installed.
+    This allows you to configure the control plane and data plane components (e.g., gateways) using [separate profiles](/docs/setup/upgrade/gateways/#installation-with-istioctl).
 
 1. **remote**: used for configuring {{< gloss "remote cluster" >}}remote clusters{{< /gloss >}} of a
     [multicluster mesh](/docs/ops/deployment/deployment-models/#multiple-clusters).

--- a/content/en/docs/setup/upgrade/gateways/index.md
+++ b/content/en/docs/setup/upgrade/gateways/index.md
@@ -43,12 +43,7 @@ the control plane.
     metadata:
       name: control-plane # REQUIRED
     spec:
-      profile: default
-      components:
-        ingressGateways:
-          - name: istio-ingressgateway
-            # MUST BE DISABLED
-            enabled: false
+      profile: minimal
     {{< /text >}}
 
 1.  Create a separate `IstioOperator` CR for the gateway(s), ensuring that it has a name and has the `empty` profile:


### PR DESCRIPTION
The default profile may be a good place to start with, but when the control plane should be handled separately from the gateway, minimal profile seems to better suit the gateway definition being in a separate setup.

As a side note, I find the use of `profile: minimal` is quite limited in current documentation. The minimal and empty profiles allow multiple IstioOperator CRs for managing the Istio installation (e.g. gateways and control planes to be separate in separate files).

(I'm even inclined to suggest default profile to be without ingress gateway, and some other profile to include both control plane and gateway - I understand this should be a separate discussion elsewhere.)

--


[ ] Configuration Infrastructure
[x] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure