### PR TITLE
added port 15053 to the docs

### DIFF
--- a/content/en/docs/ops/deployment/requirements/index.md
+++ b/content/en/docs/ops/deployment/requirements/index.md
@@ -98,6 +98,7 @@ The following ports and protocols are used by the Istio sidecar proxy (Envoy).
 | 15008 | TCP | Envoy tunnel port (inbound) | No |
 | 15020 | HTTP | Merged Prometheus telemetry from Istio agent, Envoy, and application | No |
 | 15021 | HTTP | Health checks | No |
+| 15053 | DNS | DNS resolution | Yes |
 | 15090 | HTTP | Envoy Prometheus telemetry | No |
 
 The following ports and protocols are used by the Istio control plane (istiod).


### PR DESCRIPTION
Port 15053 is exposed by the pod but it wasn't documented.

The short description is based on the following comment: https://github.com/istio/istio/pull/22369#issuecomment-604513008 from @costinm  (which is back in March). 

Would be great if costin can take a look if the short description is correct.

