### PR TITLE
keep meshID untouched for external cp test

### DIFF
--- a/content/en/docs/setup/additional-setup/external-controlplane/test.sh
+++ b/content/en/docs/setup/additional-setup/external-controlplane/test.sh
@@ -40,7 +40,6 @@ snip_set_up_the_remote_cluster_1_modified() {
     # Update config file: delete CA certificates and meshID
     sed -i \
         -e '/proxyMetadata:/,+2d' \
-        -e '/meshID: mesh1/,+2d' \
         remote-config-cluster.yaml
 }
 
@@ -50,7 +49,6 @@ snip_set_up_the_control_plane_in_the_external_cluster_2_modified() {
     # Update config file: delete CA certificates and meshID, and update pilot vars
     sed -i \
         -e '/proxyMetadata:/,+2d' \
-        -e '/meshID: mesh1/,+2d' \
         -e '/INJECTION_WEBHOOK_CONFIG_NAME: ""/d' \
         -e "s/VALIDATION_WEBHOOK_CONFIG_NAME: \"\"/ISTIOD_CUSTOM_HOST: ${EXTERNAL_ISTIOD_ADDR}/" \
         external-istiod.yaml


### PR DESCRIPTION
Think this should work :)  else, I need to understand why we have meshID in our initial doc.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
