### PR TITLE
clarifying VM installations for multi-cluster meshes

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -176,6 +176,11 @@ Install Istio and expose the control plane so that your virtual machine can acce
 
     {{< /tabset >}}
 
+    {{< warning >}}
+    The above command, for Multi-Cluster meshes requires the flag `--clusterID`
+    to indicate to which cluster the Workload is authenticating to.
+    {{< /warning >}}
+
 ## Configure the virtual machine
 
 Run the following commands on the virtual machine you want to add to the Istio mesh:

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -177,8 +177,8 @@ Install Istio and expose the control plane so that your virtual machine can acce
     {{< /tabset >}}
 
     {{< warning >}}
-    The above command, for Multi-Cluster meshes requires the flag `--clusterID`
-    to indicate to which cluster the Workload is authenticating to.
+    When connecting a VM to a multicluster Istio mesh, you will need to add the `--clusterID` argument to
+    the above command. Set the value to the name of the cluster corresponding to the `istioctl` context.
     {{< /warning >}}
 
 ## Configure the virtual machine


### PR DESCRIPTION
This took me quite some time to figure out, as the actual issue is so simple that I kept overlooking it (added it to the docs to spare other people's debugging time).

Though with some extra effort the --clusterID flag could be found out at execution time.