### PR TITLE
No need to create namespace manually for --watchNamespaces

### DIFF
--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -108,6 +108,8 @@ spec:
   values:
     global:
       istioNamespace: istio-namespace1
+    meshConfig:
+      rootNamespace: istio-namespace1
 {{< /text >}}
 
 {{< tip >}}


### PR DESCRIPTION
After this https://github.com/istio/istio/pull/29557, now it's no longer required to create namespaces manually.

The following config will automatically create a namespace for `--watchNamespaces`.

```
$ istioctl operator init --watchedNamespaces=ns1
```
```
# cat iop.yaml
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  namespace: ns1
  name: example-istiocontrolplane
spec:
  values:
    global:
      istioNamespace: ns1
    meshConfig:
      rootNamespace: ns1
```
```
$ istioctl install -f iop.yaml
```