### PR TITLE
use valid cluster name for testing external control plane on kind cluster

### DIFF
--- a/content/en/docs/setup/additional-setup/external-controlplane/index.md
+++ b/content/en/docs/setup/additional-setup/external-controlplane/index.md
@@ -68,6 +68,17 @@ $ export CTX_REMOTE_CLUSTER=remote_cluster
 $ export REMOTE_CLUSTER_NAME=remote_cluster
 {{< /text >}}
 
+{{< warning >}}
+If you are using [kind](docs/setup/platform-setup/kind/) cluster for testing external control plane, make sure to use the following names.
+
+{{< text bash >}}
+$ export CTX_EXTERNAL_CLUSTER=kind-external-cluster
+$ export CTX_REMOTE_CLUSTER=kind-remote-cluster
+$ export REMOTE_CLUSTER_NAME=remote-cluster
+{{< /text >}}
+
+{{< /warning >}}
+
 ## Cluster configuration
 
 ### Set up a gateway in the external cluster

--- a/content/en/docs/setup/additional-setup/external-controlplane/index.md
+++ b/content/en/docs/setup/additional-setup/external-controlplane/index.md
@@ -69,7 +69,7 @@ $ export REMOTE_CLUSTER_NAME=remote_cluster
 {{< /text >}}
 
 {{< warning >}}
-If you are using [kind](docs/setup/platform-setup/kind/) cluster for testing external control plane, make sure to use the following names.
+If you are using [kind](/docs/setup/platform-setup/kind/) cluster for testing external control plane, make sure to use the following names.
 
 {{< text bash >}}
 $ export CTX_EXTERNAL_CLUSTER=kind-external-cluster

--- a/content/en/docs/setup/additional-setup/external-controlplane/snips.sh
+++ b/content/en/docs/setup/additional-setup/external-controlplane/snips.sh
@@ -26,6 +26,12 @@ export CTX_REMOTE_CLUSTER=remote_cluster
 export REMOTE_CLUSTER_NAME=remote_cluster
 }
 
+snip_environment_variables_2() {
+export CTX_EXTERNAL_CLUSTER=kind-external-cluster
+export CTX_REMOTE_CLUSTER=kind-remote-cluster
+export REMOTE_CLUSTER_NAME=remote-cluster
+}
+
 snip_set_up_a_gateway_in_the_external_cluster_1() {
 cat <<EOF > controlplane-gateway.yaml
 apiVersion: install.istio.io/v1alpha1


### PR DESCRIPTION
Ref: https://preliminary.istio.io/latest/docs/setup/additional-setup/external-controlplane/#environment-variables

As we have a platform setup guide for [kind](https://preliminary.istio.io/latest/docs/setup/platform-setup/kind/), I was trying to test the external control plane and failed during the cluster setup. 

```
$  kind create cluster --name external_cluster
Creating cluster "external_cluster" ...
 ✓ Ensuring node image (kindest/node:v1.19.1) 🖼
 ✓ Preparing nodes 📦  
 ✓ Writing configuration 📜 
 ✗ Starting control-plane 🕹️ 
ERROR: failed to create cluster: failed to init node with kubeadm: command "docker exec --privileged external_cluster-control-plane kubeadm init --skip-phases=preflight --config=/kind/kubeadm.conf --skip-token-print --v=6" failed with error: exit status 1
Command Output: I1215 13:49:24.310279     187 initconfiguration.go:200] loading configuration from "/kind/kubeadm.conf"
[config] WARNING: Ignored YAML document with GroupVersionKind kubeadm.k8s.io/v1beta2, Kind=JoinConfiguration
hostport external_cluster-control-plane:6443: host 'external_cluster-control-plane' must be a valid IP address or a valid RFC-1123 DNS subdomain
```

A user trying to test an external control plane will need a valid context name generated by `kind`. 

```
 kind create cluster --name external-cluster
 kind create cluster --name remote-cluster
```
```
$ kind get clusters
external-cluster
remote-cluster
```

`kind` automatically append `kind-` to the cluster context name. 
```
$ kubectl config view
...
contexts:
- context:
    cluster: kind-external-cluster
    user: kind-external-cluster
  name: kind-external-cluster
- context:
    cluster: kind-remote-cluster
    user: kind-remote-cluster
  name: kind-remote-cluster
current-context: kind-remote-cluster
```