### PR TITLE
use right tick to indicate components installed

### DIFF
--- a/content/en/docs/setup/additional-setup/config-profiles/index.md
+++ b/content/en/docs/setup/additional-setup/config-profiles/index.md
@@ -48,14 +48,14 @@ Some additional vendor-specific configuration profiles are also available.
 For more information, refer to the [setup instructions](/docs/setup/platform-setup) for your platform.
 {{< /tip >}}
 
-The components marked as **X** are installed within each profile:
+The components marked as &#x2714; are installed within each profile:
 
 |     | default | demo | minimal | remote | empty | preview |
 | --- | --- | --- | --- | --- | --- | --- |
 | Core components | | | | | | | |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`istio-egressgateway` | | X | | | | | | |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`istio-ingressgateway` | X | X | | | | X |
-| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`istiod` | X | X | X | | | X |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`istio-egressgateway` | | &#x2714; | | | | | | |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`istio-ingressgateway` | &#x2714; | &#x2714; | | | | &#x2714; |
+| &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`istiod` | &#x2714; | &#x2714; | &#x2714; | | | &#x2714; |
 
 To further customize Istio, a number of addon components can also be installed.
 Refer to [integrations](/docs/ops/integrations) for more details.


### PR DESCRIPTION
Ref: https://preliminary.istio.io/latest/docs/setup/additional-setup/config-profiles/

This slightly improves user experience, when the user first looks at the table, the `X` indicates not installed unless the user read the text about the table.

Before:
![before](https://user-images.githubusercontent.com/2920003/102478048-24f71c80-4083-11eb-93a3-e14ab76948a0.png)

After: 

![after](https://user-images.githubusercontent.com/2920003/102478054-26c0e000-4083-11eb-9b7e-1028e75cdee4.png)


