### PR TITLE
correct secret naming spec using in Gateway configuration

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination-sds/index.md
@@ -215,8 +215,7 @@ to hold the configuration of the NGINX server:
     $ kubectl create secret generic client-credential-cacert --from-file=ca.crt=example.com.crt -n istio-system
     {{< /text >}}
 
-    Note that the secret name for an Istio CA-only certificate must end with `-cacert` and the secret **must** be
-    created in the same namespace as Istio is deployed in, `istio-system` in this case.
+    Note that the secret **must** be created in the same namespace as Istio is deployed in, `istio-system` in this case.
 
     {{< warning >}}
     The secret name **should not** begin with `istio` or `prometheus`, and the secret **should not** contain a `token` field.
@@ -322,7 +321,7 @@ to hold the configuration of the NGINX server:
             number: 443
           tls:
             mode: SIMPLE
-            credentialName: client-credential # this must match the secret created earlier without the "-cacert" suffix
+            credentialName: client-credential # this must match the secret created earlier, if the secret name ends with "-cacert", "-cacert" suffix can be ignored
             sni: my-nginx.mesh-external.svc.cluster.local
     EOF
     {{< /text >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.

In practice, secret name used in Gateway.tls.credentialName is not restricted to ending with "-cacert". Just that, when suffixed with it, "-cacert" suffix can be ignored for short.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
