### PR TITLE
add secret name restriction for egressgateway mtls origination

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination-sds/index.md
@@ -548,7 +548,8 @@ to hold the configuration of the NGINX server:
 
     {{< warning >}}
     The secret name **should not** begin with `istio` or `prometheus`, and
-    the secret **should not** contain a `token` field.
+    the secret **should not** contain a `token` field, and
+    the secret **should not** end with `-cacert`.
     {{< /warning >}}
 
 1.  Create an egress `Gateway` for `my-nginx.mesh-external.svc.cluster.local`, port 443, and destination rules and


### PR DESCRIPTION
Please provide a description for what this PR is for.

By practicing, secret name ends with "-cacert" is not supported when using in egressgateway mtls origination, or else the connection is refused by returning "upstream connect error or disconnect/reset before headers. reset reason: connection failure, transport failure reason: TLS error: Secret is not supplied by SDS"

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
