### PR TITLE
Update supported platforms pages

### DIFF
--- a/content/en/boilerplates/untested-platform.md
+++ b/content/en/boilerplates/untested-platform.md
@@ -2,6 +2,6 @@
 ---
 {{< warning >}}
 This document has never been tested on Istio Community Testing days for an Istio release.
-It is not known if the documentation provided  is still relevant. If you find any issues, then
+It is not known if the documentation provided is still relevant. If you find any issues, then
 please submit PRs to update this document.
 {{< /warning >}}

--- a/content/en/boilerplates/untested-platform.md
+++ b/content/en/boilerplates/untested-platform.md
@@ -1,0 +1,7 @@
+---
+---
+{{< warning >}}
+This document has never been tested on Istio Community Testing days for an Istio release.
+It is not known if the documentation provided  is still relevant. If you find any issues, then
+please submit PRs to update this document.
+{{< /warning >}}

--- a/content/en/docs/setup/platform-setup/MicroK8s/index.md
+++ b/content/en/docs/setup/platform-setup/MicroK8s/index.md
@@ -11,11 +11,9 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
-{{< warning >}}
-This page was last updated August 28, 2019. This document has never been
-tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
-is still relevant. If you find any issues, then  please submit PRs to update this document.
-{{< /warning >}}
+This page was last updated August 28, 2019.
+
+{{< boilerplate untested-platform >}}
 
 Follow these instructions to prepare MicroK8s for using Istio.
 

--- a/content/en/docs/setup/platform-setup/MicroK8s/index.md
+++ b/content/en/docs/setup/platform-setup/MicroK8s/index.md
@@ -11,6 +11,12 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
+{{< warning >}}
+This page was last updated August 28, 2019. This document has never been
+tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
+is still relevant. If you find any issues, then  please submit PRs to update this document.
+{{< /warning >}}
+
 Follow these instructions to prepare MicroK8s for using Istio.
 
 {{< warning >}}

--- a/content/en/docs/setup/platform-setup/alicloud/index.md
+++ b/content/en/docs/setup/platform-setup/alicloud/index.md
@@ -11,11 +11,9 @@ owner: istio/wg-environments-maintainers
 test: n/a
 ---
 
-{{< warning >}}
-This page was last updated August 8, 2018. This document has never been
-tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
-is still relevant. If you find any issues, then  please submit PRs to update this document.
-{{< /warning >}}
+This page was last updated August 8, 2018.
+
+{{< boilerplate untested-platform >}}
 
 Follow these instructions to prepare an
 [Alibaba Cloud Kubernetes Container Service](https://www.alibabacloud.com/product/kubernetes)

--- a/content/en/docs/setup/platform-setup/alicloud/index.md
+++ b/content/en/docs/setup/platform-setup/alicloud/index.md
@@ -11,6 +11,12 @@ owner: istio/wg-environments-maintainers
 test: n/a
 ---
 
+{{< warning >}}
+This page was last updated August 8, 2018. This document has never been
+tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
+is still relevant. If you find any issues, then  please submit PRs to update this document.
+{{< /warning >}}
+
 Follow these instructions to prepare an
 [Alibaba Cloud Kubernetes Container Service](https://www.alibabacloud.com/product/kubernetes)
 cluster for Istio.

--- a/content/en/docs/setup/platform-setup/azure/index.md
+++ b/content/en/docs/setup/platform-setup/azure/index.md
@@ -11,11 +11,9 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
-{{< warning >}}
-This page was last updated September 12, 2019. This document has never been
-tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
-is still relevant. If you find any issues, then  please submit PRs to update this document.
-{{< /warning >}}
+This page was last updated September 12, 2019.
+
+{{< boilerplate untested-platform >}}
 
 Follow these instructions to prepare an Azure cluster for Istio.
 

--- a/content/en/docs/setup/platform-setup/azure/index.md
+++ b/content/en/docs/setup/platform-setup/azure/index.md
@@ -11,6 +11,12 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
+{{< warning >}}
+This page was last updated September 12, 2019. This document has never been
+tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
+is still relevant. If you find any issues, then  please submit PRs to update this document.
+{{< /warning >}}
+
 Follow these instructions to prepare an Azure cluster for Istio.
 
 You can deploy a Kubernetes cluster to Azure via [AKS](https://azure.microsoft.com/en-us/services/kubernetes-service/) or [AKS-Engine](https://github.com/azure/aks-engine) which fully supports Istio.

--- a/content/en/docs/setup/platform-setup/docker/index.md
+++ b/content/en/docs/setup/platform-setup/docker/index.md
@@ -12,13 +12,6 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
-{{< warning >}}
-This page was last updated August 28, 2019. The community has not tested this
-as part of its release testing since prior to 1.2, which  was released December 10, 2019.
-It is not known if the documentation provided is still relevant. If you find any issues, then
-please submit PRs to update this document.
-{{< /warning >}}
-
 1. To run Istio with Docker Desktop, install a version which contains a supported Kubernetes version
     ({{< supported_kubernetes_versions >}}).
 

--- a/content/en/docs/setup/platform-setup/docker/index.md
+++ b/content/en/docs/setup/platform-setup/docker/index.md
@@ -12,6 +12,13 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
+{{< warning >}}
+This page was last updated August 28, 2019. The community has not tested this
+as part of its release testing since prior to 1.2, which  was released December 10, 2019.
+It is not known if the documentation provided is still relevant. If you find any issues, then
+please submit PRs to update this document.
+{{< /warning >}}
+
 1. To run Istio with Docker Desktop, install a version which contains a supported Kubernetes version
     ({{< supported_kubernetes_versions >}}).
 

--- a/content/en/docs/setup/platform-setup/gardener/index.md
+++ b/content/en/docs/setup/platform-setup/gardener/index.md
@@ -10,11 +10,9 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
-{{< warning >}}
-This page was last updated June 28, 2019. This document has never been
-tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
-is still relevant. If you find any issues, then  please submit PRs to update this document.
-{{< /warning >}}
+This page was last updated June 28, 2019.
+
+{{< boilerplate untested-platform >}}
 
 ## Bootstrapping Gardener
 

--- a/content/en/docs/setup/platform-setup/gardener/index.md
+++ b/content/en/docs/setup/platform-setup/gardener/index.md
@@ -10,6 +10,12 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
+{{< warning >}}
+This page was last updated June 28, 2019. This document has never been
+tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
+is still relevant. If you find any issues, then  please submit PRs to update this document.
+{{< /warning >}}
+
 ## Bootstrapping Gardener
 
 To set up your own [Gardener](https://gardener.cloud), see the

--- a/content/en/docs/setup/platform-setup/kubesphere/index.md
+++ b/content/en/docs/setup/platform-setup/kubesphere/index.md
@@ -8,6 +8,12 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
+{{< warning >}}
+This page was last updated February 17, 2018. This document has never been
+tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
+is still relevant. If you find any issues, then  please submit PRs to update this document.
+{{< /warning >}}
+
 Follow these instructions to prepare the [KubeSphere Container Platform](https://github.com/kubesphere/kubesphere) for Istio. You can download KubeSphere to easily install a Kubernetes cluster on your Linux machines.
 
 {{< tip >}}

--- a/content/en/docs/setup/platform-setup/kubesphere/index.md
+++ b/content/en/docs/setup/platform-setup/kubesphere/index.md
@@ -8,11 +8,9 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
-{{< warning >}}
-This page was last updated February 17, 2018. This document has never been
-tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
-is still relevant. If you find any issues, then  please submit PRs to update this document.
-{{< /warning >}}
+This page was last updated February 17, 2018.
+
+{{< boilerplate untested-platform >}}
 
 Follow these instructions to prepare the [KubeSphere Container Platform](https://github.com/kubesphere/kubesphere) for Istio. You can download KubeSphere to easily install a Kubernetes cluster on your Linux machines.
 

--- a/content/en/docs/setup/platform-setup/oci/index.md
+++ b/content/en/docs/setup/platform-setup/oci/index.md
@@ -11,11 +11,7 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
-{{< warning >}}
-This page was last updated January 4, 2019. This document has never been
-tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
-is still relevant. If you find any issues, then  please submit PRs to update this document.
-{{< /warning >}}
+{{< boilerplate untested-platform >}}
 
 Follow these instructions to prepare an OKE cluster for Istio.
 

--- a/content/en/docs/setup/platform-setup/oci/index.md
+++ b/content/en/docs/setup/platform-setup/oci/index.md
@@ -11,6 +11,12 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
+{{< warning >}}
+This page was last updated January 4, 2019. This document has never been
+tested on Istio Community Testing days for an Istio release. It is not known if the documentation provided
+is still relevant. If you find any issues, then  please submit PRs to update this document.
+{{< /warning >}}
+
 Follow these instructions to prepare an OKE cluster for Istio.
 
 1. Create a new OKE cluster within your OCI tenancy. The simplest way to do this is by using the 'Quick Cluster' option within the [web console](https://docs.cloud.oracle.com/iaas/Content/ContEng/Tasks/contengcreatingclusterusingoke.htm). You may also use the [OCI cli](https://docs.cloud.oracle.com/iaas/Content/API/SDKDocs/cliinstall.htm) as shown below.

--- a/content/en/docs/setup/platform-setup/oci/index.md
+++ b/content/en/docs/setup/platform-setup/oci/index.md
@@ -11,6 +11,8 @@ owner: istio/wg-environments-maintainers
 test: no
 ---
 
+This page was last updated January 4, 2019.
+
 {{< boilerplate untested-platform >}}
 
 Follow these instructions to prepare an OKE cluster for Istio.


### PR DESCRIPTION
Per WG Leads meeting update the docs for platform setup instructions.

Update the last time they were updated and when they were updated.

Turns out

* Alibaba
* Azure
* Kubernetes Gardner
* Kubesphere
* Oracle Cloud Infrastructure (oci)

have never been tested on an Istio community testing day.

The last time Docker was tested was for 1.2 release.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[X] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
