### PR TITLE
multicluster: use cluster name from exported context

### DIFF
--- a/content/en/docs/setup/install/multicluster/multi-primary/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary/index.md
@@ -38,7 +38,7 @@ spec:
     global:
       meshID: mesh1
       multiCluster:
-        clusterName: cluster1
+        clusterName: $CTX_CLUSTER1
       network: network1
 EOF
 {{< /text >}}
@@ -62,7 +62,7 @@ spec:
     global:
       meshID: mesh1
       multiCluster:
-        clusterName: cluster2
+        clusterName: $CTX_CLUSTER2
       network: network1
 EOF
 {{< /text >}}

--- a/content/en/docs/setup/install/multicluster/multi-primary/snips.sh
+++ b/content/en/docs/setup/install/multicluster/multi-primary/snips.sh
@@ -29,7 +29,7 @@ spec:
     global:
       meshID: mesh1
       multiCluster:
-        clusterName: cluster1
+        clusterName: $CTX_CLUSTER1
       network: network1
 EOF
 }
@@ -47,7 +47,7 @@ spec:
     global:
       meshID: mesh1
       multiCluster:
-        clusterName: cluster2
+        clusterName: $CTX_CLUSTER2
       network: network1
 EOF
 }


### PR DESCRIPTION
Ref: https://preliminary.istio.io/latest/docs/setup/install/multicluster/multi-primary

This makes it easy to copy a snippet and run it directly even when the cluster name is different.