### PR TITLE
In-place upgrade: filename is optional

### DIFF
--- a/content/en/docs/setup/upgrade/in-place/index.md
+++ b/content/en/docs/setup/upgrade/in-place/index.md
@@ -55,7 +55,7 @@ can be found in the `bin/` subdirectory of the downloaded package.
 1. Begin the upgrade by running this command:
 
     {{< text bash >}}
-    $ istioctl upgrade -f `<your-custom-configuration-file>`
+    $ istioctl upgrade
     {{< /text >}}
 
     {{< warning >}}


### PR DESCRIPTION
In-place upgrades can be done directly by running `istioctl upgrade`. `-f` is only required if the user installs Istio by custom profile. Anyway, we are displaying a warning just after this command to provide info on how to perform an upgrade with `-f`.