### PR TITLE
gateway-upgrade: using operator requires namespace to be manually created

### DIFF
--- a/content/en/docs/setup/upgrade/gateways/index.md
+++ b/content/en/docs/setup/upgrade/gateways/index.md
@@ -163,6 +163,7 @@ from the control plane.
 1.  Apply the files to the cluster with the following commands:
 
     {{< text bash >}}
+    $ kubectl create namespace istio-system
     $ kubectl apply -n istio-system -f control-plane-1-8-0.yaml
     $ kubectl apply -n istio-system -f gateways.yaml
     {{< /text >}}


### PR DESCRIPTION
Ref: https://preliminary.istio.io/latest/docs/setup/upgrade/gateways/#installation-with-operator

If the user is using an operator to upgrade gateways, they need to manually create a namespace before applying control plane and gateway config. Otherwise, the following error will occur.
```
Error from server (NotFound): error when creating "STDIN": namespaces "istio-system" not found
```