### PR TITLE
note the --revision flag for eastwest gateway

### DIFF
--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -76,6 +76,10 @@ $ @samples/multicluster/gen-eastwest-gateway.sh@ \
     istioctl --context="${CTX_CLUSTER1}" install -y -f -
 {{< /text >}}
 
+{{< tip >}}
+If the control-plane was installed with a revision, add the `--revision rev` flag to the `gen-eastwest-gateway.sh` command.
+{{< /tip >}}
+
 Wait for the east-west gateway to be assigned an external IP address:
 
 {{< text bash >}}

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -76,9 +76,9 @@ $ @samples/multicluster/gen-eastwest-gateway.sh@ \
     istioctl --context="${CTX_CLUSTER1}" install -y -f -
 {{< /text >}}
 
-{{< tip >}}
+{{< warning >}}
 If the control-plane was installed with a revision, add the `--revision rev` flag to the `gen-eastwest-gateway.sh` command.
-{{< /tip >}}
+{{< /warning >}}
 
 Wait for the east-west gateway to be assigned an external IP address:
 

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -80,9 +80,9 @@ $ @samples/multicluster/gen-eastwest-gateway.sh@ \
     istioctl --context="${CTX_CLUSTER1}" install -y -f -
 {{< /text >}}
 
-{{< tip >}}
+{{< warning >}}
 If the control-plane was installed with a revision, add the `--revision rev` flag to the `gen-eastwest-gateway.sh` command.
-{{< /tip >}}
+{{< /warning >}}
 
 Wait for the east-west gateway to be assigned an external IP address:
 

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -80,6 +80,10 @@ $ @samples/multicluster/gen-eastwest-gateway.sh@ \
     istioctl --context="${CTX_CLUSTER1}" install -y -f -
 {{< /text >}}
 
+{{< tip >}}
+If the control-plane was installed with a revision, add the `--revision rev` flag to the `gen-eastwest-gateway.sh` command.
+{{< /tip >}}
+
 Wait for the east-west gateway to be assigned an external IP address:
 
 {{< text bash >}}

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -90,6 +90,10 @@ $ @samples/multicluster/gen-eastwest-gateway.sh@ \
     istioctl --context="${CTX_CLUSTER1}" install -y -f -
 {{< /text >}}
 
+{{< tip >}}
+If the control-plane was installed with a revision, add the `--revision rev` flag to the `gen-eastwest-gateway.sh` command.
+{{< /tip >}}
+
 Wait for the east-west gateway to be assigned an external IP address:
 
 {{< text bash >}}

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -90,9 +90,9 @@ $ @samples/multicluster/gen-eastwest-gateway.sh@ \
     istioctl --context="${CTX_CLUSTER1}" install -y -f -
 {{< /text >}}
 
-{{< tip >}}
+{{< warning >}}
 If the control-plane was installed with a revision, add the `--revision rev` flag to the `gen-eastwest-gateway.sh` command.
-{{< /tip >}}
+{{< /warning >}}
 
 Wait for the east-west gateway to be assigned an external IP address:
 

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -81,9 +81,9 @@ Install Istio and expose the control plane so that your virtual machine can acce
     $ @samples/multicluster/gen-eastwest-gateway.sh@ --single-cluster | istioctl install -y -f -
     {{< /text >}}
 
-{{< tip >}}
+{{< warning >}}
 If the control-plane was installed with a revision, add the `--revision rev` flag to the `gen-eastwest-gateway.sh` command.
-{{< /tip >}}
+{{< /warning >}}
 
 1. Expose the control plane using the provided sample configuration:
 

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -81,6 +81,10 @@ Install Istio and expose the control plane so that your virtual machine can acce
     $ @samples/multicluster/gen-eastwest-gateway.sh@ --single-cluster | istioctl install -y -f -
     {{< /text >}}
 
+{{< tip >}}
+If the control-plane was installed with a revision, add the `--revision rev` flag to the `gen-eastwest-gateway.sh` command.
+{{< /tip >}}
+
 1. Expose the control plane using the provided sample configuration:
 
     {{< text bash >}}


### PR DESCRIPTION
This is something that can be easily misconfigured, and difficult for users to discover. 

I've been able to replicate this issue: https://github.com/istio/istio/issues/29234 when not specifying the revision flag on the eastwest script, but installing the control plane with a revision, and having an old control plane without a revision. 
