### PR TITLE
update virtual machine docs and fix multi-network doc

### DIFF
--- a/content/en/docs/examples/virtual-machines/multi-network/index.md
+++ b/content/en/docs/examples/virtual-machines/multi-network/index.md
@@ -72,7 +72,7 @@ When following the [Virtual Machine Installation](/docs/setup/install/virtual-ma
     {{< text bash >}}
     $ istioctl install -f ./vmintegration.yaml
     {{< /text >}}
-    
+
 1. Specify the cluster name and network when installing the East-West gateway.
 
     {{< text bash >}}
@@ -166,10 +166,10 @@ At this point we should be able to send traffic to `httpbin.default.svc.cluster.
     {{< /text >}}
 
     Lastly create a workload with the external IP of the VM (substitute `VM_IP` with the IP of your VM):
-    
+
     {{< tip >}}
     You can skip this step if using Automated WorkloadEntry Creation.
-    {{< /tip >}} 
+    {{< /tip >}}
 
     {{< text bash >}}
     $ cat <<EOF | kubectl -n <vm-namespace> apply -f -

--- a/content/en/docs/examples/virtual-machines/multi-network/index.md
+++ b/content/en/docs/examples/virtual-machines/multi-network/index.md
@@ -76,7 +76,9 @@ When following the [Virtual Machine Installation](/docs/setup/install/virtual-ma
 1. Specify the cluster name and network when installing the East-West gateway.
 
     {{< text bash >}}
-    $ istioctl install -f ./vmintegration.yaml
+    $ @samples/multicluster/gen-eastwest-gateway.sh@ \
+        --mesh mesh1 --cluster kube-cluster --network main-network | \
+        istioctl install -y -f -
     {{< /text >}}
 
 ### Specify the network for the VM sidecar

--- a/content/en/docs/examples/virtual-machines/multi-network/index.md
+++ b/content/en/docs/examples/virtual-machines/multi-network/index.md
@@ -24,84 +24,11 @@ bare metal and the clusters.
 
 - One or more Kubernetes clusters with versions: {{< supported_kubernetes_versions >}}.
 
-- Virtual machines (VMs) must have IP connectivity to the Ingress gateways in the mesh.
+- Virtual machines (VMs) must have IP connectivity to the east-west gateways in the mesh.
 
-- Services in the cluster must be accessible through the Ingress gateway.
+- Services in the cluster must be accessible through the east-west gateway.
 
-## Installation steps
-
-Setup consists of preparing the mesh for expansion and installing and configuring each VM.
-
-### Preparing your environment
-
-When expanding Istio's mesh capabilities to VMs across multiple networks (where the VM is in a network where traffic cannot directly route to pods in the Kubernetes cluster, for example), we'll need to take advantage of Istio's split-horizon DNS capabilities.
-
-Before we get started, you should prepare a VM and connect it to the Istio control plane through the Ingress Gateway. These steps are detailed in [Setup: Install: Virtual Machine Installation](/docs/setup/install/virtual-machine/).
-
-**Note** There are a few alterations to that document as follows:
-
-{{< warning >}}
-You must alter the VM set up instructions based on the suggestions in this section!
-{{< /warning >}}
-
-1. When we create the `IstioOperator` resource, we need to specify the network for the cluster.
-1. When creating the `WorkloadEntry` template as part of the `WorkloadGroup`, we need to set the `network` field.
-1. We need to specify the `clusterName` and `networkName` when creating the East-West Gateway.
-
-### Installing the Istio Control Plane
-
-When following the [Virtual Machine Installation](/docs/setup/install/virtual-machine/#install-the-istio-control-plane) setup guide to install the control plane, we will need to tweak the installation as follows:
-
-1. Specify the cluster's network in the `IstioOperator` spec.
-
-    {{< text bash yaml >}}
-    $ cat <<EOF > ./vmintegration.yaml
-    apiVersion: install.istio.io/v1alpha1
-    kind: IstioOperator
-    spec:
-      values:
-        global:
-          multiCluster:
-            clusterName: kube-cluster
-          network: main-network
-    EOF
-    {{< /text >}}
-
-1. Install the control plane with the network configured.
-
-    {{< text bash >}}
-    $ istioctl install -f ./vmintegration.yaml
-    {{< /text >}}
-
-1. Specify the cluster name and network when installing the East-West gateway.
-
-    {{< text bash >}}
-    $ @samples/multicluster/gen-eastwest-gateway.sh@ \
-        --mesh mesh1 --cluster kube-cluster --network main-network | \
-        istioctl install -y -f -
-    {{< /text >}}
-
-### Specify the network for the VM sidecar
-
-Specify the network before following the [Virtual Machine Installation](/docs/setup/install/virtual-machine/#create-files-to-transfer-to-the-virtual-machine) setup guide for creating files to transfer to the virtual machine:
-
-    {{< text bash >}}
-    $ NETWORK=vm-network
-    {{< /text >}}
-
-### Create Gateway for application traffic
-
-The last step is to create a `Gateway` resource that routes application traffic from the VMs to services running in the cluster.
-
-    {{< text bash >}}
-    $ kubectl --context="${CTX_CLUSTER1}" apply -n istio-system -f \
-        @samples/multicluster/expose-services.yaml@
-    {{< /text >}}
-
-Applying this gateway will route any of the traffic from the VM destined for the workloads in the mesh running on `*.local` via the
-East-West gateway.
-
-At this point, you can continue with the [Setup Virtual Machine documentation](/docs/setup/install/virtual-machine/).
+- Installation must be completed using [virtual machine installation](/docs/setup/install/virtual-machine) instructions, following steps for Multi-Network.
 
 ## Verify setup
 

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -36,6 +36,7 @@ and `SERVICE_ACCOUNT`
     $ VM_NAMESPACE="<the name of your service namespace>"
     $ WORK_DIR="<a certificate working directory>"
     $ SERVICE_ACCOUNT="<name of the Kubernetes service account you want to use for your VM>"
+    $ NETWORK="<this can be left blank for single-network installations>
     {{< /text >}}
 
 1. Create the working directory:
@@ -118,14 +119,15 @@ If the control-plane was installed with a revision, add the `--revision rev` fla
     apiVersion: networking.istio.io/v1alpha3
     kind: WorkloadGroup
     metadata:
-      name: ${VM_APP}
-      namespace: ${VM_NAMESPACE}
+      name: "${VM_APP}"
+      namespace: "${VM_NAMESPACE}"
     spec:
       metadata:
         labels:
-          app: ${VM_APP}
+          app: "${VM_APP}"
       template:
-        serviceAccount: ${SERVICE_ACCOUNT}
+        serviceAccount: "${SERVICE_ACCOUNT}"
+        network: "${NETWORK}"
     EOF
     {{< /text >}}
 
@@ -145,14 +147,15 @@ If the control-plane was installed with a revision, add the `--revision rev` fla
     apiVersion: networking.istio.io/v1alpha3
     kind: WorkloadGroup
     metadata:
-      name: ${VM_APP}
-      namespace: ${VM_NAMESPACE}
+      name: "${VM_APP}"
+      namespace: "${VM_NAMESPACE}"
     spec:
       metadata:
         labels:
-          app: ${VM_APP}
+          app: "${VM_APP}"
       template:
-        serviceAccount: ${SERVICE_ACCOUNT}
+        serviceAccount: "${SERVICE_ACCOUNT}"
+        network: "${NETWORK}"
     EOF
     {{< /text >}}
 

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -36,7 +36,7 @@ and `SERVICE_ACCOUNT`
     $ VM_NAMESPACE="<the name of your service namespace>"
     $ WORK_DIR="<a certificate working directory>"
     $ SERVICE_ACCOUNT="<name of the Kubernetes service account you want to use for your VM>"
-    $ NETWORK="<this can be left blank for single-network installations>
+    $ NETWORK="<this can be left blank for single-network installations>"
     {{< /text >}}
 
 1. Create the working directory:

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -140,7 +140,7 @@ Install Istio and expose the control plane so that your virtual machine can acce
     {{< /text >}}
 
     {{< /tab >}}
-    
+
     {{< /tabset >}}
 
 1. Expose services inside the cluster via the east-west gateway:

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -31,19 +31,36 @@ This guide is tested and validated but note that VM support is still an alpha fe
 and `SERVICE_ACCOUNT`
     (e.g., `WORK_DIR="${HOME}/vmintegration"`):
 
+    {{< tabset category-name="network-mode" >}}
+
+    {{< tab name="Single-Network" category-value="single" >}}
+
     {{< text bash >}}
     $ VM_APP="<the name of the application this VM will run>"
     $ VM_NAMESPACE="<the name of your service namespace>"
     $ WORK_DIR="<a certificate working directory>"
     $ SERVICE_ACCOUNT="<name of the Kubernetes service account you want to use for your VM>"
+    $ NETWORK=""
+    $ CLUSTER="Kubernetes"
     {{< /text >}}
 
-1. For Multi-Network installations, specify `CLUSTER` and `NETWORK`
+    {{< tab name="Multi-Network" category-value="multiple" >}}
+
+    {{< /tab >}}
 
     {{< text bash >}}
-    $ NETWORK=""
-    $ CLUSTER=""
+    $ VM_APP="<the name of the application this VM will run>"
+    $ VM_NAMESPACE="<the name of your service namespace>"
+    $ WORK_DIR="<a certificate working directory>"
+    $ SERVICE_ACCOUNT="<name of the Kubernetes service account you want to use for your VM>"
+    # Customize values for multi-cluster/multi-network as needed
+    $ NETWORK="kube-network"
+    $ CLUSTER="cluster1"
     {{< /text >}}
+
+    {{< /tab >}}
+
+    {{< /tabset >}}
 
 1. Create the working directory:
 
@@ -123,6 +140,8 @@ Install Istio and expose the control plane so that your virtual machine can acce
     {{< /text >}}
 
     {{< /tab >}}
+    
+    {{< /tabset >}}
 
 1. Expose services inside the cluster via the east-west gateway:
 
@@ -154,6 +173,8 @@ Install Istio and expose the control plane so that your virtual machine can acce
     {{< /text >}}
 
     {{< /tab >}}
+
+    {{< /tabset >}}
 
 ## Configure the VM namespace
 
@@ -250,7 +271,7 @@ Install Istio and expose the control plane so that your virtual machine can acce
     {{< tab name="Default" category-value="default" >}}
 
     {{< text bash >}}
-    $ istioctl x workload entry configure -f workloadgroup.yaml -o "${WORK_DIR}"
+    $ istioctl x workload entry configure -f workloadgroup.yaml -o "${WORK_DIR}" --clusterID "${CLUSTER}"
     {{< /text >}}
 
     {{< /tab >}}
@@ -263,17 +284,12 @@ Install Istio and expose the control plane so that your virtual machine can acce
     {{< /warning >}}
 
     {{< text bash >}}
-    $ istioctl x workload entry configure -f workloadgroup.yaml -o "${WORK_DIR}" --autoregister
+    $ istioctl x workload entry configure -f workloadgroup.yaml -o "${WORK_DIR}" --clusterID "${CLUSTER}" --autoregister
     {{< /text >}}
 
     {{< /tab >}}
 
     {{< /tabset >}}
-
-    {{< warning >}}
-    When connecting a VM to an Istio control plane with the `clusterName`configured, you will need to add the `--clusterID`
-    argument to the above command. Set the value to the name of the cluster corresponding to the `istioctl` context.
-    {{< /warning >}}
 
 ## Configure the virtual machine
 

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -114,7 +114,19 @@ If the control-plane was installed with a revision, add the `--revision rev` fla
     {{< tab name="Default" category-value="default" >}}
 
     {{< text bash >}}
-    $ istioctl x workload group create --name "${VM_APP}" --namespace "${VM_NAMESPACE}" --labels app="${VM_APP}" --serviceAccount "${SERVICE_ACCOUNT}" > workloadgroup.yaml
+    $ cat <<EOF > workloadgroup.yaml
+    apiVersion: networking.istio.io/v1alpha3
+    kind: WorkloadGroup
+    metadata:
+      name: ${VM_APP}
+      namespace: ${VM_NAMESPACE}
+    spec:
+      metadata:
+        labels:
+          app: ${VM_APP}
+      template:
+        serviceAccount: ${SERVICE_ACCOUNT}
+    EOF
     {{< /text >}}
 
     {{< /tab >}}
@@ -129,7 +141,19 @@ If the control-plane was installed with a revision, add the `--revision rev` fla
     1. Generate the `WorkloadGroup`:
 
     {{< text bash >}}
-    $ istioctl x workload group create --name "${VM_APP}" --namespace "${VM_NAMESPACE}" --labels app="${VM_APP}" --serviceAccount "${SERVICE_ACCOUNT}" > workloadgroup.yaml
+    $ cat <<EOF > workloadgroup.yaml
+    apiVersion: networking.istio.io/v1alpha3
+    kind: WorkloadGroup
+    metadata:
+      name: ${VM_APP}
+      namespace: ${VM_NAMESPACE}
+    spec:
+      metadata:
+        labels:
+          app: ${VM_APP}
+      template:
+        serviceAccount: ${SERVICE_ACCOUNT}
+    EOF
     {{< /text >}}
 
     1. Push the `WorkloadGroup` to the cluster:

--- a/content/zh/docs/setup/install/virtual-machine/index.md
+++ b/content/zh/docs/setup/install/virtual-machine/index.md
@@ -34,7 +34,7 @@ test: no
     $ VM_NAMESPACE="<the name of your service namespace>"
     $ WORK_DIR="<a certificate working directory>"
     $ SERVICE_ACCOUNT="<name of the Kubernetes service account you want to use for your VM>"
-    $ NETWORK="<this can be left blank for single-network installations>
+    $ NETWORK="<this can be left blank for single-network installations>"
     {{< /text >}}
 
 1. 创建工作目录：

--- a/content/zh/docs/setup/install/virtual-machine/index.md
+++ b/content/zh/docs/setup/install/virtual-machine/index.md
@@ -108,7 +108,7 @@ test: no
 
     {{< tab name="默认" category-value="default" >}}
 
-    {< text bash >}}
+    {{< text bash >}}
     $ cat <<EOF > workloadgroup.yaml
     apiVersion: networking.istio.io/v1alpha3
     kind: WorkloadGroup
@@ -136,7 +136,7 @@ test: no
 
     1. 生成 `WorkloadGroup`:
 
-        {< text bash >}}
+        {{< text bash >}}
         $ cat <<EOF > workloadgroup.yaml
         apiVersion: networking.istio.io/v1alpha3
         kind: WorkloadGroup

--- a/content/zh/docs/setup/install/virtual-machine/index.md
+++ b/content/zh/docs/setup/install/virtual-machine/index.md
@@ -107,8 +107,20 @@ test: no
 
     {{< tab name="默认" category-value="default" >}}
 
-    {{< text bash >}}
-    $ istioctl x workload group create --name "${VM_APP}" --namespace "${VM_NAMESPACE}" --labels app="${VM_APP}" --serviceAccount "${SERVICE_ACCOUNT}" > workloadgroup.yaml
+    {< text bash >}}
+    $ cat <<EOF > workloadgroup.yaml
+    apiVersion: networking.istio.io/v1alpha3
+    kind: WorkloadGroup
+    metadata:
+      name: ${VM_APP}
+      namespace: ${VM_NAMESPACE}
+    spec:
+      metadata:
+        labels:
+          app: ${VM_APP}
+      template:
+        serviceAccount: ${SERVICE_ACCOUNT}
+    EOF
     {{< /text >}}
 
     {{< /tab >}}
@@ -122,8 +134,20 @@ test: no
 
     1. 生成 `WorkloadGroup`:
 
-        {{< text bash >}}
-        $ istioctl x workload group create --name "${VM_APP}" --namespace "${VM_NAMESPACE}" --labels app="${VM_APP}" --serviceAccount "${SERVICE_ACCOUNT}" > workloadgroup.yaml
+        {< text bash >}}
+        $ cat <<EOF > workloadgroup.yaml
+        apiVersion: networking.istio.io/v1alpha3
+        kind: WorkloadGroup
+        metadata:
+          name: ${VM_APP}
+          namespace: ${VM_NAMESPACE}
+        spec:
+          metadata:
+            labels:
+              app: ${VM_APP}
+          template:
+            serviceAccount: ${SERVICE_ACCOUNT}
+        EOF
         {{< /text >}}
 
     1. 将 `WorkloadGroup` 应用到集群中：

--- a/content/zh/docs/setup/install/virtual-machine/index.md
+++ b/content/zh/docs/setup/install/virtual-machine/index.md
@@ -34,7 +34,6 @@ test: no
     $ VM_NAMESPACE="<the name of your service namespace>"
     $ WORK_DIR="<a certificate working directory>"
     $ SERVICE_ACCOUNT="<name of the Kubernetes service account you want to use for your VM>"
-    $ NETWORK="<this can be left blank for single-network installations>"
     {{< /text >}}
 
 1. 创建工作目录：
@@ -109,20 +108,7 @@ test: no
     {{< tab name="默认" category-value="default" >}}
 
     {{< text bash >}}
-    $ cat <<EOF > workloadgroup.yaml
-    apiVersion: networking.istio.io/v1alpha3
-    kind: WorkloadGroup
-    metadata:
-      name: "${VM_APP}"
-      namespace: "${VM_NAMESPACE}"
-    spec:
-      metadata:
-        labels:
-          app: "${VM_APP}"
-      template:
-        serviceAccount: "${SERVICE_ACCOUNT}"
-        network: "${NETWORK}"
-    EOF
+    $ istioctl x workload group create --name "${VM_APP}" --namespace "${VM_NAMESPACE}" --labels app="${VM_APP}" --serviceAccount "${SERVICE_ACCOUNT}" > workloadgroup.yaml
     {{< /text >}}
 
     {{< /tab >}}
@@ -137,20 +123,7 @@ test: no
     1. 生成 `WorkloadGroup`:
 
         {{< text bash >}}
-        $ cat <<EOF > workloadgroup.yaml
-        apiVersion: networking.istio.io/v1alpha3
-        kind: WorkloadGroup
-        metadata:
-          name: "${VM_APP}"
-          namespace: "${VM_NAMESPACE}"
-        spec:
-          metadata:
-            labels:
-              app: "${VM_APP}"
-          template:
-            serviceAccount: "${SERVICE_ACCOUNT}"
-            network: "${NETWORK}"
-        EOF
+        $ istioctl x workload group create --name "${VM_APP}" --namespace "${VM_NAMESPACE}" --labels app="${VM_APP}" --serviceAccount "${SERVICE_ACCOUNT}" > workloadgroup.yaml
         {{< /text >}}
 
     1. 将 `WorkloadGroup` 应用到集群中：

--- a/content/zh/docs/setup/install/virtual-machine/index.md
+++ b/content/zh/docs/setup/install/virtual-machine/index.md
@@ -34,6 +34,7 @@ test: no
     $ VM_NAMESPACE="<the name of your service namespace>"
     $ WORK_DIR="<a certificate working directory>"
     $ SERVICE_ACCOUNT="<name of the Kubernetes service account you want to use for your VM>"
+    $ NETWORK="<this can be left blank for single-network installations>
     {{< /text >}}
 
 1. 创建工作目录：
@@ -112,14 +113,15 @@ test: no
     apiVersion: networking.istio.io/v1alpha3
     kind: WorkloadGroup
     metadata:
-      name: ${VM_APP}
-      namespace: ${VM_NAMESPACE}
+      name: "${VM_APP}"
+      namespace: "${VM_NAMESPACE}"
     spec:
       metadata:
         labels:
-          app: ${VM_APP}
+          app: "${VM_APP}"
       template:
-        serviceAccount: ${SERVICE_ACCOUNT}
+        serviceAccount: "${SERVICE_ACCOUNT}"
+        network: "${NETWORK}"
     EOF
     {{< /text >}}
 
@@ -139,14 +141,15 @@ test: no
         apiVersion: networking.istio.io/v1alpha3
         kind: WorkloadGroup
         metadata:
-          name: ${VM_APP}
-          namespace: ${VM_NAMESPACE}
+          name: "${VM_APP}"
+          namespace: "${VM_NAMESPACE}"
         spec:
           metadata:
             labels:
-              app: ${VM_APP}
+              app: "${VM_APP}"
           template:
-            serviceAccount: ${SERVICE_ACCOUNT}
+            serviceAccount: "${SERVICE_ACCOUNT}"
+            network: "${NETWORK}"
         EOF
         {{< /text >}}
 


### PR DESCRIPTION
- [X] Use heredoc/file for workload group instead of `istioctl x workload group create` cc @howardjohn 
- [X] Multi-network doc uses new installation steps 
- [ ] examples/virtual-machines endpoint validation should use hello-world instead of httpbin to match setup/virtual-machine

fixes https://github.com/istio/istio/issues/29499
fixes https://github.com/istio/istio.io/issues/8602

Not sure how we track translated docs becoming out of sync...