### PR TITLE
Add info about using Metallb for multi-cluster setup on kind

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -433,6 +433,7 @@ Manolache
 Marshalers
 memcached
 memcached-2's
+MetalLB
 Mesos
 mesos-dns
 metadata

--- a/content/en/boilerplates/multi-cluster-with-metallb.md
+++ b/content/en/boilerplates/multi-cluster-with-metallb.md
@@ -1,3 +1,5 @@
 ---
 ---
+{{< tip >}}
 If you are testing multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
+{{< /tip >}}

--- a/content/en/boilerplates/multi-cluster-with-metallb.md
+++ b/content/en/boilerplates/multi-cluster-with-metallb.md
@@ -1,0 +1,3 @@
+---
+---
+If you are testing multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -16,6 +16,10 @@ across cluster boundaries.
 Before proceeding, be sure to complete the steps under
 [before you begin](/docs/setup/install/multicluster/before-you-begin).
 
+{{< tip >}}
+If you are testing primary-remote multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
+{{< /tip >}}
+
 In this configuration, both `cluster1` and `cluster2` observe the API Servers
 in each cluster for endpoints.
 

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -16,9 +16,7 @@ across cluster boundaries.
 Before proceeding, be sure to complete the steps under
 [before you begin](/docs/setup/install/multicluster/before-you-begin).
 
-{{< tip >}}
 {{< boilerplate multi-cluster-with-metallb >}}
-{{< /tip >}}
 
 In this configuration, both `cluster1` and `cluster2` observe the API Servers
 in each cluster for endpoints.

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -17,7 +17,7 @@ Before proceeding, be sure to complete the steps under
 [before you begin](/docs/setup/install/multicluster/before-you-begin).
 
 {{< tip >}}
-If you are testing primary-remote multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
+If you are testing multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
 {{< /tip >}}
 
 In this configuration, both `cluster1` and `cluster2` observe the API Servers

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -17,7 +17,7 @@ Before proceeding, be sure to complete the steps under
 [before you begin](/docs/setup/install/multicluster/before-you-begin).
 
 {{< tip >}}
-If you are testing multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
+{{< boilerplate multi-cluster-with-metallb >}}
 {{< /tip >}}
 
 In this configuration, both `cluster1` and `cluster2` observe the API Servers

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -17,7 +17,7 @@ Before proceeding, be sure to complete the steps under
 [before you begin](/docs/setup/install/multicluster/before-you-begin).
 
 {{< tip >}}
-If you are testing multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
+{{< boilerplate multi-cluster-with-metallb >}}
 {{< /tip >}}
 
 In this configuration, cluster `cluster1` will observe the API Servers in

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -16,9 +16,7 @@ connectivity between the pods in both clusters.
 Before proceeding, be sure to complete the steps under
 [before you begin](/docs/setup/install/multicluster/before-you-begin).
 
-{{< tip >}}
 {{< boilerplate multi-cluster-with-metallb >}}
-{{< /tip >}}
 
 In this configuration, cluster `cluster1` will observe the API Servers in
 both clusters for endpoints. In this way, the control plane will be able to

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -17,7 +17,7 @@ Before proceeding, be sure to complete the steps under
 [before you begin](/docs/setup/install/multicluster/before-you-begin).
 
 {{< tip >}}
-If you are testing primary-remote multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
+If you are testing multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
 {{< /tip >}}
 
 In this configuration, cluster `cluster1` will observe the API Servers in

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -129,7 +129,7 @@ $ istioctl x create-remote-secret \
 Save the address of `cluster1`’s east-west gateway.
 
 {{< tip >}}
-If you are testing primary-remote multicluster setup on `Kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
+If you are testing primary-remote multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
 {{< /tip >}}
 
 {{< text bash >}}

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -128,6 +128,10 @@ $ istioctl x create-remote-secret \
 
 Save the address of `cluster1`’s east-west gateway.
 
+{{< tip >}}
+If you are testing primary-remote multi-cluster setup on `Kind` you can use [Metallb](https://metallb.universe.tf/installation/) to make use of EXTERNAL-IP for Load Balancer.
+{{< /tip >}}
+
 {{< text bash >}}
 $ export DISCOVERY_ADDRESS=$(kubectl \
     --context="${CTX_CLUSTER1}" \

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -16,6 +16,10 @@ connectivity between the pods in both clusters.
 Before proceeding, be sure to complete the steps under
 [before you begin](/docs/setup/install/multicluster/before-you-begin).
 
+{{< tip >}}
+If you are testing primary-remote multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
+{{< /tip >}}
+
 In this configuration, cluster `cluster1` will observe the API Servers in
 both clusters for endpoints. In this way, the control plane will be able to
 provide service discovery for workloads in both clusters.
@@ -127,10 +131,6 @@ $ istioctl x create-remote-secret \
 ## Configure `cluster2` as a remote
 
 Save the address of `cluster1`’s east-west gateway.
-
-{{< tip >}}
-If you are testing primary-remote multicluster setup on `kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
-{{< /tip >}}
 
 {{< text bash >}}
 $ export DISCOVERY_ADDRESS=$(kubectl \

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -129,7 +129,7 @@ $ istioctl x create-remote-secret \
 Save the address of `cluster1`’s east-west gateway.
 
 {{< tip >}}
-If you are testing primary-remote multi-cluster setup on `Kind` you can use [Metallb](https://metallb.universe.tf/installation/) to make use of EXTERNAL-IP for Load Balancer.
+If you are testing primary-remote multicluster setup on `Kind` you can use [MetalLB](https://metallb.universe.tf/installation/) to make use of `EXTERNAL-IP` for `LoadBalancer` services.
 {{< /tip >}}
 
 {{< text bash >}}


### PR DESCRIPTION
To test primary-remote multi-cluster setup on `kind`, The `cluster2` requires `remotePilotAddress`  which can be `eastwestgateway` load balancer ip. Considering KinD does not come with load balancer, `Metallb` helps provide external IP as a load balancer.
