### PR TITLE
remove caAddres, no longer needed

### DIFF
--- a/content/en/docs/setup/additional-setup/external-controlplane/index.md
+++ b/content/en/docs/setup/additional-setup/external-controlplane/index.md
@@ -231,7 +231,6 @@ spec:
 
   values:
     global:
-      caAddress: $EXTERNAL_ISTIOD_ADDR:15012
       istioNamespace: external-istiod
       meshID: mesh1
       multiCluster:
@@ -289,7 +288,6 @@ spec:
       enabled: false
   values:
     global:
-      caAddress: $EXTERNAL_ISTIOD_ADDR:15012
       istioNamespace: external-istiod
       operatorManageWebhooks: true
       meshID: mesh1

--- a/content/en/docs/setup/additional-setup/external-controlplane/snips.sh
+++ b/content/en/docs/setup/additional-setup/external-controlplane/snips.sh
@@ -157,7 +157,6 @@ spec:
 
   values:
     global:
-      caAddress: $EXTERNAL_ISTIOD_ADDR:15012
       istioNamespace: external-istiod
       meshID: mesh1
       multiCluster:
@@ -205,7 +204,6 @@ spec:
       enabled: false
   values:
     global:
-      caAddress: $EXTERNAL_ISTIOD_ADDR:15012
       istioNamespace: external-istiod
       operatorManageWebhooks: true
       meshID: mesh1


### PR DESCRIPTION
it just defaults to discoveryAddr

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
