### PR TITLE
Use experimental as feature stage

### DIFF
--- a/content/en/about/feature-stages/index.md
+++ b/content/en/about/feature-stages/index.md
@@ -43,7 +43,7 @@ Below is our list of existing features and their current phases. This informatio
 | Enabling custom filters in Envoy | Alpha
 | CNI container interface | Alpha
 | [Sidecar API](/docs/reference/config/networking/sidecar/) | Beta
-| [DNS Proxying](docs/ops/configuration/traffic-management/dns-proxy/) | Alpha
+| [DNS Proxying](/docs/ops/configuration/traffic-management/dns-proxy/) | Alpha
 
 ### Observability
 

--- a/content/en/about/feature-stages/index.md
+++ b/content/en/about/feature-stages/index.md
@@ -43,6 +43,7 @@ Below is our list of existing features and their current phases. This informatio
 | Enabling custom filters in Envoy | Alpha
 | CNI container interface | Alpha
 | [Sidecar API](/docs/reference/config/networking/sidecar/) | Beta
+| [DNS Proxying](docs/ops/configuration/traffic-management/dns-proxy/) | Alpha
 
 ### Observability
 

--- a/content/en/boilerplates/experimental.md
+++ b/content/en/boilerplates/experimental.md
@@ -1,0 +1,6 @@
+---
+---
+{{< warning >}}
+This feature is actively in [development](https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE.md) and is
+considered `experimental`.
+{{< /warning >}}

--- a/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -1,13 +1,11 @@
 ---
-title: DNS Proxying [Experimental]
-description: How to configure DNS proxying (experimental).
+title: DNS Proxying
+description: How to configure DNS proxying.
 weight: 60
 keywords: [traffic-management,dns,virtual-machine]
 owner: istio/wg-networking-maintainers
 test: no
 ---
-
-{{< boilerplate experimental >}}
 
 In addition to capturing application traffic, Istio can also capture DNS requests to improve the performance and usability of your mesh.
 When proxying DNS, all DNS requests from an application will be redirected to the sidecar, which stores a local mapping of domain names to IP addresses. If the request can be handled by the sidecar, it will directly return a response to the application, avoiding a roundtrip to the upstream DNS server. Otherwise, the request is forwarded upstream following the standard `/etc/resolv.conf` DNS configuration.

--- a/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -1,15 +1,13 @@
 ---
-title: DNS Proxying
-description: How to configure DNS proxying.
+title: DNS Proxying [Experimental]
+description: How to configure DNS proxying (experimental).
 weight: 60
 keywords: [traffic-management,dns,virtual-machine]
 owner: istio/wg-networking-maintainers
 test: no
 ---
 
-{{< warning >}}
-This feature is currently [experimental](https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE.md) and considered `alpha`.
-{{< /warning >}}
+{{< boilerplate experimental >}}
 
 In addition to capturing application traffic, Istio can also capture DNS requests to improve the performance and usability of your mesh.
 When proxying DNS, all DNS requests from an application will be redirected to the sidecar, which stores a local mapping of domain names to IP addresses. If the request can be handled by the sidecar, it will directly return a response to the application, avoiding a roundtrip to the upstream DNS server. Otherwise, the request is forwarded upstream following the standard `/etc/resolv.conf` DNS configuration.

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -1,6 +1,6 @@
 ---
-title: Configuring Gateway Network Topology [experimental]
-description: How to configure gateway network topology.
+title: Configuring Gateway Network Topology [Experimental]
+description: How to configure gateway network topology (experimental).
 weight: 60
 keywords: [traffic-management,ingress,gateway]
 owner: istio/wg-networking-maintainers
@@ -9,10 +9,7 @@ test: no
 
 ## Configuring network topologies
 
-{{< warning >}}
-This feature is actively in [development](https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE.md) and is
-considered `pre-alpha`.
-{{< /warning >}}
+{{< boilerplate experimental >}}
 
 Istio provides the ability to manage settings like [X-Forwarded-For](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for) (XFF)
 and [X-Forwarded-Client-Cert](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-client-cert)

--- a/content/en/docs/reference/config/proxy_extensions/wasm_telemetry/index.md
+++ b/content/en/docs/reference/config/proxy_extensions/wasm_telemetry/index.md
@@ -1,5 +1,5 @@
 ---
-title: Wasm-based Telemetry (Experimental)
+title: Wasm-based Telemetry [Experimental]
 description: How to enable telemetry generation with the Wasm runtime (experimental).
 weight: 60
 owner: istio/wg-policies-and-telemetry-maintainers

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -14,7 +14,7 @@ test: no
 Follow this guide to deploy Istio and connect a virtual machine to it.
 
 {{< tip >}}
-This guide is tested and validated but note that VM support is still an alpha feature not recommended for production.
+This guide is tested and validated but note that VM support is still an experimental feature not recommended for production.
 {{< /tip >}}
 
 ## Prerequisites

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -1,6 +1,6 @@
 ---
-title: Virtual Machine Installation [Experimental]
-description: Deploy Istio and connect a workload running within a virtual machine to it (experimental).
+title: Virtual Machine Installation
+description: Deploy Istio and connect a workload running within a virtual machine to it.
 weight: 40
 keywords:
 - kubernetes
@@ -14,7 +14,7 @@ test: no
 Follow this guide to deploy Istio and connect a virtual machine to it.
 
 {{< tip >}}
-This guide is tested and validated but note that VM support is still an experimental feature not recommended for production.
+This guide is tested and validated but note that VM support is still an alpha feature not recommended for production.
 {{< /tip >}}
 
 ## Prerequisites

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -1,6 +1,6 @@
 ---
-title: Virtual Machine Installation
-description: Deploy Istio and connect a workload running within a virtual machine to it.
+title: Virtual Machine Installation [Experimental]
+description: Deploy Istio and connect a workload running within a virtual machine to it (experimental).
 weight: 40
 keywords:
 - kubernetes
@@ -104,10 +104,7 @@ Install Istio and expose the control plane so that your virtual machine can acce
 
     {{< tab name="Automated WorkloadEntry Creation" category-value="autoreg" >}}
 
-    {{< warning >}}
-    This feature is actively in [development](https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE.md) and is
-    considered `pre-alpha`.
-    {{< /warning >}}
+    {{< boilerplate experimental >}}
 
     {{< text bash >}}
     $ istioctl install -f vm-cluster.yaml --set values.pilot.env.PILOT_ENABLE_WORKLOAD_ENTRY_AUTOREGISTRATION=true --set values.pilot.env.PILOT_ENABLE_WORKLOAD_ENTRY_HEALTHCHECKS=true
@@ -222,10 +219,7 @@ EOF
 
 First, create a template `WorkloadGroup` for the VM(s):
 
-{{< warning >}}
-This feature is actively in [development](https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE.md) and is
-considered `pre-alpha`.
-{{< /warning >}}
+{{< boilerplate experimental >}}
 
 {{< text bash >}}
 $ cat <<EOF > workloadgroup.yaml
@@ -313,10 +307,7 @@ $ istioctl x workload entry configure -f workloadgroup.yaml -o "${WORK_DIR}" --c
 
 {{< tab name="Automated WorkloadEntry Creation" category-value="autoreg" >}}
 
-{{< warning >}}
-This feature is actively in [development](https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE.md) and is
-considered `pre-alpha`.
-{{< /warning >}}
+{{< boilerplate experimental >}}
 
 {{< text bash >}}
 $ istioctl x workload entry configure -f workloadgroup.yaml -o "${WORK_DIR}" --clusterID "${CLUSTER}" --autoregister

--- a/content/en/docs/setup/upgrade/gateways/index.md
+++ b/content/en/docs/setup/upgrade/gateways/index.md
@@ -1,16 +1,13 @@
 ---
-title: Managing Gateways with Multiple Revisions [experimental]
-description: Configuring and upgrading Istio with gateways.
+title: Managing Gateways with Multiple Revisions [Experimental]
+description: Configuring and upgrading Istio with gateways (experimental).
 weight: 30
 keywords: [kubernetes,upgrading,gateway]
 owner: istio/wg-environments-maintainers
 test: no
 ---
 
-{{< warning >}}
-This feature is actively in [development](https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE.md) and is
-considered `pre-alpha`.
-{{< /warning >}}
+{{< boilerplate experimental >}}
 
 With a single `IstioOperator` CR, any gateways defined in the CR (including the `istio-ingressgateway` installed in the
 default profile) are upgraded in place, even when the

--- a/content/en/docs/tasks/observability/distributed-tracing/configurability/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/configurability/index.md
@@ -1,6 +1,6 @@
 ---
-title: Configurability (Beta/Development)
-description: How to configure tracing options (beta/development).
+title: Configurability [Beta/Experimental]
+description: How to configure tracing options (beta/experimental).
 weight: 60
 keywords: [telemetry,tracing]
 owner: istio/wg-policies-and-telemetry-maintainers

--- a/content/en/docs/tasks/security/cert-management/custom-ca-k8s/index.md
+++ b/content/en/docs/tasks/security/cert-management/custom-ca-k8s/index.md
@@ -1,6 +1,6 @@
 ---
-title: Custom CA Integration using Kubernetes CSR [experimental]
-description: Shows how to use a Custom Certificate Authority (that integrates with the Kubernetes CSR API) to provision Istio workload certificates.
+title: Custom CA Integration using Kubernetes CSR [Experimental]
+description: Shows how to use a Custom Certificate Authority (that integrates with the Kubernetes CSR API) to provision Istio workload certificates (experimental).
 weight: 100
 keywords: [security,certificate]
 aliases:
@@ -9,10 +9,7 @@ owner: istio/wg-security-maintainers
 test: no
 ---
 
-{{< warning >}}
-This feature is actively in [development](https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE.md) and is
-considered `pre-alpha`.
-{{< /warning >}}
+{{< boilerplate experimental >}}
 
 This feature requires Kubernetes version >= 1.18.
 


### PR DESCRIPTION
Pre-alpha/Development are deprecated in favor of Experimental (see
https://github.com/istio/community/pull/495). Update docs to reference
this phase.


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure