### PR TITLE
Silence curl command

### DIFF
--- a/content/en/docs/examples/bookinfo/index.md
+++ b/content/en/docs/examples/bookinfo/index.md
@@ -138,7 +138,7 @@ If you use GKE, please ensure your cluster has at least 4 standard GKE nodes. If
     example from `ratings`:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -s productpage:9080/productpage | grep -o "<title>.*</title>"
+    $ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -sS productpage:9080/productpage | grep -o "<title>.*</title>"
     <title>Simple Bookstore App</title>
     {{< /text >}}
 

--- a/content/en/docs/examples/bookinfo/index.md
+++ b/content/en/docs/examples/bookinfo/index.md
@@ -138,7 +138,7 @@ If you use GKE, please ensure your cluster has at least 4 standard GKE nodes. If
     example from `ratings`:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl productpage:9080/productpage | grep -o "<title>.*</title>"
+    $ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -s productpage:9080/productpage | grep -o "<title>.*</title>"
     <title>Simple Bookstore App</title>
     {{< /text >}}
 

--- a/content/en/docs/examples/bookinfo/snips.sh
+++ b/content/en/docs/examples/bookinfo/snips.sh
@@ -60,7 +60,7 @@ reviews-v3-1813607990-8ch52      2/2       Running   0          6m
 ENDSNIP
 
 snip_start_the_application_services_6() {
-kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl productpage:9080/productpage | grep -o "<title>.*</title>"
+kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -s productpage:9080/productpage | grep -o "<title>.*</title>"
 }
 
 ! read -r -d '' snip_start_the_application_services_6_out <<\ENDSNIP

--- a/content/en/docs/examples/bookinfo/snips.sh
+++ b/content/en/docs/examples/bookinfo/snips.sh
@@ -60,7 +60,7 @@ reviews-v3-1813607990-8ch52      2/2       Running   0          6m
 ENDSNIP
 
 snip_start_the_application_services_6() {
-kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -s productpage:9080/productpage | grep -o "<title>.*</title>"
+kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -sS productpage:9080/productpage | grep -o "<title>.*</title>"
 }
 
 ! read -r -d '' snip_start_the_application_services_6_out <<\ENDSNIP

--- a/content/en/docs/examples/microservices-istio/add-new-microservice-version/index.md
+++ b/content/en/docs/examples/microservices-istio/add-new-microservice-version/index.md
@@ -44,7 +44,7 @@ tests, end-to-end tests and tests in a staging environment.
     1.  Send a request to the pod and see that it returns the correct result:
 
         {{< text bash >}}
-        $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -- curl "$REVIEWS_V2_POD_IP:9080/reviews/7"
+        $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -- curl -sS "$REVIEWS_V2_POD_IP:9080/reviews/7"
         {"id": "7","reviews": [{  "reviewer": "Reviewer1",  "text": "An extremely entertaining play by Shakespeare. The slapstick humour is refreshing!", "rating": {"stars": 5, "color": "black"}},{  "reviewer": "Reviewer2",  "text": "Absolutely fun and entertaining. The play lacks thematic depth when compared to other plays by Shakespeare.", "rating": {"stars": 4, "color": "black"}}]}
         {{< /text >}}
 

--- a/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
+++ b/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
@@ -97,7 +97,7 @@ microservice.
     with a curl command from your testing pod:
 
     {{< text bash >}}
-    $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -c sleep -- curl -s productpage:9080/productpage | grep -o "<title>.*</title>"
+    $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -c sleep -- curl -sS productpage:9080/productpage | grep -o "<title>.*</title>"
     <title>Simple Bookstore App</title>
     {{< /text >}}
 

--- a/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
+++ b/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
@@ -97,7 +97,7 @@ microservice.
     with a curl command from your testing pod:
 
     {{< text bash >}}
-    $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -c sleep -- curl productpage:9080/productpage | grep -o "<title>.*</title>"
+    $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -c sleep -- curl -s productpage:9080/productpage | grep -o "<title>.*</title>"
     <title>Simple Bookstore App</title>
     {{< /text >}}
 

--- a/content/en/docs/examples/microservices-istio/production-testing/index.md
+++ b/content/en/docs/examples/microservices-istio/production-testing/index.md
@@ -17,7 +17,7 @@ Test your microservice, in production!
 1.  Issue an HTTP request from the testing pod to one of your services:
 
     {{< text bash >}}
-    $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -- curl http://ratings:9080/ratings/7
+    $ kubectl exec $(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}') -- curl -sS http://ratings:9080/ratings/7
     {{< /text >}}
 
 ## Chaos testing

--- a/content/en/docs/examples/virtual-machines/multi-network/index.md
+++ b/content/en/docs/examples/virtual-machines/multi-network/index.md
@@ -126,7 +126,7 @@ At this point we should be able to send traffic to `httpbin.default.svc.cluster.
 1. Send a request from the `sleep` service on the pod to the VM's HTTP service:
 
     {{< text bash >}}
-    $ kubectl exec -it sleep-88ddbcfdd-rm42k -c sleep -- curl cloud-vm.${VM_NAMESPACE}.svc.cluster.local:8080
+    $ kubectl exec -it sleep-88ddbcfdd-rm42k -c sleep -- curl -sS cloud-vm.${VM_NAMESPACE}.svc.cluster.local:8080
     {{< /text >}}
 
     You should see something similar to the output below.

--- a/content/en/docs/examples/virtual-machines/single-network/index.md
+++ b/content/en/docs/examples/virtual-machines/single-network/index.md
@@ -128,7 +128,7 @@ $ curl -v httpbin.default.svc.cluster.local:8000/headers
 1. Send a request from the `sleep` service on the pod to the virtual machine HTTP service:
 
     {{< text bash >}}
-    $ kubectl exec -it sleep-88ddbcfdd-rm42k -c sleep -- curl cloud-vm.${VM_NAMESPACE}.svc.cluster.local:8080
+    $ kubectl exec -it sleep-88ddbcfdd-rm42k -c sleep -- curl -sS cloud-vm.${VM_NAMESPACE}.svc.cluster.local:8080
     {{< /text >}}
 
     You will see output similar to this:

--- a/content/en/docs/ops/configuration/security/root-transition/index.md
+++ b/content/en/docs/ops/configuration/security/root-transition/index.md
@@ -78,7 +78,7 @@ and how to transition to a new root certificate with a 10 year lifetime.
     The following command shows an example to check the Envoy’s certificate for a pod.
 
     {{< text bash>}}
-    $ kubectl exec [YOUR_POD] -c istio-proxy -n [YOUR_NAMESPACE] -- curl http://localhost:15000/certs | head -c 1000
+    $ kubectl exec [YOUR_POD] -c istio-proxy -n [YOUR_NAMESPACE] -- curl -sS http://localhost:15000/certs | head -c 1000
     {
      "certificates": [
       {

--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -161,7 +161,7 @@ Follow these steps to get started with Istio:
     checking for the page title in the response:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -s productpage:9080/productpage | grep -o "<title>.*</title>"
+    $ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -sS productpage:9080/productpage | grep -o "<title>.*</title>"
     <title>Simple Bookstore App</title>
     {{< /text >}}
 

--- a/content/en/docs/setup/getting-started/snips.sh
+++ b/content/en/docs/setup/getting-started/snips.sh
@@ -101,7 +101,7 @@ reviews-v3-7dbcdcbc56-m8dph       2/2     Running   0          2m41s
 ENDSNIP
 
 snip_deploy_the_sample_application_bookinfo_4() {
-kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -s productpage:9080/productpage | grep -o "<title>.*</title>"
+kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -sS productpage:9080/productpage | grep -o "<title>.*</title>"
 }
 
 ! read -r -d '' snip_deploy_the_sample_application_bookinfo_4_out <<\ENDSNIP

--- a/content/en/docs/setup/install/multicluster/verify/index.md
+++ b/content/en/docs/setup/install/multicluster/verify/index.md
@@ -142,7 +142,7 @@ Send one request from the `Sleep` pod on `cluster1` to the `HelloWorld` service:
 $ kubectl exec --context="${CTX_CLUSTER1}" -n sample -c sleep \
     "$(kubectl get pod --context="${CTX_CLUSTER1}" -n sample -l \
     app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-    -- curl helloworld.sample:5000/hello
+    -- curl -sS helloworld.sample:5000/hello
 {{< /text >}}
 
 Repeat this request several times and verify that the `HelloWorld` version
@@ -160,7 +160,7 @@ Now repeat this process from the `Sleep` pod on `cluster2`:
 $ kubectl exec --context="${CTX_CLUSTER2}" -n sample -c sleep \
     "$(kubectl get pod --context="${CTX_CLUSTER2}" -n sample -l \
     app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-    -- curl helloworld.sample:5000/hello
+    -- curl -sS helloworld.sample:5000/hello
 {{< /text >}}
 
 Repeat this request several times and verify that the `HelloWorld` version

--- a/content/en/docs/setup/install/multicluster/verify/snips.sh
+++ b/content/en/docs/setup/install/multicluster/verify/snips.sh
@@ -100,7 +100,7 @@ snip_verifying_crosscluster_traffic_1() {
 kubectl exec --context="${CTX_CLUSTER1}" -n sample -c sleep \
     "$(kubectl get pod --context="${CTX_CLUSTER1}" -n sample -l \
     app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-    -- curl helloworld.sample:5000/hello
+    -- curl -sS helloworld.sample:5000/hello
 }
 
 ! read -r -d '' snip_verifying_crosscluster_traffic_2 <<\ENDSNIP
@@ -113,7 +113,7 @@ snip_verifying_crosscluster_traffic_3() {
 kubectl exec --context="${CTX_CLUSTER2}" -n sample -c sleep \
     "$(kubectl get pod --context="${CTX_CLUSTER2}" -n sample -l \
     app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-    -- curl helloworld.sample:5000/hello
+    -- curl -sS helloworld.sample:5000/hello
 }
 
 ! read -r -d '' snip_verifying_crosscluster_traffic_4 <<\ENDSNIP

--- a/content/en/docs/tasks/observability/logs/access-log/index.md
+++ b/content/en/docs/tasks/observability/logs/access-log/index.md
@@ -89,7 +89,7 @@ The following table shows an example using the default access log format for a r
 1.  Send a request from `sleep` to `httpbin`:
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -v httpbin:8000/status/418
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v httpbin:8000/status/418
     ...
     < HTTP/1.1 418 Unknown
     < server: envoy

--- a/content/en/docs/tasks/observability/logs/access-log/snips.sh
+++ b/content/en/docs/tasks/observability/logs/access-log/snips.sh
@@ -35,7 +35,7 @@ ENDSNIP
 ENDSNIP
 
 snip_test_the_access_log_1() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -v httpbin:8000/status/418
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v httpbin:8000/status/418
 }
 
 ! read -r -d '' snip_test_the_access_log_1_out <<\ENDSNIP

--- a/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
@@ -1,6 +1,6 @@
 ---
 title: Classifying Metrics Based on Request or Response (Experimental)
-description: This task shows you how to improve telemetry by grouping requests and responses by their type. 
+description: This task shows you how to improve telemetry by grouping requests and responses by their type.
 weight: 27
 keywords: [telemetry,metrics,classify,request-based,openapispec,swagger]
 owner: istio/wg-policies-and-telemetry-maintainers
@@ -319,7 +319,7 @@ spec:
    `2xx`. Alternatively, use the following command to verify that Istio generates the data for your new dimension:
 
     {{< text bash >}}
-    $ kubectl exec pod-name -c istio-proxy -- curl 'localhost:15000/stats/prometheus' | grep istio_
+    $ kubectl exec pod-name -c istio-proxy -- curl -sS 'localhost:15000/stats/prometheus' | grep istio_
     {{< /text >}}
 
     In the output, locate the metric (e.g. `istio_requests_total`) and verify the presence of the new or changed dimension.

--- a/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
@@ -155,7 +155,7 @@ Use the following command to verify that Istio generates the data for your new
 or modified dimensions:
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=productpage -o jsonpath='{.items[0].metadata.name}')" -c istio-proxy -- curl 'localhost:15000/stats/prometheus' | grep istio_requests_total
+$ kubectl exec "$(kubectl get pod -l app=productpage -o jsonpath='{.items[0].metadata.name}')" -c istio-proxy -- curl -sS 'localhost:15000/stats/prometheus' | grep istio_requests_total
 {{< /text >}}
 
 For example, in the output, locate the metric `istio_requests_total` and

--- a/content/en/docs/tasks/observability/metrics/customize-metrics/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/customize-metrics/snips.sh
@@ -89,7 +89,7 @@ curl "http://$GATEWAY_URL/productpage"
 }
 
 snip_verify_the_results_2() {
-kubectl exec "$(kubectl get pod -l app=productpage -o jsonpath='{.items[0].metadata.name}')" -c istio-proxy -- curl 'localhost:15000/stats/prometheus' | grep istio_requests_total
+kubectl exec "$(kubectl get pod -l app=productpage -o jsonpath='{.items[0].metadata.name}')" -c istio-proxy -- curl -sS 'localhost:15000/stats/prometheus' | grep istio_requests_total
 }
 
 ! read -r -d '' snip_use_expressions_for_values_1 <<\ENDSNIP

--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -324,7 +324,7 @@ the local rate limit for `productpage` instances allows 10 req/min.
 To confirm this, send internal `productpage` requests, from the `ratings` pod, using the following `curl` command:
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl productpage:9080/productpage | grep -o "<title>.*</title>"
+$ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -s productpage:9080/productpage | grep -o "<title>.*</title>"
 <title>Simple Bookstore App</title>
 {{< /text >}}
 

--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -324,7 +324,7 @@ the local rate limit for `productpage` instances allows 10 req/min.
 To confirm this, send internal `productpage` requests, from the `ratings` pod, using the following `curl` command:
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -s productpage:9080/productpage | grep -o "<title>.*</title>"
+$ kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -sS productpage:9080/productpage | grep -o "<title>.*</title>"
 <title>Simple Bookstore App</title>
 {{< /text >}}
 

--- a/content/en/docs/tasks/security/authentication/authn-policy/index.md
+++ b/content/en/docs/tasks/security/authentication/authn-policy/index.md
@@ -56,7 +56,7 @@ $ kubectl exec "$(kubectl get pod -l app=sleep -n bar -o jsonpath={.items..metad
 This one-liner command conveniently iterates through all reachability combinations:
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl -sS "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl -s "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.foo to httpbin.legacy: 200
@@ -99,14 +99,14 @@ upstream request to the backend. That header's presence is evidence that mutual 
 used. For example:
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo --curl -sS http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
+$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl -s http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
     "X-Forwarded-Client-Cert": "By=spiffe://cluster.local/ns/foo/sa/httpbin;Hash=<redacted>;Subject=\"\";URI=spiffe://cluster.local/ns/foo/sa/sleep"
 {{< /text >}}
 
 When the server doesn't have sidecar, the `X-Forwarded-Client-Cert` header is not there, which implies requests are in plain text.
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.legacy:8000/headers -sS | grep X-Forwarded-Client-Cert
+$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.legacy:8000/headers -s | grep X-Forwarded-Client-Cert
 
 {{< /text >}}
 
@@ -140,7 +140,7 @@ Since it doesn't specify a value for the `selector` field, the policy applies to
 Run the test command again:
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.foo to httpbin.legacy: 200
@@ -186,7 +186,7 @@ EOF
 As this policy is applied on workloads in namespace `foo` only, you should see only request from client-without-sidecar (`sleep.legacy`) to `httpbin.foo` start to fail.
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.foo to httpbin.legacy: 200
@@ -240,7 +240,7 @@ EOF
 Again, run the probing command. As expected, request from `sleep.legacy` to `httpbin.bar` starts failing with the same reasons.
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.foo to httpbin.legacy: 200
@@ -306,7 +306,7 @@ EOF
 1. You can only use `portLevelMtls` if the port is bound to a service. Istio ignores it otherwise.
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.foo to httpbin.legacy: 200
@@ -360,7 +360,7 @@ EOF
 Re-running the request from `sleep.legacy`, you should see a success return code again (200), confirming service-specific policy overrides the namespace-wide policy.
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name})" -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -sS -o /dev/null -w "%{http_code}\n"
+$ kubectl exec "$(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name})" -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
 200
 {{< /text >}}
 

--- a/content/en/docs/tasks/security/authentication/authn-policy/index.md
+++ b/content/en/docs/tasks/security/authentication/authn-policy/index.md
@@ -99,7 +99,7 @@ upstream request to the backend. That header's presence is evidence that mutual 
 used. For example:
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -sS http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
+$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo --curl -sS http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
     "X-Forwarded-Client-Cert": "By=spiffe://cluster.local/ns/foo/sa/httpbin;Hash=<redacted>;Subject=\"\";URI=spiffe://cluster.local/ns/foo/sa/sleep"
 {{< /text >}}
 

--- a/content/en/docs/tasks/security/authentication/authn-policy/index.md
+++ b/content/en/docs/tasks/security/authentication/authn-policy/index.md
@@ -56,7 +56,7 @@ $ kubectl exec "$(kubectl get pod -l app=sleep -n bar -o jsonpath={.items..metad
 This one-liner command conveniently iterates through all reachability combinations:
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl -sS "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.foo to httpbin.legacy: 200
@@ -99,14 +99,14 @@ upstream request to the backend. That header's presence is evidence that mutual 
 used. For example:
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
+$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -sS http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
     "X-Forwarded-Client-Cert": "By=spiffe://cluster.local/ns/foo/sa/httpbin;Hash=<redacted>;Subject=\"\";URI=spiffe://cluster.local/ns/foo/sa/sleep"
 {{< /text >}}
 
 When the server doesn't have sidecar, the `X-Forwarded-Client-Cert` header is not there, which implies requests are in plain text.
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.legacy:8000/headers -s | grep X-Forwarded-Client-Cert
+$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.legacy:8000/headers -sS | grep X-Forwarded-Client-Cert
 
 {{< /text >}}
 
@@ -140,7 +140,7 @@ Since it doesn't specify a value for the `selector` field, the policy applies to
 Run the test command again:
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.foo to httpbin.legacy: 200
@@ -186,7 +186,7 @@ EOF
 As this policy is applied on workloads in namespace `foo` only, you should see only request from client-without-sidecar (`sleep.legacy`) to `httpbin.foo` start to fail.
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.foo to httpbin.legacy: 200
@@ -240,7 +240,7 @@ EOF
 Again, run the probing command. As expected, request from `sleep.legacy` to `httpbin.bar` starts failing with the same reasons.
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.foo to httpbin.legacy: 200
@@ -306,7 +306,7 @@ EOF
 1. You can only use `portLevelMtls` if the port is bound to a service. Istio ignores it otherwise.
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.foo to httpbin.legacy: 200
@@ -360,7 +360,7 @@ EOF
 Re-running the request from `sleep.legacy`, you should see a success return code again (200), confirming service-specific policy overrides the namespace-wide policy.
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name})" -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
+$ kubectl exec "$(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name})" -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 200
 {{< /text >}}
 

--- a/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
+++ b/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
@@ -77,7 +77,7 @@ kubectl get destinationrules.networking.istio.io --all-namespaces -o yaml | grep
 ENDSNIP
 
 snip_auto_mutual_tls_1() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -sS http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo --curl -sS http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
 }
 
 ! read -r -d '' snip_auto_mutual_tls_1_out <<\ENDSNIP

--- a/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
+++ b/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
@@ -45,7 +45,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -n bar -o jsonpath={.items..metadat
 ENDSNIP
 
 snip_setup_3() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl -sS "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl -s "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_setup_3_out <<\ENDSNIP
@@ -77,7 +77,7 @@ kubectl get destinationrules.networking.istio.io --all-namespaces -o yaml | grep
 ENDSNIP
 
 snip_auto_mutual_tls_1() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo --curl -sS http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl -s http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
 }
 
 ! read -r -d '' snip_auto_mutual_tls_1_out <<\ENDSNIP
@@ -85,7 +85,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadat
 ENDSNIP
 
 snip_auto_mutual_tls_2() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.legacy:8000/headers -sS | grep X-Forwarded-Client-Cert
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.legacy:8000/headers -s | grep X-Forwarded-Client-Cert
 }
 
 ! read -r -d '' snip_auto_mutual_tls_2_out <<\ENDSNIP
@@ -106,7 +106,7 @@ EOF
 }
 
 snip_globally_enabling_istio_mutual_tls_in_strict_mode_2() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_globally_enabling_istio_mutual_tls_in_strict_mode_2_out <<\ENDSNIP
@@ -141,7 +141,7 @@ EOF
 }
 
 snip_namespacewide_policy_2() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_namespacewide_policy_2_out <<\ENDSNIP
@@ -188,7 +188,7 @@ EOF
 }
 
 snip_enable_mutual_tls_per_workload_3() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_enable_mutual_tls_per_workload_3_out <<\ENDSNIP
@@ -250,7 +250,7 @@ EOF
 }
 
 snip_enable_mutual_tls_per_workload_7() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_enable_mutual_tls_per_workload_7_out <<\ENDSNIP
@@ -297,7 +297,7 @@ EOF
 }
 
 snip_policy_precedence_3() {
-kubectl exec "$(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name})" -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -sS -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name})" -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_policy_precedence_3_out <<\ENDSNIP

--- a/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
+++ b/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
@@ -45,7 +45,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -n bar -o jsonpath={.items..metadat
 ENDSNIP
 
 snip_setup_3() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl -sS "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_setup_3_out <<\ENDSNIP
@@ -77,7 +77,7 @@ kubectl get destinationrules.networking.istio.io --all-namespaces -o yaml | grep
 ENDSNIP
 
 snip_auto_mutual_tls_1() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -sS http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
 }
 
 ! read -r -d '' snip_auto_mutual_tls_1_out <<\ENDSNIP
@@ -85,7 +85,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadat
 ENDSNIP
 
 snip_auto_mutual_tls_2() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.legacy:8000/headers -s | grep X-Forwarded-Client-Cert
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.legacy:8000/headers -sS | grep X-Forwarded-Client-Cert
 }
 
 ! read -r -d '' snip_auto_mutual_tls_2_out <<\ENDSNIP
@@ -106,7 +106,7 @@ EOF
 }
 
 snip_globally_enabling_istio_mutual_tls_in_strict_mode_2() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_globally_enabling_istio_mutual_tls_in_strict_mode_2_out <<\ENDSNIP
@@ -141,7 +141,7 @@ EOF
 }
 
 snip_namespacewide_policy_2() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_namespacewide_policy_2_out <<\ENDSNIP
@@ -188,7 +188,7 @@ EOF
 }
 
 snip_enable_mutual_tls_per_workload_3() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_enable_mutual_tls_per_workload_3_out <<\ENDSNIP
@@ -250,7 +250,7 @@ EOF
 }
 
 snip_enable_mutual_tls_per_workload_7() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar" "legacy"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl "http://httpbin.${to}:8000/ip" -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_enable_mutual_tls_per_workload_7_out <<\ENDSNIP
@@ -297,7 +297,7 @@ EOF
 }
 
 snip_policy_precedence_3() {
-kubectl exec "$(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name})" -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n legacy -o jsonpath={.items..metadata.name})" -c sleep -n legacy -- curl http://httpbin.foo:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_policy_precedence_3_out <<\ENDSNIP

--- a/content/en/docs/tasks/security/authentication/mtls-migration/index.md
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/index.md
@@ -147,7 +147,7 @@ Now, both the `foo` and `bar` namespaces enforce mutual TLS only traffic, so you
 failing for both.
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 {{< /text >}}
 
 ## Clean up the example

--- a/content/en/docs/tasks/security/authentication/mtls-migration/index.md
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/index.md
@@ -58,7 +58,7 @@ the policies to enforce STRICT mutual TLS between the workloads.
     All requests should succeed with return code 200.
 
     {{< text bash >}}
-    $ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+    $ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
     sleep.foo to httpbin.foo: 200
     sleep.foo to httpbin.bar: 200
     sleep.bar to httpbin.foo: 200
@@ -103,7 +103,7 @@ EOF
 Now, you should see the request from `sleep.legacy` to `httpbin.foo` failing.
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.bar to httpbin.foo: 200

--- a/content/en/docs/tasks/security/authentication/mtls-migration/index.md
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/index.md
@@ -58,7 +58,7 @@ the policies to enforce STRICT mutual TLS between the workloads.
     All requests should succeed with return code 200.
 
     {{< text bash >}}
-    $ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+    $ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
     sleep.foo to httpbin.foo: 200
     sleep.foo to httpbin.bar: 200
     sleep.bar to httpbin.foo: 200
@@ -103,7 +103,7 @@ EOF
 Now, you should see the request from `sleep.legacy` to `httpbin.foo` failing.
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 sleep.foo to httpbin.foo: 200
 sleep.foo to httpbin.bar: 200
 sleep.bar to httpbin.foo: 200
@@ -147,7 +147,7 @@ Now, both the `foo` and `bar` namespaces enforce mutual TLS only traffic, so you
 failing for both.
 
 {{< text bash >}}
-$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+$ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 {{< /text >}}
 
 ## Clean up the example

--- a/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
@@ -35,7 +35,7 @@ kubectl apply -f samples/sleep/sleep.yaml -n legacy
 }
 
 snip_set_up_the_cluster_3() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_set_up_the_cluster_3_out <<\ENDSNIP
@@ -76,7 +76,7 @@ EOF
 }
 
 snip_lock_down_to_mutual_tls_by_namespace_2() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_lock_down_to_mutual_tls_by_namespace_2_out <<\ENDSNIP
@@ -111,7 +111,7 @@ EOF
 }
 
 snip_lock_down_mutual_tls_for_the_entire_mesh_2() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 snip_clean_up_the_example_1() {

--- a/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
@@ -35,7 +35,7 @@ kubectl apply -f samples/sleep/sleep.yaml -n legacy
 }
 
 snip_set_up_the_cluster_3() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_set_up_the_cluster_3_out <<\ENDSNIP
@@ -76,7 +76,7 @@ EOF
 }
 
 snip_lock_down_to_mutual_tls_by_namespace_2() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 ! read -r -d '' snip_lock_down_to_mutual_tls_by_namespace_2_out <<\ENDSNIP

--- a/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
@@ -111,7 +111,7 @@ EOF
 }
 
 snip_lock_down_mutual_tls_for_the_entire_mesh_2() {
-for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -sS -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
+for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(kubectl get pod -l app=sleep -n ${from} -o jsonpath={.items..metadata.name})" -c sleep -n ${from} -- curl http://httpbin.${to}:8000/ip -s -o /dev/null -w "sleep.${from} to httpbin.${to}: %{http_code}\n"; done; done
 }
 
 snip_clean_up_the_example_1() {

--- a/content/en/docs/tasks/security/authorization/authz-deny/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-deny/index.md
@@ -33,7 +33,7 @@ Before tackling this task you must perform the following actions:
 * Verify that `sleep` talks to `httpbin` with the following command:
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
+$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 200
 {{< /text >}}
 
@@ -71,14 +71,14 @@ In this case, the policy denies requests if their method is `GET`.
 1. Verify that `GET` requests are denied:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -sS -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 
 1. Verify that `POST` requests are allowed:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/post" -X POST -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/post" -X POST -sS -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
 
@@ -112,14 +112,14 @@ a header value that is not `admin`:
 1. Verify that `GET` requests with the HTTP header `x-token: admin` are allowed:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: admin" -sS -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
 
 1. Verify that GET requests with the HTTP header `x-token: guest` are denied:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: guest" -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: guest" -sS -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 

--- a/content/en/docs/tasks/security/authorization/authz-deny/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-deny/snips.sh
@@ -27,7 +27,7 @@ kubectl apply -f <(istioctl kube-inject -f samples/sleep/sleep.yaml) -n foo
 }
 
 snip_before_you_begin_2() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_before_you_begin_2_out <<\ENDSNIP
@@ -54,7 +54,7 @@ EOF
 }
 
 snip_explicitly_deny_a_request_2() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_explicitly_deny_a_request_2_out <<\ENDSNIP
@@ -62,7 +62,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadat
 ENDSNIP
 
 snip_explicitly_deny_a_request_3() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/post" -X POST -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/post" -X POST -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_explicitly_deny_a_request_3_out <<\ENDSNIP
@@ -92,7 +92,7 @@ EOF
 }
 
 snip_explicitly_deny_a_request_5() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: admin" -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: admin" -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_explicitly_deny_a_request_5_out <<\ENDSNIP
@@ -100,7 +100,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadat
 ENDSNIP
 
 snip_explicitly_deny_a_request_6() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: guest" -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/get" -X GET -H "x-token: guest" -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_explicitly_deny_a_request_6_out <<\ENDSNIP

--- a/content/en/docs/tasks/security/authorization/authz-http/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-http/test.sh
@@ -48,7 +48,7 @@ function verify {
 
   for ((i=1; i<="$REPEAT"; i++)); do
     set +e
-    response=$(kubectl exec "${sleep_pod}" -c sleep -n "default" -- curl "${ingress_url}" -s -w "\n%{http_code}\n")
+    response=$(kubectl exec "${sleep_pod}" -c sleep -n "default" -- curl "${ingress_url}" -sS -w "\n%{http_code}\n")
     set -e
     mapfile -t respArray <<< "$response"
     code=${respArray[-1]}

--- a/content/en/docs/tasks/security/authorization/authz-jwt/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-jwt/index.md
@@ -35,7 +35,7 @@ Deploy the example namespace and workloads using these commands:
 * Verify that `sleep` successfully communicates with `httpbin` using this command:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/ip -sS -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
 
@@ -70,14 +70,14 @@ accepts a JWT issued by `testing@secure.istio.io`:
 1. Verify that a request with an invalid JWT is denied:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -H "Authorization: Bearer invalidToken" -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -H "Authorization: Bearer invalidToken" -w "%{http_code}\n"
     401
     {{< /text >}}
 
 1. Verify that a request without a JWT is allowed because there is no authorization policy:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
 
@@ -117,14 +117,14 @@ This causes Istio to generate the attribute `requestPrincipal` with the value `t
 1. Verify that a request with a valid JWT is allowed:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n"
     200
     {{< /text >}}
 
 1. Verify that a request without a JWT is denied:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 
@@ -167,14 +167,14 @@ the JWT to have a claim named `groups` containing the value `group1`:
 1. Verify that a request with the JWT that includes `group1` in the `groups` claim is allowed:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -H "Authorization: Bearer $TOKEN_GROUP" -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -H "Authorization: Bearer $TOKEN_GROUP" -w "%{http_code}\n"
     200
     {{< /text >}}
 
 1. Verify that a request with a JWT, which doesn’t have the `groups` claim is rejected:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n"
     403
     {{< /text >}}
 

--- a/content/en/docs/tasks/security/authorization/authz-jwt/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-jwt/snips.sh
@@ -27,7 +27,7 @@ kubectl apply -f <(istioctl kube-inject -f samples/sleep/sleep.yaml) -n foo
 }
 
 snip_before_you_begin_2() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/ip -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl http://httpbin.foo:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_before_you_begin_2_out <<\ENDSNIP
@@ -52,7 +52,7 @@ EOF
 }
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_2() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -H "Authorization: Bearer invalidToken" -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -H "Authorization: Bearer invalidToken" -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_2_out <<\ENDSNIP
@@ -60,7 +60,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadat
 ENDSNIP
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_3() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_3_out <<\ENDSNIP
@@ -95,7 +95,7 @@ TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools
 ENDSNIP
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_6() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_6_out <<\ENDSNIP
@@ -103,7 +103,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadat
 ENDSNIP
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_7() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_7_out <<\ENDSNIP
@@ -141,7 +141,7 @@ TOKEN_GROUP=$(curl https://raw.githubusercontent.com/istio/istio/master/security
 ENDSNIP
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_10() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -H "Authorization: Bearer $TOKEN_GROUP" -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -H "Authorization: Bearer $TOKEN_GROUP" -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_10_out <<\ENDSNIP
@@ -149,7 +149,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadat
 ENDSNIP
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_11() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -s -o /dev/null -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -o /dev/null -H "Authorization: Bearer $TOKEN" -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_11_out <<\ENDSNIP

--- a/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/index.md
@@ -70,14 +70,14 @@ Notice that it may take tens of seconds for the authorization policy to be propa
     * `sleep` in the `default` namespace are denied.
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 
     * `sleep` in the `sleep-allow` namespace are allowed.
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
 
@@ -110,12 +110,12 @@ Notice that it may take tens of seconds for the authorization policy to be propa
 1. Verify that requests to `httpbin` from both `sleep` in `default` namespace and `sleep-allow` namespace are denied.
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 
@@ -148,14 +148,14 @@ Notice that it may take tens of seconds for the authorization policy to be propa
     * `sleep` in the `default` namespace are denied.
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
     403
     {{< /text >}}
 
     * `sleep` in the `sleep-allow` namespace are allowed.
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+    $ kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
     200
     {{< /text >}}
 

--- a/content/en/docs/tasks/security/authorization/authz-td-migration/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-td-migration/snips.sh
@@ -58,7 +58,7 @@ EOF
 }
 
 snip_before_you_begin_4() {
-kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_before_you_begin_4_out <<\ENDSNIP
@@ -66,7 +66,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name}
 ENDSNIP
 
 snip_before_you_begin_5() {
-kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_before_you_begin_5_out <<\ENDSNIP
@@ -90,7 +90,7 @@ kubectl delete pod --all -n sleep-allow
 }
 
 snip_migrate_trust_domain_without_trust_domain_aliases_5() {
-kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_migrate_trust_domain_without_trust_domain_aliases_5_out <<\ENDSNIP
@@ -98,7 +98,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name}
 ENDSNIP
 
 snip_migrate_trust_domain_without_trust_domain_aliases_6() {
-kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_migrate_trust_domain_without_trust_domain_aliases_6_out <<\ENDSNIP
@@ -119,7 +119,7 @@ istioctl install --set profile=demo -f td-installation.yaml -y
 }
 
 snip_migrate_trust_domain_with_trust_domain_aliases_2() {
-kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_migrate_trust_domain_with_trust_domain_aliases_2_out <<\ENDSNIP
@@ -127,7 +127,7 @@ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name}
 ENDSNIP
 
 snip_migrate_trust_domain_with_trust_domain_aliases_3() {
-kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -s -o /dev/null -w "%{http_code}\n"
+kubectl exec "$(kubectl -n sleep-allow get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -n sleep-allow -- curl http://httpbin.default:8000/ip -sS -o /dev/null -w "%{http_code}\n"
 }
 
 ! read -r -d '' snip_migrate_trust_domain_with_trust_domain_aliases_3_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -144,7 +144,7 @@ any other unintentional accesses.
 1.  Make a couple of requests to external HTTPS services from `SOURCE_POD` to verify that they are now blocked:
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sSI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
     command terminated with exit code 35
     command terminated with exit code 35
     {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -93,7 +93,7 @@ You can then decide to [configure access to external services](#controlled-acces
     successful `200` responses:
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sSI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
     HTTP/2 200
     HTTP/2 200
     {{< /text >}}
@@ -144,7 +144,7 @@ any other unintentional accesses.
 1.  Make a couple of requests to external HTTPS services from `SOURCE_POD` to verify that they are now blocked:
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sSI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
     command terminated with exit code 35
     command terminated with exit code 35
     {{< /text >}}
@@ -191,7 +191,7 @@ any other unintentional accesses.
 1.  Make a request to the external HTTP service from `SOURCE_POD`:
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -s http://httpbin.org/headers
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS http://httpbin.org/headers
     {
       "headers": {
         "Accept": "*/*",
@@ -240,7 +240,7 @@ any other unintentional accesses.
 1.  Make a request to the external HTTPS service from `SOURCE_POD`:
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://www.google.com | grep  "HTTP/"
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sSI https://www.google.com | grep  "HTTP/"
     HTTP/2 200
     {{< /text >}}
 
@@ -264,7 +264,7 @@ In this example, you set a timeout rule on calls to the `httpbin.org` service.
     httpbin.org external service:
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- time curl -o /dev/null -s -w "%{http_code}\n" http://httpbin.org/delay/5
+    $ kubectl exec "$SOURCE_POD" -c sleep -- time curl -o /dev/null -sS -w "%{http_code}\n" http://httpbin.org/delay/5
     200
     real    0m5.024s
     user    0m0.003s
@@ -296,7 +296,7 @@ In this example, you set a timeout rule on calls to the `httpbin.org` service.
 1.  Wait a few seconds, then make the _curl_ request again:
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- time curl -o /dev/null -s -w "%{http_code}\n" http://httpbin.org/delay/5
+    $ kubectl exec "$SOURCE_POD" -c sleep -- time curl -o /dev/null -sS -w "%{http_code}\n" http://httpbin.org/delay/5
     504
     real    0m3.149s
     user    0m0.004s
@@ -421,7 +421,7 @@ within the cluster. Any external request bypasses the sidecar and goes straight 
 For example:
 
 {{< text bash >}}
-$ kubectl exec "$SOURCE_POD" -c sleep -- curl -s http://httpbin.org/headers
+$ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS http://httpbin.org/headers
 {
   "headers": {
     "Accept": "*/*",

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/snips.sh
@@ -41,7 +41,7 @@ ALLOW_ANY
 ENDSNIP
 
 snip_envoy_passthrough_to_external_services_3() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sSI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
 }
 
 ! read -r -d '' snip_envoy_passthrough_to_external_services_3_out <<\ENDSNIP
@@ -57,7 +57,7 @@ spec:
 ENDSNIP
 
 snip_change_to_the_blockingbydefault_policy_3() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sSI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
 }
 
 ! read -r -d '' snip_change_to_the_blockingbydefault_policy_3_out <<\ENDSNIP
@@ -84,7 +84,7 @@ EOF
 }
 
 snip_access_an_external_http_service_2() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -s http://httpbin.org/headers
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sS http://httpbin.org/headers
 }
 
 ! read -r -d '' snip_access_an_external_http_service_2_out <<\ENDSNIP
@@ -127,7 +127,7 @@ EOF
 }
 
 snip_access_an_external_https_service_2() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://www.google.com | grep  "HTTP/"
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sSI https://www.google.com | grep  "HTTP/"
 }
 
 ! read -r -d '' snip_access_an_external_https_service_2_out <<\ENDSNIP
@@ -143,7 +143,7 @@ kubectl logs "$SOURCE_POD" -c istio-proxy | tail
 ENDSNIP
 
 snip_manage_traffic_to_external_services_1() {
-kubectl exec "$SOURCE_POD" -c sleep -- time curl -o /dev/null -s -w "%{http_code}\n" http://httpbin.org/delay/5
+kubectl exec "$SOURCE_POD" -c sleep -- time curl -o /dev/null -sS -w "%{http_code}\n" http://httpbin.org/delay/5
 }
 
 ! read -r -d '' snip_manage_traffic_to_external_services_1_out <<\ENDSNIP
@@ -172,7 +172,7 @@ EOF
 }
 
 snip_manage_traffic_to_external_services_3() {
-kubectl exec "$SOURCE_POD" -c sleep -- time curl -o /dev/null -s -w "%{http_code}\n" http://httpbin.org/delay/5
+kubectl exec "$SOURCE_POD" -c sleep -- time curl -o /dev/null -sS -w "%{http_code}\n" http://httpbin.org/delay/5
 }
 
 ! read -r -d '' snip_manage_traffic_to_external_services_3_out <<\ENDSNIP
@@ -213,7 +213,7 @@ kubectl describe pod kube-apiserver -n kube-system | grep 'service-cluster-ip-ra
 ENDSNIP
 
 snip_access_the_external_services_1() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -s http://httpbin.org/headers
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sS http://httpbin.org/headers
 }
 
 ! read -r -d '' snip_access_the_external_services_1_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/snips.sh
@@ -57,7 +57,7 @@ spec:
 ENDSNIP
 
 snip_change_to_the_blockingbydefault_policy_3() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -sSI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sI https://edition.cnn.com | grep "HTTP/"
 }
 
 ! read -r -d '' snip_change_to_the_blockingbydefault_policy_3_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/test.sh
@@ -72,7 +72,7 @@ snip_before_you_begin_3
 
 echo "SOURCE_POD: $SOURCE_POD"
 
-kubectl exec "$SOURCE_POD" -c sleep -- curl -v http://httpbin.org/headers
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v http://httpbin.org/headers
 
 #_verify_elided snip_access_the_external_services_1 "$snip_access_the_external_services_1_out"
 # TODO This doesn't work, curl returns 502.

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination-sds/index.md
@@ -330,7 +330,7 @@ to hold the configuration of the NGINX server:
 1.  Send an HTTP request to `http://my-nginx.mesh-external.svc.cluster.local`:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -s http://my-nginx.mesh-external.svc.cluster.local
+    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -sS http://my-nginx.mesh-external.svc.cluster.local
     <!DOCTYPE html>
     <html>
     <head>
@@ -659,7 +659,7 @@ to hold the configuration of the NGINX server:
 1.  Send an HTTP request to `http://my-nginx.mesh-external.svc.cluster.local`:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -s http://my-nginx.mesh-external.svc.cluster.local
+    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -sS http://my-nginx.mesh-external.svc.cluster.local
     <!DOCTYPE html>
     <html>
     <head>

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination-sds/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination-sds/snips.sh
@@ -247,7 +247,7 @@ EOF
 }
 
 snip_configure_simple_tls_origination_for_egress_traffic_5() {
-kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -s http://my-nginx.mesh-external.svc.cluster.local
+kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -sS http://my-nginx.mesh-external.svc.cluster.local
 }
 
 ! read -r -d '' snip_configure_simple_tls_origination_for_egress_traffic_5_out <<\ENDSNIP
@@ -500,7 +500,7 @@ EOF
 }
 
 snip_configure_mutual_tls_origination_for_egress_traffic_using_sds_5() {
-kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -s http://my-nginx.mesh-external.svc.cluster.local
+kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -sS http://my-nginx.mesh-external.svc.cluster.local
 }
 
 ! read -r -d '' snip_configure_mutual_tls_origination_for_egress_traffic_using_sds_5_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -92,7 +92,7 @@ be done by the egress gateway, as opposed to by the sidecar in the previous exam
 1.  Verify that your `ServiceEntry` was applied correctly by sending a request to [http://edition.cnn.com/politics](https://edition.cnn.com/politics).
 
     {{< text bash >}}
-    $ kubectl exec "${SOURCE_POD}" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+    $ kubectl exec "${SOURCE_POD}" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
     HTTP/1.1 301 Moved Permanently
     ...
     location: https://edition.cnn.com/politics
@@ -201,7 +201,7 @@ be done by the egress gateway, as opposed to by the sidecar in the previous exam
 1.  Send an HTTP request to [http://edition.cnn.com/politics](https://edition.cnn.com/politics).
 
     {{< text bash >}}
-    $ kubectl exec "${SOURCE_POD}" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+    $ kubectl exec "${SOURCE_POD}" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
     HTTP/1.1 200 OK
     ...
     {{< /text >}}
@@ -578,7 +578,7 @@ to hold the configuration of the NGINX server:
 1.  Send an HTTP request to `http://my-nginx.mesh-external.svc.cluster.local`:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -s http://my-nginx.mesh-external.svc.cluster.local
+    $ kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -sS http://my-nginx.mesh-external.svc.cluster.local
     <!DOCTYPE html>
     <html>
     <head>

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/snips.sh
@@ -61,7 +61,7 @@ EOF
 }
 
 snip_perform_tls_origination_with_an_egress_gateway_2() {
-kubectl exec "${SOURCE_POD}" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+kubectl exec "${SOURCE_POD}" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_perform_tls_origination_with_an_egress_gateway_2_out <<\ENDSNIP
@@ -163,7 +163,7 @@ EOF
 }
 
 snip_perform_tls_origination_with_an_egress_gateway_5() {
-kubectl exec "${SOURCE_POD}" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+kubectl exec "${SOURCE_POD}" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_perform_tls_origination_with_an_egress_gateway_5_out <<\ENDSNIP
@@ -455,7 +455,7 @@ EOF
 }
 
 snip_configure_mutual_tls_origination_for_egress_traffic_4() {
-kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -s http://my-nginx.mesh-external.svc.cluster.local
+kubectl exec "$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})" -c sleep -- curl -sS http://my-nginx.mesh-external.svc.cluster.local
 }
 
 ! read -r -d '' snip_configure_mutual_tls_origination_for_egress_traffic_4_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -116,7 +116,7 @@ First create a `ServiceEntry` to allow direct traffic to an external service.
 1.  Verify that your `ServiceEntry` was applied correctly by sending an HTTP request to [http://edition.cnn.com/politics](http://edition.cnn.com/politics).
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
     ...
     HTTP/1.1 301 Moved Permanently
     ...
@@ -211,7 +211,7 @@ First create a `ServiceEntry` to allow direct traffic to an external service.
 1.  Resend the HTTP request to [http://edition.cnn.com/politics](https://edition.cnn.com/politics).
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
     ...
     HTTP/1.1 301 Moved Permanently
     ...
@@ -279,7 +279,7 @@ You need to specify port 443 with protocol `TLS` in a corresponding `ServiceEntr
 1.  Verify that your `ServiceEntry` was applied correctly by sending an HTTPS request to [https://edition.cnn.com/politics](https://edition.cnn.com/politics).
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sL -o /dev/null -D - https://edition.cnn.com/politics
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sSL -o /dev/null -D - https://edition.cnn.com/politics
     ...
     HTTP/2 200
     Content-Type: text/html; charset=utf-8
@@ -364,7 +364,7 @@ You need to specify port 443 with protocol `TLS` in a corresponding `ServiceEntr
     The output should be the same as before.
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sL -o /dev/null -D - https://edition.cnn.com/politics
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sSL -o /dev/null -D - https://edition.cnn.com/politics
     ...
     HTTP/2 200
     Content-Type: text/html; charset=utf-8
@@ -508,7 +508,7 @@ external service.
     bypass its sidecar proxy, it will not be able to access external sites and will be blocked by the network policy.
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -n test-egress -l app=sleep -o jsonpath={.items..metadata.name})" -n test-egress -c sleep -- curl -v https://edition.cnn.com/politics
+    $ kubectl exec "$(kubectl get pod -n test-egress -l app=sleep -o jsonpath={.items..metadata.name})" -n test-egress -c sleep -- curl -v -sS https://edition.cnn.com/politics
     Hostname was NOT found in DNS cache
       Trying 151.101.65.67...
       Trying 2a04:4e42:200::323...
@@ -563,7 +563,7 @@ external service.
     Network Policy you defined. `istio-egressgateway` forwards the traffic to `edition.cnn.com`.
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -n test-egress -l app=sleep -o jsonpath={.items..metadata.name})" -n test-egress -c sleep -- curl -s -o /dev/null -w "%{http_code}\n" https://edition.cnn.com/politics
+    $ kubectl exec "$(kubectl get pod -n test-egress -l app=sleep -o jsonpath={.items..metadata.name})" -n test-egress -c sleep -- curl -sS -o /dev/null -w "%{http_code}\n" https://edition.cnn.com/politics
     200
     {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
@@ -54,7 +54,7 @@ EOF
 }
 
 snip_egress_gateway_for_http_traffic_2() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_egress_gateway_for_http_traffic_2_out <<\ENDSNIP
@@ -135,7 +135,7 @@ EOF
 }
 
 snip_egress_gateway_for_http_traffic_5() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_egress_gateway_for_http_traffic_5_out <<\ENDSNIP
@@ -183,7 +183,7 @@ EOF
 }
 
 snip_egress_gateway_for_https_traffic_2() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -sL -o /dev/null -D - https://edition.cnn.com/politics
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sSL -o /dev/null -D - https://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_egress_gateway_for_https_traffic_2_out <<\ENDSNIP
@@ -260,7 +260,7 @@ EOF
 }
 
 snip_egress_gateway_for_https_traffic_4() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -sL -o /dev/null -D - https://edition.cnn.com/politics
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sSL -o /dev/null -D - https://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_egress_gateway_for_https_traffic_4_out <<\ENDSNIP
@@ -344,7 +344,7 @@ EOF
 }
 
 snip_apply_kubernetes_network_policies_8() {
-kubectl exec "$(kubectl get pod -n test-egress -l app=sleep -o jsonpath={.items..metadata.name})" -n test-egress -c sleep -- curl -v https://edition.cnn.com/politics
+kubectl exec "$(kubectl get pod -n test-egress -l app=sleep -o jsonpath={.items..metadata.name})" -n test-egress -c sleep -- curl -v -sS https://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_apply_kubernetes_network_policies_8_out <<\ENDSNIP
@@ -392,7 +392,7 @@ EOF
 }
 
 snip_apply_kubernetes_network_policies_13() {
-kubectl exec "$(kubectl get pod -n test-egress -l app=sleep -o jsonpath={.items..metadata.name})" -n test-egress -c sleep -- curl -s -o /dev/null -w "%{http_code}\n" https://edition.cnn.com/politics
+kubectl exec "$(kubectl get pod -n test-egress -l app=sleep -o jsonpath={.items..metadata.name})" -n test-egress -c sleep -- curl -sS -o /dev/null -w "%{http_code}\n" https://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_apply_kubernetes_network_policies_13_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
@@ -95,7 +95,7 @@ Kubernetes Services for egress traffic work with other protocols as well.
     Note that the _curl_ command below uses the [Kubernetes DNS format for services](https://v1-13.docs.kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-records): `<service name>.<namespace>.svc.cluster.local`.
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD_WITHOUT_ISTIO" -n without-istio -c sleep -- curl my-httpbin.default.svc.cluster.local/headers
+    $ kubectl exec "$SOURCE_POD_WITHOUT_ISTIO" -n without-istio -c sleep -- curl -sS my-httpbin.default.svc.cluster.local/headers
     {
       "headers": {
         "Accept": "*/*",
@@ -128,7 +128,7 @@ Kubernetes Services for egress traffic work with other protocols as well.
     the `Host` header equals to your service's hostname.
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl my-httpbin.default.svc.cluster.local/headers
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS my-httpbin.default.svc.cluster.local/headers
     {
       "headers": {
         "Accept": "*/*",
@@ -201,7 +201,7 @@ $ kubectl delete service my-httpbin
     Use the `--resolve` option of `curl` to access `wikipedia.org` by the cluster IP:
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD_WITHOUT_ISTIO" -n without-istio -c sleep -- curl -s --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page | grep -o "<title>.*</title>"
+    $ kubectl exec "$SOURCE_POD_WITHOUT_ISTIO" -n without-istio -c sleep -- curl -sS --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page | grep -o "<title>.*</title>"
     <title>Wikipedia, the free encyclopedia</title>
     {{< /text >}}
 
@@ -225,7 +225,7 @@ $ kubectl delete service my-httpbin
 1.  Access `wikipedia.org` by your Kubernetes service's cluster IP from the source pod with Istio sidecar:
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -s --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page | grep -o "<title>.*</title>"
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page | grep -o "<title>.*</title>"
     <title>Wikipedia, the free encyclopedia</title>
     {{< /text >}}
 
@@ -234,7 +234,7 @@ $ kubectl delete service my-httpbin
     in the output of your service as the cluster IP.
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -v --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page -o /dev/null
+    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page -o /dev/null
     * Added en.wikipedia.org:443:172.21.156.230 to DNS cache
     * Hostname en.wikipedia.org was found in DNS cache
     *   Trying 172.21.156.230...

--- a/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/snips.sh
@@ -68,7 +68,7 @@ my-httpbin   ExternalName   <none>       httpbin.org   80/TCP    4s
 ENDSNIP
 
 snip_kubernetes_externalname_service_to_access_an_external_service_3() {
-kubectl exec "$SOURCE_POD_WITHOUT_ISTIO" -n without-istio -c sleep -- curl my-httpbin.default.svc.cluster.local/headers
+kubectl exec "$SOURCE_POD_WITHOUT_ISTIO" -n without-istio -c sleep -- curl -sS my-httpbin.default.svc.cluster.local/headers
 }
 
 ! read -r -d '' snip_kubernetes_externalname_service_to_access_an_external_service_3_out <<\ENDSNIP
@@ -96,7 +96,7 @@ EOF
 }
 
 snip_kubernetes_externalname_service_to_access_an_external_service_5() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl my-httpbin.default.svc.cluster.local/headers
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sS my-httpbin.default.svc.cluster.local/headers
 }
 
 ! read -r -d '' snip_kubernetes_externalname_service_to_access_an_external_service_5_out <<\ENDSNIP
@@ -161,7 +161,7 @@ my-wikipedia   ClusterIP   172.21.156.230   <none>        443/TCP   21h
 ENDSNIP
 
 snip_use_a_kubernetes_service_with_endpoints_to_access_an_external_service_4() {
-kubectl exec "$SOURCE_POD_WITHOUT_ISTIO" -n without-istio -c sleep -- curl -s --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page | grep -o "<title>.*</title>"
+kubectl exec "$SOURCE_POD_WITHOUT_ISTIO" -n without-istio -c sleep -- curl -sS --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page | grep -o "<title>.*</title>"
 }
 
 ! read -r -d '' snip_use_a_kubernetes_service_with_endpoints_to_access_an_external_service_4_out <<\ENDSNIP
@@ -183,7 +183,7 @@ EOF
 }
 
 snip_use_a_kubernetes_service_with_endpoints_to_access_an_external_service_6() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -s --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page | grep -o "<title>.*</title>"
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sS --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page | grep -o "<title>.*</title>"
 }
 
 ! read -r -d '' snip_use_a_kubernetes_service_with_endpoints_to_access_an_external_service_6_out <<\ENDSNIP
@@ -191,7 +191,7 @@ kubectl exec "$SOURCE_POD" -c sleep -- curl -s --resolve en.wikipedia.org:443:"$
 ENDSNIP
 
 snip_use_a_kubernetes_service_with_endpoints_to_access_an_external_service_7() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -v --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page -o /dev/null
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v --resolve en.wikipedia.org:443:"$(kubectl get service my-wikipedia -o jsonpath='{.spec.clusterIP}')" https://en.wikipedia.org/wiki/Main_Page -o /dev/null
 }
 
 ! read -r -d '' snip_use_a_kubernetes_service_with_endpoints_to_access_an_external_service_7_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -85,7 +85,7 @@ This time, however, use a single `ServiceEntry` to enable both HTTP and HTTPS ac
 1.  Make a request to the external HTTP service:
 
     {{< text syntax=bash snip_id=curl_simple >}}
-    $ kubectl exec "${SOURCE_POD}" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+    $ kubectl exec "${SOURCE_POD}" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
     HTTP/1.1 301 Moved Permanently
     ...
     location: https://edition.cnn.com/politics
@@ -157,7 +157,7 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
 1. Send an HTTP request to `http://edition.cnn.com/politics`, as in the previous section:
 
     {{< text syntax=bash snip_id=curl_origination_http >}}
-    $ kubectl exec "${SOURCE_POD}" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+    $ kubectl exec "${SOURCE_POD}" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
     HTTP/1.1 200 OK
     ...
     {{< /text >}}
@@ -175,7 +175,7 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
 1.  Note that the applications that used HTTPS to access the external service continue to work as before:
 
     {{< text syntax=bash snip_id=curl_origination_https >}}
-    $ kubectl exec "${SOURCE_POD}" -c sleep -- curl -sL -o /dev/null -D - https://edition.cnn.com/politics
+    $ kubectl exec "${SOURCE_POD}" -c sleep -- curl -sSL -o /dev/null -D - https://edition.cnn.com/politics
     HTTP/2 200
     ...
     {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
@@ -53,7 +53,7 @@ EOF
 }
 
 snip_curl_simple() {
-kubectl exec "${SOURCE_POD}" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+kubectl exec "${SOURCE_POD}" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_curl_simple_out <<\ENDSNIP
@@ -101,7 +101,7 @@ EOF
 }
 
 snip_curl_origination_http() {
-kubectl exec "${SOURCE_POD}" -c sleep -- curl -sL -o /dev/null -D - http://edition.cnn.com/politics
+kubectl exec "${SOURCE_POD}" -c sleep -- curl -sSL -o /dev/null -D - http://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_curl_origination_http_out <<\ENDSNIP
@@ -110,7 +110,7 @@ HTTP/1.1 200 OK
 ENDSNIP
 
 snip_curl_origination_https() {
-kubectl exec "${SOURCE_POD}" -c sleep -- curl -sL -o /dev/null -D - https://edition.cnn.com/politics
+kubectl exec "${SOURCE_POD}" -c sleep -- curl -sSL -o /dev/null -D - https://edition.cnn.com/politics
 }
 
 ! read -r -d '' snip_curl_origination_https_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh
@@ -31,7 +31,7 @@ _wait_for_deployment default sleep
 snip_before_you_begin_4
 
 confirm_blocking() {
-kubectl exec "$SOURCE_POD" -c sleep -- curl -I https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -I https://edition.cnn.com | grep "HTTP/"
+kubectl exec "$SOURCE_POD" -c sleep -sS -I https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -I https://edition.cnn.com | grep "HTTP/"
 }
 _verify_contains confirm_blocking "command terminated with exit code 35"
 

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
@@ -137,7 +137,7 @@ to hold the configuration of the NGINX server:
     printed correctly, i.e., `common name (CN)` is equal to `nginx.example.com`.
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod  -l run=my-nginx -o jsonpath={.items..metadata.name})" -c istio-proxy -- curl -v -k --resolve nginx.example.com:443:127.0.0.1 https://nginx.example.com
+    $ kubectl exec "$(kubectl get pod  -l run=my-nginx -o jsonpath={.items..metadata.name})" -c istio-proxy -- curl -sS -v -k --resolve nginx.example.com:443:127.0.0.1 https://nginx.example.com
     ...
     SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
     ALPN, server accepted to use http/1.1

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/snips.sh
@@ -115,7 +115,7 @@ EOF
 }
 
 snip_deploy_an_nginx_server_5() {
-kubectl exec "$(kubectl get pod  -l run=my-nginx -o jsonpath={.items..metadata.name})" -c istio-proxy -- curl -v -k --resolve nginx.example.com:443:127.0.0.1 https://nginx.example.com
+kubectl exec "$(kubectl get pod  -l run=my-nginx -o jsonpath={.items..metadata.name})" -c istio-proxy -- curl -sS -v -k --resolve nginx.example.com:443:127.0.0.1 https://nginx.example.com
 }
 
 ! read -r -d '' snip_deploy_an_nginx_server_5_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/distribute/index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/distribute/index.md
@@ -68,7 +68,7 @@ Call the `HelloWorld` service from the `Sleep` pod:
 $ kubectl exec --context="${CTX_R1_Z1}" -n sample -c sleep \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l \
   app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-  -- curl -sL helloworld.sample:5000/hello
+  -- curl -sSL helloworld.sample:5000/hello
 {{< /text >}}
 
 Repeat this a number of times and verify that the number of replies

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/distribute/snips.sh
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/distribute/snips.sh
@@ -49,5 +49,5 @@ snip_verify_the_distribution_1() {
 kubectl exec --context="${CTX_R1_Z1}" -n sample -c sleep \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l \
   app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-  -- curl -sL helloworld.sample:5000/hello
+  -- curl -sSL helloworld.sample:5000/hello
 }

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/index.md
@@ -88,7 +88,7 @@ Call the `HelloWorld` service from the `Sleep` pod:
 $ kubectl exec --context="${CTX_R1_Z1}" -n sample -c sleep \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l \
   app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-  -- curl -sL helloworld.sample:5000/hello
+  -- curl -sSL helloworld.sample:5000/hello
 Hello version: region1.zone1, instance: helloworld-region1.zone1-86f77cd7b-cpxhv
 {{< /text >}}
 
@@ -106,7 +106,7 @@ for `HelloWorld` in `region1.zone1`:
 $ kubectl --context="${CTX_R1_Z1}" exec \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l app=helloworld \
   -l version=region1.zone1 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
 {{< /text >}}
 
 Call the `HelloWorld` service from the `Sleep` pod:
@@ -115,7 +115,7 @@ Call the `HelloWorld` service from the `Sleep` pod:
 $ kubectl exec --context="${CTX_R1_Z1}" -n sample -c sleep \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l \
   app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-  -- curl -sL helloworld.sample:5000/hello
+  -- curl -sSL helloworld.sample:5000/hello
 Hello version: region1.zone2, instance: helloworld-region1.zone2-86f77cd7b-cpxhv
 {{< /text >}}
 
@@ -132,7 +132,7 @@ the `HelloWorld` in `region1.zone2` to fail when called:
 $ kubectl --context="${CTX_R1_Z2}" exec \
   "$(kubectl get pod --context="${CTX_R1_Z2}" -n sample -l app=helloworld \
   -l version=region1.zone2 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
 {{< /text >}}
 
 Call the `HelloWorld` service from the `Sleep` pod:
@@ -141,7 +141,7 @@ Call the `HelloWorld` service from the `Sleep` pod:
 $ kubectl exec --context="${CTX_R1_Z1}" -n sample -c sleep \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l \
   app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-  -- curl -sL helloworld.sample:5000/hello
+  -- curl -sSL helloworld.sample:5000/hello
 Hello version: region2.zone3, instance: helloworld-region2.zone3-86f77cd7b-cpxhv
 {{< /text >}}
 
@@ -158,7 +158,7 @@ the `HelloWorld` in `region2.zone3` to fail when called:
 $ kubectl --context="${CTX_R2_Z3}" exec \
   "$(kubectl get pod --context="${CTX_R2_Z3}" -n sample -l app=helloworld \
   -l version=region2.zone3 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
 {{< /text >}}
 
 Call the `HelloWorld` service from the `Sleep` pod:
@@ -167,7 +167,7 @@ Call the `HelloWorld` service from the `Sleep` pod:
 $ kubectl exec --context="${CTX_R1_Z1}" -n sample -c sleep \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l \
   app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-  -- curl -sL helloworld.sample:5000/hello
+  -- curl -sSL helloworld.sample:5000/hello
 Hello version: region3.zone4, instance: helloworld-region3.zone4-86f77cd7b-cpxhv
 {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/snips.sh
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/snips.sh
@@ -50,7 +50,7 @@ snip_verify_traffic_stays_in_region1zone1_1() {
 kubectl exec --context="${CTX_R1_Z1}" -n sample -c sleep \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l \
   app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-  -- curl -sL helloworld.sample:5000/hello
+  -- curl -sSL helloworld.sample:5000/hello
 }
 
 ! read -r -d '' snip_verify_traffic_stays_in_region1zone1_1_out <<\ENDSNIP
@@ -61,14 +61,14 @@ snip_failover_to_region1zone2_1() {
 kubectl --context="${CTX_R1_Z1}" exec \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l app=helloworld \
   -l version=region1.zone1 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
 }
 
 snip_failover_to_region1zone2_2() {
 kubectl exec --context="${CTX_R1_Z1}" -n sample -c sleep \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l \
   app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-  -- curl -sL helloworld.sample:5000/hello
+  -- curl -sSL helloworld.sample:5000/hello
 }
 
 ! read -r -d '' snip_failover_to_region1zone2_2_out <<\ENDSNIP
@@ -79,14 +79,14 @@ snip_failover_to_region2zone3_1() {
 kubectl --context="${CTX_R1_Z2}" exec \
   "$(kubectl get pod --context="${CTX_R1_Z2}" -n sample -l app=helloworld \
   -l version=region1.zone2 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
 }
 
 snip_failover_to_region2zone3_2() {
 kubectl exec --context="${CTX_R1_Z1}" -n sample -c sleep \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l \
   app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-  -- curl -sL helloworld.sample:5000/hello
+  -- curl -sSL helloworld.sample:5000/hello
 }
 
 ! read -r -d '' snip_failover_to_region2zone3_2_out <<\ENDSNIP
@@ -97,14 +97,14 @@ snip_failover_to_region3zone4_1() {
 kubectl --context="${CTX_R2_Z3}" exec \
   "$(kubectl get pod --context="${CTX_R2_Z3}" -n sample -l app=helloworld \
   -l version=region2.zone3 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
 }
 
 snip_failover_to_region3zone4_2() {
 kubectl exec --context="${CTX_R1_Z1}" -n sample -c sleep \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l \
   app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-  -- curl -sL helloworld.sample:5000/hello
+  -- curl -sSL helloworld.sample:5000/hello
 }
 
 ! read -r -d '' snip_failover_to_region3zone4_2_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -177,7 +177,7 @@ In this step, you will change that behavior so that all traffic goes to `v1`.
 
     {{< text bash json >}}
     $ export SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})
-    $ kubectl exec "${SLEEP_POD}" -c sleep -- curl -s http://httpbin:8000/headers
+    $ kubectl exec "${SLEEP_POD}" -c sleep -- curl -sS http://httpbin:8000/headers
     {
       "headers": {
         "Accept": "*/*",
@@ -250,7 +250,7 @@ log entries for `v1` and none for `v2`:
 1. Send in traffic:
 
     {{< text bash >}}
-    $ kubectl exec "${SLEEP_POD}" -c sleep -- curl -s http://httpbin:8000/headers
+    $ kubectl exec "${SLEEP_POD}" -c sleep -- curl -sS http://httpbin:8000/headers
     {{< /text >}}
 
     Now, you should see access logging for both `v1` and `v2`. The access logs

--- a/content/en/docs/tasks/traffic-management/mirroring/snips.sh
+++ b/content/en/docs/tasks/traffic-management/mirroring/snips.sh
@@ -152,7 +152,7 @@ EOF
 
 snip_creating_a_default_routing_policy_2() {
 export SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.name})
-kubectl exec "${SLEEP_POD}" -c sleep -- curl -s http://httpbin:8000/headers
+kubectl exec "${SLEEP_POD}" -c sleep -- curl -sS http://httpbin:8000/headers
 }
 
 ! read -r -d '' snip_creating_a_default_routing_policy_2_out <<\ENDSNIP
@@ -213,7 +213,7 @@ EOF
 }
 
 snip_mirroring_traffic_to_v2_2() {
-kubectl exec "${SLEEP_POD}" -c sleep -- curl -s http://httpbin:8000/headers
+kubectl exec "${SLEEP_POD}" -c sleep -- curl -sS http://httpbin:8000/headers
 }
 
 snip_mirroring_traffic_to_v2_3() {

--- a/content/en/docs/tasks/traffic-management/traffic-shifting/test.sh
+++ b/content/en/docs/tasks/traffic-management/traffic-shifting/test.sh
@@ -43,7 +43,7 @@ function reviews_v3_traffic_percentage() {
   local v3_count=0
   local v3_search_string="glyphicon glyphicon-star" # search string present in reviews_v3 response html
   for ((i = 1; i <= total_request_count; i++)); do
-    if (kubectl exec "${SLEEP_POD}" -c sleep -n "default" -- curl -s $INGRESS_URL/productpage | grep -q "$v3_search_string"); then
+    if (kubectl exec "${SLEEP_POD}" -c sleep -n "default" -- curl -sS $INGRESS_URL/productpage | grep -q "$v3_search_string"); then
       v3_count=$((v3_count + 1))
     fi
   done

--- a/content/en/news/security/istio-security-2020-007/index.md
+++ b/content/en/news/security/istio-security-2020-007/index.md
@@ -58,7 +58,7 @@ CVE-2020-8663 is addressed in Envoy by adding a configurable limit on [downstrea
 
     {{< text bash >}}
     $ ISTIO_INGRESS_PODNAME=$(kubectl get pods -l app=istio-ingressgateway -n istio-system  -o jsonpath="{.items[0].metadata.name}")
-    $ kubectl --namespace istio-system exec -i -t  ${ISTIO_INGRESS_PODNAME} -c istio-proxy -- curl http://localhost:15000/runtime
+    $ kubectl --namespace istio-system exec -i -t  ${ISTIO_INGRESS_PODNAME} -c istio-proxy -- curl -sS http://localhost:15000/runtime
 
     {
     "entries": {


### PR DESCRIPTION
The curl commands usually have some extraneous output (at least on my Mac):
```
kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl productpage:9080/productpage | grep -o "<title>.*</title>"


  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5183  100  5183    0     0   8072      0 --:--:-- --:--:-- --:--:--  8073
<title>Simple Bookstore App</title>
```

Adding the `-s` removes the progress meter. I know if would also possibly remove the error coming back if things were setup incorrectly, but the grep would have removed that as well.

