### PR TITLE
Fix link to standard Istio metric

### DIFF
--- a/content/en/docs/concepts/observability/index.md
+++ b/content/en/docs/concepts/observability/index.md
@@ -76,7 +76,7 @@ In addition to the proxy-level metrics, Istio provides a set of service-oriented
 basic service monitoring needs: latency, traffic, errors, and saturation. Istio ships with a default set of
 [dashboards](/docs/tasks/observability/metrics/using-istio-dashboard/) for monitoring service behaviors based on these metrics.
 
-The [standard Istio metrics](https://istio.io/v1.6/docs/reference/config/policy-and-telemetry/metrics/) are
+The [standard Istio metrics](/docs/reference/config/metrics/) are
 exported to [Prometheus](/docs/ops/integrations/prometheus/) by default.
 
 Use of the service-level metrics is entirely optional. Operators may choose to turn off generation and collection of these metrics to meet their individual


### PR DESCRIPTION
Fix the error link to stand Istio metric.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
