### PR TITLE
Add transport api version to rate limiting service.

### DIFF
--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -108,6 +108,7 @@ backend, is used below.
                     envoy_grpc:
                       cluster_name: rate_limit_cluster
                     timeout: 10s
+                  transport_api_version: V3
         - applyTo: CLUSTER
           match:
             cluster:


### PR DESCRIPTION
Envoy has dropped v2 and auto support for transport API version. V3 has to be specified explicitly. This is to match the modification in rate limiting test: https://github.com/istio/istio/pull/29896/files#diff-e70a1e1fb56c8da4454d9ca108a7105f4c8e3540337da94822ac208909cfcb77