### PR TITLE
Add upgrade notes about 1.7.x to 1.8 regarding http 1xx and 204.

### DIFF
--- a/content/en/news/releases/1.8.x/announcing-1.8/upgrade-notes/index.md
+++ b/content/en/news/releases/1.8.x/announcing-1.8/upgrade-notes/index.md
@@ -134,3 +134,7 @@ ingressGateways:
         - name: ISTIO_META_ROUTER_MODE
           value: "sni-dnat"
 {{< /text >}}
+
+## Connectivity issues among your proxies when updating from 1.7.x (where x < 5)
+
+When upgrading your Istio data plane from 1.7.x (where x < 5) to 1.8, you may observe connectivity issues between your gateway and your sidecars or among your sidecars with 503 errors in the log. This happens when 1.7.5+ proxies send HTTP 1xx or 204 response codes with headers that 1.7.x proxies reject. To fix this, upgrade all your proxies (gateways and sidecars) to 1.7.5+ as soon as possible. ([Issue 29427](https://github.com/istio/istio/issues/29427), [More information](https://github.com/istio/istio/pull/28450))


### PR DESCRIPTION
This is from https://github.com/istio/istio/pull/29497/.

It is not generated automatically with 1.8.2 release, so add it manually.