### PR TITLE
Fix RateLimit example manifest

### DIFF
--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -99,7 +99,7 @@ backend, is used below.
             value:
               name: envoy.filters.http.ratelimit
               typed_config:
-                "@type": type.googleapis.com/envoy.config.filter.http.rate_limit.v3.RateLimit
+                "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
                 # domain can be anything! Match it to the ratelimter service config
                 domain: productpage-ratelimit
                 failure_mode_deny: true

--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -155,8 +155,8 @@ backend, is used below.
             routeConfiguration:
               vhost:
                 name: "*:80"
-                  route:
-                    action: ANY
+                route:
+                  action: ANY
           patch:
             operation: MERGE
             # Applies the rate limit rules.


### PR DESCRIPTION
> Please provide a description for what this PR is for.

This PR fixes the example EnvoyFilter manifest.

I got an error when I applied the manifest of EnvoyFilter named filter-ratelimit using "kubectl apply".

Error message:

> Error from server: error when creating "filter-ratelimit.yaml": admission webhook "validation.istio.io" denied the request: configuration is invalid: Envoy filter: could not resolve Any message type: type.googleapis.com/envoy.config.filter.http.rate_limit.v3.RateLimit

I think `@type` in `typed_config` should be [type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit](https://github.com/envoyproxy/envoy/blob/5abba7833632509ed0ab4bbef3b99ebf4171ccd1/api/envoy/extensions/filters/http/ratelimit/v3/rate_limit.proto#L23) or [type.googleapis.com/envoy.config.filter.http.rate_limit.v2.RateLimit](https://github.com/envoyproxy/envoy/blob/5abba7833632509ed0ab4bbef3b99ebf4171ccd1/api/envoy/config/filter/http/rate_limit/v2/rate_limit.proto#L25).

And the third manifest in this page has YAML syntax error.

> And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[x] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
