### PR TITLE
dashboard controlz: append ns to pod for controlz output

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/controlz/index.md
+++ b/content/en/docs/ops/diagnostic-tools/controlz/index.md
@@ -28,7 +28,7 @@ To access the ControlZ page of istiod, you can port-forward its ControlZ endpoin
 locally and connect through your local browser:
 
 {{< text bash >}}
-$ istioctl dashboard controlz <istiod pod name>.istio-system
+$ istioctl dashboard controlz deployment/istiod.istio-system
 {{< /text >}}
 
 This will redirect the component's ControlZ page to `http://localhost:9876` for remote access.

--- a/content/en/docs/ops/diagnostic-tools/controlz/index.md
+++ b/content/en/docs/ops/diagnostic-tools/controlz/index.md
@@ -28,7 +28,7 @@ To access the ControlZ page of istiod, you can port-forward its ControlZ endpoin
 locally and connect through your local browser:
 
 {{< text bash >}}
-$ istioctl dashboard controlz <istiod pod name> -n istio-system
+$ istioctl dashboard controlz <istiod pod name>.istio-system
 {{< /text >}}
 
 This will redirect the component's ControlZ page to `http://localhost:9876` for remote access.


### PR DESCRIPTION
To fix https://github.com/istio/istio/issues/30208


Controlz does not accept the `-n` flag, instead, the namespace is inferred to the pod name.

Install Istio.
```
[istio-1.9.0-beta.0]$ ./bin/istioctl install --set values.global.jwtPolicy=first-party-jwt
```

List pod.
```
[istio-1.9.0-beta.0]$ k get po -n istio-system
NAME                                   READY   STATUS    RESTARTS   AGE
istio-ingressgateway-758896c45-q6vpk   1/1     Running   0          13m
istiod-8645cf86d4-9gh29                1/1     Running   0          13m
```

Controlz dashboard
```
[istio-1.9.0-beta.0]$ istioctl dashboard controlz istiod-8645cf86d4-9gh29.istio-system
http://localhost:9876
```