### PR TITLE
Silence curl commands for multicluster

### DIFF
--- a/content/en/docs/setup/install/multicluster/verify/index.md
+++ b/content/en/docs/setup/install/multicluster/verify/index.md
@@ -142,7 +142,7 @@ Send one request from the `Sleep` pod on `cluster1` to the `HelloWorld` service:
 $ kubectl exec --context="${CTX_CLUSTER1}" -n sample -c sleep \
     "$(kubectl get pod --context="${CTX_CLUSTER1}" -n sample -l \
     app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-    -- curl helloworld.sample:5000/hello
+    -- curl -s helloworld.sample:5000/hello
 {{< /text >}}
 
 Repeat this request several times and verify that the `HelloWorld` version
@@ -160,7 +160,7 @@ Now repeat this process from the `Sleep` pod on `cluster2`:
 $ kubectl exec --context="${CTX_CLUSTER2}" -n sample -c sleep \
     "$(kubectl get pod --context="${CTX_CLUSTER2}" -n sample -l \
     app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-    -- curl helloworld.sample:5000/hello
+    -- curl -s helloworld.sample:5000/hello
 {{< /text >}}
 
 Repeat this request several times and verify that the `HelloWorld` version

--- a/content/en/docs/setup/install/multicluster/verify/snips.sh
+++ b/content/en/docs/setup/install/multicluster/verify/snips.sh
@@ -100,7 +100,7 @@ snip_verifying_crosscluster_traffic_1() {
 kubectl exec --context="${CTX_CLUSTER1}" -n sample -c sleep \
     "$(kubectl get pod --context="${CTX_CLUSTER1}" -n sample -l \
     app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-    -- curl helloworld.sample:5000/hello
+    -- curl -s helloworld.sample:5000/hello
 }
 
 ! read -r -d '' snip_verifying_crosscluster_traffic_2 <<\ENDSNIP
@@ -113,7 +113,7 @@ snip_verifying_crosscluster_traffic_3() {
 kubectl exec --context="${CTX_CLUSTER2}" -n sample -c sleep \
     "$(kubectl get pod --context="${CTX_CLUSTER2}" -n sample -l \
     app=sleep -o jsonpath='{.items[0].metadata.name}')" \
-    -- curl helloworld.sample:5000/hello
+    -- curl -s helloworld.sample:5000/hello
 }
 
 ! read -r -d '' snip_verifying_crosscluster_traffic_4 <<\ENDSNIP


### PR DESCRIPTION
Without this, curl outputs request performance stats, causing issues during comparison against expected output.



[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure