### PR TITLE
vm docs: fix bullets for generated files

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -286,7 +286,7 @@ Next, use the `istioctl x workload entry` command to generate:
 
 * `cluster.env`: Contains metadata that identifies what namespace, service account, network CIDR and (optionally) what inbound ports to capture.
 * `istio-token`: A Kubernetes token used to get certs from the CA.
-* `mesh.yaml`: Provides ProxyConfig to configure `discoveryAddress`, health-checking probes, and some authentication options.
+* `mesh.yaml`: Provides `ProxyConfig` to configure `discoveryAddress`, health-checking probes, and some authentication options.
 * `root-cert.pem`: The root certificate used to authenticate.
 * `hosts`: An addendum to `/etc/hosts` that the proxy will use to reach istiod for xDS.*
 

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -283,9 +283,10 @@ If third party tokens are not enabled, you should add the option `--set values.g
 {{< /warning >}}
 
 Next, use the `istioctl x workload entry` command to generate:
+
 * `cluster.env`: Contains metadata that identifies what namespace, service account, network CIDR and (optionally) what inbound ports to capture.
 * `istio-token`: A Kubernetes token used to get certs from the CA.
-* `mesh.yaml`: Provides additional Istio metadata including, network name, trust domain and other values.
+* `mesh.yaml`: Provides ProxyConfig to configure `discoveryAddress`, health-checking probes, and some authentication options.
 * `root-cert.pem`: The root certificate used to authenticate.
 * `hosts`: An addendum to `/etc/hosts` that the proxy will use to reach istiod for xDS.*
 


### PR DESCRIPTION
Fixes this formatting to be bullets: 

<img width="966" alt="Screen Shot 2021-01-21 at 10 56 28 AM" src="https://user-images.githubusercontent.com/16195656/105398523-52317000-5bd7-11eb-9c8b-08af12b9d28e.png">

Also made a slight copy change to `mesh.yaml` cc @howardjohn 