### PR TITLE
Missing profile in the canary update example

### DIFF
--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -261,6 +261,7 @@ metadata:
   name: example-istiocontrolplane-1-8-1
 spec:
   revision: 1-8-1
+  profile: demo
 {{< /text >}}
 
 Apply the updated `IstioOperator` CR to the cluster. After that, you will have two control plane deployments and services running side-by-side:


### PR DESCRIPTION
We should either specify a profile or have a "..." at the end of the yaml to make it clear that it's not a complete yaml.
<img width="902" alt="image" src="https://user-images.githubusercontent.com/5502967/105516543-026caa80-5ca4-11eb-8f0d-4678f9f488be.png">


[ ] Configuration Infrastructure
[X ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure