### PR TITLE
Stop recommending binding to localhost

### DIFF
--- a/content/en/faq/applications/cassandra.md
+++ b/content/en/faq/applications/cassandra.md
@@ -9,15 +9,14 @@ By default, Cassandra broadcasts the address it uses for binding
 (accepting connections) to other Cassandra nodes as its address. This
 is usually the pod IP address and works fine without a service
 mesh. However, with a service mesh this configuration does not
-work. Istio and other service meshes require `localhost`
-(`127.0.0.1`) to be the address for binding.
+work. Istio requires (`0.0.0.0`) to be the address for binding.
 
 There are two configuration parameters to pay attention to:
 [`listen_address`](http://cassandra.apache.org/doc/latest/configuration/cassandra_config_file.html?highlight=listen_address#listen-address)
 and
 [`broadcast_address`](http://cassandra.apache.org/doc/latest/configuration/cassandra_config_file.html?highlight=listen_address#broadcast-address). For
 running Cassandra in an Istio mesh,
-the `listen_address` parameter should be set to `127.0.0.1` and the
+the `listen_address` parameter should be set to `0.0.0.0` and the
 `broadcast_address` parameter should be set to the pod IP address.
 
 These configuration parameters are defined in `cassandra.yaml` in the

--- a/content/en/faq/applications/elasticsearch.md
+++ b/content/en/faq/applications/elasticsearch.md
@@ -14,7 +14,7 @@ as the publishing address and no further configuration will be
 needed.
 
 If the default configuration does not work, you can set the
-`network.bind_host` to `0.0.0.0` or `localhost` (`127.0.0.1`) and
+`network.bind_host` to `0.0.0.0` and
 `network.publish_host` to the pod IP. For example:
 
 {{< text yaml >}}

--- a/content/en/faq/applications/nifi.md
+++ b/content/en/faq/applications/nifi.md
@@ -7,7 +7,7 @@ keywords: [nifi]
 
 [Apache NiFi](https://nifi.apache.org) poses some challenges to get it running on Istio. These challenges come from the clustering
 requirements it has. For example, there is a requirement that cluster components must be uniquely addressable using cluster-wide
-host names. This requirement conflicts with Istio's requirement that workloads bind and listen on `localhost` / `127.0.0.1` within
+host names. This requirement conflicts with Istio's requirement that workloads bind and listen on `0.0.0.0` within
 the pod.
 
 There are different ways to work around these issues based on your configuration requirements for your NiFi deployment. NiFi has

--- a/content/en/faq/applications/redis.md
+++ b/content/en/faq/applications/redis.md
@@ -6,9 +6,8 @@ keywords: [redis]
 ---
 
 Similar to other services deployed in an Istio service mesh, Redis instances
-need to listen on `localhost` (`127.0.0.1`). However, each Redis slave instance
-should announce an address that can be used by master to reach it, which cannot
-also be `localhost` (`127.0.0.1`).
+need to listen on `0.0.0.0`. However, each Redis slave instance
+should announce an address that can be used by master to reach it, which cannot also be `0.0.0.0`.
 
 Use the Redis configuration parameter `replica-announce-ip` to announce the
 correct address.  For example, set `replica-announce-ip` to the IP address of

--- a/content/en/faq/applications/zookeeper.md
+++ b/content/en/faq/applications/zookeeper.md
@@ -6,14 +6,12 @@ keywords: [zookeeper]
 ---
 
 By default, Zookeeper listens on the pod IP address for communication
-between servers. Istio and other service meshes require `localhost`
-(`127.0.0.1`) to be the address to listen on.
+between servers. Istio and other service meshes require `0.0.0.0` to be the address to listen on.
 
 There is a configuration parameter that can be used to change this
 default behavior:
 [`quorumListenOnAllIPs`](https://zookeeper.apache.org/doc/r3.5.7/zookeeperAdmin.html).
-This option allows Zookeeper to listen on all addresses including the
-`localhost`. Set this parameter to `true` by using the
+This option allows Zookeeper to listen on all addresses. Set this parameter to `true` by using the
 following command where `$ZK_CONFIG_FILE` is your Zookeeper
 configuration file.
 


### PR DESCRIPTION
This is both not recommend and likely we are going to make this broken
in Istio 1.10, in favor of making all of these work out of the box,
assuming users did *not* follow our documentation to set this to
localhost

Note: the doc is a bit awkward as we are in the middle period where currently 127.0.0.1 or 0.0.0.0 work, and in the future anything but 127.0.0.1 will work, so we can only recommend 0.0.0.0. In the future, when the networking changes are ready, these docs will probably just be deleted as they will work out of the box.