### PR TITLE
Remove localhost recommendation

### DIFF
--- a/content/en/docs/ops/deployment/requirements/index.md
+++ b/content/en/docs/ops/deployment/requirements/index.md
@@ -139,9 +139,8 @@ Because TLS communication is not server first, TLS encrypted server first traffi
 
 ## Application Bind Address
 
-When Istio captures inbound traffic, it will redirect it to the `localhost` address. As a result, applications should bind to either
-`localhost` (`127.0.0.1` for IPv4 or `::1` for IPv6) or wildcard (`0.0.0.0` for IPv4 or `::` for IPv6). Applications listening on their
-pod IP will need to be modified.
+When Istio captures inbound traffic, it will redirect it to the `localhost` address. As a result, applications should bind to
+wildcard (`0.0.0.0` for IPv4 or `::` for IPv6). Applications listening on their pod IP will need to be modified.
 
 ## Outbound traffic
 


### PR DESCRIPTION
We are going to break `localhost` listeners: https://docs.google.com/document/d/1j-5_XpeMTnT9mV_8dbSOeU7rfH-5YNtN_JJFZ2mmQ_w/edit#. It was bad advice to begin with, written by myself I believe



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure