### PR TITLE
Use the correct filename extension

### DIFF
--- a/content/en/docs/setup/additional-setup/sidecar-injection/index.md
+++ b/content/en/docs/setup/additional-setup/sidecar-injection/index.md
@@ -36,8 +36,8 @@ $ istioctl kube-inject -f @samples/sleep/sleep.yaml@ | kubectl apply -f -
 By default, this will use the in-cluster configuration. Alternatively, injection can be done using local copies of the configuration.
 
 {{< text bash >}}
-$ kubectl -n istio-system get configmap istio-sidecar-injector -o=jsonpath='{.data.config}' > inject-config.yaml
-$ kubectl -n istio-system get configmap istio-sidecar-injector -o=jsonpath='{.data.values}' > inject-values.yaml
+$ kubectl -n istio-system get configmap istio-sidecar-injector -o=jsonpath='{.data.config}' > inject-config.tmpl
+$ kubectl -n istio-system get configmap istio-sidecar-injector -o=jsonpath='{.data.values}' > inject-values.json
 $ kubectl -n istio-system get configmap istio -o=jsonpath='{.data.mesh}' > mesh-config.yaml
 {{< /text >}}
 
@@ -45,9 +45,9 @@ Run `kube-inject` over the input file and deploy.
 
 {{< text bash >}}
 $ istioctl kube-inject \
-    --injectConfigFile inject-config.yaml \
+    --injectConfigFile inject-config.tmpl \
     --meshConfigFile mesh-config.yaml \
-    --valuesFile inject-values.yaml \
+    --valuesFile inject-values.json \
     --filename @samples/sleep/sleep.yaml@ \
     | kubectl apply -f -
 {{< /text >}}


### PR DESCRIPTION
Use the same filename extensions as shown by `istioctl kube-inject --help`

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
