### PR TITLE
`apply` is deprecated in 1.8  instead of `install`

### DIFF
--- a/content/zh/docs/setup/getting-started/index.md
+++ b/content/zh/docs/setup/getting-started/index.md
@@ -71,7 +71,7 @@ Istio {{< istio_version >}} 已经在 Kubernetes 版本 {{< supported_kubernetes
 1. 安装 `demo` 配置
 
     {{< text bash >}}
-    $ istioctl manifest apply --set profile=demo
+    $ istioctl manifest install --set profile=demo
     {{< /text >}}
 
 1. 为了验证是否安装成功，需要先确保以下 Kubernetes 服务正确部署，然后验证除 `jaeger-agent` 服务外的其他服务，是否均有正确的 `CLUSTER-IP`：


### PR DESCRIPTION
fix Doc Error #8888



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure