### PR TITLE
Kops Docs: Fix ServiceAccountVolume proposed configuration

### DIFF
--- a/content/en/docs/setup/platform-setup/kops/index.md
+++ b/content/en/docs/setup/platform-setup/kops/index.md
@@ -24,9 +24,6 @@ If you wish to run Istio [Secret Discovery Service](https://www.envoyproxy.io/do
         - api
         - istio-ca
         serviceAccountIssuer: kubernetes.default.svc
-        serviceAccountKeyFile:
-        - /srv/kubernetes/server.key
-        serviceAccountSigningKeyFile: /srv/kubernetes/server.key
     {{< /text >}}
 
 1. Perform the update:


### PR DESCRIPTION
Seems that after merging https://github.com/kubernetes/kops/pull/9534 there is no need to specify paths for key-files for service Account Token Volume Projection.

Instead, current configuration proposed is making Istio unable to verify JWT token with errors. 
```
2021-02-01T22:05:23.240319Z     error   ads     Failed to authenticate client from x.x.x.x
Authenticator ClientCertAuthenticator: no verified chain is found
; Authenticator KubeJWTAuthenticator: failed to validate the JWT from cluster Kubernetes: the service account authentication returns an error: [invalid bearer token, square/go-jose: error in cryptographic primitive, unknown]
```

In this commit, we remove the paths, letting Kops handles the default ones that are working as expected.

Relevant PR also opened at Kops repo https://github.com/kubernetes/kops/pull/10712

[x] Configuration Infrastructure
[x] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[x] User Experience
[ ] Developer Infrastructure
