### PR TITLE
Update observability best practices

### DIFF
--- a/content/en/docs/ops/best-practices/observability/index.md
+++ b/content/en/docs/ops/best-practices/observability/index.md
@@ -20,11 +20,6 @@ This deployment of Prometheus is intentionally configured with a very short rete
 quick-start Prometheus deployment is also configured to collect metrics from each Envoy proxy
 running in the mesh, augmenting each metric with a set of labels about their origin (`instance`,
 `pod`, and `namespace`).
- 
-While the quick-start configuration is well-suited for small clusters and monitoring for short time horizons,
-it is not suitable for large-scale meshes or monitoring over a period of days or weeks. In particular,
-the introduced labels can increase metrics cardinality, requiring a large amount of storage. And, when trying
-to identify trends and differences in traffic over time, access to historical data can be paramount.
 
 {{< image width="80%"
     link="./production-prometheus.svg"

--- a/content/en/docs/ops/best-practices/observability/index.md
+++ b/content/en/docs/ops/best-practices/observability/index.md
@@ -16,10 +16,11 @@ in combination with a collection of [recording rules](https://prometheus.io/docs
 Istio no longer ships with Prometheus in its default profile. To enable Prometheus please see
 the [Prometheus integration](../../../ops/integrations/prometheus/) addon documentation.
 
-While the `Quick Start` installation is well-suited for small clusters and monitoring for short time horizons,
-it is not suitable for large-scale meshes or monitoring over a period of days or weeks. In particular,
-the introduced labels can increase metrics cardinality, requiring a large amount of storage. And, when trying
-to identify trends and differences in traffic over time, access to historical data can be paramount.
+While the `Option 1: Quick Start` installation mentioned in the [Prometheus integration](../../../ops/integrations/prometheus/)
+guide is well-suited for small clusters and monitoring for short time horizons, it is not suitable for large-scale
+meshes or monitoring over a period of days or weeks. In particular,  the introduced labels can increase metrics
+cardinality, requiring a large amount of storage. And, when trying to identify trends and differences in traffic over
+time, access to historical data can be paramount.
 
 {{< image width="80%"
     link="./production-prometheus.svg"

--- a/content/en/docs/ops/best-practices/observability/index.md
+++ b/content/en/docs/ops/best-practices/observability/index.md
@@ -13,14 +13,18 @@ The recommended approach for production-scale monitoring of Istio meshes with Pr
 is to use [hierarchical federation](https://prometheus.io/docs/prometheus/latest/federation/#hierarchical-federation)
 in combination with a collection of [recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/).
 
-Istio no longer ships with Prometheus in its default profile. To enable Prometheus please see
-the [Prometheus integration](../../../ops/integrations/prometheus/) addon documentation.
-
-While the `Option 1: Quick Start` installation mentioned in the [Prometheus integration](../../../ops/integrations/prometheus/)
-guide is well-suited for small clusters and monitoring for short time horizons, it is not suitable for large-scale
-meshes or monitoring over a period of days or weeks. In particular,  the introduced labels can increase metrics
-cardinality, requiring a large amount of storage. And, when trying to identify trends and differences in traffic over
-time, access to historical data can be paramount.
+Although installing Istio does not deploy [Prometheus](http://prometheus.io) by default, the
+[Getting Started](/docs/setup/getting-started/) instructions install the `Option 1: Quick Start` deployment
+of Prometheus described in the [Prometheus integration guide](/docs/ops/integrations/prometheus/).
+This deployment of Prometheus is intentionally configured with a very short retention window (6 hours). The
+quick-start Prometheus deployment is also configured to collect metrics from each Envoy proxy
+running in the mesh, augmenting each metric with a set of labels about their origin (`instance`,
+`pod`, and `namespace`).
+ 
+While the quick-start configuration is well-suited for small clusters and monitoring for short time horizons,
+it is not suitable for large-scale meshes or monitoring over a period of days or weeks. In particular,
+the introduced labels can increase metrics cardinality, requiring a large amount of storage. And, when trying
+to identify trends and differences in traffic over time, access to historical data can be paramount.
 
 {{< image width="80%"
     link="./production-prometheus.svg"

--- a/content/en/docs/ops/best-practices/observability/index.md
+++ b/content/en/docs/ops/best-practices/observability/index.md
@@ -14,7 +14,7 @@ is to use [hierarchical federation](https://prometheus.io/docs/prometheus/latest
 in combination with a collection of [recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/).
 
 Istio no longer ships with Prometheus in its default profile. To enable Prometheus please see
-the [Prometheus integration](../../ops/integrations/prometheus/) addon documentation.
+the [Prometheus integration](../../../ops/integrations/prometheus/) addon documentation.
 
 While the `Quick Start` installation is well-suited for small clusters and monitoring for short time horizons,
 it is not suitable for large-scale meshes or monitoring over a period of days or weeks. In particular,

--- a/content/en/docs/ops/best-practices/observability/index.md
+++ b/content/en/docs/ops/best-practices/observability/index.md
@@ -13,14 +13,10 @@ The recommended approach for production-scale monitoring of Istio meshes with Pr
 is to use [hierarchical federation](https://prometheus.io/docs/prometheus/latest/federation/#hierarchical-federation)
 in combination with a collection of [recording rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/).
 
-In default deployments of Istio, a deployment of [Prometheus](http://prometheus.io) is
-provided for collecting metrics generated for all mesh traffic. This deployment of
-Prometheus is intentionally deployed with a very short retention window (6 hours). The
-default Prometheus deployment is also configured to collect metrics from each Envoy proxy
-running in the mesh, augmenting each metric with a set of labels about their origin (`instance`,
-`pod`, and `namespace`).
+Istio no longer ships with Prometheus in its default profile. To enable Prometheus please see
+the [Prometheus integration](../../ops/integrations/prometheus/) addon documentation.
 
-While the default configuration is well-suited for small clusters and monitoring for short time horizons,
+While the `Quick Start` installation is well-suited for small clusters and monitoring for short time horizons,
 it is not suitable for large-scale meshes or monitoring over a period of days or weeks. In particular,
 the introduced labels can increase metrics cardinality, requiring a large amount of storage. And, when trying
 to identify trends and differences in traffic over time, access to historical data can be paramount.

--- a/content/en/docs/ops/integrations/prometheus/index.md
+++ b/content/en/docs/ops/integrations/prometheus/index.md
@@ -21,6 +21,13 @@ $ kubectl apply -f {{< github_file >}}/samples/addons/prometheus.yaml
 
 This will deploy Prometheus into your cluster. This is intended for demonstration only, and is not tuned for performance or security.
 
+{{< warning >}}
+While the quick-start configuration is well-suited for small clusters and monitoring for short time horizons,
+it is not suitable for large-scale meshes or monitoring over a period of days or weeks. In particular,
+the introduced labels can increase metrics cardinality, requiring a large amount of storage. And, when trying
+to identify trends and differences in traffic over time, access to historical data can be paramount.
+{{< /warning >}}
+
 ### Option 2: Customizable install
 
 Consult the [Prometheus documentation](https://www.prometheus.io/) to get started deploying Prometheus into your environment. See [Configuration](#Configuration) for more information on configuring Prometheus to scrape Istio deployments.


### PR DESCRIPTION
Istio no longer ships with Prometheus. Reference the Prometheus addon.


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure