### PR TITLE
Fix helm docs for Istio 1.9.0

### DIFF
--- a/content/en/boilerplates/helm-hub-tag.md
+++ b/content/en/boilerplates/helm-hub-tag.md
@@ -2,6 +2,6 @@
 ---
 {{< warning >}}
 Prior to Istio 1.9.0, installations using the Helm charts required hub and tag arguments:
---set global.hub="docker.io/istio" and --set global.tag="1.8.2". As of Istio
+`--set global.hub="docker.io/istio"` and `--set global.tag="1.8.2"`. As of Istio
 1.9.0 these are is no longer required.
 {{< /warning >}}

--- a/content/en/boilerplates/helm-hub-tag.md
+++ b/content/en/boilerplates/helm-hub-tag.md
@@ -1,0 +1,7 @@
+---
+---
+{{< warning >}}
+Prior to Istio 1.9.0, installations using the Helm charts required hub and tag arguments:
+--set global.hub="docker.io/istio" and --set global.tag="1.8.2". As of Istio
+1.9.0 these are is no longer required.
+{{< /warning >}}

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -17,6 +17,12 @@ installing Istio via [Istioctl](/docs/setup/install/istioctl/) or the
 
 This feature is currently considered [alpha](/about/feature-stages/).
 
+{{< warning >}}
+Prior to Istio 1.9.0 installation using the Helm charts required the arguments
+`--set global.hub="docker.io/istio"` and `--set global.tag="1.9.0"`. As of Istio
+1.9.0 this is no longer required, but is for older version.
+{{< /warning >}}
+
 ## Prerequisites
 
 1. [Download the Istio release](/docs/setup/getting-started/#download).
@@ -68,8 +74,6 @@ to the missing `istio-token` volume.
 
     {{< text bash >}}
     $ helm install istiod manifests/charts/istio-control/istio-discovery \
-        --set global.hub="docker.io/istio" \
-        --set global.tag="{{< istio_full_version >}}" \
         -n istio-system
     {{< /text >}}
 
@@ -78,8 +82,6 @@ to the missing `istio-token` volume.
 
     {{< text bash >}}
     $ helm install istio-ingress manifests/charts/gateways/istio-ingress \
-        --set global.hub="docker.io/istio" \
-        --set global.tag="{{< istio_full_version >}}" \
         -n istio-system
     {{< /text >}}
 
@@ -88,8 +90,6 @@ to the missing `istio-token` volume.
 
     {{< text bash >}}
     $ helm install istio-egress manifests/charts/gateways/istio-egress \
-        --set global.hub="docker.io/istio" \
-        --set global.tag="{{< istio_full_version >}}" \
         -n istio-system
     {{< /text >}}
 
@@ -175,8 +175,6 @@ gateways is [actively in development](/docs/setup/upgrade/gateways/) and is cons
     {{< text bash >}}
     $ helm install istiod-canary manifests/charts/istio-control/istio-discovery \
         --set revision=canary \
-        --set global.hub="docker.io/istio" \
-        --set global.tag=<version_to_upgrade> \
         -n istio-system
     {{< /text >}}
 
@@ -221,8 +219,6 @@ preserve your custom configuration during Helm upgrades.
 
     {{< text bash >}}
     $ helm upgrade istiod manifests/charts/istio-control/istio-discovery \
-        --set global.hub="docker.io/istio" \
-        --set global.tag=<version_to_upgrade> \
         -n istio-system
     {{< /text >}}
 
@@ -231,12 +227,8 @@ preserve your custom configuration during Helm upgrades.
 
     {{< text bash >}}
     $ helm upgrade istio-ingress manifests/charts/gateways/istio-ingress \
-        --set global.hub="docker.io/istio" \
-        --set global.tag=<version_to_upgrade>\
         -n istio-system
     $ helm upgrade istio-egress manifests/charts/gateways/istio-egress \
-        --set global.hub="docker.io/istio" \
-        --set global.tag=<version_to_upgrade> \
         -n istio-system
     {{< /text >}}
 

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -17,11 +17,7 @@ installing Istio via [Istioctl](/docs/setup/install/istioctl/) or the
 
 This feature is currently considered [alpha](/about/feature-stages/).
 
-{{< warning >}}
-Prior to Istio 1.9.0 installation using the Helm charts required the arguments
-`--set global.hub="docker.io/istio"` and `--set global.tag="1.9.0"`. As of Istio
-1.9.0 this is no longer required, but is for older version.
-{{< /warning >}}
+{{< boilerplate helm-hub-tag >}}
 
 ## Prerequisites
 

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -66,6 +66,8 @@ To avoid a vulnerability, ensure that the operator deployment is sufficiently se
       --set watchedNamespaces="istio-namespace1\,istio-namespace2"
     {{< /text >}}
 
+    {{< boilerplate helm-hub-tag >}}
+   
     Note that you need to [download the Istio release](/docs/setup/getting-started/#download)
     to run the above command.
     {{< /tip >}}
@@ -239,6 +241,8 @@ $ helm install istio-operator manifests/charts/istio-operator \
   --set watchedNamespaces=istio-system \
   --set revision=1-9-0
 {{< /text >}}
+
+{{< boilerplate helm-hub-tag >}}
 
 Note that you need to [download the Istio release](/docs/setup/getting-started/#download)
 to run the above command.

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -62,10 +62,8 @@ To avoid a vulnerability, ensure that the operator deployment is sufficiently se
 
     {{< text bash >}}
     $ helm install istio-operator manifests/charts/istio-operator \
-      --set hub=docker.io/istio \
-      --set tag={{< istio_full_version >}} \
       --set operatorNamespace=istio-operator \
-      --set watchedNamespaces=istio-namespace1,istio-namespace2
+      --set watchedNamespaces="istio-namespace1\,istio-namespace2"
     {{< /text >}}
 
     Note that you need to [download the Istio release](/docs/setup/getting-started/#download)
@@ -237,11 +235,9 @@ You can alternatively use Helm to deploy another operator with a different revis
 
 {{< text bash >}}
 $ helm install istio-operator manifests/charts/istio-operator \
-  --set hub=docker.io/istio \
-  --set tag={{< istio_full_version >}} \
   --set operatorNamespace=istio-operator \
   --set watchedNamespaces=istio-system \
-  --set revision=1-8-1
+  --set revision=1-9-0
 {{< /text >}}
 
 Note that you need to [download the Istio release](/docs/setup/getting-started/#download)

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -67,7 +67,7 @@ To avoid a vulnerability, ensure that the operator deployment is sufficiently se
     {{< /text >}}
 
     {{< boilerplate helm-hub-tag >}}
-   
+
     Note that you need to [download the Istio release](/docs/setup/getting-started/#download)
     to run the above command.
     {{< /tip >}}


### PR DESCRIPTION
We no longer have to provide --set hub and tag options in Istio 1.9.0

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
