### PR TITLE
Add warning and workarounds for revision validation bug

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -475,6 +475,7 @@ nginx
 NiFi
 NLBs
 Node.js
+non-revisioned
 non-sandboxed
 normalization
 ns

--- a/content/en/docs/setup/upgrade/canary/index.md
+++ b/content/en/docs/setup/upgrade/canary/index.md
@@ -56,6 +56,14 @@ istio-sidecar-injector          1          7m56s
 istio-sidecar-injector-canary   1          3m18s
 {{< /text >}}
 
+{{< warning >}}
+Due to [a bug](https://github.com/istio/istio/issues/28880) in the creation of the `ValidatingWebhookConfiguration` during install, initial installations of Istio __must not__ specify a revision. As a temporary workaround, for Istio resource validation to continue working after removing the non-revisioned Istio installation, the `ValidatingWebhookConfiguration` must be manually pointed to the revision that should handle validation.
+
+One way to accomplish this is to edit the webhook in-place by running `kubectl edit validatingwebhookconfiguration istiod-istio-system` and changing the `service` name from `istiod` to `istiod-<REVISION>` where `<REVISION>` is the revision that should handle validation. Alternatively, a `ValidatingWebhookConfiguration` can be created from [this template]({{< github_blob >}}/manifests/charts/base/templates/validatingwebhookconfiguration.yaml) and applied after removing the old validating webhook.
+
+An alternative to changing where the `ValidatingWebhookConfiguration` points is to manually create a service called `istiod` pointing to the target revision using [this service]({{< github_blob >}}/manifests/charts/istio-control/istio-discovery/templates/service.yaml) as a template.
+{{</ warning >}}
+
 ## Data plane
 
 Unlike istiod, Istio gateways do not run revision-specific instances, but are instead in-place upgraded to use the new control plane revision.


### PR DESCRIPTION
Add warning and several workarounds for validating webhook issue with revisions. Should be cherry-picked to `1.9` docs

cc @costinm @zerobfd

[ ] Configuration Infrastructure
[x] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
