### PR TITLE
Update make gen to do a format-go and check in updated files

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -80,7 +80,7 @@ site:
 snips:
 	@scripts/gen_snips.sh
 
-gen: snips tidy-go
+gen: snips tidy-go format-go
 
 gen-check: gen check-clean-repo
 

--- a/pkg/test/istioio/script.go
+++ b/pkg/test/istioio/script.go
@@ -36,10 +36,8 @@ const (
 	kubeConfigEnvVar    = "KUBECONFIG"
 )
 
-var (
-	// Logging scope for the script output.
-	scriptLog = log.RegisterScope("script", "output of test scripts", 0)
-)
+// Logging scope for the script output.
+var scriptLog = log.RegisterScope("script", "output of test scripts", 0)
 
 var _ Step = Script{}
 
@@ -91,7 +89,7 @@ func (s Script) run(ctx framework.TestContext) {
 
 	// Copy the command to workDir.
 	_, fileName := filepath.Split(s.Name())
-	if err := ioutil.WriteFile(path.Join(ctx.WorkDir(), fileName), []byte(command), 0644); err != nil {
+	if err := ioutil.WriteFile(path.Join(ctx.WorkDir(), fileName), []byte(command), 0o644); err != nil {
 		ctx.Fatalf("failed copying command %s to workDir: %v", s.Name(), err)
 	}
 

--- a/pkg/test/istioio/snapshot.go
+++ b/pkg/test/istioio/snapshot.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"sync"
 
-	"istio.io/istio/pkg/test/scopes"
-
 	"github.com/golang/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,6 +29,7 @@ import (
 	"istio.io/istio/pkg/config/schema/collection"
 	"istio.io/istio/pkg/config/schema/collections"
 	"istio.io/istio/pkg/kube"
+	"istio.io/istio/pkg/test/scopes"
 )
 
 var (

--- a/tests/setup/multicluster/doc_test.go
+++ b/tests/setup/multicluster/doc_test.go
@@ -16,9 +16,8 @@ package setupconfig
 import (
 	"testing"
 
-	"istio.io/istio/pkg/test/framework"
-
 	"istio.io/istio.io/pkg/test/istioio"
+	"istio.io/istio/pkg/test/framework"
 )
 
 func TestMain(m *testing.M) {

--- a/tests/setup/profile_default/doc_test.go
+++ b/tests/setup/profile_default/doc_test.go
@@ -16,10 +16,9 @@ package setupconfig
 import (
 	"testing"
 
+	"istio.io/istio.io/pkg/test/istioio"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
-
-	"istio.io/istio.io/pkg/test/istioio"
 )
 
 func TestMain(m *testing.M) {

--- a/tests/setup/profile_demo/doc_test.go
+++ b/tests/setup/profile_demo/doc_test.go
@@ -16,11 +16,10 @@ package setupconfig
 import (
 	"testing"
 
+	"istio.io/istio.io/pkg/test/istioio"
 	"istio.io/istio/pkg/test/framework"
 	"istio.io/istio/pkg/test/framework/components/istio"
 	"istio.io/istio/pkg/test/framework/resource"
-
-	"istio.io/istio.io/pkg/test/istioio"
 )
 
 func TestMain(m *testing.M) {

--- a/tests/setup/profile_none/doc_test.go
+++ b/tests/setup/profile_none/doc_test.go
@@ -16,9 +16,8 @@ package setupconfig
 import (
 	"testing"
 
-	"istio.io/istio/pkg/test/framework"
-
 	"istio.io/istio.io/pkg/test/istioio"
+	"istio.io/istio/pkg/test/framework"
 )
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
https://github.com/istio/istio.io/pull/8901 is not being merged since the common-files update updated the `go` formatter and
that PR doesn't contain the updated files.

The change to call the formatter during a `make gen` will prevent this from occurring the next time, and updating the file should let a retest on https://github.com/istio/istio.io/pull/8901 merge the common-file updates.