### PR TITLE
Remove alpha warning from VM install guide

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -13,10 +13,6 @@ test: yes
 
 Follow this guide to deploy Istio and connect a virtual machine to it.
 
-{{< tip >}}
-This guide is tested and validated but note that VM support is still an alpha feature not recommended for production.
-{{< /tip >}}
-
 ## Prerequisites
 
 1. [Download the Istio release](/docs/setup/getting-started/#download)


### PR DESCRIPTION
Update VM instructions to remove Alpha warning.

I checked all the things marked Beta on the feature-status page to see if there was an appropriate replacement, but none of those pages have any relevant boilerplate to copy.

[ ] Configuration Infrastructure
[X] Docs
[X] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
