### PR TITLE
s/service-apis/gateway-api/

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/service-apis/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/service-apis/index.md
@@ -7,7 +7,7 @@ owner: istio/wg-networking-maintainers
 test: yes
 ---
 
-This task describes how to configure Istio to expose a service outside of the service mesh cluster, using the Kubernetes [Service APIs](https://kubernetes-sigs.github.io/service-apis/).
+This task describes how to configure Istio to expose a service outside of the service mesh cluster, using the Kubernetes [Gateway API](https://kubernetes-sigs.github.io/gateway-api/).
 These APIs are an actively developed evolution of the Kubernetes [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
 and [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) APIs.
 
@@ -29,7 +29,7 @@ and [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) 
 
 ## Configuring a Gateway
 
-See the [Service APIs](https://kubernetes-sigs.github.io/service-apis/) documentation for information about the APIs.
+See the [Service APIs](https://kubernetes-sigs.github.io/gateway-api/) documentation for information about the APIs.
 
 1. Deploy a test application:
 

--- a/content/en/docs/tasks/traffic-management/ingress/service-apis/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/service-apis/index.md
@@ -7,7 +7,7 @@ owner: istio/wg-networking-maintainers
 test: yes
 ---
 
-This task describes how to configure Istio to expose a service outside of the service mesh cluster, using the Kubernetes [Gateway API](https://kubernetes-sigs.github.io/gateway-api/).
+This task describes how to configure Istio to expose a service outside of the service mesh cluster, using the Kubernetes [Service APIs](https://kubernetes-sigs.github.io/gateway-api/).
 These APIs are an actively developed evolution of the Kubernetes [Service](https://kubernetes.io/docs/concepts/services-networking/service/)
 and [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) APIs.
 


### PR DESCRIPTION
The Service APIs project has renamed.  The repo redirects but the GitHub pages do not.  This change is the minimum required to make the URLs work.  I *assume* all the code examples should still work, but haven't tested them.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
