### PR TITLE
Add out-of-mesh server metadata info into telemetry v2 faq.

### DIFF
--- a/content/en/faq/metrics-and-logs/telemetry-v1-vs-v2.md
+++ b/content/en/faq/metrics-and-logs/telemetry-v1-vs-v2.md
@@ -22,6 +22,9 @@ v2 which are listed below:
   missing peer attributes like workload name, namespace and labels.
   However, if both peers have proxies injected all the labels mentioned
   [here](/docs/reference/config/metrics/) are available in the generated metrics.
+  At Istio 1.8 release, a solution was added to distribute server workload metadata
+  to client sidecar, which makes client side metric have server workload metadata labels
+  filled even when the server workload is out of the mesh.
 
 * **TCP metadata exchange requires mTLS**
   TCP metadata exchange relies on the [Istio ALPN protocol](/docs/tasks/observability/metrics/tcp-metrics/#understanding-tcp-telemetry-collection)

--- a/content/en/faq/metrics-and-logs/telemetry-v1-vs-v2.md
+++ b/content/en/faq/metrics-and-logs/telemetry-v1-vs-v2.md
@@ -22,9 +22,9 @@ v2 which are listed below:
   missing peer attributes like workload name, namespace and labels.
   However, if both peers have proxies injected all the labels mentioned
   [here](/docs/reference/config/metrics/) are available in the generated metrics.
-Starting with the Istio 1.8 release, a solution was added to distribute server workload metadata
-  to client sidecar, which makes client side metric have server workload metadata labels
-  filled even when the server workload is out of the mesh.
+  When the server workload is out of the mesh, server workload metadata is still
+  distributed to client sidecar, causing client side metrics to have server workload
+  metadata labels filled.
 
 * **TCP metadata exchange requires mTLS**
   TCP metadata exchange relies on the [Istio ALPN protocol](/docs/tasks/observability/metrics/tcp-metrics/#understanding-tcp-telemetry-collection)

--- a/content/en/faq/metrics-and-logs/telemetry-v1-vs-v2.md
+++ b/content/en/faq/metrics-and-logs/telemetry-v1-vs-v2.md
@@ -22,7 +22,7 @@ v2 which are listed below:
   missing peer attributes like workload name, namespace and labels.
   However, if both peers have proxies injected all the labels mentioned
   [here](/docs/reference/config/metrics/) are available in the generated metrics.
-  At Istio 1.8 release, a solution was added to distribute server workload metadata
+Starting with the Istio 1.8 release, a solution was added to distribute server workload metadata
   to client sidecar, which makes client side metric have server workload metadata labels
   filled even when the server workload is out of the mesh.
 


### PR DESCRIPTION


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure