### PR TITLE
fix circuit breaker task

### DIFF
--- a/content/en/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/en/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -51,7 +51,7 @@ when calling the `httpbin` service:
             http1MaxPendingRequests: 1
             maxRequestsPerConnection: 1
         outlierDetection:
-          consecutiveErrors: 1
+          consecutive5xxErrors: 1
           interval: 1s
           baseEjectionTime: 3m
           maxEjectionPercent: 100
@@ -76,7 +76,7 @@ when calling the `httpbin` service:
             maxConnections: 1
         outlierDetection:
           baseEjectionTime: 3m
-          consecutiveErrors: 1
+          consecutive5xxErrors: 1
           interval: 1s
           maxEjectionPercent: 100
     {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/circuit-breaking/snips.sh
+++ b/content/en/docs/tasks/traffic-management/circuit-breaking/snips.sh
@@ -37,7 +37,7 @@ spec:
         http1MaxPendingRequests: 1
         maxRequestsPerConnection: 1
     outlierDetection:
-      consecutiveErrors: 1
+      consecutive5xxErrors: 1
       interval: 1s
       baseEjectionTime: 3m
       maxEjectionPercent: 100
@@ -63,7 +63,7 @@ spec:
         maxConnections: 1
     outlierDetection:
       baseEjectionTime: 3m
-      consecutiveErrors: 1
+      consecutive5xxErrors: 1
       interval: 1s
       maxEjectionPercent: 100
 ENDSNIP


### PR DESCRIPTION
use `consecutive5xxErrors` instead of `consecutiveErrors `

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
