### PR TITLE
Fixed "are is" to "are"  and addressed an incorrect link

### DIFF
--- a/content/en/boilerplates/helm-hub-tag.md
+++ b/content/en/boilerplates/helm-hub-tag.md
@@ -3,5 +3,5 @@
 {{< warning >}}
 Prior to Istio 1.9.0, installations using the Helm charts required hub and tag arguments:
 `--set global.hub="docker.io/istio"` and `--set global.tag="1.8.2"`. As of Istio
-1.9.0 these are is no longer required.
+1.9.0 these are no longer required.
 {{< /warning >}}

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -183,7 +183,7 @@ gateways is [actively in development](/docs/setup/upgrade/gateways/) and is cons
       istiod-canary-9cc9fd96f-jpc7n   1/1     Running   0          34m   canary
     {{< /text >}}
 
-1. Follow the steps [here](/docs/setup/upgrade/#data-plane) to test or migrate
+1. Follow the steps [here](/docs/setup/upgrade/canary/) to test or migrate
    existing workloads to use the canary control plane.
 
 1. Once you have verified and migrated your workloads to use the canary control


### PR DESCRIPTION
This PR addresses a typo and a link that seems to be incorrect

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure