### PR TITLE
Fix syntax on local rate limiting

### DIFF
--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -268,7 +268,7 @@ spec:
         routeConfiguration:
           vhost:
             name: "inbound|http|9080"
-             route:
+            route:
               action: ANY
       patch:
         operation: MERGE


### PR DESCRIPTION
Currently when trying to do the final task in the rate limiting task, you get a yaml syntax error:

```
error: error parsing STDIN: error converting YAML to JSON: yaml: line 30: did not find expected key
```

This resolves that yaml error.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
