### PR TITLE
Fix istio.io tests when moving to later kubectl

### DIFF
--- a/tests/util/addons.sh
+++ b/tests/util/addons.sh
@@ -38,6 +38,7 @@ function _deploy_and_wait_for_addons() {
                  _wait_for_deployment istio-system jaeger
                  ;;
     kiali)      kubectl apply -f "$KIALI_MANIFEST_URL"
+                 kubectl apply -f "$KIALI_MANIFEST_URL" # Need to apply twice due to a reace condition
                  _wait_for_deployment istio-system kiali
                  ;;
     prometheus) kubectl apply -f "$PROMETHEUS_MANIFEST_URL"


### PR DESCRIPTION
The CI pipeline moved to a later build image which contains an updated kubectl which seems to be causing some issue with the doc tests.  I am working on fixing them up with this PR.