### PR TITLE
[release-1.9] Bump basic auth 1.9 Wasm extension module to 1.9.2

### DIFF
--- a/content/en/docs/ops/configuration/extensibility/wasm-module-distribution/index.md
+++ b/content/en/docs/ops/configuration/extensibility/wasm-module-distribution/index.md
@@ -86,7 +86,7 @@ spec:
                code:
                  remote:
                    http_uri:
-                     uri: https://github.com/istio-ecosystem/wasm-extensions/releases/download/{{< istio_version >}}.1/basic-auth.wasm
+                     uri: https://github.com/istio-ecosystem/wasm-extensions/releases/download/{{< istio_version >}}.2/basic-auth.wasm
                    # Optional: specifying sha256 checksum will let istio agent verify the checksum of downloaded artifacts.
                    # It is **highly** recommended to provide the checksum, since missing checksum will cause the Wasm module to be downloaded repeatedly.
                    # To compute the sha256 checksum of a Wasm module, download the module and run `sha256sum` command with it.


### PR DESCRIPTION
Dump basic auth Wasm module version again to 1.9.2 to include hosts option: https://github.com/istio-ecosystem/wasm-extensions/issues/50