### PR TITLE
Use non-deprecated filter names

### DIFF
--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -90,9 +90,9 @@ backend, is used below.
             listener:
               filterChain:
                 filter:
-                  name: "envoy.http_connection_manager"
+                  name: "envoy.filters.network.http_connection_manager"
                   subFilter:
-                    name: "envoy.router"
+                    name: "envoy.filters.http.router"
           patch:
             operation: INSERT_BEFORE
             # Adds the Envoy Rate Limit Filter in HTTP filter chain.
@@ -197,7 +197,7 @@ spec:
       listener:
         filterChain:
           filter:
-            name: "envoy.http_connection_manager"
+            name: "envoy.filters.network.http_connection_manager"
       patch:
         operation: INSERT_BEFORE
         value:
@@ -252,7 +252,7 @@ spec:
       listener:
         filterChain:
           filter:
-            name: "envoy.http_connection_manager"
+            name: "envoy.filters.network.http_connection_manager"
       patch:
         operation: INSERT_BEFORE
         value:


### PR DESCRIPTION
`istioctl analyze` will warn the following

```
... Schema validation warning: using deprecated filter name "envoy.http_connection_manager"; use "envoy.filters.network.http_connection_manager" instead
... Schema validation warning: using deprecated filter name "envoy.router"; use "envoy.filters.http.router" instead
```

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
