### PR TITLE
Remove content-length from egress test

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -195,7 +195,6 @@ any other unintentional accesses.
     {
       "headers": {
         "Accept": "*/*",
-        "Content-Length": "0",
         "Host": "httpbin.org",
         ...
         "X-Envoy-Decorator-Operation": "httpbin.org:80/*",

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/snips.sh
@@ -91,7 +91,6 @@ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS http://httpbin.org/headers
 {
   "headers": {
     "Accept": "*/*",
-    "Content-Length": "0",
     "Host": "httpbin.org",
     ...
     "X-Envoy-Decorator-Operation": "httpbin.org:80/*",


### PR DESCRIPTION
Chatted with John Howard and this was removed. I am opening an issue for hm to verify that it should be removed in this test, and removing from the test for now.