### PR TITLE
Update Cert comparison command

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/multicluster/index.md
+++ b/content/en/docs/ops/diagnostic-tools/multicluster/index.md
@@ -48,8 +48,8 @@ To verify certs are configured correctly, you can compare the root-cert in each 
 
 {{< text bash >}}
 $ diff \
-   $(kubectl --context="${CTX_CLUSTER1}" -n istio-system get secret cacerts -ojsonpath='{.data.root-cert\.pem}') \
-   $(kubectl --context="${CTX_CLUSTER1}" -n istio-system get secret cacerts -ojsonpath='{.data.root-cert\.pem}')
+   <(kubectl --context="${CTX_CLUSTER1}" -n istio-system get secret cacerts -ojsonpath='{.data.root-cert\.pem}') \
+   <(kubectl --context="${CTX_CLUSTER2}" -n istio-system get secret cacerts -ojsonpath='{.data.root-cert\.pem}')
 {{< /text >}}
 
 You can follow the [Plugin CA Certs](/docs/tasks/security/cert-management/plugin-ca-cert/) guide, ensuring to run


### PR DESCRIPTION

The diff was checking `CTX_CLUSTER1` against itself. In order to get the command to work, I also needed to pass the values as named pipes.


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure