### PR TITLE
[release-1.6] grab_reference_docs.sh release-1.6

### DIFF
--- a/content/en/docs/reference/commands/istioctl/index.html
+++ b/content/en/docs/reference/commands/istioctl/index.html
@@ -4757,6 +4757,18 @@ These environment variables affect the behavior of the <code>istioctl</code> com
 <td>If enabled, pilot will set the incremental flag of the options in the mcp controller to true, and then galley may push data incrementally, it depends on whether the resource supports incremental. By default, this is false.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_LEGACY_INBOUND_LISTENERS</code></td>
+<td>Boolean</td>
+<td><code>false</code></td>
+<td>Enable legacy inbound listeners. When enabled, inbound redirection to port 15001 will be supported. If disabled, inbound requests must be directed to port 15006 and will be routed by a single listener. This is intended for migration purposes only.</td>
+</tr>
+<tr>
+<td><code>PILOT_ENABLE_LOOP_BLOCKER</code></td>
+<td>Boolean</td>
+<td><code>true</code></td>
+<td>If enabled, Envoy will be configured to prevent traffic directly to the inbound/outbound ports (15001/15006). This prevents traffic loops. This option will be removed, and considered always enabled, in 1.9.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_MYSQL_FILTER</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>

--- a/content/en/docs/reference/commands/mixs/index.html
+++ b/content/en/docs/reference/commands/mixs/index.html
@@ -503,6 +503,18 @@ These environment variables affect the behavior of the <code>mixs</code> command
 <td>If enabled, pilot will set the incremental flag of the options in the mcp controller to true, and then galley may push data incrementally, it depends on whether the resource supports incremental. By default, this is false.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_LEGACY_INBOUND_LISTENERS</code></td>
+<td>Boolean</td>
+<td><code>false</code></td>
+<td>Enable legacy inbound listeners. When enabled, inbound redirection to port 15001 will be supported. If disabled, inbound requests must be directed to port 15006 and will be routed by a single listener. This is intended for migration purposes only.</td>
+</tr>
+<tr>
+<td><code>PILOT_ENABLE_LOOP_BLOCKER</code></td>
+<td>Boolean</td>
+<td><code>true</code></td>
+<td>If enabled, Envoy will be configured to prevent traffic directly to the inbound/outbound ports (15001/15006). This prevents traffic loops. This option will be removed, and considered always enabled, in 1.9.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_MYSQL_FILTER</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>

--- a/content/en/docs/reference/commands/operator/index.html
+++ b/content/en/docs/reference/commands/operator/index.html
@@ -285,6 +285,18 @@ These environment variables affect the behavior of the <code>operator</code> com
 <td>If enabled, pilot will set the incremental flag of the options in the mcp controller to true, and then galley may push data incrementally, it depends on whether the resource supports incremental. By default, this is false.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_LEGACY_INBOUND_LISTENERS</code></td>
+<td>Boolean</td>
+<td><code>false</code></td>
+<td>Enable legacy inbound listeners. When enabled, inbound redirection to port 15001 will be supported. If disabled, inbound requests must be directed to port 15006 and will be routed by a single listener. This is intended for migration purposes only.</td>
+</tr>
+<tr>
+<td><code>PILOT_ENABLE_LOOP_BLOCKER</code></td>
+<td>Boolean</td>
+<td><code>true</code></td>
+<td>If enabled, Envoy will be configured to prevent traffic directly to the inbound/outbound ports (15001/15006). This prevents traffic loops. This option will be removed, and considered always enabled, in 1.9.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_MYSQL_FILTER</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>

--- a/content/en/docs/reference/commands/pilot-agent/index.html
+++ b/content/en/docs/reference/commands/pilot-agent/index.html
@@ -820,6 +820,18 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <td>If enabled, pilot will set the incremental flag of the options in the mcp controller to true, and then galley may push data incrementally, it depends on whether the resource supports incremental. By default, this is false.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_LEGACY_INBOUND_LISTENERS</code></td>
+<td>Boolean</td>
+<td><code>false</code></td>
+<td>Enable legacy inbound listeners. When enabled, inbound redirection to port 15001 will be supported. If disabled, inbound requests must be directed to port 15006 and will be routed by a single listener. This is intended for migration purposes only.</td>
+</tr>
+<tr>
+<td><code>PILOT_ENABLE_LOOP_BLOCKER</code></td>
+<td>Boolean</td>
+<td><code>true</code></td>
+<td>If enabled, Envoy will be configured to prevent traffic directly to the inbound/outbound ports (15001/15006). This prevents traffic loops. This option will be removed, and considered always enabled, in 1.9.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_MYSQL_FILTER</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>

--- a/content/en/docs/reference/commands/pilot-discovery/index.html
+++ b/content/en/docs/reference/commands/pilot-discovery/index.html
@@ -733,6 +733,18 @@ These environment variables affect the behavior of the <code>pilot-discovery</co
 <td>If enabled, pilot will set the incremental flag of the options in the mcp controller to true, and then galley may push data incrementally, it depends on whether the resource supports incremental. By default, this is false.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_LEGACY_INBOUND_LISTENERS</code></td>
+<td>Boolean</td>
+<td><code>false</code></td>
+<td>Enable legacy inbound listeners. When enabled, inbound redirection to port 15001 will be supported. If disabled, inbound requests must be directed to port 15006 and will be routed by a single listener. This is intended for migration purposes only.</td>
+</tr>
+<tr>
+<td><code>PILOT_ENABLE_LOOP_BLOCKER</code></td>
+<td>Boolean</td>
+<td><code>true</code></td>
+<td>If enabled, Envoy will be configured to prevent traffic directly to the inbound/outbound ports (15001/15006). This prevents traffic loops. This option will be removed, and considered always enabled, in 1.9.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_MYSQL_FILTER</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>

--- a/content/en/docs/reference/config/proxy_extensions/metadata_exchange/index.html
+++ b/content/en/docs/reference/config/proxy_extensions/metadata_exchange/index.html
@@ -3,7 +3,7 @@ WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL
 source_repo: https://github.com/istio/proxy
 title: Metadata Exchange Config
 description: Configuration for Metadata Exchange Filter.
-location: https://istio.io/docs/reference/config/proxy_extensions/metadata_exchange.html.
+location: https://istio.io/docs/reference/config/proxy_extensions/metadata_exchange.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
 weight: 20


### PR DESCRIPTION
There is an issue with checking out the repo on Windows (see #9050).

The correct fix is to fix the problem upstream (done in https://github.com/istio/proxy/pull/3214), do this step to update the release-1.6 branch, and when this is merged, pull the 1.6 branch into the main branch archives.