### PR TITLE
Typo

### DIFF
--- a/content/en/docs/reference/config/networking/virtual-service/index.html
+++ b/content/en/docs/reference/config/networking/virtual-service/index.html
@@ -13,7 +13,7 @@ number_of_entries: 24
 <p>Configuration affecting traffic routing. Here are a few terms useful to define
 in the context of traffic routing.</p>
 
-<p><code>Service</code> a unit of application behavior bound to a unique name in a
+<p><code>Service</code> - A unit of application behavior bound to a unique name in a
 service registry. Services consist of multiple network <em>endpoints</em>
 implemented by workload instances running on pods, containers, VMs etc.</p>
 


### PR DESCRIPTION
Missing dash and capitalization when defining terms. It did not follow the pattern set by the other term definitions.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
