### PR TITLE
revise "Getting Started" page to be friendly for new istio users to use bookinfo sample

### DIFF
--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -348,6 +348,30 @@ by viewing the Bookinfo product page using a browser.
 
 1.  Paste the output from the previous command into your web browser and confirm that the Bookinfo product page is displayed.
 
+### Apply default destination rules
+
+Before you can use Istio to control the Bookinfo version routing, you need to define the available
+versions, called *subsets*, in [destination rules](/docs/concepts/traffic-management/#destination-rules).
+
+Run the following command to create default destination rules for the Bookinfo services:
+
+{{< text bash >}}
+$ kubectl apply -f @samples/bookinfo/networking/destination-rule-all.yaml@
+{{< /text >}}
+
+{{< tip >}}
+The `default` and `demo` [configuration profiles](/docs/setup/additional-setup/config-profiles/) have [auto mutual TLS](/docs/tasks/security/authentication/authn-policy/#auto-mutual-tls) enabled by default.
+To enforce mutual TLS, use the destination rules in `samples/bookinfo/networking/destination-rule-all-mtls.yaml`.
+{{< /tip >}}
+
+Wait a few seconds for the destination rules to propagate.
+
+You can display the destination rules with the following command:
+
+{{< text bash >}}
+$ kubectl get destinationrules -o yaml
+{{< /text >}}
+
 ## View the dashboard {#dashboard}
 
 Istio integrates with [several](/docs/ops/integrations) different telemetry applications. These can help you gain

--- a/content/en/docs/setup/getting-started/snips.sh
+++ b/content/en/docs/setup/getting-started/snips.sh
@@ -224,6 +224,14 @@ snip_verify_external_access_confirm_1() {
 echo "http://$GATEWAY_URL/productpage"
 }
 
+snip_apply_default_destination_rules_1() {
+kubectl apply -f samples/bookinfo/networking/destination-rule-all.yaml
+}
+
+snip_apply_default_destination_rules_2() {
+kubectl get destinationrules -o yaml
+}
+
 snip_view_the_dashboard_dashboard_1() {
 kubectl apply -f samples/addons
 kubectl rollout status deployment/kiali -n istio-system

--- a/content/en/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/en/docs/tasks/traffic-management/request-routing/index.md
@@ -17,7 +17,8 @@ microservice.
 * Setup Istio by following the instructions in the
 [Installation guide](/docs/setup/).
 
-* Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application.
+* Deploy the [Bookinfo](/docs/examples/bookinfo/) sample application including the
+[default destination rules](/docs/examples/bookinfo/#apply-default-destination-rules).
 
 * Review the [Traffic Management](/docs/concepts/traffic-management) concepts doc. Before attempting this task, you should be familiar with important terms such as *destination rule*, *virtual service*, and *subset*.
 


### PR DESCRIPTION
Originally in the page `setup/Getting Started`, when deploying the sample application using 

`kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml`

the destination rules are not applied at all, which will cause routing problems when doing other tasks of the sample application. 
In the page `examples/bookinfo application`, the destination rules are mentioned to be required for the routing rules. However, there is a tip showing that `If you installed Istio using the Getting Started instructions, you already have Bookinfo installed and you can skip these steps.`. New users may skip applying the destination rules, and get stuck for a moment.

This repo is to copy & paste the destination rule part in `examples/bookinfo application` to `setup/Getting Started` for better new user experience.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
