### PR TITLE
Update grab_reference_docs to allow `latest/` in location:

### DIFF
--- a/content/en/docs/reference/config/security/authorization-policy/index.html
+++ b/content/en/docs/reference/config/security/authorization-policy/index.html
@@ -3,7 +3,7 @@ WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL
 source_repo: https://github.com/istio/api
 title: Authorization Policy
 description: Configuration for access control on workloads.
-location: https://istio.io/docs/reference/config/security/authorization-policy.html
+location: https://istio.io/latest/docs/reference/config/security/authorization-policy.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
 schema: istio.security.v1beta1.AuthorizationPolicy


### PR DESCRIPTION
There was a change in istio/api to add `latest` into the location path. This cause the script to ignore that file, and it wasn't scrapped. This change will scrape files with `latest/docs` in the path (as well as the previous `docs`).

The location is allowed have `latest`, which will be removed from the destination

This now works
`location: https://istio.io/latest/docs/reference/config/security/authorization-policy.html` -> `docs/reference/config/security/authorization-policy`

as well as the former
`location: https://istio.io/docs/reference/config/security/authorization-policy.html` -> `docs/reference/config/security/authorization-policy`


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure