### PR TITLE
Fix configuring k8 gateway api

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/service-apis/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/service-apis/index.md
@@ -16,7 +16,7 @@ and [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) 
 1. Install the Service APIs CRDs:
 
     {{< text bash >}}
-    $ kubectl kustomize "github.com/kubernetes-sigs/service-apis/config/crd?ref=v0.1.0" | kubectl apply -f -
+    $ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.2.0" | kubectl apply -f -
     {{< /text >}}
 
 1. Install Istio, or reconfigure an existing installation to enable the Service APIs controller:

--- a/content/en/docs/tasks/traffic-management/ingress/service-apis/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/service-apis/snips.sh
@@ -21,7 +21,7 @@
 ####################################################################################################
 
 snip_setup_1() {
-kubectl kustomize "github.com/kubernetes-sigs/service-apis/config/crd?ref=v0.1.0" | kubectl apply -f -
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.2.0" | kubectl apply -f -
 }
 
 snip_setup_2() {


### PR DESCRIPTION
To fix https://github.com/istio/istio.io/issues/9338

Ref: https://github.com/kubernetes-sigs/gateway-api
Service APIs is renamed to Gateway API

After update.
```
$ curl -s -I -HHost:httpbin.example.com "http://$INGRESS_HOST:$INGRESS_PORT/get"
HTTP/1.1 200 OK
server: istio-envoy
date: Mon, 22 Mar 2021 10:03:45 GMT
content-type: application/json
content-length: 1730
access-control-allow-origin: *
access-control-allow-credentials: true
x-envoy-upstream-service-time: 2
```
