### PR TITLE
Wildcard configuration for arbitrary domains with non root user

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/snips.sh
@@ -175,7 +175,8 @@ kubectl delete destinationrule egressgateway-for-wikipedia
 
 snip_setup_egress_gateway_with_sni_proxy_1() {
 cat <<EOF > ./sni-proxy.conf
-user www-data;
+# setup custom path that do not require root access
+pid /tmp/nginx.pid;
 
 events {
 }
@@ -190,7 +191,7 @@ stream {
   # tcp forward proxy by SNI
   server {
     resolver 8.8.8.8 ipv6=off;
-    listen       127.0.0.1:8443;
+    listen       127.0.0.1:18443;
     proxy_pass   \$ssl_preread_server_name:443;
     ssl_preread  on;
   }
@@ -222,6 +223,7 @@ spec:
         service:
           ports:
           - port: 443
+            targetPort: 8443
             name: https
         overlays:
         - kind: Deployment
@@ -236,18 +238,14 @@ spec:
                 mountPath: /etc/nginx
                 readOnly: true
               securityContext:
-                runAsNonRoot: false
-                runAsUser: 0
+                runAsNonRoot: true
+                runAsUser: 101
           - path: spec.template.spec.volumes[-1]
             value: |
               name: sni-proxy-config
               configMap:
                 name: egress-sni-proxy-configmap
                 defaultMode: 292 # 0444
-  values:
-    gateways:
-      istio-egressgateway:
-        runAsRoot: true
 EOF
 }
 
@@ -275,7 +273,7 @@ spec:
   - sni-proxy.local
   location: MESH_EXTERNAL
   ports:
-  - number: 8443
+  - number: 18443
     name: tcp
     protocol: TCP
   resolution: STATIC
@@ -379,7 +377,7 @@ spec:
     - destination:
         host: sni-proxy.local
         port:
-          number: 8443
+          number: 18443
       weight: 100
 ---
 # The following filter is used to forward the original SNI (sent by the application) as the SNI of the
@@ -453,8 +451,8 @@ kubectl logs -l istio=egressgateway-with-sni-proxy -c istio-proxy -n istio-syste
 }
 
 ! read -r -d '' snip_configure_traffic_through_egress_gateway_with_sni_proxy_6 <<\ENDSNIP
-[2019-01-02T16:34:23.312Z] "- - -" 0 - 578 79141 624 - "-" "-" "-" "-" "127.0.0.1:8443" outbound|8443||sni-proxy.local 127.0.0.1:55018 172.30.109.84:443 172.30.109.112:45346 en.wikipedia.org
-[2019-01-02T16:34:24.079Z] "- - -" 0 - 586 65770 638 - "-" "-" "-" "-" "127.0.0.1:8443" outbound|8443||sni-proxy.local 127.0.0.1:55034 172.30.109.84:443 172.30.109.112:45362 de.wikipedia.org
+[2019-01-02T16:34:23.312Z] "- - -" 0 - 578 79141 624 - "-" "-" "-" "-" "127.0.0.1:18443" outbound|18443||sni-proxy.local 127.0.0.1:55018 172.30.109.84:443 172.30.109.112:45346 en.wikipedia.org
+[2019-01-02T16:34:24.079Z] "- - -" 0 - 586 65770 638 - "-" "-" "-" "-" "127.0.0.1:18443" outbound|18443||sni-proxy.local 127.0.0.1:55034 172.30.109.84:443 172.30.109.112:45362 de.wikipedia.org
 ENDSNIP
 
 snip_configure_traffic_through_egress_gateway_with_sni_proxy_7() {

--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh
@@ -31,7 +31,7 @@ _wait_for_deployment default sleep
 snip_before_you_begin_4
 
 confirm_blocking() {
-kubectl exec "$SOURCE_POD" -c sleep -sS -I https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -I https://edition.cnn.com | grep "HTTP/"
+kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -I https://www.google.com | grep  "HTTP/"; kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -I https://edition.cnn.com | grep "HTTP/"
 }
 _verify_contains confirm_blocking "command terminated with exit code 35"
 
@@ -86,7 +86,7 @@ _wait_for_istio envoyfilter istio-system egress-gateway-sni-verifier
 _verify_same snip_configure_traffic_through_egress_gateway_with_sni_proxy_4 "$snip_configure_traffic_through_egress_gateway_with_sni_proxy_4_out"
 
 _verify_lines snip_configure_traffic_through_egress_gateway_with_sni_proxy_5 "
-+ outbound|8443||sni-proxy.local
++ outbound|18443||sni-proxy.local
 + en.wikipedia.org
 + de.wikipedia.org
 "


### PR DESCRIPTION
This PR is to track the change for issue: https://github.com/istio/istio.io/issues/9348


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

It contains the necessary change to run the solution with non root user. 

**The change includes:**
- The created egress gateway (istio-proxy container) will use port 8443 to handle the request for 443 request from sidecar, so egress gateway can run as non-root user. 
- The sni-proxy in the same  egressgateway pod will change to listen on port 18443 instead, since 8443 is used by istio-proxy in the same pod. 
- sni-proxy nginx pid file setup with custom path that do not require root access. 
- The port section in egressgateway-with-sni-proxy.yaml is optional, since it is actually the current default behavior for gateway. Still leave it here to demonstrate this Wildcard configuration solution actually could be used not only for the 443 port, but can be customized to support any port with tls protocol. 
```
              ports:
              - port: 443
                targetPort: 8443
                name: https
```


I made the change for files:
`content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md`
`content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh`

For file: `content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/snips.sh`
As it mentioned as below, I assume it would be automatically updated. 
```
THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
#          docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
```

Thanks.