### PR TITLE
Separate Functionality and API for Gateway status

### DIFF
--- a/content/en/about/feature-stages/index.md
+++ b/content/en/about/feature-stages/index.md
@@ -37,7 +37,7 @@ Below is our list of existing features and their current phases. This informatio
 | Traffic Control: label/content based routing, traffic shifting | Stable
 | Resilience features: timeouts, retries, connection pools, outlier detection | Stable
 | Gateway Functionality (Ingress, Egress for all protocols) | Stable
-| Gateway APIs (Ingress, Egress for all protocols) | Stable
+| Gateway APIs (Ingress, Egress for all protocols) | Beta
 | TLS termination and SNI Support in Gateways | Stable
 | SNI (multiple certs) at ingress | Stable
 | [Locality load balancing](/docs/tasks/traffic-management/locality-load-balancing/) | Beta

--- a/content/en/about/feature-stages/index.md
+++ b/content/en/about/feature-stages/index.md
@@ -36,7 +36,8 @@ Below is our list of existing features and their current phases. This informatio
 | Protocols: Websockets / MongoDB  | Stable
 | Traffic Control: label/content based routing, traffic shifting | Stable
 | Resilience features: timeouts, retries, connection pools, outlier detection | Stable
-| Gateway: Ingress, Egress for all protocols | Stable
+| Gateway Functionality (Ingress, Egress for all protocols) | Stable
+| Gateway APIs (Ingress, Egress for all protocols) | Stable
 | TLS termination and SNI Support in Gateways | Stable
 | SNI (multiple certs) at ingress | Stable
 | [Locality load balancing](/docs/tasks/traffic-management/locality-load-balancing/) | Beta


### PR DESCRIPTION

This separates API and Gateway into two separate fields since they have different maturity. Follow up from https://github.com/istio/enhancements/pull/16

I had a failure on my local system with make lint that I don't think is related. 