### PR TITLE
Use consistent quoting in API examples

### DIFF
--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -315,8 +315,8 @@ authentication for the workloads with the `app:reviews` label must use mutual
 TLS:
 
 {{< text yaml >}}
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "example-peer-policy"
   namespace: "foo"
@@ -409,8 +409,8 @@ The following peer authentication policy requires all workloads in namespace
 `foo` to use mutual TLS:
 
 {{< text yaml >}}
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "example-policy"
   namespace: "foo"
@@ -426,8 +426,8 @@ mutual TLS on port `80` for the `app:example-app` workload, and uses the mutual 
 settings of the namespace-wide peer authentication policy for all other ports:
 
 {{< text yaml >}}
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "example-workload-policy"
   namespace: "foo"
@@ -885,7 +885,7 @@ configures an authorization policy to only allows the `bookinfo-ratings-v2`
 service in the Istio mesh to access the MongoDB workload.
 
 {{< text yaml >}}
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
   name: mongodb-policy

--- a/content/en/docs/ops/common-problems/security-issues/index.md
+++ b/content/en/docs/ops/common-problems/security-issues/index.md
@@ -19,8 +19,8 @@ With Istio, you can enable authentication for end users through [request authent
 1. If `jwksUri` isn’t set, make sure the JWT issuer is of url format and `url + /.well-known/openid-configuration` can be opened in browser; for example, if the JWT issuer is `https://accounts.google.com`, make sure `https://accounts.google.com/.well-known/openid-configuration` is a valid url and can be opened in a browser.
 
     {{< text yaml >}}
-    apiVersion: "security.istio.io/v1beta1"
-    kind: "RequestAuthentication"
+    apiVersion: security.istio.io/v1beta1
+    kind: RequestAuthentication
     metadata:
       name: "example-3"
     spec:

--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -48,8 +48,8 @@ To configure strict mutual TLS, run:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   namespace: "istio-io-health"

--- a/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
@@ -26,8 +26,8 @@ kubectl create ns istio-io-health
 
 snip_liveness_and_readiness_probes_using_the_command_approach_2() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   namespace: "istio-io-health"

--- a/content/en/docs/tasks/security/authentication/authn-policy/index.md
+++ b/content/en/docs/tasks/security/authentication/authn-policy/index.md
@@ -119,8 +119,8 @@ The mesh-wide peer authentication policy should not have a `selector` and must b
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   namespace: "istio-system"
@@ -172,8 +172,8 @@ To change mutual TLS for all workloads within a particular namespace, use a name
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   namespace: "foo"
@@ -207,8 +207,8 @@ For example, the following peer authentication policy and destination rule enabl
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n bar -f -
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "httpbin"
   namespace: "bar"
@@ -225,8 +225,8 @@ And a destination rule:
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n bar -f -
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "httpbin"
 spec:
@@ -264,8 +264,8 @@ To refine the mutual TLS settings per port, you must configure the `portLevelMtl
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n bar -f -
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "httpbin"
   namespace: "bar"
@@ -285,8 +285,8 @@ As before, you also need a destination rule:
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n bar -f -
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "httpbin"
 spec:
@@ -327,8 +327,8 @@ Note that you've already created a namespace-wide policy that enables mutual TLS
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n foo -f -
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "overwrite-example"
   namespace: "foo"
@@ -345,8 +345,8 @@ and destination rule:
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n foo -f -
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "overwrite-example"
 spec:
@@ -438,8 +438,8 @@ Now, add a request authentication policy that requires end-user JWT for the ingr
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "RequestAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
 metadata:
   name: "jwt-example"
   namespace: istio-system
@@ -521,8 +521,8 @@ To reject requests without valid tokens, add an authorization policy with a rule
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "AuthorizationPolicy"
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
 metadata:
   name: "frontend-ingress"
   namespace: istio-system
@@ -551,8 +551,8 @@ To refine authorization with a token requirement per host, path, or method, chan
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "AuthorizationPolicy"
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
 metadata:
   name: "frontend-ingress"
   namespace: istio-system

--- a/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
+++ b/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
@@ -94,8 +94,8 @@ ENDSNIP
 
 snip_globally_enabling_istio_mutual_tls_in_strict_mode_1() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   namespace: "istio-system"
@@ -129,8 +129,8 @@ kubectl delete peerauthentication -n istio-system default
 
 snip_namespacewide_policy_1() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
   namespace: "foo"
@@ -159,8 +159,8 @@ ENDSNIP
 
 snip_enable_mutual_tls_per_workload_1() {
 cat <<EOF | kubectl apply -n bar -f -
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "httpbin"
   namespace: "bar"
@@ -175,8 +175,8 @@ EOF
 
 snip_enable_mutual_tls_per_workload_2() {
 cat <<EOF | kubectl apply -n bar -f -
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "httpbin"
 spec:
@@ -213,8 +213,8 @@ ENDSNIP
 
 snip_enable_mutual_tls_per_workload_5() {
 cat <<EOF | kubectl apply -n bar -f -
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "httpbin"
   namespace: "bar"
@@ -232,8 +232,8 @@ EOF
 
 snip_enable_mutual_tls_per_workload_6() {
 cat <<EOF | kubectl apply -n bar -f -
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "httpbin"
 spec:
@@ -268,8 +268,8 @@ ENDSNIP
 
 snip_policy_precedence_1() {
 cat <<EOF | kubectl apply -n foo -f -
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "overwrite-example"
   namespace: "foo"
@@ -284,8 +284,8 @@ EOF
 
 snip_policy_precedence_2() {
 cat <<EOF | kubectl apply -n foo -f -
-apiVersion: "networking.istio.io/v1alpha3"
-kind: "DestinationRule"
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
 metadata:
   name: "overwrite-example"
 spec:
@@ -362,8 +362,8 @@ ENDSNIP
 
 snip_enduser_authentication_4() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "RequestAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
 metadata:
   name: "jwt-example"
   namespace: istio-system
@@ -430,8 +430,8 @@ ENDSNIP
 
 snip_require_a_valid_token_1() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "AuthorizationPolicy"
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
 metadata:
   name: "frontend-ingress"
   namespace: istio-system
@@ -457,8 +457,8 @@ ENDSNIP
 
 snip_require_valid_tokens_perpath_1() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "AuthorizationPolicy"
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
 metadata:
   name: "frontend-ingress"
   namespace: istio-system

--- a/content/en/docs/tasks/security/authentication/mtls-migration/index.md
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/index.md
@@ -90,8 +90,8 @@ to only accept mutual TLS traffic.
 
 {{< text bash >}}
 $ kubectl apply -n foo -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
 spec:
@@ -133,8 +133,8 @@ We recommend you use [Istio Authorization](/docs/tasks/security/authorization/au
 
 {{< text bash >}}
 $ kubectl apply -n istio-system -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
 spec:

--- a/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
@@ -65,8 +65,8 @@ ENDSNIP
 
 snip_lock_down_to_mutual_tls_by_namespace_1() {
 kubectl apply -n foo -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
 spec:
@@ -100,8 +100,8 @@ ENDSNIP
 
 snip_lock_down_mutual_tls_for_the_entire_mesh_1() {
 kubectl apply -n istio-system -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
 spec:

--- a/content/en/docs/tasks/security/authorization/authz-http/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-http/index.md
@@ -79,8 +79,8 @@ and then grant more access to the workload gradually and incrementally.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: "security.istio.io/v1beta1"
-    kind: "AuthorizationPolicy"
+    apiVersion: security.istio.io/v1beta1
+    kind: AuthorizationPolicy
     metadata:
       name: "productpage-viewer"
       namespace: default
@@ -112,8 +112,8 @@ and then grant more access to the workload gradually and incrementally.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: "security.istio.io/v1beta1"
-    kind: "AuthorizationPolicy"
+    apiVersion: security.istio.io/v1beta1
+    kind: AuthorizationPolicy
     metadata:
       name: "details-viewer"
       namespace: default
@@ -137,8 +137,8 @@ and then grant more access to the workload gradually and incrementally.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: "security.istio.io/v1beta1"
-    kind: "AuthorizationPolicy"
+    apiVersion: security.istio.io/v1beta1
+    kind: AuthorizationPolicy
     metadata:
       name: "reviews-viewer"
       namespace: default
@@ -170,8 +170,8 @@ and then grant more access to the workload gradually and incrementally.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: "security.istio.io/v1beta1"
-    kind: "AuthorizationPolicy"
+    apiVersion: security.istio.io/v1beta1
+    kind: AuthorizationPolicy
     metadata:
       name: "ratings-viewer"
       namespace: default

--- a/content/en/docs/tasks/security/authorization/authz-http/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-http/snips.sh
@@ -34,8 +34,8 @@ EOF
 
 snip_configure_access_control_for_workloads_using_http_traffic_2() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "AuthorizationPolicy"
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
 metadata:
   name: "productpage-viewer"
   namespace: default
@@ -52,8 +52,8 @@ EOF
 
 snip_configure_access_control_for_workloads_using_http_traffic_3() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "AuthorizationPolicy"
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
 metadata:
   name: "details-viewer"
   namespace: default
@@ -73,8 +73,8 @@ EOF
 
 snip_configure_access_control_for_workloads_using_http_traffic_4() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "AuthorizationPolicy"
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
 metadata:
   name: "reviews-viewer"
   namespace: default
@@ -94,8 +94,8 @@ EOF
 
 snip_configure_access_control_for_workloads_using_http_traffic_5() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "AuthorizationPolicy"
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
 metadata:
   name: "ratings-viewer"
   namespace: default

--- a/content/en/docs/tasks/security/authorization/authz-jwt/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-jwt/index.md
@@ -52,8 +52,8 @@ accepts a JWT issued by `testing@secure.istio.io`:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: "security.istio.io/v1beta1"
-    kind: "RequestAuthentication"
+    apiVersion: security.istio.io/v1beta1
+    kind: RequestAuthentication
     metadata:
       name: "jwt-example"
       namespace: foo

--- a/content/en/docs/tasks/security/authorization/authz-jwt/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-jwt/snips.sh
@@ -36,8 +36,8 @@ ENDSNIP
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_1() {
 kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "RequestAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: RequestAuthentication
 metadata:
   name: "jwt-example"
   namespace: foo

--- a/content/en/docs/tasks/security/cert-management/plugin-ca-cert/index.md
+++ b/content/en/docs/tasks/security/cert-management/plugin-ca-cert/index.md
@@ -120,8 +120,8 @@ security protection.
 
     {{< text bash >}}
     $ kubectl apply -n foo -f - <<EOF
-    apiVersion: "security.istio.io/v1beta1"
-    kind: "PeerAuthentication"
+    apiVersion: security.istio.io/v1beta1
+    kind: PeerAuthentication
     metadata:
       name: "default"
     spec:

--- a/content/en/docs/tasks/security/cert-management/plugin-ca-cert/snips.sh
+++ b/content/en/docs/tasks/security/cert-management/plugin-ca-cert/snips.sh
@@ -58,8 +58,8 @@ kubectl apply -f <(istioctl kube-inject -f samples/sleep/sleep.yaml) -n foo
 
 snip_deploying_example_services_2() {
 kubectl apply -n foo -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
-kind: "PeerAuthentication"
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
 metadata:
   name: "default"
 spec:


### PR DESCRIPTION
This matches istio/api examples and all Kubernetes best practices. This
quoting sets a bad precedent that is copy and pasted around the web.



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure