### PR TITLE
Update kube version in description to align with cmd

### DIFF
--- a/content/en/docs/setup/platform-setup/minikube/index.md
+++ b/content/en/docs/setup/platform-setup/minikube/index.md
@@ -36,7 +36,7 @@ Refer to the [`api-server` reference docs](https://kubernetes.io/docs/reference/
     $ minikube config set driver kvm2
     {{< /text >}}
 
-1.  Start minikube with 16384 `MB` of memory and 4 `CPUs`. This example uses Kubernetes version **1.18.10**.
+1.  Start minikube with 16384 `MB` of memory and 4 `CPUs`. This example uses Kubernetes version **1.20.2**.
     You can change the version to any Kubernetes version supported by Istio by altering the
     `--kubernetes-version` value:
 


### PR DESCRIPTION
In doc: https://istio.io/latest/docs/setup/platform-setup/minikube/

The cmd line has been updated to recent version as: `minikube start --memory=16384 --cpus=4 --kubernetes-version=v1.20.2`

The description also need to be updated to align with the cmd.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
