### PR TITLE
Fix the OpenGraph preview image

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -34,10 +34,10 @@
         {{ if .Permalink }}
             <meta property="og:url" content="{{ .Permalink }}">
         {{ end }}
-        <meta property="og:image" content="{{ .Site.BaseURL }}/img/istio-whitelogo-bluebackground-framed.svg">
+        <meta property="og:image" content="{{ .Site.BaseURL | absURL }}/img/istio-whitelogo-bluebackground-framed.svg">
         <meta property="og:image:alt" content="Istio Logo">
-        <meta property="og:image:width" content="112">
-        <meta property="og:image:height" content="150">
+        <meta property="og:image:width" content="1024">
+        <meta property="og:image:height" content="1024">
         <meta property="og:site_name" content="Istio">
 
         <!-- Twitter card -->

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -32,7 +32,7 @@
         <meta property="og:type" content="website">
         <meta property="og:description" content="{{ template "description" . }}">
         {{ if .Permalink }}
-            <meta property="og:url" content="{{ .Permalink }}">
+            <meta property="og:url" content="{{ .Permalink | absURL }}">
         {{ end }}
         <meta property="og:image" content="{{ .Site.BaseURL | absURL }}/img/istio-whitelogo-bluebackground-framed.svg">
         <meta property="og:image:alt" content="Istio Logo">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -32,9 +32,9 @@
         <meta property="og:type" content="website">
         <meta property="og:description" content="{{ template "description" . }}">
         {{ if .Permalink }}
-            <meta property="og:url" content="{{ .Permalink | absURL }}">
+            <meta property="og:url" content="{{ .Permalink }}">
         {{ end }}
-        <meta property="og:image" content="{{ .Site.BaseURL | absURL }}/img/istio-whitelogo-bluebackground-framed.svg">
+        <meta property="og:image" content="https://raw.githubusercontent.com/istio/istio.io/master/static/img/istio-whitelogo-bluebackground-framed.svg">
         <meta property="og:image:alt" content="Istio Logo">
         <meta property="og:image:width" content="1024">
         <meta property="og:image:height" content="1024">


### PR DESCRIPTION
The <og:image> tag in the site metadata is used to display an image when you paste an Istio URL into Google Chat, for example.  At the moment it doesn't take the right image:

![image](https://user-images.githubusercontent.com/132510/113008949-6b264680-916f-11eb-8cec-4279881f8979.png)

The URL in there currently is relative (`/latest/img/istio-whitelogo-bluebackground-framed.svg`) but it should be absolute according to https://ogp.me/.

I don't currently have access to our Netlify setup and I'm not sure if it passes the hosted URL through to Hugo in order that this would works, so let's test it.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
