### PR TITLE
Restore istioctl experimental wait in _wait_for_istio()

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/test.sh
@@ -96,8 +96,6 @@ snip_configure_a_mutual_tls_ingress_gateway_2
 
 # wait for the change to propagate
 _wait_for_istio gateway default mygateway
-#TODO Temoporary: Remove sleep once _wait_for_istio is enabled again
-sleep 1
 
 _verify_failure snip_configure_a_mutual_tls_ingress_gateway_3
 

--- a/tests/util/helpers.sh
+++ b/tests/util/helpers.sh
@@ -84,16 +84,15 @@ _wait_for_deployment() {
 # Wait for Istio config to propagate
 # usage: _wait_for_istio <kind> <namespace> <name>
 _wait_for_istio() {
-# TODO: Put back when istioctl wait is functiuoning correctly
-#    local kind="$1"
-#    local namespace="$2"
-#    local name="$3"
+    local kind="$1"
+    local namespace="$2"
+    local name="$3"
     local start=$(date +%s)
-#    if ! istioctl experimental wait --for=distribution --timeout=10s "$kind" "$name.$namespace"; then
-#        echo "Failed distribution of $kind $name in namespace $namespace"
-#        istioctl ps
-#        echo "TEST: wait for failed, but continuing."
-#    fi
+    if ! istioctl experimental wait --for=distribution --timeout=10s "$kind" "$name.$namespace"; then
+        echo "Failed distribution of $kind $name in namespace $namespace"
+        istioctl ps
+        echo "TEST: wait for failed, but continuing."
+    fi
     echo "Duration: $(($(date +%s)-start)) seconds"
 }
 


### PR DESCRIPTION

Based on some change in the `istioctl experimental wait`, try enabling it and see if we still see the 5 min timeouts in the logs.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure