### PR TITLE
Update feature stages

### DIFF
--- a/content/en/docs/releases/feature-stages/index.md
+++ b/content/en/docs/releases/feature-stages/index.md
@@ -104,7 +104,7 @@ Experimental features are purposefully not listed on this page.
 | [Kubernetes: Istio Control Plane Installation](/docs/setup/) | Stable
 | [Multicluster Mesh](/docs/setup/install/multicluster/) | Beta
 | [External Control Plane](/docs/setup/additional-setup/external-controlplane/) | Alpha
-| [Kubernetes: Istio Control Plane Upgrade](/docs/setup/upgrade/) | Beta
+| [Kubernetes: Istio Control Plane In-Place Upgrade](/docs/setup/upgrade/in-place) | Beta
 | Basic Configuration Resource Validation | Beta
 | [Istio CNI plugin](/docs/setup/additional-setup/cni/) | Alpha
 | IPv6 Support for Kubernetes | Alpha. Dual-stack IPv4 and IPv6 is not supported.


### PR DESCRIPTION

The feature/link called "upgrades" on the feature status page links to a high level page that refers to three different features, one of which is explicitly experimental on the target page. This fixes the link to point at in-place upgrades. In-place upgrades are also the only one of the three that's currently beta. 


[ ] Configuration Infrastructure
[ ] Docs
[x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure