### PR TITLE
Update ref docs for the release-1.9 branch

### DIFF
--- a/content/en/docs/reference/commands/istioctl/index.html
+++ b/content/en/docs/reference/commands/istioctl/index.html
@@ -5158,6 +5158,12 @@ These environment variables affect the behavior of the <code>istioctl</code> com
 <td>EnableThriftFilter enables injection of `envoy.filters.network.thrift_proxy` in the filter chain.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_UNSAFE_RUNTIME_ASSERTIONS</code></td>
+<td>Boolean</td>
+<td><code>false</code></td>
+<td>If enabled, addition runtime asserts will be performed. These checks are both expensive and panic on failure. As a result, this should be used only for testing.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_VIRTUAL_SERVICE_DELEGATE</code></td>
 <td>Boolean</td>
 <td><code>true</code></td>
@@ -5293,7 +5299,7 @@ These environment variables affect the behavior of the <code>istioctl</code> com
 <td><code>PILOT_XDS_CACHE_SIZE</code></td>
 <td>Integer</td>
 <td><code>20000</code></td>
-<td>The maximum number of cache entries for the XDS cache. If the size is &lt;= 0, the cache will have no upper bound.</td>
+<td>The maximum number of cache entries for the XDS cache.</td>
 </tr>
 <tr>
 <td><code>PILOT_XDS_CACHE_STATS</code></td>

--- a/content/en/docs/reference/commands/operator/index.html
+++ b/content/en/docs/reference/commands/operator/index.html
@@ -374,6 +374,12 @@ These environment variables affect the behavior of the <code>operator</code> com
 <td>EnableThriftFilter enables injection of `envoy.filters.network.thrift_proxy` in the filter chain.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_UNSAFE_RUNTIME_ASSERTIONS</code></td>
+<td>Boolean</td>
+<td><code>false</code></td>
+<td>If enabled, addition runtime asserts will be performed. These checks are both expensive and panic on failure. As a result, this should be used only for testing.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_VIRTUAL_SERVICE_DELEGATE</code></td>
 <td>Boolean</td>
 <td><code>true</code></td>
@@ -509,7 +515,7 @@ These environment variables affect the behavior of the <code>operator</code> com
 <td><code>PILOT_XDS_CACHE_SIZE</code></td>
 <td>Integer</td>
 <td><code>20000</code></td>
-<td>The maximum number of cache entries for the XDS cache. If the size is &lt;= 0, the cache will have no upper bound.</td>
+<td>The maximum number of cache entries for the XDS cache.</td>
 </tr>
 <tr>
 <td><code>PILOT_XDS_CACHE_STATS</code></td>

--- a/content/en/docs/reference/commands/pilot-agent/index.html
+++ b/content/en/docs/reference/commands/pilot-agent/index.html
@@ -939,6 +939,12 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <td>EnableThriftFilter enables injection of `envoy.filters.network.thrift_proxy` in the filter chain.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_UNSAFE_RUNTIME_ASSERTIONS</code></td>
+<td>Boolean</td>
+<td><code>false</code></td>
+<td>If enabled, addition runtime asserts will be performed. These checks are both expensive and panic on failure. As a result, this should be used only for testing.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_VIRTUAL_SERVICE_DELEGATE</code></td>
 <td>Boolean</td>
 <td><code>true</code></td>
@@ -1074,7 +1080,7 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <td><code>PILOT_XDS_CACHE_SIZE</code></td>
 <td>Integer</td>
 <td><code>20000</code></td>
-<td>The maximum number of cache entries for the XDS cache. If the size is &lt;= 0, the cache will have no upper bound.</td>
+<td>The maximum number of cache entries for the XDS cache.</td>
 </tr>
 <tr>
 <td><code>PILOT_XDS_CACHE_STATS</code></td>

--- a/content/en/docs/reference/commands/pilot-discovery/index.html
+++ b/content/en/docs/reference/commands/pilot-discovery/index.html
@@ -788,6 +788,12 @@ These environment variables affect the behavior of the <code>pilot-discovery</co
 <td>EnableThriftFilter enables injection of `envoy.filters.network.thrift_proxy` in the filter chain.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_UNSAFE_RUNTIME_ASSERTIONS</code></td>
+<td>Boolean</td>
+<td><code>false</code></td>
+<td>If enabled, addition runtime asserts will be performed. These checks are both expensive and panic on failure. As a result, this should be used only for testing.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_VIRTUAL_SERVICE_DELEGATE</code></td>
 <td>Boolean</td>
 <td><code>true</code></td>
@@ -923,7 +929,7 @@ These environment variables affect the behavior of the <code>pilot-discovery</co
 <td><code>PILOT_XDS_CACHE_SIZE</code></td>
 <td>Integer</td>
 <td><code>20000</code></td>
-<td>The maximum number of cache entries for the XDS cache. If the size is &lt;= 0, the cache will have no upper bound.</td>
+<td>The maximum number of cache entries for the XDS cache.</td>
 </tr>
 <tr>
 <td><code>PILOT_XDS_CACHE_STATS</code></td>

--- a/content/en/docs/reference/config/istio.operator.v1alpha1/index.html
+++ b/content/en/docs/reference/config/istio.operator.v1alpha1/index.html
@@ -104,7 +104,9 @@ No
 <td><code>string</code></td>
 <td>
 <p>Namespace to install control plane resources into. If unset, Istio will be installed into the same namespace
-as the <code>IstioOperator</code> CR.</p>
+as the <code>IstioOperator</code> CR. You must also set <code>values.global.istioNamespace</code> if you wish to install Istio in
+a custom namespace.
+If you have enabled CNI, you must  exclude this namespace by adding it to the list <code>values.cni.excludeNamespaces</code>.</p>
 
 </td>
 <td>

--- a/content/en/docs/reference/config/networking/destination-rule/index.html
+++ b/content/en/docs/reference/config/networking/destination-rule/index.html
@@ -239,9 +239,6 @@ namespaces by default.</p>
 the destination rule is declared in. Similarly, the value &ldquo;*&rdquo; is reserved and
 defines an export to all namespaces.</p>
 
-<p>NOTE: in the current release, the <code>exportTo</code> value is restricted to
-&ldquo;.&rdquo; or &ldquo;*&rdquo; (i.e., the current namespace or all namespaces).</p>
-
 </td>
 <td>
 No
@@ -694,7 +691,7 @@ spec:
         http2MaxRequests: 1000
         maxRequestsPerConnection: 10
     outlierDetection:
-      consecutiveErrors: 7
+      consecutive5xxErrors: 7
       interval: 5m
       baseEjectionTime: 15m
 </code></pre>
@@ -717,7 +714,7 @@ spec:
         http2MaxRequests: 1000
         maxRequestsPerConnection: 10
     outlierDetection:
-      consecutiveErrors: 7
+      consecutive5xxErrors: 7
       interval: 5m
       baseEjectionTime: 15m
 </code></pre>

--- a/content/en/docs/reference/config/networking/envoy-filter/index.html
+++ b/content/en/docs/reference/config/networking/envoy-filter/index.html
@@ -67,9 +67,9 @@ spec:
     patch:
       operation: INSERT_BEFORE
       value:
-        # This is the full filter config including the name and config or typed_config section.
+        # This is the full filter config including the name and typed_config section.
         name: &quot;envoy.config.filter.network.custom_protocol&quot;
-        config:
+        typed_config:
          ...
   - applyTo: NETWORK_FILTER # http connection manager is a filter in Envoy
     match:
@@ -111,26 +111,30 @@ spec:
       context: SIDECAR_INBOUND
       listener:
         portNumber: 8080
+        filterChain:
+          filter:
+            name: &quot;envoy.filters.network.http_connection_manager&quot;
+            subFilter:
+              name: &quot;envoy.filters.http.router&quot;
     patch:
-      operation: ADD
-      filterClass: AUTHZ # This filter will run *after* the Istio authz filter.
+      operation: INSERT_BEFORE
       value: # lua filter specification
-        name: envoy.filters.http.lua
-        typed_config:
+       name: envoy.lua
+       typed_config:
           &quot;@type&quot;: &quot;type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua&quot;
           inlineCode: |
-           function envoy_on_request(request_handle)
-             -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
-             local headers, body = request_handle:httpCall(
-              &quot;lua_cluster&quot;,
-              {
-               [&quot;:method&quot;] = &quot;POST&quot;,
-               [&quot;:path&quot;] = &quot;/acl&quot;,
-               [&quot;:authority&quot;] = &quot;internal.org.net&quot;
-              },
-             &quot;authorize call&quot;,
-             5000)
-           end
+            function envoy_on_request(request_handle)
+              -- Make an HTTP call to an upstream host with the following headers, body, and timeout.
+              local headers, body = request_handle:httpCall(
+               &quot;lua_cluster&quot;,
+               {
+                [&quot;:method&quot;] = &quot;POST&quot;,
+                [&quot;:path&quot;] = &quot;/acl&quot;,
+                [&quot;:authority&quot;] = &quot;internal.org.net&quot;
+               },
+              &quot;authorize call&quot;,
+              5000)
+            end
   # The second patch adds the cluster that is referenced by the lua code
   # cds match is omitted as a new cluster is being added
   - applyTo: CLUSTER
@@ -143,12 +147,16 @@ spec:
         type: STRICT_DNS
         connect_timeout: 0.5s
         lb_policy: ROUND_ROBIN
-        hosts:
-        - socket_address:
-            protocol: TCP
-            address: &quot;internal.org.net&quot;
-            port_value: 8888
-
+        load_assignment:
+          cluster_name: lua_cluster
+          endpoints:
+          - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    protocol: TCP
+                    address: &quot;internal.org.net&quot;
+                    port_value: 8888
 </code></pre>
 
 <p>The following example overwrites certain fields (HTTP idle timeout
@@ -177,9 +185,11 @@ spec:
     patch:
       operation: MERGE
       value:
-        common_http_protocol_options:
-          idle_timeout: 30s
-        xff_num_trusted_hops: 5
+        typed_config:
+          &quot;@type&quot;: &quot;type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager&quot;
+          xff_num_trusted_hops: 5
+          common_http_protocol_options:
+            idle_timeout: 30s
 </code></pre>
 
 <p>The following example inserts an attributegen filter
@@ -249,9 +259,9 @@ spec:
           grpc_service:
             envoy_grpc:
               cluster_name: acme-ext-authz
-              initial_metadata:
-              - key: foo
-                value: myauth.acme # required by local ext auth server.
+            initial_metadata:
+            - key: foo
+              value: myauth.acme # required by local ext auth server.
 </code></pre>
 
 <p>A workload in the <code>myns</code> namespace needs to access a different ext_auth server
@@ -315,8 +325,10 @@ spec:
                 remote:
                   http_uri:
                     uri: http://my-wasm-binary-uri
-            configuration: |
-              {}
+            configuration:
+              &quot;@type&quot;: &quot;type.googleapis.com/google.protobuf.StringValue&quot;
+              value: |
+                {}
   # The second patch instructs to apply the above Wasm filter to the listener/http connection manager.
   - applyTo: HTTP_FILTER
     match:
@@ -1165,7 +1177,7 @@ configuration.</p>
 <td>
 <p>Merge the provided config with the generated config using
 proto merge semantics. If you are specifying config in its
-entirity, use <code>REPLACE</code> instead.</p>
+entirety, use <code>REPLACE</code> instead.</p>
 
 </td>
 </tr>

--- a/content/en/docs/reference/config/networking/gateway/index.html
+++ b/content/en/docs/reference/config/networking/gateway/index.html
@@ -253,8 +253,7 @@ spec:
   hosts:
   - mongosvr.prod.svc.cluster.local # name of internal Mongo service
   gateways:
-  - some-config-namespace/my-gateway # can omit the namespace if gateway is in same
-                                       namespace as virtual service.
+  - some-config-namespace/my-gateway # can omit the namespace if gateway is in same namespace as virtual service.
   tcp:
   - match:
     - port: 27017
@@ -278,8 +277,7 @@ spec:
   hosts:
   - mongosvr.prod.svc.cluster.local # name of internal Mongo service
   gateways:
-  - some-config-namespace/my-gateway # can omit the namespace if gateway is in same
-                                       namespace as virtual service.
+  - some-config-namespace/my-gateway # can omit the namespace if gateway is in same namespace as virtual service.
   tcp:
   - match:
     - port: 27017

--- a/content/en/docs/reference/config/networking/service-entry/index.html
+++ b/content/en/docs/reference/config/networking/service-entry/index.html
@@ -593,13 +593,13 @@ spec:
   endpoints:
   - address: us.foo.bar.com
     ports:
-      https: 8080
+      http: 8080
   - address: uk.foo.bar.com
     ports:
-      https: 9080
+      http: 9080
   - address: in.foo.bar.com
     ports:
-      https: 7080
+      http: 7080
 </code></pre>
 
 <p>{{</tab>}}
@@ -948,9 +948,6 @@ defines an export to all namespaces.</p>
 <p>For a Kubernetes Service, the equivalent effect can be achieved by setting
 the annotation &ldquo;networking.istio.io/exportTo&rdquo; to a comma-separated list
 of namespace names.</p>
-
-<p>NOTE: in the current release, the <code>exportTo</code> value is restricted to
-&ldquo;.&rdquo; or &ldquo;*&rdquo; (i.e., the current namespace or all namespaces).</p>
 
 </td>
 <td>

--- a/content/en/docs/reference/config/networking/sidecar/index.html
+++ b/content/en/docs/reference/config/networking/sidecar/index.html
@@ -667,7 +667,7 @@ Yes
 <h2 id="WorkloadSelector">WorkloadSelector</h2>
 <section>
 <p><code>WorkloadSelector</code> specifies the criteria used to determine if the
-<code>Gateway</code>, <code>Sidecar</code>, or <code>EnvoyFilter</code> or <code>ServiceEntry</code>
+<code>Gateway</code>, <code>Sidecar</code>, <code>EnvoyFilter</code>, or <code>ServiceEntry</code>
 configuration can be applied to a proxy. The matching criteria
 includes the metadata associated with a proxy, workload instance
 info such as labels attached to the pod/VM, or any other info that

--- a/content/en/docs/reference/config/networking/virtual-service/index.html
+++ b/content/en/docs/reference/config/networking/virtual-service/index.html
@@ -512,7 +512,7 @@ spec:
     name: example-http
     protocol: HTTP
   resolution: DNS
-
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -544,7 +544,7 @@ spec:
     name: example-http
     protocol: HTTP
   resolution: DNS
-
+---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
@@ -950,7 +950,7 @@ spec:
   - headers:
       request:
         set:
-          test: true
+          test: &quot;true&quot;
     route:
     - destination:
         host: reviews.prod.svc.cluster.local
@@ -981,7 +981,7 @@ spec:
   - headers:
       request:
         set:
-          test: true
+          test: &quot;true&quot;
     route:
     - destination:
         host: reviews.prod.svc.cluster.local
@@ -2274,7 +2274,7 @@ Yes
 <td><code>perTryTimeout</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration">Duration</a></code></td>
 <td>
-<p>Timeout per retry attempt for a given request. format: 1h/1m/1s/1ms. MUST BE &gt;=1ms.
+<p>Timeout per attempt for a given request, including the initial call and any retries. Format: 1h/1m/1s/1ms. MUST BE &gt;=1ms.
 Default is same value as request
 <code>timeout</code> of the <a href="/docs/reference/config/networking/virtual-service/#HTTPRoute">HTTP route</a>,
 which means no timeout.</p>

--- a/content/en/docs/reference/config/networking/workload-group/index.html
+++ b/content/en/docs/reference/config/networking/workload-group/index.html
@@ -52,7 +52,7 @@ spec:
      path: /foo/bar
      host: 127.0.0.1
      port: 3100
-     scheme: https
+     scheme: HTTPS
      httpHeaders:
      - name: Lit-Header
        value: Im-The-Best

--- a/content/en/docs/reference/config/security/authorization-policy/index.html
+++ b/content/en/docs/reference/config/security/authorization-policy/index.html
@@ -59,26 +59,26 @@ but it is useful to be explicit in the policy.</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
- name: httpbin
- namespace: foo
+  name: httpbin
+  namespace: foo
 spec:
- action: ALLOW
- rules:
- - from:
-   - source:
-       principals: [&quot;cluster.local/ns/default/sa/sleep&quot;]
-   - source:
-       namespaces: [&quot;test&quot;]
-   to:
-   - operation:
-       methods: [&quot;GET&quot;]
-       paths: [&quot;/info*&quot;]
-   - operation:
-       methods: [&quot;POST&quot;]
-       paths: [&quot;/data&quot;]
-   when:
-   - key: request.auth.claims[iss]
-     values: [&quot;https://accounts.google.com&quot;]
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        principals: [&quot;cluster.local/ns/default/sa/sleep&quot;]
+    - source:
+        namespaces: [&quot;test&quot;]
+    to:
+    - operation:
+        methods: [&quot;GET&quot;]
+        paths: [&quot;/info*&quot;]
+    - operation:
+        methods: [&quot;POST&quot;]
+        paths: [&quot;/data&quot;]
+    when:
+    - key: request.auth.claims[iss]
+      values: [&quot;https://accounts.google.com&quot;]
 </code></pre>
 
 <p>The following is another example that sets <code>action</code> to &ldquo;DENY&rdquo; to create a deny policy.
@@ -88,17 +88,17 @@ in the &ldquo;foo&rdquo; namespace.</p>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
- name: httpbin
- namespace: foo
+  name: httpbin
+  namespace: foo
 spec:
- action: DENY
- rules:
- - from:
-   - source:
-       namespaces: [&quot;dev&quot;]
-   to:
-   - operation:
-       methods: [&quot;POST&quot;]
+  action: DENY
+  rules:
+  - from:
+    - source:
+        namespaces: [&quot;dev&quot;]
+    to:
+    - operation:
+        methods: [&quot;POST&quot;]
 </code></pre>
 
 <p>The following authorization policy sets the <code>action</code> to &ldquo;AUDIT&rdquo;. It will audit any GET requests to the path with the
@@ -113,7 +113,7 @@ spec:
   selector:
     matchLabels:
       app: myapi
-  action: audit
+  action: AUDIT
   rules:
   - to:
     - operation:
@@ -138,12 +138,12 @@ namespace, the policy applies to all namespaces in a mesh.</li>
 <pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
- name: policy
- namespace: bar
+  name: policy
+  namespace: bar
 spec:
- selector:
-   matchLabels:
-     app: httpbin
+  selector:
+    matchLabels:
+      app: httpbin
 </code></pre>
 
 <p>The following authorization policy applies to all workloads in namespace foo.</p>

--- a/content/en/docs/reference/config/security/request_authentication/index.html
+++ b/content/en/docs/reference/config/security/request_authentication/index.html
@@ -79,17 +79,19 @@ spec:
   selector:
     matchLabels:
       app: httpbin
- rules:
- - from:
-   - source:
-       requestPrincipals: [&quot;issuer-foo/*&quot;]
-   to:
-     hosts: [&quot;example.com&quot;]
- - from:
-   - source:
-       requestPrincipals: [&quot;issuer-bar/*&quot;]
-   to:
-     hosts: [&quot;another-host.com&quot;]
+  rules:
+  - from:
+    - source:
+        requestPrincipals: [&quot;issuer-foo/*&quot;]
+    to:
+    - operation:
+        hosts: [&quot;example.com&quot;]
+  - from:
+    - source:
+        requestPrincipals: [&quot;issuer-bar/*&quot;]
+    to:
+    - operation:
+        hosts: [&quot;another-host.com&quot;]
 </code></pre>
 
 <ul>
@@ -107,13 +109,13 @@ spec:
   selector:
     matchLabels:
       app: httpbin
- rules:
- - from:
-   - source:
-       requestPrincipals: [&quot;*&quot;]
- - to:
-   - operation:
-       paths: [&quot;/healthz&quot;]
+  rules:
+  - from:
+    - source:
+        requestPrincipals: [&quot;*&quot;]
+  - to:
+    - operation:
+        paths: [&quot;/healthz&quot;]
 </code></pre>
 
 <table class="message-fields">


### PR DESCRIPTION
Please provide a description for what this PR is for.

No `make update_ref_docs` was done on the `release-1.9` branch. I ran one today. I'm not sure if there are any additional PRs in the repos used to generate the reference docs post the 1.9.2 release, or if these match the actual 1.9.2 commits.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
