### PR TITLE
Added security advisory for gateway port change

### DIFF
--- a/content/en/news/security/istio-security-2021-002/check.sh
+++ b/content/en/news/security/istio-security-2021-002/check.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eEuo pipefail
+
+RED='\033[0;31m'
+NC='\033[0m'
+
+INGRESS_LABEL="istio=ingressgateway"
+INGRESS_NAMESPACE="istio-system"
+
+INGRESS_LABEL_KEY=$(echo $INGRESS_LABEL | cut -d '=' -f 1)
+INGRESS_LABEL_VAL=$(echo $INGRESS_LABEL | cut -d '=' -f 2)
+
+ingress_pod=$(kubectl -n $INGRESS_NAMESPACE get pod \
+  -l $INGRESS_LABEL \
+  -o jsonpath='{.items[0].metadata.name}' || true)
+
+if [ -z "$ingress_pod" ]; then
+  echo "No ingress pod found in \"${INGRESS_NAMESPACE}\" with label selectors \"${INGRESS_LABEL}\""
+  exit 1
+fi
+
+echo "Inspecting Istio ingress gateway pod \"${ingress_pod}\" in \"${INGRESS_NAMESPACE}\" namespace"
+
+ingress_ports=$(istioctl proxy-config listeners \
+  $ingress_pod.$INGRESS_NAMESPACE \
+  | awk 'NR > 1 {print $2}')
+
+function check_port {
+  local policy_name=$1
+  local port=$2
+
+  local found=false
+  local ip
+  for ip in $ingress_ports; do
+    if [ "$ip" == "$port" ]; then
+      found=true
+      break
+    fi
+  done
+  if ! $found; then
+    echo -e "${RED} Authorization Policy \"$policy_name\" has port \"$port\" that needs to be migrated. ${NC}"
+  fi
+}
+
+authz_policies=$(kubectl -n $INGRESS_NAMESPACE get authorizationpolicies | awk 'NR > 1 {print $1}')
+echo -e "Checking Authorization Policies attached to \"$ingress_pod\"\n"
+
+for p in $authz_policies; do
+  policy=$(kubectl -n $INGRESS_NAMESPACE get authorizationpolicy $p -o json)
+  label_selector=$(echo "${policy}" |\
+    jq -r --arg KEY "$INGRESS_LABEL_KEY" '.spec.selector.matchLabels[$KEY]')
+  if [ $label_selector != $INGRESS_LABEL_VAL ]; then
+    continue
+  fi
+  policy_ports=$(echo "${policy}" | jq -r '.spec.rules[]|select(.to)|.to[]|.operation|select(.ports)|.ports[]')
+  policy_notports=$(echo "${policy}" | jq -r '.spec.rules[]|select(.to)|.to[]|.operation|select(.notPorts)|.notPorts[]')
+  for pp in $policy_ports; do
+    check_port $p $pp
+  done
+  for pp in $policy_notports; do
+    check_port $p $pp
+  done
+done

--- a/content/en/news/security/istio-security-2021-002/check.sh
+++ b/content/en/news/security/istio-security-2021-002/check.sh
@@ -53,7 +53,7 @@ function check_port {
     fi
   done
   if ! $found; then
-    echo -e "${RED} Authorization Policy \"$policy_name\" has port \"$port\" that needs to be migrated. ${NC}"
+    echo -e "${RED} Authorization Policy \"${policy_name}\" has port \"${port}\" that needs to be migrated. ${NC}"
   fi
 }
 

--- a/content/en/news/security/istio-security-2021-002/index.md
+++ b/content/en/news/security/istio-security-2021-002/index.md
@@ -18,13 +18,13 @@ misconfiguration related vulnerability:
 
 - **Incorrect gateway ports on Authorization Policies on upgrades**: In Istio
 versions 1.6 and later, the default container ports for Istio ingress
-gateways are updated from port “80” to “8080” and “443” to “8443” to allow
+gateways are updated from port "80" to "8080" and "443" to "8443" to allow
 [gateways to run as non-root](/news/releases/1.7.x/announcing-1.7/upgrade-notes/#gateways-run-as-non-root)
 by default. With this change, any existing Authorization Policies targeting
-Istio ingress gateway on ports “80” and “443” need to be migrated to use the
-new container ports “8080” and “8443” before upgrading to the listed versions.
+Istio ingress gateway on ports "80" and "443" need to be migrated to use the
+new container ports "8080" and "8443" before upgrading to the listed versions.
 Failure to migrate might result in traffic reaching at ingress gateway service
-ports “80” and “443” to be incorrectly allowed or blocked thereby causing policy
+ports "80" and "443" to be incorrectly allowed or blocked thereby causing policy
 violations.
 
 Example of an Authorization Policy resource that needs to be updated:
@@ -53,8 +53,8 @@ Example of an Authorization Policy resource that needs to be updated:
     {{< /text >}}
 
 The above policy in Istio versions 1.5 and prior will block all access to path
-“/admin” for traffic reaching Istio ingress gateway on container ports “80”
-and “443”. On upgrading to Istio version 1.6 and later, this policy should
+"/admin" for traffic reaching Istio ingress gateway on container ports "80"
+and "443". On upgrading to Istio version 1.6 and later, this policy should
 be updated to the following to have the same effect.
 
     {{< text yaml >}}

--- a/content/en/news/security/istio-security-2021-002/index.md
+++ b/content/en/news/security/istio-security-2021-002/index.md
@@ -52,9 +52,9 @@ Example of an authorization policy resource that needs to be updated:
     {{< /text >}}
 
 The above policy in Istio versions 1.5 and prior will block all access to path
-"/admin" for traffic reaching Istio ingress gateway on container ports "80"
-and "443". On upgrading to Istio version 1.6 and later, this policy should
-be updated to the following to have the same effect.
+`/admin` for traffic reaching an Istio ingress gateway on container ports `80`
+and `443`. On upgrading to Istio version 1.6 and later, this policy should
+be updated to the following to have the same effect:
 
     {{< text yaml >}}
     apiVersion: "security.istio.io/v1beta1"

--- a/content/en/news/security/istio-security-2021-002/index.md
+++ b/content/en/news/security/istio-security-2021-002/index.md
@@ -16,18 +16,18 @@ skip_seealso: true
 Upgrading to Istio version 1.6 and higher may result in misconfigured
 Authorization Policies:
 
-- **Incorrect gateway ports on Authorization Policies on upgrades**: In Istio
+- **Incorrect gateway ports on authorization policies on upgrades**: In Istio
 versions 1.6 and later, the default container ports for Istio ingress
 gateways are updated from port "80" to "8080" and "443" to "8443" to allow
 [gateways to run as non-root](/news/releases/1.7.x/announcing-1.7/upgrade-notes/#gateways-run-as-non-root)
-by default. With this change, any existing Authorization Policies targeting
-Istio ingress gateway on ports "80" and "443" need to be migrated to use the
-new container ports "8080" and "8443" before upgrading to the listed versions.
-Failure to migrate might result in traffic reaching at ingress gateway service
-ports "80" and "443" to be incorrectly allowed or blocked thereby causing policy
+by default. With this change, any existing authorization policies targeting
+an Istio ingress gateway on ports `80` and `443` need to be migrated to use the
+new container ports `8080` and `8443`, before upgrading to the listed versions.
+Failure to migrate may result in traffic reaching ingress gateway service
+ports `80` and `443` to be incorrectly allowed or blocked, thereby causing policy
 violations.
 
-Example of an Authorization Policy resource that needs to be updated:
+Example of an authorization policy resource that needs to be updated:
 
     {{< text yaml >}}
     apiVersion: "security.istio.io/v1beta1"

--- a/content/en/news/security/istio-security-2021-002/index.md
+++ b/content/en/news/security/istio-security-2021-002/index.md
@@ -81,18 +81,18 @@ be updated to the following to have the same effect.
 
 ## Mitigation
 
-- Update your misconfigured Authorization policies before upgrading to the
-listed Istio versions. You can use this [script](./check.sh)
+- Update your authorization policies before upgrading to the
+affected Istio versions. You can use this [script](./check.sh)
 to check if any of the existing authorization policies
-attached to the default Istio ingress gateway in istio-system namespace needs
-to be updated. If you’re using a custom gateway installation you can customize
+attached to the default Istio ingress gateway in the `istio-system` namespace need
+to be updated. If you’re using a custom gateway installation, you can customize
 the script to run with parameters applicable to your environment.
 
-It is recommended to create a copy of your existing misconfigured Authorization
-policies, update the copied version to use new gateway workload ports and
-apply both existing and updated policies in your cluster before initiating
+It is recommended to create a copy of your existing authorization
+policies, update the copied version to use new gateway workload ports, and
+apply both existing and updated policies in your cluster, before initiating
 the upgrade process. You should only delete the old policies after a
-successful upgrade to ensure no policy violations occur on upgrade
+successful upgrade, to ensure no policy violations occur on upgrade
 failures or rollbacks.
 
 ## Credit

--- a/content/en/news/security/istio-security-2021-002/index.md
+++ b/content/en/news/security/istio-security-2021-002/index.md
@@ -13,7 +13,7 @@ skip_seealso: true
 
 {{< security_bulletin >}}
 
-Upgrading from Istio versions 1.5 and prior, to 1.6 and later, may result in misconfigured access control:
+Upgrading from Istio versions 1.5 and prior, to 1.6 and later, may result in access control bypass:
 
 - **Incorrect gateway ports on authorization policies on upgrades**: In Istio
 versions 1.6 and later, the default container ports for Istio ingress

--- a/content/en/news/security/istio-security-2021-002/index.md
+++ b/content/en/news/security/istio-security-2021-002/index.md
@@ -13,8 +13,7 @@ skip_seealso: true
 
 {{< security_bulletin >}}
 
-Upgrading to Istio version 1.6 and higher may result in misconfigured
-Authorization Policies:
+Upgrading from Istio versions 1.5 and prior, to 1.6 and later, may result in misconfigured access control:
 
 - **Incorrect gateway ports on authorization policies on upgrades**: In Istio
 versions 1.6 and later, the default container ports for Istio ingress

--- a/content/en/news/security/istio-security-2021-002/index.md
+++ b/content/en/news/security/istio-security-2021-002/index.md
@@ -1,7 +1,7 @@
 ---
 title: ISTIO-SECURITY-2021-002
 subtitle: Security Bulletin
-description: Ingress gateway authorization policy violation on upgrades.
+description: Upgrades from older Istio versions can affect access control to an ingress gateway due to a change of container ports.
 cves: [N/A]
 cvss: "N/A"
 vector: ""

--- a/content/en/news/security/istio-security-2021-002/index.md
+++ b/content/en/news/security/istio-security-2021-002/index.md
@@ -1,0 +1,103 @@
+---
+title: ISTIO-SECURITY-2021-002
+subtitle: Security Bulletin
+description: Ingress gateway authorization policy violation on upgrades.
+cves: [N/A]
+cvss: "N/A"
+vector: ""
+releases: ["All releases 1.6 and later"]
+publishdate: 2021-04-06
+keywords: [CVE]
+skip_seealso: true
+---
+
+{{< security_bulletin >}}
+
+Upgrading to Istio version 1.6 and higher is vulnerable to the following
+misconfiguration related vulnerability:
+
+- **Incorrect gateway ports on Authorization Policies on upgrades**: In Istio
+versions 1.6 and later, the default container ports for Istio ingress
+gateways are updated from port “80” to “8080” and “443” to “8443” to allow
+[gateways to run as non-root](/news/releases/1.7.x/announcing-1.7/upgrade-notes/#gateways-run-as-non-root)
+by default. With this change, any existing Authorization Policies targeting
+Istio ingress gateway on ports “80” and “443” need to be migrated to use the
+new container ports “8080” and “8443” before upgrading to the listed versions.
+Failure to migrate might result in traffic reaching at ingress gateway service
+ports “80” and “443” to be incorrectly allowed or blocked thereby causing policy
+violations.
+
+Example of an Authorization Policy resource that needs to be updated:
+
+    {{< text yaml >}}
+    apiVersion: "security.istio.io/v1beta1"
+    kind: "AuthorizationPolicy"
+    metadata:
+      name: block-admin-access
+      namespace: istio-system
+    spec:
+      selector:
+        matchLabels:
+          istio: ingressgateway
+      action: DENY
+      rules:
+      -  to:
+        - operation:
+            paths: ["/admin"]
+            ports: [ "80" ]
+      -  to:
+        - operation:
+            paths: ["/admin"]
+            ports: [ "443" ]
+
+    {{< /text >}}
+
+The above policy in Istio versions 1.5 and prior will block all access to path
+“/admin” for traffic reaching Istio ingress gateway on container ports “80”
+and “443”. On upgrading to Istio version 1.6 and later, this policy should
+be updated to the following to have the same effect.
+
+    {{< text yaml >}}
+    apiVersion: "security.istio.io/v1beta1"
+    kind: "AuthorizationPolicy"
+    metadata:
+      name: block-admin-access
+      namespace: istio-system
+    spec:
+      selector:
+        matchLabels:
+          istio: ingressgateway
+      action: DENY
+      rules:
+      -  to:
+        - operation:
+            paths: ["/admin"]
+            ports: [ "8080" ]
+      -  to:
+        - operation:
+            paths: ["/admin"]
+            ports: [ "8443"
+    {{< /text >}}
+
+## Mitigation
+
+- Update your misconfigured Authorization policies before upgrading to the
+listed Istio versions. You can use this [script](./check.sh)
+to check if any of the existing authorization policies
+attached to the default Istio ingress gateway in istio-system namespace needs
+to be updated. If you’re using a custom gateway installation you can customize
+the script to run with parameters applicable to your environment.
+
+It is recommended to create a copy of your existing misconfigured Authorization
+policies, update the copied version to use new gateway workload ports and
+apply both existing and updated policies in your cluster before initiating
+the upgrade process. You should only delete the old policies after a
+successful upgrade to ensure no policy violations occur on upgrade
+failures or rollbacks.
+
+## Credit
+
+We'd like to thank [Neeraj Poddar](https://twitter.com/nrjpoddar)
+for reporting this vulnerability.
+
+{{< boilerplate "security-vulnerability" >}}

--- a/content/en/news/security/istio-security-2021-002/index.md
+++ b/content/en/news/security/istio-security-2021-002/index.md
@@ -13,8 +13,8 @@ skip_seealso: true
 
 {{< security_bulletin >}}
 
-Upgrading to Istio version 1.6 and higher is vulnerable to the following
-misconfiguration related vulnerability:
+Upgrading to Istio version 1.6 and higher may result in misconfigured
+Authorization Policies:
 
 - **Incorrect gateway ports on Authorization Policies on upgrades**: In Istio
 versions 1.6 and later, the default container ports for Istio ingress
@@ -98,6 +98,6 @@ failures or rollbacks.
 ## Credit
 
 We'd like to thank [Neeraj Poddar](https://twitter.com/nrjpoddar)
-for reporting this vulnerability.
+for reporting this issue.
 
 {{< boilerplate "security-vulnerability" >}}

--- a/content/en/news/security/istio-security-2021-002/index.md
+++ b/content/en/news/security/istio-security-2021-002/index.md
@@ -6,7 +6,7 @@ cves: [N/A]
 cvss: "N/A"
 vector: ""
 releases: ["All releases 1.6 and later"]
-publishdate: 2021-04-06
+publishdate: 2021-04-07
 keywords: [CVE]
 skip_seealso: true
 ---


### PR DESCRIPTION
Added a script that users can run to evaluate if any of their existing
Authorization Policies need to be migrated.



[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure