### PR TITLE
Bump istio version to head of 1.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v0.0.0-20
 require (
 	github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f
 	github.com/pmezard/go-difflib v1.0.0
-	istio.io/istio v0.0.0-20210412210842-f171f4daffb4
+	istio.io/istio v0.0.0-20210413235758-a57ed8a5b016
 	istio.io/pkg v0.0.0-20210405163638-bd457cbec517
 	k8s.io/apimachinery v0.20.5
 	k8s.io/client-go v0.20.5

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v0.0.0-20
 require (
 	github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f
 	github.com/pmezard/go-difflib v1.0.0
-	istio.io/istio v0.0.0-20210411051758-2af8df9263a0
+	istio.io/istio v0.0.0-20210412210842-f171f4daffb4
 	istio.io/pkg v0.0.0-20210405163638-bd457cbec517
 	k8s.io/apimachinery v0.20.5
 	k8s.io/client-go v0.20.5

--- a/go.sum
+++ b/go.sum
@@ -1476,8 +1476,8 @@ istio.io/client-go v0.0.0-20210406025641-c740ff1f4def/go.mod h1:gJdlzn6YV0YaDKvA
 istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
 istio.io/gogo-genproto v0.0.0-20210405163638-fcb891f20a5a h1:e3x86okAVbui7ddsCcuY9r3QjPI/Ulf31lVRfGiGFKM=
 istio.io/gogo-genproto v0.0.0-20210405163638-fcb891f20a5a/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
-istio.io/istio v0.0.0-20210411051758-2af8df9263a0 h1:EXrg/WoR8n/fJtPPzdbev4mnwISuQXIKIZVu7fEsX3E=
-istio.io/istio v0.0.0-20210411051758-2af8df9263a0/go.mod h1:PAibYYXK8UVodBLj6IDyuXK84K78yJKWON1meQ52dpE=
+istio.io/istio v0.0.0-20210412210842-f171f4daffb4 h1:2nYYagzVftfFDQzvrsRmjysIAHgfAsvlvqWu/Wc41ns=
+istio.io/istio v0.0.0-20210412210842-f171f4daffb4/go.mod h1:PAibYYXK8UVodBLj6IDyuXK84K78yJKWON1meQ52dpE=
 istio.io/pkg v0.0.0-20210405163638-bd457cbec517 h1:/sXEpTOaE2VCQ7kR5D4oXxXUeWs6U0OSzMp1ANlZ3g0=
 istio.io/pkg v0.0.0-20210405163638-bd457cbec517/go.mod h1:U14DF4p1AViKhOwpVv1UPEWtknGytJyfJw6hqVi0TmM=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=

--- a/go.sum
+++ b/go.sum
@@ -1476,8 +1476,8 @@ istio.io/client-go v0.0.0-20210406025641-c740ff1f4def/go.mod h1:gJdlzn6YV0YaDKvA
 istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
 istio.io/gogo-genproto v0.0.0-20210405163638-fcb891f20a5a h1:e3x86okAVbui7ddsCcuY9r3QjPI/Ulf31lVRfGiGFKM=
 istio.io/gogo-genproto v0.0.0-20210405163638-fcb891f20a5a/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
-istio.io/istio v0.0.0-20210412210842-f171f4daffb4 h1:2nYYagzVftfFDQzvrsRmjysIAHgfAsvlvqWu/Wc41ns=
-istio.io/istio v0.0.0-20210412210842-f171f4daffb4/go.mod h1:PAibYYXK8UVodBLj6IDyuXK84K78yJKWON1meQ52dpE=
+istio.io/istio v0.0.0-20210413235758-a57ed8a5b016 h1:vLj/P4siJ7toH8eJ5SiBjla1oTiUjS1Bgx3rcOOeCw8=
+istio.io/istio v0.0.0-20210413235758-a57ed8a5b016/go.mod h1:PAibYYXK8UVodBLj6IDyuXK84K78yJKWON1meQ52dpE=
 istio.io/pkg v0.0.0-20210405163638-bd457cbec517 h1:/sXEpTOaE2VCQ7kR5D4oXxXUeWs6U0OSzMp1ANlZ3g0=
 istio.io/pkg v0.0.0-20210405163638-bd457cbec517/go.mod h1:U14DF4p1AViKhOwpVv1UPEWtknGytJyfJw6hqVi0TmM=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=


### PR DESCRIPTION
If this DOESN'T fail we have a problem. https://github.com/istio/istio/commit/27816e7b44c74a4e41d08658333b42a9de88d186 should make it fail, to match 1.9 behavior