### PR TITLE
Add note to generate trace data for Kiali dashboard

### DIFF
--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -377,6 +377,10 @@ Use the following instructions to deploy the [Kiali](/docs/ops/integrations/kial
 
 1.  In the left navigation menu, select _Graph_ and in the _Namespace_ drop down, select _default_.
 
+    {{< tip >}}
+    {{< boilerplate trace-generation >}}
+    {{< /tip >}}
+
     The Kiali dashboard shows an overview of your mesh with the relationships
     between the services in the `Bookinfo` sample application. It also provides
     filters to visualize the traffic flow.

--- a/content/en/docs/setup/getting-started/snips.sh
+++ b/content/en/docs/setup/getting-started/snips.sh
@@ -19,6 +19,7 @@
 # WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
 #          docs/setup/getting-started/index.md
 ####################################################################################################
+source "content/en/boilerplates/snips/trace-generation.sh"
 
 snip_download_istio_download_1() {
 curl -L https://istio.io/downloadIstio | sh -


### PR DESCRIPTION
To fix https://github.com/istio/istio.io/issues/9514

Instead of asking the user to refresh the browser several times, the script is already used to generate trace data for Kiali Dashboard. Added a `tip` so that the user can run the command and Kiali Dashboard will show data.

**After**:
![kiali-tip](https://user-images.githubusercontent.com/2920003/114697012-fb04ec80-9d3a-11eb-9a43-b53911e3b171.png)
