### PR TITLE
Add ability to automatically render feature status based on the current status from the enhancements repo

### DIFF
--- a/content/en/docs/releases/feature-stages/index.md
+++ b/content/en/docs/releases/feature-stages/index.md
@@ -46,71 +46,23 @@ Experimental features are purposefully not listed on this page.
 
 ### Traffic management
 
-| Feature           | Phase
-|-------------------|-------------------
-| Protocols: HTTP1.1 / HTTP2 / gRPC / TCP | Stable
-| Protocols: Websockets / MongoDB  | Stable
-| Traffic Control: label/content based routing, traffic shifting | Stable
-| Resilience features: timeouts, retries, connection pools, outlier detection | Stable
-| Gateway: Ingress, Egress for all protocols | Stable
-| TLS termination and SNI Support in Gateways | Stable
-| SNI (multiple certs) at ingress | Stable
-| [Locality load balancing](/docs/tasks/traffic-management/locality-load-balancing/) | Beta
-| Enabling custom filters in Envoy | Alpha
-| CNI container interface | Alpha
-| [Sidecar API](/docs/reference/config/networking/sidecar/) | Beta
-| [DNS Proxying](/docs/ops/configuration/traffic-management/dns-proxy/) | Alpha
-| [Kubernetes service-apis](/docs/tasks/traffic-management/ingress/gateway-api/) | Alpha
+{{< features section="Traffic Management" >}}
 
 ### Observability
 
-| Feature           | Phase
-|-------------------|-------------------
-| [Prometheus Integration](/docs/tasks/observability/metrics/querying-metrics/) | Stable
-| [Client and Server Telemetry Reporting](https://istio.io/v1.6/docs/reference/config/policy-and-telemetry/) | Stable
-| [Service Dashboard in Grafana](/docs/tasks/observability/metrics/using-istio-dashboard/) | Stable
-| [Distributed Tracing](/docs/tasks/observability/distributed-tracing/) | Stable
-| [Stackdriver Integration](/docs/reference/config/proxy_extensions/stackdriver/) | Stable
-| [Distributed Tracing to Zipkin / Jaeger](/docs/tasks/observability/distributed-tracing/) | Beta
-| [Trace Sampling](/docs/tasks/observability/distributed-tracing/configurability/#trace-sampling) | Beta
-| [Request Classification](/docs/tasks/observability/metrics/classify-metrics/) | Beta
+{{< features section="Observability" >}}
 
 ### Extensibility
 
-| Feature           | Phase
-|-------------------|-------------------
-| WebAssembly Extension | Alpha
+{{< features section="Extensibility" >}}
 
 ### Security and policy enforcement
 
-| Feature           | Phase
-|-------------------|-------------------
-| [Service-to-service mutual TLS](/docs/concepts/security/#mutual-tls-authentication)         | Stable
-| [Kubernetes: Service Credential Distribution](/docs/concepts/security/#pki)   | Stable
-| [Certificate management on Ingress Gateway](/docs/tasks/traffic-management/ingress/secure-ingress) | Stable
-| [Pluggable Key/Cert Support for Istio CA](/docs/tasks/security/cert-management/plugin-ca-cert/)        | Stable
-| [Authorization](/docs/concepts/security/#authorization)   | Beta
-| [End User (JWT) Authentication](/docs/concepts/security/#authentication)  | Beta
-| [Automatic mutual TLS](/docs/tasks/security/authentication/authn-policy/#auto-mutual-tls) | Beta
-| [VM: Service Credential Distribution](/docs/concepts/security/#pki)         | Beta
-| [Mutual TLS Migration](/docs/tasks/security/authentication/mtls-migration)    | Beta
+{{< features section="Security and policy enforcement" >}}
 
 ### Core
 
-| Feature           | Phase
-|-------------------|-------------------
-| [Standalone Operator](/docs/setup/install/operator/) | Beta
-| [Kubernetes: Envoy Installation and Traffic Interception](/docs/setup/) | Stable
-| [Kubernetes: Istio Control Plane Installation](/docs/setup/) | Stable
-| [Multicluster Mesh](/docs/setup/install/multicluster/) | Beta
-| [External Control Plane](/docs/setup/additional-setup/external-controlplane/) | Alpha
-| [Kubernetes: Istio Control Plane In-Place Upgrade](/docs/setup/upgrade/in-place) | Beta
-| Basic Configuration Resource Validation | Beta
-| [Istio CNI plugin](/docs/setup/additional-setup/cni/) | Alpha
-| IPv6 Support for Kubernetes | Alpha. Dual-stack IPv4 and IPv6 is not supported.
-| [Distroless Base Images for Istio](/docs/ops/configuration/security/harden-docker-images/) | Alpha
-| [Virtual Machine Integration](/docs/setup/install/virtual-machine/) | Beta
-| [Helm Based Installation](/docs/setup/install/helm/) | Alpha
+{{< features section="Core" >}}
 
 {{< idea >}}
 Please get in touch by joining our [community](/about/community/) if there are features you'd like to see in our future releases!

--- a/data/features.yaml
+++ b/data/features.yaml
@@ -1,0 +1,283 @@
+features:
+  - name: "Protocols:HTTP1.1/HTTP2/gRPC/TCP"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "Protocols:Websockets/MongoDB"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "Traffic Control: label/content based routing, traffic shifting"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "Resilience features: timeouts, retries, connection pools, outlier detection"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "Gateway: Ingress, Egress for all protocols"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "TLS termination and SNI Support in Gateways"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "SNI (multiple certs) at ingress"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "Locality load balancing"
+    link: "/docs/tasks/traffic-management/locality-load-balancing/"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "Enabling custom filters in Envoy"
+    level:
+      checklist: ""
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "CNI container interface"
+    level:
+      checklist: features/cni.md
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "Sidecar API"
+    link: "/docs/reference/config/networking/sidecar/"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "DNS Proxying"
+    link: "/docs/ops/configuration/traffic-management/dns-proxy/"
+    level:
+      checklist: ""
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "Kubernetes Service APIs"
+    link: "/docs/tasks/traffic-management/ingress/gateway-api/"
+    level:
+      checklist: features/service_apis.md
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "Prometheus Integration"
+    link: "/docs/tasks/observability/metrics/querying-metrics/"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Observability
+  - name: "Service Dashboard in Grafana"
+    link: "/docs/tasks/observability/metrics/using-istio-dashboard/"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Observability
+  - name: "Distributed Tracing"
+    link: "/docs/tasks/observability/distributed-tracing/"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Observability
+  - name: "Stackdriver Integration"
+    link: "/docs/reference/config/proxy_extensions/stackdriver/"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Observability
+  - name: "Distributed Tracing to Zipkin/Jaeger"
+    link: "/docs/tasks/observability/distributed-tracing/"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Observability
+  - name: "Trace Sampling"
+    link: "/docs/tasks/observability/distributed-tracing/configurability/#trace-sampling"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Observability
+  - name: "Request Classification"
+    link: "/docs/tasks/observability/metrics/classify-metrics/"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Observability
+  - name: "WebAssembly Extension"
+    level:
+      checklist: ""
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Extensibility
+  - name: "Service-to-service Mutual TLS"
+    link: "/docs/concepts/security/#mutual-tls-authentication"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
+  - name: "Kubernetes: Service Credential Distribution"
+    link: "/docs/concepts/security/#pki"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
+  - name: "Certificate management on Ingress Gateway"
+    link: "/docs/tasks/traffic-management/ingress/secure-ingress"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
+  - name: "Pluggable Key/Cert Support for istio CA"
+    link: "/docs/tasks/security/cert-management/plugin-ca-cert/"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
+  - name: "Authorization"
+    link: "/docs/concepts/security/#authorization"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
+  - name: "End User (JWT) Authentication"
+    link: "/docs/concepts/security/#authentication"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
+  - name: "Automatic mutual TLS"
+    link: "/docs/tasks/security/authentication/authn-policy/#auto-mutual-tls"
+    level:
+      checklist: features/auto_mtls.md
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
+  - name: "VM: Service Credential Distribution"
+    link: "/docs/concepts/security/#pki"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
+  - name: "Mutual TLS Migration"
+    link: "/docs/tasks/security/authentication/mtls-migration"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
+  - name: "In-Cluster Operator"
+    link: "/docs/setup/install/operator/"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "Kubernetes: Envoy Installation and Traffic Interception"
+    link: "/docs/setup/"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "Kubernetes: Istio Control Plane Installation"
+    link: "/docs/setup/"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "Multicluster Mesh"
+    link: "/docs/setup/install/multicluster/"
+    level:
+      checklist: features/Multi-cluster support.md
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "External Control Plane"
+    link: "/docs/setup/additional-setup/external-controlplane/"
+    level:
+      checklist: features/external_istiod.md
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "Kubernetes: Istio In-Place Control Plane Upgrade"
+    link: "/docs/setup/upgrade/in-place"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "Basic Configuration Resource Validation"
+    level:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "Istio CNI Plugin"
+    link: "/docs/setup/additional-setup/cni/"
+    level:
+      checklist: ""
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "IPv6 Support for Kubernetes"
+    level:
+      checklist: ""
+      maturity: Alpha. Dual-stack IPv4 and IPv6 is not supported.
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "Distroless Base Images for Istio"
+    link: "/docs/ops/configuration/security/harden-docker-images/"
+    level:
+      checklist: features/distroless_images.md
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "Virtual Machine Integration"
+    link: "/docs/setup/install/virtual-machine/"
+    level:
+      checklist: features/virtual_machines.md
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Core
+  - name: "Helm Based Installation"
+    link: "/docs/setup/install/helm/"
+    level:
+      checklist: features/helm_v3_support.md
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Core

--- a/layouts/shortcodes/features.html
+++ b/layouts/shortcodes/features.html
@@ -1,0 +1,42 @@
+{{$section := (.Get "section") }}
+
+<table>
+    <tr>
+        <th>Feature</th>
+        <th>Phase</th>
+    </tr>
+    {{ $features := .Site.Data.features.features }}
+    {{ range $feature := $features }}
+    {{ $featureLevel := $feature.level }}
+    {{ $featureDeprecation := $feature.deprecation }}
+
+    {{ if eq $feature.area $section }}
+
+    <tr>
+        {{ if $feature.link }}
+        <td><a href={{ $feature.link }}>{{ $feature.name }}</a></td>
+        {{ else }}
+        <td>{{ $feature.name }}</td>
+        {{end}}
+        <td>
+            {{if and ($featureDeprecation) (eq $featureDeprecation.state "deprecated") }}
+                Deprecated
+                {{ if $featureDeprecation.details }}
+                    {{ if $featureDeprecation.details.next }}
+                        with removal planned for {{ $featureDeprecation.details.next }}.
+                    {{ else }}
+                        .
+                    {{ end }}
+                    {{ if $featureDeprecation.details.replacement }}
+                        Replaced by {{ $featureDeprecation.details.replacement }}.
+                    {{ end }}
+                Was {{ trim $featureLevel.maturity "\"" }}.
+                {{ end }}
+            {{ else }}
+                {{ trim $featureLevel.maturity "\"" }}
+            {{ end }}
+        </td>
+    </tr>
+    {{ end }}
+    {{ end }}
+</table>

--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -92,6 +92,10 @@ locate_file() {
     sed -i -e "s/title: /source_repo: ${REPOX}\ntitle: /g" "${ROOTDIR}/content/en/docs${PP}/${FN}/index.html"
 }
 
+handle_feature_status_scraping() {
+    curl "https://raw.githubusercontent.com/istio/enhancements/${SOURCE_BRANCH_NAME}/features.yaml" -o "${ROOTDIR}/data/features.yaml"
+}
+
 handle_doc_scraping() {
     for repo in "${REPOS[@]}"; do
         REPO_URL=$(echo "$repo" | cut -d @ -f 1)
@@ -174,3 +178,6 @@ handle_components
 
 echo "Fetching config analysis data"
 handle_config_analysis_messages
+
+echo "Handling feature status"
+handle_feature_status_scraping


### PR DESCRIPTION
Now that we have a feature promotion process in the enhancements repo and a list of the current maturity for features in `features.yaml` that's designed to be consumable by tooling, we should use it to generate the list of features for the feature stages page.  

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure