### PR TITLE
update standard metrics documentation

### DIFF
--- a/content/en/docs/reference/config/metrics/index.md
+++ b/content/en/docs/reference/config/metrics/index.md
@@ -112,8 +112,8 @@ For TCP traffic, Istio generates the following metrics:
     destination_canonical_revision
     {{< /text >}}
 
-*   **Destination Cluster**: Name of the cluster for the destination workload.
+*   **Destination Cluster**: This identifies the cluster of the destination workload.
     This is set by: `global.multiCluster.clusterName` at cluster install time.
 
-*   **Source Cluster**: Name of the cluster for the source workload.
+*   **Source Cluster**: This identifies the cluster of the source workload.
     This is set by: `global.multiCluster.clusterName` at cluster install time.

--- a/content/en/docs/reference/config/metrics/index.md
+++ b/content/en/docs/reference/config/metrics/index.md
@@ -113,7 +113,7 @@ For TCP traffic, Istio generates the following metrics:
     {{< /text >}}
 
 *   **Destination Cluster**: Name of the cluster for the destination workload.
-    This is set by: global.multiCluster.clusterName at cluster install time.
+    This is set by: `global.multiCluster.clusterName` at cluster install time.
 
 *   **Source Cluster**: Name of the cluster for the source workload.
-    This is set by: global.multiCluster.clusterName at cluster install time.
+    This is set by: `global.multiCluster.clusterName` at cluster install time.

--- a/content/en/docs/reference/config/metrics/index.md
+++ b/content/en/docs/reference/config/metrics/index.md
@@ -9,10 +9,8 @@ aliases:
 ---
 
 The following are the standard service level metrics exported by Istio.
-Istio standard metrics are directly exported by the Envoy proxy since Istio 1.5.
-The telemetry component is [implemented](https://github.com/istio/proxy/tree/master/extensions/stats) as a [Proxy-wasm](https://github.com/proxy-wasm/spec) plugin.
 
-In prior Istio releases Mixer produced these metrics.
+The telemetry component is [implemented](https://github.com/istio/proxy/tree/master/extensions/stats) as a [Proxy-wasm](https://github.com/proxy-wasm/spec) plugin.
 
 ## Metrics
 
@@ -113,3 +111,9 @@ For TCP traffic, Istio generates the following metrics:
     destination_canonical_service
     destination_canonical_revision
     {{< /text >}}
+
+*   **Destination Cluster**: Name of the cluster for the destination workload.
+    This is set by: global.multiCluster.clusterName at cluster install time.
+
+*   **Source Cluster**: Name of the cluster for the source workload.
+    This is set by: global.multiCluster.clusterName at cluster install time.


### PR DESCRIPTION
As part of 1.10 release, ensure that the standard metrics documentation matches behavior. This also removes mentions of Mixer from the page, as that is no longer relevant.

[ X ] Policies and Telemetry
