### PR TITLE
Filter mixer docs from related content sections

### DIFF
--- a/content/en/blog/2017/adapter-model/index.md
+++ b/content/en/blog/2017/adapter-model/index.md
@@ -8,6 +8,7 @@ keywords: [adapters,mixer,policies,telemetry]
 aliases:
     - /blog/mixer-adapter-model.html
 target_release: 0.2
+exclude_from_see_also: true
 ---
 
 Istio 0.2 introduced a new Mixer adapter model which is intended to increase Mixer’s flexibility to address a varied set of infrastructure backends. This post intends to put the adapter model in context and explain how it works.

--- a/content/en/blog/2017/mixer-spof-myth/index.md
+++ b/content/en/blog/2017/mixer-spof-myth/index.md
@@ -9,6 +9,7 @@ aliases:
     - /blog/posts/2017/mixer-spof-myth.html
     - /blog/mixer-spof-myth.html
 target_release: 0.3
+exclude_from_see_also: true
 ---
 
 As [Mixer](https://istio.io/v1.6/docs/reference/config/policy-and-telemetry/) is in the request path, it is natural to question how it impacts

--- a/content/en/docs/concepts/observability/index.md
+++ b/content/en/docs/concepts/observability/index.md
@@ -2,7 +2,7 @@
 title: Observability
 description: Describes the telemetry and monitoring features provided by Istio.
 weight: 40
-keywords: [policies,telemetry,control,config]
+keywords: [telemetry,metrics,logs,tracing]
 aliases:
     - /docs/concepts/policy-and-control/mixer.html
     - /docs/concepts/policy-and-control/mixer-config.html

--- a/content/en/docs/reference/config/metrics/index.md
+++ b/content/en/docs/reference/config/metrics/index.md
@@ -2,6 +2,7 @@
 title: Istio Standard Metrics
 description: Istio standard metrics exported by Istio telemetry.
 weight: 50
+keywords: [telemetry,metrics]
 owner: istio/wg-user-experience-maintainers
 test: n/a
 aliases:

--- a/content/en/docs/tasks/observability/logs/access-log/index.md
+++ b/content/en/docs/tasks/observability/logs/access-log/index.md
@@ -2,7 +2,7 @@
 title: Getting Envoy's Access Logs
 description: This task shows you how to configure Envoy proxies to print access logs to their standard output.
 weight: 10
-keywords: [telemetry]
+keywords: [telemetry,logs]
 aliases:
     - /docs/tasks/telemetry/access-log
     - /docs/tasks/telemetry/logs/access-log/

--- a/layouts/partials/primary_bottom.html
+++ b/layouts/partials/primary_bottom.html
@@ -3,8 +3,11 @@
 {{ $skipPageNav := .Scratch.Get "skipPageNav" }}
 
             {{ if .Scratch.Get "seeAlso" }}
-                {{ $related := .Site.RegularPages.Related . | first 6 }}
-                {{ with $related }}
+                {{ $related := .Site.RegularPages.Related . | first 8 }}
+                {{ $mixerSPOF := where $related "RelPermalink" "/blog/2017/mixer-spof-myth/"}}
+                {{ $mixerAdapter := where $related "RelPermalink" "/blog/2017/adapter-model/"}}
+                {{ $seeAlso := $related | complement $mixerSPOF $mixerAdapter | first 6}}
+                {{ with $seeAlso }}
                     <nav id="see-also">
                         <h2>{{ i18n "see_also" }}</h2>
 

--- a/layouts/partials/primary_bottom.html
+++ b/layouts/partials/primary_bottom.html
@@ -3,10 +3,9 @@
 {{ $skipPageNav := .Scratch.Get "skipPageNav" }}
 
             {{ if .Scratch.Get "seeAlso" }}
-                {{ $related := .Site.RegularPages.Related . | first 8 }}
-                {{ $mixerSPOF := where $related "RelPermalink" "/blog/2017/mixer-spof-myth/"}}
-                {{ $mixerAdapter := where $related "RelPermalink" "/blog/2017/adapter-model/"}}
-                {{ $seeAlso := $related | complement $mixerSPOF $mixerAdapter | first 6}}
+                {{ $related := .Site.RegularPages.Related . }}
+                {{ $excludes := where $related "Params.exclude_from_see_also" true }}
+                {{ $seeAlso := $related | complement $excludes | first 6 }}
                 {{ with $seeAlso }}
                     <nav id="see-also">
                         <h2>{{ i18n "see_also" }}</h2>


### PR DESCRIPTION
This PR is meant to prevent Mixer blog posts from 2017 (and similar) from showing up in the `See Also` section of pages in our docs. This is to prevent user confusion and stop talking about Mixer (which has been deprecated and removed from Istio).

It also attempts to add more appropriate keywords in a few places to link docs together hopefully.

[ X ] Policies and Telemetry
