### PR TITLE
Update the reference docs for 1.9.4

### DIFF
--- a/content/en/docs/reference/commands/istioctl/index.html
+++ b/content/en/docs/reference/commands/istioctl/index.html
@@ -5008,6 +5008,12 @@ These environment variables affect the behavior of the <code>istioctl</code> com
 <td></td>
 </tr>
 <tr>
+<td><code>KUBERNETES_SERVICE_HOST</code></td>
+<td>String</td>
+<td><code></code></td>
+<td>Kuberenetes service host, set automatically when running in-cluster</td>
+</tr>
+<tr>
 <td><code>PILOT_ALLOW_METADATA_CERTS_DR_MUTUAL_TLS</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>
@@ -5236,6 +5242,12 @@ These environment variables affect the behavior of the <code>istioctl</code> com
 <td>Limits the number of concurrent pushes allowed. On larger machines this can be increased for faster pushes</td>
 </tr>
 <tr>
+<td><code>PILOT_REMOTE_CLUSTER_TIMEOUT</code></td>
+<td>Time Duration</td>
+<td><code>30s</code></td>
+<td>After this timeout expires, pilot can become ready without syncing data from clusters added via remote-secrets. Setting the timeout to 0 disables this behavior.</td>
+</tr>
+<tr>
 <td><code>PILOT_SCOPE_GATEWAY_TO_NAMESPACE</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>
@@ -5440,6 +5452,7 @@ These environment variables affect the behavior of the <code>istioctl</code> com
 <tr><td><code>pilot_xds_rds_reject</code></td><td><code>LastValue</code></td><td>Pilot rejected RDS.</td></tr>
 <tr><td><code>pilot_xds_send_time</code></td><td><code>Distribution</code></td><td>Total time in seconds Pilot takes to send generated configuration.</td></tr>
 <tr><td><code>pilot_xds_write_timeout</code></td><td><code>Sum</code></td><td>Pilot XDS response write timeouts.</td></tr>
+<tr><td><code>remote_cluster_sync_timeouts_total</code></td><td><code>Sum</code></td><td>Number of times remote clusters took too long to sync, causing slow startup that excludes remote clusters.</td></tr>
 <tr><td><code>render_manifest_total</code></td><td><code>Sum</code></td><td>Number of component manifests rendered</td></tr>
 <tr><td><code>resource_creation_total</code></td><td><code>Sum</code></td><td>Number of resources created by the operator</td></tr>
 <tr><td><code>resource_deletion_total</code></td><td><code>Sum</code></td><td>Number of resources deleted by the operator</td></tr>

--- a/content/en/docs/reference/commands/operator/index.html
+++ b/content/en/docs/reference/commands/operator/index.html
@@ -224,6 +224,12 @@ These environment variables affect the behavior of the <code>operator</code> com
 <td></td>
 </tr>
 <tr>
+<td><code>KUBERNETES_SERVICE_HOST</code></td>
+<td>String</td>
+<td><code></code></td>
+<td>Kuberenetes service host, set automatically when running in-cluster</td>
+</tr>
+<tr>
 <td><code>PILOT_ALLOW_METADATA_CERTS_DR_MUTUAL_TLS</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>
@@ -452,6 +458,12 @@ These environment variables affect the behavior of the <code>operator</code> com
 <td>Limits the number of concurrent pushes allowed. On larger machines this can be increased for faster pushes</td>
 </tr>
 <tr>
+<td><code>PILOT_REMOTE_CLUSTER_TIMEOUT</code></td>
+<td>Time Duration</td>
+<td><code>30s</code></td>
+<td>After this timeout expires, pilot can become ready without syncing data from clusters added via remote-secrets. Setting the timeout to 0 disables this behavior.</td>
+</tr>
+<tr>
 <td><code>PILOT_SCOPE_GATEWAY_TO_NAMESPACE</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>
@@ -636,6 +648,7 @@ These environment variables affect the behavior of the <code>operator</code> com
 <tr><td><code>pilot_xds_rds_reject</code></td><td><code>LastValue</code></td><td>Pilot rejected RDS.</td></tr>
 <tr><td><code>pilot_xds_send_time</code></td><td><code>Distribution</code></td><td>Total time in seconds Pilot takes to send generated configuration.</td></tr>
 <tr><td><code>pilot_xds_write_timeout</code></td><td><code>Sum</code></td><td>Pilot XDS response write timeouts.</td></tr>
+<tr><td><code>remote_cluster_sync_timeouts_total</code></td><td><code>Sum</code></td><td>Number of times remote clusters took too long to sync, causing slow startup that excludes remote clusters.</td></tr>
 <tr><td><code>render_manifest_total</code></td><td><code>Sum</code></td><td>Number of component manifests rendered</td></tr>
 <tr><td><code>resource_creation_total</code></td><td><code>Sum</code></td><td>Number of resources created by the operator</td></tr>
 <tr><td><code>resource_deletion_total</code></td><td><code>Sum</code></td><td>Number of resources deleted by the operator</td></tr>

--- a/content/en/docs/reference/commands/pilot-agent/index.html
+++ b/content/en/docs/reference/commands/pilot-agent/index.html
@@ -783,6 +783,12 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <td></td>
 </tr>
 <tr>
+<td><code>KUBERNETES_SERVICE_HOST</code></td>
+<td>String</td>
+<td><code></code></td>
+<td>Kuberenetes service host, set automatically when running in-cluster</td>
+</tr>
+<tr>
 <td><code>OUTPUT_CERTS</code></td>
 <td>String</td>
 <td><code></code></td>
@@ -1015,6 +1021,12 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <td>Integer</td>
 <td><code>100</code></td>
 <td>Limits the number of concurrent pushes allowed. On larger machines this can be increased for faster pushes</td>
+</tr>
+<tr>
+<td><code>PILOT_REMOTE_CLUSTER_TIMEOUT</code></td>
+<td>Time Duration</td>
+<td><code>30s</code></td>
+<td>After this timeout expires, pilot can become ready without syncing data from clusters added via remote-secrets. Setting the timeout to 0 disables this behavior.</td>
 </tr>
 <tr>
 <td><code>PILOT_SCOPE_GATEWAY_TO_NAMESPACE</code></td>
@@ -1261,6 +1273,7 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <tr><td><code>pilot_xds_rds_reject</code></td><td><code>LastValue</code></td><td>Pilot rejected RDS.</td></tr>
 <tr><td><code>pilot_xds_send_time</code></td><td><code>Distribution</code></td><td>Total time in seconds Pilot takes to send generated configuration.</td></tr>
 <tr><td><code>pilot_xds_write_timeout</code></td><td><code>Sum</code></td><td>Pilot XDS response write timeouts.</td></tr>
+<tr><td><code>remote_cluster_sync_timeouts_total</code></td><td><code>Sum</code></td><td>Number of times remote clusters took too long to sync, causing slow startup that excludes remote clusters.</td></tr>
 <tr><td><code>scrape_failures_total</code></td><td><code>Sum</code></td><td>The total number of failed scrapes.</td></tr>
 <tr><td><code>scrapes_total</code></td><td><code>Sum</code></td><td>The total number of scrapes.</td></tr>
 <tr><td><code>startup_duration_seconds</code></td><td><code>LastValue</code></td><td>The time from the process starting to being marked ready.</td></tr>

--- a/content/en/docs/reference/commands/pilot-discovery/index.html
+++ b/content/en/docs/reference/commands/pilot-discovery/index.html
@@ -866,6 +866,12 @@ These environment variables affect the behavior of the <code>pilot-discovery</co
 <td>Limits the number of concurrent pushes allowed. On larger machines this can be increased for faster pushes</td>
 </tr>
 <tr>
+<td><code>PILOT_REMOTE_CLUSTER_TIMEOUT</code></td>
+<td>Time Duration</td>
+<td><code>30s</code></td>
+<td>After this timeout expires, pilot can become ready without syncing data from clusters added via remote-secrets. Setting the timeout to 0 disables this behavior.</td>
+</tr>
+<tr>
 <td><code>PILOT_SCOPE_GATEWAY_TO_NAMESPACE</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>
@@ -1108,6 +1114,7 @@ These environment variables affect the behavior of the <code>pilot-discovery</co
 <tr><td><code>pilot_xds_rds_reject</code></td><td><code>LastValue</code></td><td>Pilot rejected RDS.</td></tr>
 <tr><td><code>pilot_xds_send_time</code></td><td><code>Distribution</code></td><td>Total time in seconds Pilot takes to send generated configuration.</td></tr>
 <tr><td><code>pilot_xds_write_timeout</code></td><td><code>Sum</code></td><td>Pilot XDS response write timeouts.</td></tr>
+<tr><td><code>remote_cluster_sync_timeouts_total</code></td><td><code>Sum</code></td><td>Number of times remote clusters took too long to sync, causing slow startup that excludes remote clusters.</td></tr>
 <tr><td><code>scrape_failures_total</code></td><td><code>Sum</code></td><td>The total number of failed scrapes.</td></tr>
 <tr><td><code>scrapes_total</code></td><td><code>Sum</code></td><td>The total number of scrapes.</td></tr>
 <tr><td><code>sidecar_injection_failure_total</code></td><td><code>Sum</code></td><td>Total number of failed sidecar injection requests.</td></tr>

--- a/content/en/docs/reference/config/istio.mesh.v1alpha1/index.html
+++ b/content/en/docs/reference/config/istio.mesh.v1alpha1/index.html
@@ -2038,7 +2038,7 @@ inside a mesh and how to route to endpoints in each network. For example</p>
 
 <pre><code class="language-yaml">networks:
   network1:
-  - endpoints:
+    endpoints:
     - fromRegistry: registry1 #must match kubeconfig name in Kubernetes secret
     - fromCidr: 192.168.100.0/22 #a VM network for example
     gateways:


### PR DESCRIPTION

This is a ` make update_ref_docs` made after the 1.9.4 build was made. It should be merged when the build is published to updated the docs to match the release.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure