### PR TITLE
Update istio test ref to 1.10.0-rc.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v0.0.0-20
 require (
 	github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f
 	github.com/pmezard/go-difflib v1.0.0
-	istio.io/istio v0.0.0-20210423192056-99785734c08b
+	istio.io/istio v0.0.0-20210426074441-7ebb94621205
 	istio.io/pkg v0.0.0-20210420153545-2c6acb5fef3c
 	k8s.io/apimachinery v0.20.5
 	k8s.io/client-go v0.20.5

--- a/go.sum
+++ b/go.sum
@@ -1481,8 +1481,8 @@ istio.io/client-go v1.10.0-alpha.1.0.20210420154934-5b0be5983930/go.mod h1:e61Tm
 istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
 istio.io/gogo-genproto v0.0.0-20210420153714-0c2931135d30 h1:c7AZ0LR25VUWnGxYEf5JN+CmeQc3Ahg/d3fJgmmmuiE=
 istio.io/gogo-genproto v0.0.0-20210420153714-0c2931135d30/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
-istio.io/istio v0.0.0-20210423192056-99785734c08b h1:pEuQmsZCfEE/aYUVSPAldvHFFGBLOZxmcNba4WJtyAU=
-istio.io/istio v0.0.0-20210423192056-99785734c08b/go.mod h1:NPuZ5PRFvyIx+2xHQx8qFE8zZm4xmnO4mxTvCXIyA7Y=
+istio.io/istio v0.0.0-20210426074441-7ebb94621205 h1:g1FModcaaBa2jUxt02KNKzTBWUXzQB93+x+U9eQxDGc=
+istio.io/istio v0.0.0-20210426074441-7ebb94621205/go.mod h1:NPuZ5PRFvyIx+2xHQx8qFE8zZm4xmnO4mxTvCXIyA7Y=
 istio.io/pkg v0.0.0-20210420153545-2c6acb5fef3c h1:rU3ogBd9yZCdhjuRzblyZ99CjxbnPNdpK2z2Rnk8lAw=
 istio.io/pkg v0.0.0-20210420153545-2c6acb5fef3c/go.mod h1:U14DF4p1AViKhOwpVv1UPEWtknGytJyfJw6hqVi0TmM=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=


### PR DESCRIPTION

Update the the recently built 1.10.0-rc.0


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure