### PR TITLE
Import approved web copy into new page designs

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -102,6 +102,7 @@ Aporeto
 AppOptics
 appswitch
 AppSwitch
+architected
 args.yaml
 AssemblyScript
 Atlassian
@@ -183,7 +184,9 @@ ControlZ
 CoreDNS
 coreos
 Costin
+CR
 CRD
+CRs
 CRDs
 CSRs
 Ctrl
@@ -519,6 +522,8 @@ oc
 OCI-compliant
 ok
 Okta
+onboard
+Onboard
 onboarding
 Onboarding
 onwards

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -48,7 +48,7 @@ description: A service mesh for observability, security in depth, and management
         <h1>The Istio service mesh</h1>
 
         <p class="subtitle">
-            Istio extends Kubernetes to establish a programmable, application-aware network, using the powerful Envoy service proxy. Working with both Kubernetes and traditional workloads, Istio brings standard, universal traffic management, telemetry, and security to complex deployments.
+            Istio extends Kubernetes to establish a programmable, application-aware network using the powerful Envoy service proxy. Working with both Kubernetes and traditional workloads, Istio brings standard, universal traffic management, telemetry, and security to complex deployments.
         </p>
  
         <div class="service-mesh-graph">
@@ -98,7 +98,7 @@ description: A service mesh for observability, security in depth, and management
         <h1>Istio Providers</h1>
 
         <p class="subtitle">
-            Whether you get Istio with your managed Kubernetes service, you adopt a product powered by Istio, or you install it yourself, Istio has a strong ecosystem that allows you to deploy and utilize Istio capabilities the way that works for you.
+            Istio is supported and implemented by an ecosystem of leading providers and consultants. You can install and manage Istio yourself or use a one-click install feature of your Kubernetes or cloud provider. Another option is to turn to a provider for a fully managed service mesh based on Istio. Choose the way that works for you.
         </p>
 
         <div class="companies-grid">

--- a/content/en/about/case-studies/autotrader/index.md
+++ b/content/en/about/case-studies/autotrader/index.md
@@ -1,7 +1,7 @@
 ---
 title: "Istio Pioneer AutoTrader UK Still Benefiting"
 linkTitle: "Istio Pioneer AutoTrader UK Still Benefiting"
-quote: "Istio is a service mesh that provides cross-cutting functions that all micro services environments need"
+quote: "Istio is a service mesh that provides cross-cutting functions that all micro services environments need."
 author:
     name: "Nick Chase"
     image: "/img/authors/nick-chase.png"

--- a/content/en/about/deployment/index.md
+++ b/content/en/about/deployment/index.md
@@ -1,7 +1,7 @@
 ---
 title: Deployment
 description: Deployment.
-subtitle: Istio addresses the challenges developers and operators face as monolithic applications transition towards a distributed microservice architecture
+subtitle: Read about good practices that lead to a quick and effective implementation for day 1, day 2, and day 1,000.
 weight: 34
 skip_toc: true
 skip_byline: true
@@ -14,17 +14,94 @@ doc_type: about
 
 {{< centered_block >}}
 
-## Step one
+You have decided you want to use Istio. Welcome to the world of service mesh. Congratulations, you're in great company!
 
-Istio addresses the challenges developers and operators face as monolithic applications transition towards a distributed microservice architecture. To see how, it helps to take a more detailed look at Istio’s service mesh.
+If you haven't already, you might like to try Istio out in a test environment, and run through our [Getting Started guide](../../docs/setup/getting-started/). This will give you an idea for the **traffic management**, **security** and **observability** features.
 
-## Step two
+## Do it yourself, or bring a guide?
 
-While the easy transition to mTLS for all microservices was a strong incentive, Istio also has the backing of many large organizations. Auto Trader UK was already working with Google, so knowing that Google was a strong backer of Istio gave them confidence it would be supported and grow long term.
+Istio is open-source software which you can download and install yourself. Getting a mesh installed on a Kubernetes cluster is as simple as running one command:
 
-Early success with experiments on GKE with Istio led to quick buy-in from the business. Capabilities that they had been trying to implement for months were suddenly ready in just a week. Istio was able to not only provide mTLS, but also robust retry and backup policies and outlier detection.
+{{< text bash >}}
+$ istioctl install
+{{< /text >}}
 
-## Step three
+As new versions are released, you can test them and gradually roll them out across your clusters.
 
-Istio gave Auto Trader UK the confidence to deploy all applications to the public cloud. With increased observability, they now had a new way to both manage and think about infrastructure. They suddenly had insights into performance and security, meanwhile Istio was helping them discover existing bugs that had been there all along, unnoticed.
+Many managed Kubernetes service providers have an option to automatically install and manage Istio for you. Check out our [distributors page](../about/ecosystem/) to see if your vendor supports Istio.
+
+Istio is also the engine powering many commercial service management products, with teams of experts ready to help you get on board.
+
+There is a growing community of cloud native consultants who are able to help you on your Istio journey. If you're going to work with a member of the Istio ecosystem, we recommend you loop them in early. Many of our partners and distributors have been working with the project for a very long time, and will be invaluable in guiding you on your journey.
+
+## What should you enable first?
+
+There are many great reasons for adopting Istio: from adding security to your microservices to improving the reliability of your applications. Whatever your goals, the most successful Istio implementations start by identifying one use case and solving for that. Once you've configured the mesh to solve a problem, you can easily enable other features, increasing the usefulness of your deployment.
+
+## How do I map the mesh to my architecture?
+
+Gradually onboard your services into the mesh by adding one namespace at a time. By default, services from multiple namespaces can communicate with each other, but you can easily increase isolation by selectively choosing which services to expose to other namespaces. Using namespaces also improves performance as configuration is scoped down.
+
+Istio is flexible to match the configuration of your Kubernetes cluster and network architecture. You may wish to run individual meshes and control planes on individual clusters, or you may have one.
+
+As long as pods can reach each other on the network, Istio will work; and you can even configure Istio Gateways to act as bastion hosts between networks.
+
+Learn about the [full range of deployment models](../../docs/ops/deployment/deployment-models/) in our documentation.
+
+Now is also a great time to think about which integrations you want to use: we recommend [setting up Prometheus](../../docs/ops/integrations/prometheus/#Configuration) for service monitoring, with a [hierarchical federation to an external server](../../docs/ops/best-practices/observability/). If your company's observability stack is run by a different team, now is the time to get them on board.
+
+## Adding services to the mesh on Day 1
+
+Your mesh is now configured and ready to accept services. To do that, you simply label your namespaces in Kubernetes, and when those services are redeployed, they will now include the Envoy proxy configured to talk to the Istio control plane.
+
+### Configuring services
+
+Many services will work out of the box, but by adding a little information to your Kubernetes manifests, you can make Istio much smarter. For example, setting labels for `app` and `version` will help with querying metrics later.
+
+For common ports and protocols, Istio will detect the traffic type. If it can't detect, it will fall back to treating the traffic as TCP, but you can easily [annotate the service](../../docs/ops/configuration/traffic-management/protocol-selection/) with the traffic type.
+
+Learn more about [enabling applications for use with Istio](../../docs/ops/deployment/requirements/).
+
+### Enabling security
+
+Istio will configure services in the mesh to use mTLS when talking to one another when possible. Istio will run in "permissive mTLS" mode by default, which means services will accept both encrypted and unencrypted traffic to allow traffic from non-mesh services to remain functional. After onboarding all your services to the mesh, you can [change the authentication policy to only allow encrypted traffic](../../docs/tasks/security/authentication/mtls-migration/). You can then be certain that all your traffic is encrypted.
+
+### Istio's two types of APIs
+
+Istio has APIs for platform owners and service owners. Depending on which role you play, you only need to consider a subset. For example, the platform owners will own the installation, authentication and authorization resources. Traffic management resources will be handled by the service owners. [Learn which APIs are useful to you.](../../docs/reference/config/)
+
+### Connect services on virtual machines
+
+Istio isn't just for Kubernetes; it's possible to [add services on virtual machines](../../docs/setup/install/virtual-machine/) (or bare metal) into a mesh, to get all the benefits that Istio provides such as mutual TLS, rich telemetry, and advanced traffic management capabilities.
+
+### Monitor your services
+
+Check out traffic flowing through your mesh using [Kiali](../../docs/ops/integrations/kiali/), or trace requests using [Zipkin](../../docs/tasks/observability/distributed-tracing/zipkin/) or [Jaeger](../../docs/tasks/observability/distributed-tracing/jaeger/).
+
+Use the default [Grafana](../../docs/ops/integrations/grafana/) dashboards for Istio to get automatic reporting of golden signals for services running in a mesh.
+
+## Operational considerations and Day 2
+
+As the platform owner, you're responsible for installing and keeping the mesh up to date with little impact to the service teams.
+
+### Installation
+
+With istioctl, you can easily install Istio using one of the built-in profiles. As you customize your installation to meet your requirements, it is recommended to define your configuration using the IstioOperator custom resource (CR). This gives you the option of completely delegating the job of install management to an Istio Operator, instead of doing it manually using istioctl. Use an IstioOperator CR for just the control plane and additional IstioOperator CRs for gateways for increased flexibility in upgrading.
+
+### Upgrade safely
+
+When a new version is released, Istio allows for both in-place and canary upgrades. Choosing between the two is a trade off between simplicity and potential downtime. For production environments, it’s recommended to use the [canary upgrade method](../../docs/setup/upgrade/canary/). After the new control and data plane versions are verified to be working, you can upgrade your gateways.
+
+### Monitor the mesh
+
+Istio generates detailed telemetry for all service communications within a mesh. These metrics, traces and access logs are vital for understanding how your applications are interacting with one another and identifying any performance bottlenecks. Use this information to help you set circuit breakers, timeouts, and retries and harden your applications.
+
+Just like your apps running in the mesh, Istio control plane components also export metrics. Leverage these metrics and the preconfigured Grafana dashboards to adjust your resource requests, limits and scaling.
+
+## Join the Istio community
+
+Once you're running Istio, you've become a member of a large global community. You can ask questions on [our discussion forum](https://discuss.istio.io/), or [hop on Slack](https://slack.istio.io/). And if you want to improve something, or have a feature request, you can go straight to [GitHub](https://github.com/istio/istio).
+
+Happy meshing!
+
 {{< /centered_block >}}

--- a/content/en/about/deployment/index.md
+++ b/content/en/about/deployment/index.md
@@ -28,7 +28,7 @@ $ istioctl install
 
 As new versions are released, you can test them and gradually roll them out across your clusters.
 
-Many managed Kubernetes service providers have an option to automatically install and manage Istio for you. Check out our [distributors page](../about/ecosystem/) to see if your vendor supports Istio.
+Many managed Kubernetes service providers have an option to automatically install and manage Istio for you. Check out our [distributors page](/about/ecosystem/) to see if your vendor supports Istio.
 
 Istio is also the engine powering many commercial service management products, with teams of experts ready to help you get on board.
 

--- a/content/en/about/ecosystem/index.md
+++ b/content/en/about/ecosystem/index.md
@@ -1,7 +1,7 @@
 ---
 title: Ecosystem
 description: Ecosystem.
-subtitle: "Istio is a service mesh that provides cross-cutting functions that all micro services environments need. You can get Istio from 27 distributors"
+subtitle: The array of providers who install and manage Istio, professional services, and integrations can help you get the most out of your service mesh.
 weight: 34
 skip_toc: true
 skip_byline: true
@@ -15,7 +15,7 @@ doc_type: about
     {{< tab
         name="providers"
         category-value="providers"
-        description="Locality-weighted load balancing allows administrators to control the distribution of traffic to endpoints based on the localities of where the traffic originates and where it will terminate."
+        description="Many companies build platforms and services that install, manage, and implement Istio for you. In fact, Istio implementations are built in to many providers’ Kubernetes services."
     >}}
 
     {{< companies items="providers">}}
@@ -25,7 +25,7 @@ doc_type: about
     {{< tab
         name="pro services"
         category-value="services"
-        description="Locality-weighted load balancing allows administrators to control the distribution of traffic to endpoints based on the localities of where the traffic originates and where it will terminate."
+        description="There are many people who can help you set up your Istio configuration. Here are some experts who can implement Istio for you, matching its capabilities to your requirements."
     >}}
 
     {{< interactive_panels items="pro_services" >}}
@@ -35,7 +35,7 @@ doc_type: about
     {{< tab
         name="integrations"
         category-value="integrations"
-        description="Locality-weighted load balancing allows administrators to control the distribution of traffic to endpoints based on the localities of where the traffic originates and where it will terminate."
+        description="Istio is a vibrant part of the cloud native stack. These are some of the projects and software that integrate with Istio to enable added functionality."
     >}}
 
     {{< interactive_panels items="integrations" >}}

--- a/content/en/about/faq/_index.md
+++ b/content/en/about/faq/_index.md
@@ -16,7 +16,3 @@ skip_pagenav: true
 sidebar_none: true
 doc_type: about has-toc
 ---
-
-{{< centered_block >}}
-If you don’t find what you need, you can [interact with the community](../../get-involved) to go deeper.
-{{< /centered_block >}}

--- a/content/en/about/faq/_index.md
+++ b/content/en/about/faq/_index.md
@@ -1,7 +1,7 @@
 ---
 title: FAQ
 description: Frequently Asked Questions about Istio.
-subtitle: Istio addresses the challenges developers and operators face as monolithic applications transition towards a distributed microservice architecture
+subtitle: In your search for information about Istio and service mesh technology, we hope this FAQ helps! 
 weight: 1
 layout: faq-landing
 aliases:
@@ -16,3 +16,7 @@ skip_pagenav: true
 sidebar_none: true
 doc_type: about has-toc
 ---
+
+{{< centered_block >}}
+If you don’t find what you need, you can [interact with the community](../../get-involved) to go deeper.
+{{< /centered_block >}}

--- a/content/en/about/service-mesh/index.md
+++ b/content/en/about/service-mesh/index.md
@@ -1,7 +1,7 @@
 ---
 title: The Istio service mesh
 description: Service mesh.
-subtitle: Istio addresses the challenges developers and operators face with a distributed microservice architecture. Whether you're building from scratch or migrating existing applications to cloud native, Istio can help
+subtitle: Istio addresses the challenges developers and operators face with a distributed or microservices architecture. Whether you're building from scratch or migrating existing applications to cloud native, Istio can help. 
 weight: 34
 skip_toc: true
 skip_byline: true
@@ -12,24 +12,26 @@ doc_type: about
 ---
 [comment]: <> (TODO: Replace Service mesh graphic placeholder)
 
-{{< figure src="/img/service-mesh.svg" alt="Service mesh" title="By adding a proxy 'sidecar' along with every application deployed, Istio lets you program application-aware traffic management, incredible observability, and robust security capabilities into your network." >}}
+{{< centered_block >}}
+{{< figure src="/img/service-mesh.svg" alt="Service mesh" title="By adding a proxy \"sidecar\" along with every application deployed, Istio lets you program application-aware traffic management, incredible observability, and robust security capabilities into your network." >}}
+{{< /centered_block >}}
 
 {{< centered_block >}}
 
 ## What is a Service Mesh?
 
-Modern applications are typically designed as distributed collections of microservices, with each service performing some discrete business function. A service mesh is the dedicated infrastructure layer encompassing the network of microservices that make up this type of architecture. A service mesh describes not only this network, but also the interactions between distributed application components. All data passed between services is controlled and routed by the service mesh.
+Modern applications are typically architected as distributed collections of microservices, with each collection of microservices performing some discrete business function. A service mesh is a dedicated infrastructure layer that you can add to your applications. It allows you to transparently add capabilities like observability, traffic management, and security, without adding them to your own code. The term "service mesh" describes both the type of software you use to implement this pattern, and the security or network domain that is created when you use that software.
 
-As the deployment of distributed services — such as in a Kubernetes-based system — grows in size and complexity, it can become harder to understand and manage. Requirements can include discovery, load balancing, failure recovery, metrics, and monitoring. A microservices architecture also often has more complex operational requirements, like A/B testing, canary deployments, rate limiting, access control, encryption and end-to-end authentication.
+As the deployment of distributed services, such as in a Kubernetes-based system, grows in size and complexity, it can become harder to understand and manage. Its requirements can include discovery, load balancing, failure recovery, metrics, and monitoring. A service mesh also often addresses more complex operational requirements, like A/B testing, canary deployments, rate limiting, access control, encryption, and end-to-end authentication.
 
-Service-to-service communication is what makes a distributed application possible. Routing this communication, both within and across application clusters becomes increasingly complex. Istio helps reduce this complexity while easing the strain on development teams
+Service-to-service communication is what makes a distributed application possible. Routing this communication, both within and across application clusters, becomes increasingly complex as the number of services grow. Istio helps reduce this complexity while easing the strain on development teams
 {{< /centered_block >}}
 
 {{< centered_block >}}
 
 ## What is Istio?
 
-Istio is an open source service mesh that layers transparently onto existing distributed applications. Istio’s powerful features provide a uniform and more efficient way to secure, connect, and monitor services  Istio is the path to load balancing, service-to-service authentication, and monitoring – with few or no service code changes. Its powerful control plane brings vital features, including:
+Istio is an open source service mesh that layers transparently onto existing distributed applications. Istio's powerful features provide a uniform and more efficient way to secure, connect, and monitor services. Istio is the path to load balancing, service-to-service authentication, and monitoring – with few or no service code changes. Its powerful control plane brings vital features, including:
 
 - Secure service-to-service communication in a cluster with TLS encryption, strong identity-based authentication and authorization
 - Automatic load balancing for HTTP, gRPC, WebSocket, and TCP traffic
@@ -40,39 +42,39 @@ Istio is an open source service mesh that layers transparently onto existing dis
 Istio is designed for extensibility and can handle a diverse range of deployment needs. Istio's control plane runs on Kubernetes, and you can add applications deployed in that cluster to your mesh, extend the mesh to other clusters, or even connect VMs or other endpoints running outside of Kubernetes.
 
 A large ecosystem of contributors, partners, integrations, and distributors extend and leverage Istio for a wide variety of scenarios.
-
 You can install Istio yourself, or a number of vendors have products that integrate Istio and manage it for you.
+
 {{< /centered_block >}}
 
 {{< centered_block >}}
 
-## How it works
+## How it Works
 
-Istio has two components: the control plane and the data plane.
+Istio has two components: the data plane and the control plane.
 
 The data plane is the communication between services. Without a service mesh, the network doesn't understand the traffic being sent over, and can't make any decisions based on what type of traffic it is, or who it is from or to.
 
 Service mesh uses a proxy to intercept all your network traffic, allowing a broad set of application-aware features based on configuration you set.
 
-A proxy is deployed along with each service that you start in your cluster, or runs alongside services running on VMs.
+An Envoy proxy is deployed along with each service that you start in your cluster, or runs alongside services running on VMs.
 
 The control plane takes your desired configuration, and its view of the services, and dynamically programs the proxy servers, updating them as the rules or the environment changes.
-{{< /centered_block >}}
 
 {{< figure src="/img/service-mesh-before.svg" alt="Before utilizing Istio" title="Before utilizing Istio" >}}
 {{< figure src="/img/service-mesh.svg" alt="After utilizing Istio" title="After utilizing Istio" >}}
 
+{{< /centered_block >}}
+
 # Concepts
 
 {{< feature_block header="Traffic management" image="management.svg" >}}
-Istio’s traffic routing rules let you easily control the flow of traffic and API calls between services. Istio simplifies configuration of service-level properties like circuit breakers, timeouts, and retries, and makes it easy to set up important tasks like A/B testing, canary deployments, and staged rollouts with percentage-based traffic splits. It also provides out-of-box failure recovery features that help make your application more robust against failures of dependent services or the network.
+Routing traffic, both within a single cluster and across clusters, affects performance and enables better deployment strategy. Istio's traffic routing rules let you easily control the flow of traffic and API calls between services. Istio simplifies configuration of service-level properties like circuit breakers, timeouts, and retries, and makes it easy to set up important tasks like A/B testing, canary deployments, and staged rollouts with percentage-based traffic splits.
 {{< /feature_block>}}
 
 {{< feature_block header="Observability" image="observability.svg" >}}
-Istio generates detailed telemetry for all communications within a service mesh. This telemetry provides observability of service behavior, empowering operators to troubleshoot, maintain, and optimize their applications. Even better, it does not  impose any additional burdens on service developers. Through Istio, operators gain a thorough understanding of how monitored services are interacting, both with other services and with the Istio components themselves.
+As services grow in complexity, it becomes challenging to understand behavior and performance. Istio generates detailed telemetry for all communications within a service mesh. This telemetry provides observability of service behavior, empowering operators to troubleshoot, maintain, and optimize their applications. Even better, you get almost all of this instrumentation without requiring application changes. Through Istio, operators gain a thorough understanding of how monitored services are interacting.
 
 Istio's telemetry includes detailed metrics, distributed traces, and full access logs. With Istio, you get thorough and comprehensive service mesh observability.
-
 {{< /feature_block>}}
 
 {{< feature_block header="Security capabilities" image="security.svg" >}}

--- a/content/en/about/solutions/_index.md
+++ b/content/en/about/solutions/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Solutions
 description: Solutions.
-subtitle: Istio addresses the challenges developers and operators face as monolithic applications transition towards a distributed microservice architecture
+subtitle: Learn how to succeed at security, observability, and traffic management initiatives using Istio.
 aliases:
     - /solutions
 doc_type: about

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Blog
-description: Istio addresses the challenges developers and operators face as monolithic applications transition towards a distributed microservice architecture.
+description: Read articles from contributors and users on all things Istio.
 linktitle: Blog
 sidebar_multicard: true
 icon: blog

--- a/content/en/get-involved/_index.md
+++ b/content/en/get-involved/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Get involved!
 linktitle: Get involved
-subtitle: Ask questions, engage in conversations, or contribute to Istio’s growth. Istio is an open source project that is driven by the participation of users and contributors. Join in!
+subtitle: Ask questions, be a part of the conversation, or contribute to Istio’s growth. Istio is an open source project that is driven by the participation of users and contributors. Join in!
 sidebar_none: true
 weight: 15
 skip_toc: true
@@ -14,22 +14,23 @@ doc_type: get-involved
 ## How do you want to get involved?
 
 {{% involve_block title="Ask questions" subtitle="There are a variety of ways to reach out to the community for input." icon="user" %}}
-1. **The** [**Istio discussion board**](https://discuss.istio.io/) always hosts lively participation from Istio users ready to engage. Join in to ask questions and discuss Istio.
-2. **Join our** [**Slack**](https://slack.istio.io/) and interact live with other members of the Istio community.
-3. Bring your particular Istio questions to the **gamified wizards of** [**Stack Overflow**](https://stackoverflow.com/questions/tagged/istio).
+1.   Bring your particular Istio questions to the **gamified wizards of** [**Stack Overflow**](https://stackoverflow.com/questions/tagged/istio).
+2.   **The** [**Istio discussion board**](https://discuss.istio.io/) hosts conversations with other Istio users. Join in to ask questions and discuss Istio.
+3.   **Join our** [**Slack**](https://slack.istio.io/) and interact live with other members of the Istio community.
+
 {{% /involve_block %}}
 
-{{% involve_block title="Join the conversation" subtitle="There is so much to talk about around Istio. We welcome your voice!" icon="events" %}}
+{{% involve_block title="Join the community" subtitle="There is so much to talk about around Istio. We welcome your voice!" icon="events" %}}
 1. **Attend an event!** [Follow our calendar](https://calendar.google.com/calendar/embed?src=i10ogf58krfbrsjai5qi16g4do@group.calendar.google.com) to see what is coming up!
 2. Follow us on [**Twitter - @IstioMesh**](https://twitter.com/IstioMesh)
 {{% /involve_block %}}
 
-{{% involve_block title="Bugs & Security" subtitle="Thank you for helping to improve Istio with bug reports and security vulnerabilities." icon="security" %}}
-1. Read this [**quick explanation on how to report bugs**](/docs/releases/bugs/), both in code and in documentation.
+{{% involve_block title="Bugs and Security" subtitle="Thank you for helping to improve Istio with bug reports or security vulnerability reports." icon="security" %}}
+1. Read this [**quick explanation on how to report bugs**](/docs/releases/bugs/), in code or in documentation.
 2. The Istio security team responds rapidly to **vulnerability reports**. Read [how to submit an issue](/docs/releases/security-vulnerabilities/).
 {{% /involve_block %}}
 
-{{% involve_block title="Be a contributor" subtitle="Code, documentation, community: Istio welcomes your contribution! Use these links as your entry point." icon="contribution" %}}
+{{% involve_block title="Become a contributor" subtitle="Code, documentation, community: Istio welcomes your contribution! Use these links as your entry point." icon="contribution" %}}
 1. Familiarize yourself with the Istio [code of conduct](https://github.com/istio/community/blob/master/CONTRIBUTING.md#code-of-conduct) and [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md).
 2. The [Istio Community README](https://github.com/istio/community/blob/master/README.md) is the **starting point for contributors** who want to work on code, docs or other parts of Istio.
 3. You can access our [**trove of technical content and working documents**](https://drive.google.com/corp/drive/u/0/folders/0AIS5p3eW9BCtUk9PVA) joining the [istio-team-drive-access@ Google Group](https://groups.google.com/forum/#!forum/istio-team-drive-access).

--- a/content/en/news/_index.md
+++ b/content/en/news/_index.md
@@ -1,6 +1,6 @@
 ---
 title: News
-description: Istio addresses the challenges developers and operators face as monolithic applications transition towards a distributed microservice architecture.
+description: Select security bulletins, release announcements, or support announcements to stay up to date.
 linktitle: News
 sidebar_multicard: true
 icon: bullhorn

--- a/layouts/partials/primary_top.html
+++ b/layouts/partials/primary_top.html
@@ -70,11 +70,7 @@
                     {{ end }}
 
                     {{ if .Params.subtitle }}
-                        {{ if (strings.HasSuffix .Params.subtitle ".") }}
-                            {{ errorf "Subtitles should not end in a period: '%s" .Params.subtitle }}
-                        {{ else }}
-                            <p class="subtitle">{{ .Params.subtitle }}</p>
-                        {{ end }}
+                        <p class="subtitle">{{ .Params.subtitle }}</p>
                     {{ end }}
 
                     {{ if not (or .Params.skip_byline $skipByLine) }}


### PR DESCRIPTION
This includes new copy for the following pages:

* The home page
* What is a service mesh?
* The Get Involved page
* about/deployment (also merged Adoption page text)
* about/ecosystem
* about/faq
* about/solutions
* Header text for the blog and news pages

This also included some changes to layout pages:

* layouts/blog/list.html -- New approved copy.
* layouts/news/list.html -- New approved copy.
* layouts/partials/primary_top.html -- Remove requirement that
  subtitles can't end in periods because new approved copy breaks that
  rule.

Co-authored-by: Joel Barker <joel@lionswaycontent.com>
Co-authored-by: Craig Box <craigbox@google.com>



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure