### PR TITLE
Remove citadel reference

### DIFF
--- a/content/en/docs/setup/upgrade/in-place/index.md
+++ b/content/en/docs/setup/upgrade/in-place/index.md
@@ -35,7 +35,7 @@ Before you begin the upgrade process, check the following prerequisites:
 
 {{< warning >}}
 Traffic disruption may occur during the upgrade process. To minimize the disruption, ensure
-that at least two replicas of each component (except Citadel) are running. Also, ensure that
+that at least two replicas of each component are running. Also, ensure that
 [`PodDisruptionBudgets`](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
 are configured with a minimum availability of 1.
 {{< /warning >}}

--- a/content/en/docs/setup/upgrade/in-place/index.md
+++ b/content/en/docs/setup/upgrade/in-place/index.md
@@ -35,7 +35,7 @@ Before you begin the upgrade process, check the following prerequisites:
 
 {{< warning >}}
 Traffic disruption may occur during the upgrade process. To minimize the disruption, ensure
-that at least two replicas of each component are running. Also, ensure that
+that at least two replicas of `istiod` are running. Also, ensure that
 [`PodDisruptionBudgets`](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
 are configured with a minimum availability of 1.
 {{< /warning >}}


### PR DESCRIPTION
Citadel was deprecated in Istio 1.5 and was removed in Istio 1.6



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure