### PR TITLE
Add change notes, upgrade notes, and release announcement for release 1.10

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -454,7 +454,7 @@ Kubernetes
 kubernetes.default
 kube-proxy
 KubeSphere
-Kyzy
+kyzy
 L3-4
 L4-L6
 Landlow

--- a/.spelling
+++ b/.spelling
@@ -121,6 +121,7 @@ AutoTrader
 az
 backend
 backends
+backoff
 base64
 Bazel
 Berben
@@ -283,6 +284,7 @@ emojis
 enablement
 endUser-to-Service
 env
+EnvoyFilter
 etcd
 example.com
 ExecAction
@@ -389,6 +391,7 @@ istio-discovery
 istio-ecosystem
 istio-identity
 istio-mixer
+istio-proxy
 ISTIO-SECURITY-2019-003
 ISTIO-SECURITY-2019-004
 ISTIO-SECURITY-2019-005
@@ -583,6 +586,7 @@ pre-connected
 pre-parsed
 pre-release
 pre-specified
+precheck
 preconfigured
 prefetching
 preformatted

--- a/.spelling
+++ b/.spelling
@@ -84,6 +84,7 @@ addon
 addons
 AES-NI
 Airbnb
+Aizhamal
 AKS
 AKS-Engine
 Alibaba
@@ -284,7 +285,6 @@ emojis
 enablement
 endUser-to-Service
 env
-EnvoyFilter
 etcd
 example.com
 ExecAction
@@ -453,6 +453,7 @@ Kubernetes
 kubernetes.default
 kube-proxy
 KubeSphere
+Kyzy
 L3-4
 L4-L6
 Landlow
@@ -512,6 +513,7 @@ mysqldb
 Nambiar
 namespace
 namespaces
+Naser
 natively
 Neeraj
 netmask
@@ -529,6 +531,7 @@ normalization
 ns
 NUL
 NULs
+Nurmamat
 OAuth2
 oc
 OCI-compliant
@@ -555,6 +558,7 @@ outsized
 p50
 p99
 PaaS
+Padmanabhan
 Papertrail
 parenthesization
 passthrough
@@ -706,6 +710,7 @@ strongSwan
 struct
 Styra
 src
+Srinath
 subdomain
 subdomains
 subnet
@@ -845,6 +850,7 @@ yournamespace
 Youtube
 Zack
 Zhang
+Zhihan
 Zhonghu
 Zipkin
 

--- a/.spelling
+++ b/.spelling
@@ -340,6 +340,7 @@ grafana-istio-dashboard
 Graphviz
 gRPC
 grpc
+Harvey
 helloworld
 Hashicorp
 Herness

--- a/content/en/news/releases/1.10.x/announcing-1.10/_index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/_index.md
@@ -23,7 +23,7 @@ In previous Istio versions, Istio’s control plane has watched and processed up
 
 You can think of them as a bit like Istio’s Sidecar API resources but for Istiod itself: a `Sidecar` resource limits the set of configuration that Istiod will send to Envoy. Discovery Selectors limit the set of configurations that Istio will receive and process from Kubernetes.
 
-[Check out the great write-up](/blog/2021/discovery-selectors/) by Lin, Christian, and Harvey for an in-depth walkthrough of this new feature!
+[Check out the great write-up](/blog/2021/discovery-selectors/) by Lin, Christian, and Harvey for an in-depth walk-through of this new feature!
 
 ## Stable Revision Labels
 
@@ -45,7 +45,7 @@ Now, when you’re ready to promote the `1-8-0` revision from `canary` to `prod`
     caption="Namespaces A, B, and C pointed to 1-8-0"
     >}}
 
-Check out the [updated Canary Upgrade guide](/docs/setup/upgrade/canary/#stable-revision-labels-experimental) for a walkthrough you can follow along with!
+Check out the [updated Canary Upgrade guide](/docs/setup/upgrade/canary/#stable-revision-labels-experimental) for a walk-through you can follow along with!
 
 ## Sidecar Networking Changes
 
@@ -61,7 +61,7 @@ We’ve revamped Istio.io with a totally new look! This is the first major chang
 
 This effort was sponsored by Google Cloud and we want to send a special thanks to [Craig Box](https://twitter.com/craigbox), [Aizhamal Nurmamat Kyzy](https://twitter.com/iamaijamal) and [Srinath Padmanabhan](https://twitter.com/srithreepo) for driving this effort, and to all the folks that helped review and provide feedback to early revisions.
 
-Please give us any feedback you have by filing an issue on the [istio.io repo](https://github.com/istio/istio.io).
+Please give us any feedback you have by filing an issue on the [istio.io repository](https://github.com/istio/istio.io).
 
 ## Deprecations
 

--- a/content/en/news/releases/1.10.x/announcing-1.10/_index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/_index.md
@@ -65,11 +65,7 @@ Please give us any feedback you have by filing an issue on the [istio.io reposit
 
 ## Opening Up Our Design Docs
 
-Istio's working groups keep their design documents and planning artifacts in a community Google Drive. Anyone is welcome to view these documents, but due to Istio's heritage inside Google, you first had to [join a public group](https://groups.google.com/g/istio-team-drive-access) to get access to the drive and the files within.
-
-On the 20th of May we will change the Drive so that the files are accessible to everyone on the Internet, without having to log in, or join the group. This change will make sharing Istio technical documentation easier. and is another way we're ensuring Istio is a fully open project.
-
-Files will remain at the same URLs as before, but the Drive and its sub-folders will change URLs. If you are a regular user of the Community Drive, please be aware of this change.  All contributors and Drive members will be contacted this week with the new details.
+Beginning on May 20, 2021, Istio design and planning documents will be available without login to everyone on the internet. Previously, viewing them required a Google login and group membership. This change will make sharing technical documentation easier and more open. Files will remain at the same URLs as before, but the Community Drive and its folders will change location. All contributors and Drive members will be contacted this week with the new details.
 
 ## Deprecations
 

--- a/content/en/news/releases/1.10.x/announcing-1.10/_index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/_index.md
@@ -69,7 +69,7 @@ Istio's working groups keep their design documents and planning artifacts in a c
 
 On the 20th of May we will change the Drive so that the files are accessible to everyone on the Internet, without having to log in, or join the group. This change will make sharing Istio technical documentation easier. and is another way we're ensuring Istio is a fully open project.
 
-Files will remain at the same URLs as before, but the Drive and its subfolders will change URLs. If you are a regular user of the Community Drive, please be aware of this change.  All contributors and Drive members will be contacted this week with the new details.
+Files will remain at the same URLs as before, but the Drive and its sub-folders will change URLs. If you are a regular user of the Community Drive, please be aware of this change.  All contributors and Drive members will be contacted this week with the new details.
 
 ## Deprecations
 

--- a/content/en/news/releases/1.10.x/announcing-1.10/_index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/_index.md
@@ -1,0 +1,12 @@
+---
+title: Announcing Istio 1.10
+linktitle: 1.10
+subtitle: Major Update
+description: Istio 1.10 release announcement.
+publishdate: 2021-05-18
+release: 1.10.0
+skip_list: true
+aliases:
+    - /news/announcing-1.10
+    - /news/announcing-1.10.0
+---

--- a/content/en/news/releases/1.10.x/announcing-1.10/_index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/_index.md
@@ -10,3 +10,69 @@ aliases:
     - /news/announcing-1.10
     - /news/announcing-1.10.0
 ---
+
+We’re excited to announce the release of Istio 1.10! We’d like to give a special thanks to our release managers Sam Naser and Zhihan Zhang in addition to the entire Test and Release Working Group for their work on 1.10.
+
+This is our second release of 2021 and like our last few releases we’ve continued to improve Day 2 operations for Istio users.
+
+A few of this release’s highlights:
+
+## Discovery Selectors
+
+In previous Istio versions, Istio’s control plane has watched and processed updates for all Kubernetes resources it cares about in a cluster. This can be a scalability bottleneck in large clusters or clusters with rapid configuration changes. Discovery Selectors limit the set of resources that Istiod watches for so you can easily ignore changes from namespaces that aren’t a concern for the mesh (e.g. a set of Spark Jobs).
+
+You can think of them as a bit like Istio’s Sidecar API resources but for Istiod itself: a `Sidecar` resource limits the set of configuration that Istiod will send to Envoy. Discovery Selectors limit the set of configurations that Istio will receive and process from Kubernetes.
+
+[Check out the great write-up](/blog/2021/discovery-selectors/) by Lin, Christian, and Harvey for an in-depth walkthrough of this new feature!
+
+## Stable Revision Labels
+
+Istio added support for deploying multiple control planes safely with revisions [all the way back in 1.6](/blog/2020/multiple-control-planes/) and we’ve been steadily improving support since. One of the major usability complaints about revisions has been that a lot of namespace relabeling was required to change revisions, because a label mapped directly to a specific Istio control plane deployment.
+
+With revision tags, there’s now a layer of indirection: you can create tags like `canary` and `prod`, label namespaces using those tags as revisions (i.e. `istio.io/rev=prod`), and associate a specific Istiod revision with that tag. 
+
+For example, imagine you have two revisions, `1-7-6` and `1-8-0`. You create a revision tag `prod` pointed to revision `1-7-6` and create a revision tag `canary` pointed to the newer `1-8-0` revision.
+
+{{< image width="40%"
+    link="/docs/setup/upgrade/canary/revision-tag-1.png"
+    caption="Namespaces A and B pointed to 1-7-6, namespace C pointed to 1-8-0"
+    >}}
+
+Now, when you’re ready to promote the `1-8-0` revision from `canary` to `prod`, you can re-associate the `prod` tag with the `1-8-0` Istiod revision. Now all namespaces using `istio.io/rev=prod` will use the newer `1-8-0` revision for injection.
+
+{{< image width="40%"
+    link="/docs/setup/upgrade/canary/revision-tag-2.png"
+    caption="Namespaces A, B, and C pointed to 1-8-0"
+    >}}
+
+Check out the [updated Canary Upgrade guide](/docs/setup/upgrade/canary/#stable-revision-labels-experimental) for a walkthrough you can follow along with!
+
+## Sidecar Networking Changes
+
+In previous Istio releases, Istio has rewritten pod networking to trap traffic from `eth0` and send it to applications on `lo`. Most applications bind to both interfaces and don’t notice any difference; however some applications are specifically written to only expect specific traffic on either interface (e.g. it’s common to expose admin endpoints only on `lo` and never over `eth0`, or for stateful applications to bind only to `eth0`). These applications’ behavior can be impacted by how Istio directs traffic into the pod.
+
+In 1.10, Istio is updating Envoy to send traffic to the application on `eth0` rather than `lo` by default. For new users, this should only be an improvement. For existing users, `istioctl experimental precheck` will identify pods that listen on localhost and may be impacted as IST0143.
+
+See [the write-up](/blog/2021/upcoming-networking-changes/) by John Howard for a more in depth overview of the change, how and why it might impact you, and how to preserve today’s behavior to enable a seamless migration.
+
+## A Fresh Look for Istio.io
+
+We’ve revamped Istio.io with a totally new look! This is the first major change to Istio’s site since the project launched nearly four years ago (we’ll celebrate that anniversary on May 24th!). We hope these changes help make the site more user-friendly, easier to navigate, and more readable overall.
+
+This effort was sponsored by Google Cloud and we want to send a special thanks to Craig Box, Aizhamal Nurmamat kyzy and Srinath Padmanabhan for driving this effort, and to all the folks that helped review and provide feedback to early revisions.
+
+Please give us any feedback you have by filing an issue on the [istio.io repo](https://github.com/istio/istio.io).
+
+## Deprecations
+
+Two features are being deprecated in 1.10:
+
+* Kubernetes first party JWT support (`values.global.jwtPolicy=first-party-jwt`) will be removed; it is less secure and intended only for backwards compatibility with older Kubernetes versions.
+
+* The `values.global.arch` option has been superseded by Affinity settings in Kubernetes config.
+
+See the 1.10 [change notes](/news/releases/1.10.x/announcing-1.10/change-notes/) for a more detailed overview of these deprecations.
+
+## Tell Us How We’re Doing
+
+If you have upgraded your service mesh to Istio 1.10, we would like to hear from you!  Please consider taking [this brief (~2 minute) survey](https://docs.google.com/forms/d/e/1FAIpQLSfzonL4euvGgUM7kyXjsucP4UV8mH9M2snKVFQnT-L7eIXp_g/viewform?resourcekey=0-pWz7V0MsuFrdfJ_-NTQwXQ) to help us understand what we’re doing well, and where we still need to improve.

--- a/content/en/news/releases/1.10.x/announcing-1.10/_index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/_index.md
@@ -51,7 +51,7 @@ Check out the [updated Canary Upgrade guide](/docs/setup/upgrade/canary/#stable-
 
 In previous Istio releases, Istio has rewritten pod networking to trap traffic from `eth0` and send it to applications on `lo`. Most applications bind to both interfaces and don’t notice any difference; however some applications are specifically written to only expect specific traffic on either interface (e.g. it’s common to expose admin endpoints only on `lo` and never over `eth0`, or for stateful applications to bind only to `eth0`). These applications’ behavior can be impacted by how Istio directs traffic into the pod.
 
-In 1.10, Istio is updating Envoy to send traffic to the application on `eth0` rather than `lo` by default. For new users, this should only be an improvement. For existing users, `istioctl experimental precheck` will identify pods that listen on localhost and may be impacted as IST0143.
+In 1.10, Istio is updating Envoy to send traffic to the application on `eth0` rather than `lo` by default. For new users, this should only be an improvement. For existing users, `istioctl experimental precheck` will identify pods that listen on localhost, and may be impacted, as [IST0143](/docs/reference/config/analysis/ist0143/).
 
 See [the write-up](/blog/2021/upcoming-networking-changes/) by John Howard for a more in depth overview of the change, how and why it might impact you, and how to preserve today’s behavior to enable a seamless migration.
 
@@ -63,7 +63,7 @@ This effort was sponsored by Google Cloud and we want to send a special thanks t
 
 Please give us any feedback you have by filing an issue on the [istio.io repository](https://github.com/istio/istio.io).
 
-## Opening up our design docs
+## Opening Up Our Design Docs
 
 Istio's working groups keep their design documents and planning artifacts in a community Google Drive. Anyone is welcome to view these documents, but due to Istio's heritage inside Google, you first had to [join a public group](https://groups.google.com/g/istio-team-drive-access) to get access to the drive and the files within.
 

--- a/content/en/news/releases/1.10.x/announcing-1.10/_index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/_index.md
@@ -59,7 +59,7 @@ See [the write-up](/blog/2021/upcoming-networking-changes/) by John Howard for a
 
 We’ve revamped Istio.io with a totally new look! This is the first major change to Istio’s site since the project launched nearly four years ago (we’ll celebrate that anniversary on May 24th!). We hope these changes help make the site more user-friendly, easier to navigate, and more readable overall.
 
-This effort was sponsored by Google Cloud and we want to send a special thanks to [Craig Box](https://twitter.com/craigbox), [Aizhamal Nurmamat Kyzy](https://twitter.com/iamaijamal) and [Srinath Padmanabhan](https://twitter.com/srithreepo) for driving this effort, and to all the folks that helped review and provide feedback to early revisions.
+This effort was sponsored by Google Cloud and we want to send a special thanks to [Craig Box](https://twitter.com/craigbox), [Aizhamal Nurmamat kyzy](https://twitter.com/iamaijamal) and [Srinath Padmanabhan](https://twitter.com/srithreepo) for driving this effort, and to all the folks that helped review and provide feedback to early revisions.
 
 Please give us any feedback you have by filing an issue on the [istio.io repository](https://github.com/istio/istio.io).
 

--- a/content/en/news/releases/1.10.x/announcing-1.10/_index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/_index.md
@@ -11,7 +11,7 @@ aliases:
     - /news/announcing-1.10.0
 ---
 
-We’re excited to announce the release of Istio 1.10! We’d like to give a special thanks to our release managers Sam Naser and Zhihan Zhang in addition to the entire Test and Release Working Group for their work on 1.10.
+We’re excited to announce the release of Istio 1.10! We’d like to give a special thanks to our release managers [Sam Naser](https://github.com/Monkeyanator) and [Zhihan Zhang](https://github.com/ZhiHanZ) in addition to the entire Test and Release Working Group for their work on 1.10.
 
 This is our second release of 2021 and like our last few releases we’ve continued to improve Day 2 operations for Istio users.
 
@@ -29,7 +29,7 @@ You can think of them as a bit like Istio’s Sidecar API resources but for Isti
 
 Istio added support for deploying multiple control planes safely with revisions [all the way back in 1.6](/blog/2020/multiple-control-planes/) and we’ve been steadily improving support since. One of the major usability complaints about revisions has been that a lot of namespace relabeling was required to change revisions, because a label mapped directly to a specific Istio control plane deployment.
 
-With revision tags, there’s now a layer of indirection: you can create tags like `canary` and `prod`, label namespaces using those tags as revisions (i.e. `istio.io/rev=prod`), and associate a specific Istiod revision with that tag. 
+With revision tags, there’s now a layer of indirection: you can create tags like `canary` and `prod`, label namespaces using those tags as revisions (i.e. `istio.io/rev=prod`), and associate a specific Istiod revision with that tag.
 
 For example, imagine you have two revisions, `1-7-6` and `1-8-0`. You create a revision tag `prod` pointed to revision `1-7-6` and create a revision tag `canary` pointed to the newer `1-8-0` revision.
 
@@ -59,7 +59,7 @@ See [the write-up](/blog/2021/upcoming-networking-changes/) by John Howard for a
 
 We’ve revamped Istio.io with a totally new look! This is the first major change to Istio’s site since the project launched nearly four years ago (we’ll celebrate that anniversary on May 24th!). We hope these changes help make the site more user-friendly, easier to navigate, and more readable overall.
 
-This effort was sponsored by Google Cloud and we want to send a special thanks to Craig Box, Aizhamal Nurmamat kyzy and Srinath Padmanabhan for driving this effort, and to all the folks that helped review and provide feedback to early revisions.
+This effort was sponsored by Google Cloud and we want to send a special thanks to [Craig Box](https://twitter.com/craigbox), [Aizhamal Nurmamat Kyzy](https://twitter.com/iamaijamal) and [Srinath Padmanabhan](https://twitter.com/srithreepo) for driving this effort, and to all the folks that helped review and provide feedback to early revisions.
 
 Please give us any feedback you have by filing an issue on the [istio.io repo](https://github.com/istio/istio.io).
 

--- a/content/en/news/releases/1.10.x/announcing-1.10/_index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/_index.md
@@ -63,6 +63,14 @@ This effort was sponsored by Google Cloud and we want to send a special thanks t
 
 Please give us any feedback you have by filing an issue on the [istio.io repository](https://github.com/istio/istio.io).
 
+## Opening up our design docs
+
+Istio's working groups keep their design documents and planning artifacts in a community Google Drive. Anyone is welcome to view these documents, but due to Istio's heritage inside Google, you first had to [join a public group](https://groups.google.com/g/istio-team-drive-access) to get access to the drive and the files within.
+
+On the 20th of May we will change the Drive so that the files are accessible to everyone on the Internet, without having to log in, or join the group. This change will make sharing Istio technical documentation easier. and is another way we're ensuring Istio is a fully open project.
+
+Files will remain at the same URLs as before, but the Drive and its subfolders will change URLs. If you are a regular user of the Community Drive, please be aware of this change.  All contributors and Drive members will be contacted this week with the new details.
+
 ## Deprecations
 
 Two features are being deprecated in 1.10:

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -13,6 +13,10 @@ aliases:
 
 These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/docs/releases/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.
 
+- **Deprecated** the values.global.jwtPolicy=first-party-jwt option. This option is less secure and intended for backwards compatibility
+with older Kubernetes clusters without support for more secure token authentication, but is now enabled by default in new Kubernetes versions.
+The option will be removed in future releases. See [this documentation](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) for more information.
+
 - **Deprecated** installation flags `values.global.arch` in favor of the affinity Kubernetes settings.
   ([Issue #30027](https://github.com/istio/istio/issues/30027))
 

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -1,5 +1,5 @@
 ---
-title: Change Notes
+title: Istio 1.10 Change Notes
 linktitle: 1.10 Change Notes
 description: Istio 1.10.0 release notes.
 publishdate: 2021-05-18

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -1,0 +1,177 @@
+---
+title: Change Notes
+description: Istio 1.10.0 release notes.
+weight: 10
+---
+
+# Release Notes
+
+## Deprecation Notices
+
+These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/about/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.
+
+- **Deprecated** installation flags `values.global.arch` in favor of the affinity Kubernetes settings.
+  ([Issue #30027](https://github.com/istio/istio/issues/30027))
+
+
+## Traffic Management
+
+- **Added** the `ISTIO_GATEWAY_STRIP_HOST_PORT` environment variable to control whether gateways strip host port before any processing of request by HTTP filters or routing.
+  ([Issue #25350](https://github.com/istio/istio/issues/25350))
+
+- **Added** `meshConfig.discoverySelectors` to dynamically restrict the set of namespaces for `Services`, `Pods`, and `Endpoints` that istiod processes when pushing xDS updates to improve performance on the data plane.
+  ([Issue #26679](https://github.com/istio/istio/issues/26679))
+  
+- **Fixed** configuration of TLS parameters (TLS version, TLS cipher suites, curves, etc.) with `EnvoyFilter`.
+  ([Issue #28996](https://github.com/istio/istio/issues/28996))
+
+- **Fixed** an issue where filter chain name was ignored when processing `EnvoyFilter` match.
+  ([Issue #31166](https://github.com/istio/istio/issues/31166))
+
+- **Improved** the full push scoping by adding `Sidecar` config to `sidecarScopeKnownConfigTypes`.
+
+- **Improved** virtual machine integration to clean up `iptables` rules when the service is stopped.
+  ([Issue #29556](https://github.com/istio/istio/issues/29556))
+
+- **Updated** istio-proxy drain notification strategy to immediate from gradual. 
+  ([Issue #31403](https://github.com/istio/istio/issues/31403))
+
+- **Added** CNI metrics counting repair operations.
+  ([Issue #19300](https://github.com/istio/istio/issues/19300))
+
+- **Added** `/debug/connections` istiod debug interface to list the current connected clients.
+  ([Issue #31075](https://github.com/istio/istio/issues/31075))
+
+- **Added** SDS secrets fetch failure metric `pilot_sds_certificate_errors_total`.
+  ([Issue #31779](https://github.com/istio/istio/issues/31779))
+
+- **Added** metrics for istiod informer errors.  
+
+- **Added** 'istioctl validate' and the validating webhook now report duplicate or unreachable virtual service matches.
+  ([Issue #31525](https://github.com/istio/istio/issues/31525))
+
+- **Fixed** a bug where `ISTIO_META_IDLE_TIMEOUT` is not reflected when set to "0s".
+  ([Issue #30067](https://github.com/istio/istio/issues/30067))
+
+- **Fixed** avoid unnecessary full push in service entry store.
+  ([Issue #30683](https://github.com/istio/istio/issues/30683))
+
+- **Fixed** a bug where the EnvoyFilter `HTTP_FILTER` didn't support `INSERT_FIRST`.
+  ([Issue #31573](https://github.com/istio/istio/issues/31573))
+
+- **Fixed** an issue where services with `PASSTHROUGH` load balancing were always sent mTLS traffic, even if the destinations did not support mTLS.
+  ([Issue #23494](https://github.com/istio/istio/issues/23494))
+
+- **Fixed** a bug where `EnvoyFilter` with service match did not work for inbound clusters.
+  
+
+## Security
+
+- **Updated** configuration to sign istiod certificates using Kubernetes CA (`PILOT_CERT_PROVIDER=kubernetes`) will not be honored in
+clusters with version 1.22 and greater.
+  ([Issue #22161](https://github.com/istio/istio/issues/22161))
+
+- **Added** experimental option to configure Envoy to fetch the JWKS by itself. This should be enabled if the `jwks_uri` is a mesh cluster URL for mTLS and has other benefits like retries, JWKS caching etc. 
+This is disabled by default and can be enabled by setting `PILOT_JWT_ENABLE_REMOTE_JWKS` to true.
+  ([Issue #28742](https://github.com/istio/istio/issues/28742))
+
+- **Added** an environment variable `PILOT_JWT_PUB_KEY_REFRESH_INTERVAL` to configure the interval of
+istiod fetching the `jwks_uri` for the JWKS public key. Users can set the refresh interval with 
+`--set values.pilot.env.PILOT_JWT_PUB_KEY_REFRESH_INTERVAL=<duration>` during installation.
+The default interval is 20m. Valid time units are "ns", "us", "ms", "s", "m", "h".
+
+- **Added**  istiod JWT public key refresh job will now retry the failed fetch of the `jwks_uri` with exponential backoff.
+  ([Issue #30261](https://github.com/istio/istio/issues/30261))
+
+- **Added** an experimental feature to allow dry-run of an `AuthorizationPolicy` without actually enforcing the policy.
+ ([Usage](https://istio.io/latest/docs/tasks/security/authorization/authz-dry-run/), [Design](https://docs.google.com/document/d/1xQdZsEgJ3Ld2qebfT3EJkg2COTtCR1TqBVojmnvI78g), [PR](https://github.com/istio/api/pull/1933))
+
+- Improved the experimental [External Authorization](https://istio.io/latest/docs/tasks/security/authorization/authz-custom/) feature with new capabilities:
+- **Added** the `timeout` field to configure the timeout (default is 10m) between the ext_authz filter and the external service.
+- **Added** the `include_additional_headers_in_check` field to send additional headers to the external service.
+- **Added** the `include_request_body_in_check` field to send the body to the external service.
+- **Supported** prefix and suffix match in the `include_request_headers_in_check`, `headers_to_upstream_on_allow` and `headers_to_downstream_on_deny` field.
+- **Deprecated** the `include_headers_in_check` field with the new `include_request_headers_in_check` field for better naming.
+ ([Reference](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR](https://github.com/istio/api/pull/1926))
+
+- **Fixed** removed ability to configure `trustDomain` from Helm `global.values`. Now it is configured through `meshConfig.trustDomain` ([Issue #27734](https://github.com/istio/istio/issues/27734))
+
+- **Fixed** an issue causing simple TLS traffic to ports not exposed by a `Service` to be rejected by servers when in `PERMISSIVE` mTLS mode.
+  ([Issue #31297](https://github.com/istio/istio/issues/31297))
+  
+
+## Telemetry
+
+- **Added** experimental support for the Telemetry API.
+  ([Issue #24284](https://github.com/istio/istio/issues/24284))
+
+- **Fixed** missing `destination_cluster` label at metric reported by client proxy on request failures.
+  ([Issue #29373](https://github.com/istio/istio/issues/29373))
+
+- **Fixed** an issue where Envoy did not start up properly when duplicate stats tags were configured.
+  ([Issue #31270](https://github.com/istio/istio/issues/31270))
+
+
+## Extensibility
+
+- **Added** reliable Wasm module remote load with istio-agent.
+  ([Issue #29989](https://github.com/istio/istio/issues/29989))
+
+
+## Installation
+
+- **Improved** `ConfigMaps` to be read directly rather than from volume mounts. This improves the speed
+of updates and ensures that for external istiod installations that the configmaps are read from the config cluster.
+  ([Issue #31410](https://github.com/istio/istio/issues/31410))
+
+- **Improved** the sidecar injector to better utilize pod labels to determine if injection is required.
+  ([Issue #30013](https://github.com/istio/istio/issues/30013))
+
+- **Updated** non-revisioned installs to target the label `istio.io/rev=default` for injection in addition to the
+existing default injection labels (`istio-injection=enabled` and `sidecar.istio.io/inject=true`).
+
+- **Added** support for slash characters in environment variables on `injectionURL`.
+  ([Issue #31732](https://github.com/istio/istio/issues/31732))
+
+- **Added** an `external` profile for installing Istio with an external control plane and deprecated the `remote` profile.
+  ([Issue #32370](https://github.com/istio/istio/issues/32370))
+
+- **Added** `istioctl experimental revision tag` command group. Revision tags act as aliases for
+control plane revisions. Users can label their namespaces with a revision tag rather than pointing them
+directly at a revision and selectively decide the granularity of their namespace labels. This makes it possible
+to perform upgrades with the ease of in-place upgrades while having the safety revision-based upgrades
+under the hood.
+
+- **Fixed** a bug preventing `istioctl kube-inject` from working with revisions.
+  ([Issue #30991](https://github.com/istio/istio/issues/30991))
+
+- **Improved** the output of istioctl YAML diff commands.
+  ([Issue #31186](https://github.com/istio/istio/issues/31186))
+
+- **Removed** the `15012` and `15443` ports from the default gateway installation. These can be explicitly
+[added](https://istio.io/latest/docs/setup/install/istioctl/#configure-gateways) if desired, although it is
+recommended to follow the new [multicluster installation guide](https://istio.io/latest/docs/setup/install/multicluster/) instead.
+  
+  
+## istioctl
+
+- **Updated** the experimental `precheck` command to identify potential upgrade issues prior to actually running an upgrade.
+  
+- **Updated** `istioctl kube-inject` to call webhook server to get the injection template by default.
+  ([Issue #29270](https://github.com/istio/istio/issues/29270))
+
+- **Added** `istioctl experimental internal-debug` to retrieve istiod debug information via a secured debug interface.
+  ([Issue #31338](https://github.com/istio/istio/issues/31338))
+
+- **Added** `istioctl proxy-config -o yaml` to display in YAML along with the current JSON and short format.
+ ([Usage]( https://istio.io/latest/docs/reference/commands/istioctl/#istioctl-proxy-config), [Issue #31695](https://github.com/istio/istio/issues/31695))
+
+- **Added** the `istioctl proxy-config all` command to view the full proxy configuration.
+
+- **Added** tooling for revision-centric view of current Istio deployments in a cluster. This is to
+provide a better understanding of deployments- such as the number of istiod, gateway pods, `IstioOperator` CRs-
+defining a particular revision, and the number of pods with sidecars pointing to a particular revision. ([Issue #23892](https://github.com/istio/istio/issues/23892))
+
+- **Added** a new analyzer for invalid webhook configurations.  
+
+- **Fixed** fail correctly when `istioctl x create-remote-secret --secret-name` points to a non-existent secret in the remote cluster.  ([Issue #30723](https://github.com/istio/istio/issues/30723))

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -14,24 +14,26 @@ aliases:
 These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/docs/releases/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.
 
 - **Deprecated** the `values.global.jwtPolicy=first-party-jwt` option. This option is less secure and intended for backwards compatibility
-with older Kubernetes clusters without support for more secure token authentication but is now enabled by default in new Kubernetes versions.
-The option will be removed in future releases. See [this documentation](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) for more information.
+with older Kubernetes clusters without support for more secure token authentication but is now enabled by default in new Kubernetes versions. See [this documentation](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) for more information.
 
 - **Deprecated** the `values.global.arch` option in favor of the affinity Kubernetes settings.
   ([Issue #30027](https://github.com/istio/istio/issues/30027))
+  
+- **Deprecated** the `remote` installation profile and added the `external` profile for installing Istio with an external control plane.
+  ([Issue #32370](https://github.com/istio/istio/issues/32370))
 
 ## Traffic Management
 
 - **Added** `meshConfig.discoverySelectors` to dynamically restrict the set of namespaces for `Services`, `Pods`, and `Endpoints` that istiod processes when pushing xDS updates to improve performance on the data plane.
   ([Blog](/blog/2021/discovery-selectors/), [Issue #26679](https://github.com/istio/istio/issues/26679))
 
-- **Added** the `ISTIO_GATEWAY_STRIP_HOST_PORT` environment variable to control whether gateways strip host port before any processing of request by HTTP filters or routing. This option is disabled by default.
+- **Added** the `ISTIO_GATEWAY_STRIP_HOST_PORT` environment variable to control whether gateways strip the host port before any processing of requests by HTTP filters or routing. This option is disabled by default.
   ([Issue #25350](https://github.com/istio/istio/issues/25350))
 
 - **Fixed** configuration of TLS parameters (TLS version, TLS cipher suites, curves, etc.) with `EnvoyFilter`.
   ([Issue #28996](https://github.com/istio/istio/issues/28996))
 
-- **Fixed** an issue where filter chain name was ignored when processing `EnvoyFilter` match.
+- **Fixed** an issue where the filter chain name was ignored when processing `EnvoyFilter` match.
   ([Issue #31166](https://github.com/istio/istio/issues/31166))
 
 - **Improved** the full push scoping by adding `Sidecar` config to `sidecarScopeKnownConfigTypes`.
@@ -59,7 +61,7 @@ The option will be removed in future releases. See [this documentation](/docs/op
 - **Fixed** a bug causing unnecessary full push in service entry store.
   ([Issue #30683](https://github.com/istio/istio/issues/30683))
 
-- **Fixed** a bug where the EnvoyFilter `HTTP_FILTER` didn't support `INSERT_FIRST`.
+- **Fixed** a bug where the `EnvoyFilter` `HTTP_FILTER` didn't support `INSERT_FIRST`.
   ([Issue #31573](https://github.com/istio/istio/issues/31573))
 
 - **Fixed** an issue where services with `PASSTHROUGH` load balancing were always sent mTLS traffic, even if the destinations did not support mTLS.
@@ -70,18 +72,18 @@ The option will be removed in future releases. See [this documentation](/docs/op
 ## Security
 
 - **Added** an experimental feature to allow dry-run of an `AuthorizationPolicy` without actually enforcing the policy.
- ([Usage](/docs/tasks/security/authorization/authz-dry-run/), [Design](https://docs.google.com/document/d/1xQdZsEgJ3Ld2qebfT3EJkg2COTtCR1TqBVojmnvI78g), [PR](https://github.com/istio/api/pull/1933))
+ ([Usage](/docs/tasks/security/authorization/authz-dry-run/), [Design](https://docs.google.com/document/d/1xQdZsEgJ3Ld2qebfT3EJkg2COTtCR1TqBVojmnvI78g), [PR #1933](https://github.com/istio/api/pull/1933))
 
 - **Updated** configuration to sign istiod certificates using Kubernetes CA (`PILOT_CERT_PROVIDER=kubernetes`) will not be honored in
 clusters with version 1.22 and greater.
   ([Issue #22161](https://github.com/istio/istio/issues/22161))
 
-- Improved the experimental [External Authorization](/docs/tasks/security/authorization/authz-custom/) feature with new capabilities:
+- **Improved** the experimental [External Authorization](/docs/tasks/security/authorization/authz-custom/) feature with new capabilities:
     - **Added** the `timeout` field to configure the timeout (default is `10m`) between the `ext_authz` filter and the external service.
     - **Added** the `include_additional_headers_in_check` field to send additional headers to the external service.
     - **Added** the `include_request_body_in_check` field to send the body to the external service.
     - **Supported** prefix and suffix match in the `include_request_headers_in_check`, `headers_to_upstream_on_allow` and `headers_to_downstream_on_deny` field.
-    - **Deprecated** the `include_headers_in_check` field with the new `include_request_headers_in_check` field for better naming. ([Reference](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR](https://github.com/istio/api/pull/1926))
+    - **Deprecated** the `include_headers_in_check` field with the new `include_request_headers_in_check` field for better naming. ([Reference](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR #1926](https://github.com/istio/api/pull/1926))
 
 - **Added** experimental option to configure Envoy to fetch the JWKS by itself. This should be enabled if the `jwks_uri` is a mesh cluster URL for mTLS and has other benefits like retries, JWKS caching etc.
 This is disabled by default and can be enabled by setting `PILOT_JWT_ENABLE_REMOTE_JWKS` to true.
@@ -92,10 +94,10 @@ istiod fetching the `jwks_uri` for the JWKS public key. Users can set the refres
 `--set values.pilot.env.PILOT_JWT_PUB_KEY_REFRESH_INTERVAL=<duration>` during installation.
 The default interval is `20m`. Valid time units are "ns", "us", "ms", "s", "m", "h".
 
-- **Added**  istiod JWT public key refresh job will now retry the failed fetch of the `jwks_uri` with exponential backoff.
+- **Update** the istiod JWT public key refresh job to retry the failed fetch of the `jwks_uri` with exponential backoff.
   ([Issue #30261](https://github.com/istio/istio/issues/30261))
 
-- **Fixed** removed ability to configure `trustDomain` from Helm `global.values`. Now it is configured through `meshConfig.trustDomain` ([Issue #27734](https://github.com/istio/istio/issues/27734))
+- **Removed** ability to configure `trustDomain` from Helm `global.values`. Now it is configured through `meshConfig.trustDomain` ([Issue #27734](https://github.com/istio/istio/issues/27734))
 
 - **Fixed** an issue causing simple TLS traffic to ports not exposed by a `Service` to be rejected by servers when in `PERMISSIVE` mTLS mode.
   ([Issue #31297](https://github.com/istio/istio/issues/31297))
@@ -105,7 +107,7 @@ The default interval is `20m`. Valid time units are "ns", "us", "ms", "s", "m", 
 - **Added** experimental support for the Telemetry API.
   ([Issue #24284](https://github.com/istio/istio/issues/24284))
 
-- **Fixed** missing `destination_cluster` label at metric reported by client proxy on request failures.
+- **Fixed** the missing `destination_cluster` metric label reported by client proxy on request failures.
   ([Issue #29373](https://github.com/istio/istio/issues/29373))
 
 - **Fixed** an issue where Envoy did not start up properly when duplicate stats tags were configured.
@@ -121,7 +123,7 @@ The default interval is `20m`. Valid time units are "ns", "us", "ms", "s", "m", 
 - **Added** `istioctl experimental revision tag` command group. Revision tags act as aliases for
 control plane revisions. Users can label their namespaces with a revision tag rather than pointing them
 directly at a revision and selectively decide the granularity of their namespace labels. This makes it possible
-to perform upgrades with the ease of in-place upgrades while having the safety revision-based upgrades
+to perform upgrades with the ease of in-place upgrades while having the safety of revision-based upgrades
 under the hood. Read more about using revision tags [here](/docs/setup/upgrade/canary/#stable-revision-labels-experimental).
 
 - **Improved** `ConfigMaps` to be read directly rather than from volume mounts. This improves the speed
@@ -156,7 +158,7 @@ recommended to follow the new [multicluster installation guide](/docs/setup/inst
 
 - **Updated** the `istioctl experimental precheck` command to identify potential upgrade issues prior to actually running an upgrade.
 
-- **Updated** `istioctl kube-inject` to call webhook server to get the injection template by default.
+- **Updated** `istioctl kube-inject` to call the webhook server to get the injection template by default.
   ([Issue #29270](https://github.com/istio/istio/issues/29270))
 
 - **Added** `istioctl experimental internal-debug` to retrieve istiod debug information via a secured debug interface.
@@ -176,4 +178,4 @@ defining a particular revision, and the number of pods with sidecars pointing to
 
 - **Added** a new analyzer for invalid webhook configurations.
 
-- **Fixed** fail correctly when `istioctl x create-remote-secret --secret-name` points to a non-existent secret in the remote cluster.  ([Issue #30723](https://github.com/istio/istio/issues/30723))
+- **Fixed** an issue where `istioctl x create-remote-secret --secret-name` failed incorrectly when pointing to a non-existent secret in the remote cluster.  ([Issue #30723](https://github.com/istio/istio/issues/30723))

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -77,12 +77,11 @@ clusters with version 1.22 and greater.
   ([Issue #22161](https://github.com/istio/istio/issues/22161))
 
 - Improved the experimental [External Authorization](/docs/tasks/security/authorization/authz-custom/) feature with new capabilities:
-   - **Added** the `timeout` field to configure the timeout (default is `10m`) between the `ext_authz` filter and the external service.
-   - **Added** the `include_additional_headers_in_check` field to send additional headers to the external service.
-   - **Added** the `include_request_body_in_check` field to send the body to the external service.
-   - **Supported** prefix and suffix match in the `include_request_headers_in_check`, `headers_to_upstream_on_allow` and `headers_to_downstream_on_deny` field.
-   - **Deprecated** the `include_headers_in_check` field with the new `include_request_headers_in_check` field for better naming.
-    ([Reference](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR](https://github.com/istio/api/pull/1926))
+    - **Added** the `timeout` field to configure the timeout (default is `10m`) between the `ext_authz` filter and the external service.
+    - **Added** the `include_additional_headers_in_check` field to send additional headers to the external service.
+    - **Added** the `include_request_body_in_check` field to send the body to the external service.
+    - **Supported** prefix and suffix match in the `include_request_headers_in_check`, `headers_to_upstream_on_allow` and `headers_to_downstream_on_deny` field.
+    - **Deprecated** the `include_headers_in_check` field with the new `include_request_headers_in_check` field for better naming. ([Reference](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR](https://github.com/istio/api/pull/1926))
 
 - **Added** experimental option to configure Envoy to fetch the JWKS by itself. This should be enabled if the `jwks_uri` is a mesh cluster URL for mTLS and has other benefits like retries, JWKS caching etc.
 This is disabled by default and can be enabled by setting `PILOT_JWT_ENABLE_REMOTE_JWKS` to true.

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -1,12 +1,10 @@
 ---
 title: Change Notes
-linktitle: 1.10
+linktitle: 1.10 Change Notes
 description: Istio 1.10.0 release notes.
 publishdate: 2021-05-18
 release: 1.10
 weight: 10
-aliases:
-    - /news/announcing-1.10
 ---
 
 ## Deprecation Notices
@@ -18,7 +16,7 @@ with older Kubernetes clusters without support for more secure token authenticat
 
 - **Deprecated** the `values.global.arch` option in favor of the affinity Kubernetes settings.
   ([Issue #30027](https://github.com/istio/istio/issues/30027))
-  
+
 - **Deprecated** the `remote` installation profile and added the `external` profile for installing Istio with an external control plane.
   ([Issue #32370](https://github.com/istio/istio/issues/32370))
 

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -22,11 +22,11 @@ The option will be removed in future releases. See [this documentation](/docs/op
 
 ## Traffic Management
 
-- **Added** the `ISTIO_GATEWAY_STRIP_HOST_PORT` environment variable to control whether gateways strip host port before any processing of request by HTTP filters or routing. This option is disabled by default.
-  ([Blog](/blog/2021/discovery-selectors/), [Issue #25350](https://github.com/istio/istio/issues/25350))
-
 - **Added** `meshConfig.discoverySelectors` to dynamically restrict the set of namespaces for `Services`, `Pods`, and `Endpoints` that istiod processes when pushing xDS updates to improve performance on the data plane.
-  ([Issue #26679](https://github.com/istio/istio/issues/26679))
+  ([Blog](/blog/2021/discovery-selectors/), [Issue #26679](https://github.com/istio/istio/issues/26679))
+
+- **Added** the `ISTIO_GATEWAY_STRIP_HOST_PORT` environment variable to control whether gateways strip host port before any processing of request by HTTP filters or routing. This option is disabled by default.
+  ([Issue #25350](https://github.com/istio/istio/issues/25350))
 
 - **Fixed** configuration of TLS parameters (TLS version, TLS cipher suites, curves, etc.) with `EnvoyFilter`.
   ([Issue #28996](https://github.com/istio/istio/issues/28996))
@@ -122,6 +122,12 @@ The default interval is `20m`. Valid time units are "ns", "us", "ms", "s", "m", 
 
 ## Installation
 
+- **Added** `istioctl experimental revision tag` command group. Revision tags act as aliases for
+control plane revisions. Users can label their namespaces with a revision tag rather than pointing them
+directly at a revision and selectively decide the granularity of their namespace labels. This makes it possible
+to perform upgrades with the ease of in-place upgrades while having the safety revision-based upgrades
+under the hood. Read more about using revision tags [here](/docs/setup/upgrade/canary/#stable-revision-labels-experimental).
+
 - **Improved** `ConfigMaps` to be read directly rather than from volume mounts. This improves the speed
 of updates and ensures that for external istiod installations that the configmaps are read from the config cluster.
   ([Issue #31410](https://github.com/istio/istio/issues/31410))
@@ -137,12 +143,6 @@ existing default injection labels (`istio-injection=enabled` and `sidecar.istio.
 
 - **Added** an `external` profile for installing Istio with an external control plane and deprecated the `remote` profile.
   ([Issue #32370](https://github.com/istio/istio/issues/32370))
-
-- **Added** `istioctl experimental revision tag` command group. Revision tags act as aliases for
-control plane revisions. Users can label their namespaces with a revision tag rather than pointing them
-directly at a revision and selectively decide the granularity of their namespace labels. This makes it possible
-to perform upgrades with the ease of in-place upgrades while having the safety revision-based upgrades
-under the hood.
 
 - **Fixed** a bug preventing `istioctl kube-inject` from working with revisions.
   ([Issue #30991](https://github.com/istio/istio/issues/30991))

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -53,9 +53,6 @@ The option will be removed in future releases. See [this documentation](/docs/op
 
 - **Added** metrics for istiod informer errors.
 
-- **Added** 'istioctl validate' and the validating webhook now report duplicate or unreachable virtual service matches.
-  ([Issue #31525](https://github.com/istio/istio/issues/31525))
-
 - **Fixed** a bug where `ISTIO_META_IDLE_TIMEOUT` is not reflected when set to `0s`.
   ([Issue #30067](https://github.com/istio/istio/issues/30067))
 
@@ -163,6 +160,9 @@ recommended to follow the new [multicluster installation guide](/docs/setup/inst
 
 - **Added** `istioctl experimental internal-debug` to retrieve istiod debug information via a secured debug interface.
   ([Issue #31338](https://github.com/istio/istio/issues/31338))
+
+- **Added** 'istioctl validate' and the validating webhook now report duplicate or unreachable virtual service matches.
+  ([Issue #31525](https://github.com/istio/istio/issues/31525))
 
 - **Added** `istioctl proxy-config -o yaml` to display in YAML along with the current JSON and short format.
  ([Usage](/docs/reference/commands/istioctl/#istioctl-proxy-config), [Issue #31695](https://github.com/istio/istio/issues/31695))

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -77,12 +77,12 @@ clusters with version 1.22 and greater.
   ([Issue #22161](https://github.com/istio/istio/issues/22161))
 
 - Improved the experimental [External Authorization](/docs/tasks/security/authorization/authz-custom/) feature with new capabilities:
-  - **Added** the `timeout` field to configure the timeout (default is `10m`) between the `ext_authz` filter and the external service.
-  - **Added** the `include_additional_headers_in_check` field to send additional headers to the external service.
-  - **Added** the `include_request_body_in_check` field to send the body to the external service.
-  - **Supported** prefix and suffix match in the `include_request_headers_in_check`, `headers_to_upstream_on_allow` and `headers_to_downstream_on_deny` field.
-  - **Deprecated** the `include_headers_in_check` field with the new `include_request_headers_in_check` field for better naming.
-   ([Reference](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR](https://github.com/istio/api/pull/1926))
+   - **Added** the `timeout` field to configure the timeout (default is `10m`) between the `ext_authz` filter and the external service.
+   - **Added** the `include_additional_headers_in_check` field to send additional headers to the external service.
+   - **Added** the `include_request_body_in_check` field to send the body to the external service.
+   - **Supported** prefix and suffix match in the `include_request_headers_in_check`, `headers_to_upstream_on_allow` and `headers_to_downstream_on_deny` field.
+   - **Deprecated** the `include_headers_in_check` field with the new `include_request_headers_in_check` field for better naming.
+    ([Reference](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR](https://github.com/istio/api/pull/1926))
 
 - **Added** experimental option to configure Envoy to fetch the JWKS by itself. This should be enabled if the `jwks_uri` is a mesh cluster URL for mTLS and has other benefits like retries, JWKS caching etc.
 This is disabled by default and can be enabled by setting `PILOT_JWT_ENABLE_REMOTE_JWKS` to true.

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -150,6 +150,8 @@ existing default injection labels (`istio-injection=enabled` and `sidecar.istio.
 [added](/docs/setup/install/istioctl/#configure-gateways) if desired, although it is
 recommended to follow the new [multicluster installation guide](/docs/setup/install/multicluster/) instead.
 
+- **Updated** Kiali addon to the latest version `v1.34`.
+
 ## istioctl
 
 - **Updated** the `istioctl experimental precheck` command to identify potential upgrade issues prior to actually running an upgrade.

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -14,7 +14,7 @@ aliases:
 These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/docs/releases/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.
 
 - **Deprecated** the `values.global.jwtPolicy=first-party-jwt` option. This option is less secure and intended for backwards compatibility
-with older Kubernetes clusters without support for more secure token authentication, but is now enabled by default in new Kubernetes versions.
+with older Kubernetes clusters without support for more secure token authentication but is now enabled by default in new Kubernetes versions.
 The option will be removed in future releases. See [this documentation](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) for more information.
 
 - **Deprecated** the `values.global.arch` option in favor of the affinity Kubernetes settings.
@@ -39,7 +39,7 @@ The option will be removed in future releases. See [this documentation](/docs/op
 - **Improved** virtual machine integration to clean up `iptables` rules when the service is stopped.
   ([Issue #29556](https://github.com/istio/istio/issues/29556))
 
-- **Updated** istio-proxy drain notification strategy to immediate from gradual.
+- **Updated** istio-proxy drain notification strategy from gradual to immediate.
   ([Issue #31403](https://github.com/istio/istio/issues/31403))
 
 - **Added** CNI metrics counting repair operations.
@@ -56,7 +56,7 @@ The option will be removed in future releases. See [this documentation](/docs/op
 - **Fixed** a bug where `ISTIO_META_IDLE_TIMEOUT` is not reflected when set to `0s`.
   ([Issue #30067](https://github.com/istio/istio/issues/30067))
 
-- **Fixed** avoid unnecessary full push in service entry store.
+- **Fixed** a bug causing unnecessary full push in service entry store.
   ([Issue #30683](https://github.com/istio/istio/issues/30683))
 
 - **Fixed** a bug where the EnvoyFilter `HTTP_FILTER` didn't support `INSERT_FIRST`.
@@ -69,9 +69,20 @@ The option will be removed in future releases. See [this documentation](/docs/op
 
 ## Security
 
+- **Added** an experimental feature to allow dry-run of an `AuthorizationPolicy` without actually enforcing the policy.
+ ([Usage](/docs/tasks/security/authorization/authz-dry-run/), [Design](https://docs.google.com/document/d/1xQdZsEgJ3Ld2qebfT3EJkg2COTtCR1TqBVojmnvI78g), [PR](https://github.com/istio/api/pull/1933))
+
 - **Updated** configuration to sign istiod certificates using Kubernetes CA (`PILOT_CERT_PROVIDER=kubernetes`) will not be honored in
 clusters with version 1.22 and greater.
   ([Issue #22161](https://github.com/istio/istio/issues/22161))
+
+- Improved the experimental [External Authorization](/docs/tasks/security/authorization/authz-custom/) feature with new capabilities:
+  - **Added** the `timeout` field to configure the timeout (default is `10m`) between the `ext_authz` filter and the external service.
+  - **Added** the `include_additional_headers_in_check` field to send additional headers to the external service.
+  - **Added** the `include_request_body_in_check` field to send the body to the external service.
+  - **Supported** prefix and suffix match in the `include_request_headers_in_check`, `headers_to_upstream_on_allow` and `headers_to_downstream_on_deny` field.
+  - **Deprecated** the `include_headers_in_check` field with the new `include_request_headers_in_check` field for better naming.
+   ([Reference](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR](https://github.com/istio/api/pull/1926))
 
 - **Added** experimental option to configure Envoy to fetch the JWKS by itself. This should be enabled if the `jwks_uri` is a mesh cluster URL for mTLS and has other benefits like retries, JWKS caching etc.
 This is disabled by default and can be enabled by setting `PILOT_JWT_ENABLE_REMOTE_JWKS` to true.
@@ -84,17 +95,6 @@ The default interval is `20m`. Valid time units are "ns", "us", "ms", "s", "m", 
 
 - **Added**  istiod JWT public key refresh job will now retry the failed fetch of the `jwks_uri` with exponential backoff.
   ([Issue #30261](https://github.com/istio/istio/issues/30261))
-
-- **Added** an experimental feature to allow dry-run of an `AuthorizationPolicy` without actually enforcing the policy.
- ([Usage](/docs/tasks/security/authorization/authz-dry-run/), [Design](https://docs.google.com/document/d/1xQdZsEgJ3Ld2qebfT3EJkg2COTtCR1TqBVojmnvI78g), [PR](https://github.com/istio/api/pull/1933))
-
-- Improved the experimental [External Authorization](/docs/tasks/security/authorization/authz-custom/) feature with new capabilities:
-- **Added** the `timeout` field to configure the timeout (default is `10m`) between the `ext_authz` filter and the external service.
-- **Added** the `include_additional_headers_in_check` field to send additional headers to the external service.
-- **Added** the `include_request_body_in_check` field to send the body to the external service.
-- **Supported** prefix and suffix match in the `include_request_headers_in_check`, `headers_to_upstream_on_allow` and `headers_to_downstream_on_deny` field.
-- **Deprecated** the `include_headers_in_check` field with the new `include_request_headers_in_check` field for better naming.
- ([Reference](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR](https://github.com/istio/api/pull/1926))
 
 - **Fixed** removed ability to configure `trustDomain` from Helm `global.values`. Now it is configured through `meshConfig.trustDomain` ([Issue #27734](https://github.com/istio/istio/issues/27734))
 
@@ -153,7 +153,7 @@ recommended to follow the new [multicluster installation guide](/docs/setup/inst
 
 ## istioctl
 
-- **Updated** the experimental `precheck` command to identify potential upgrade issues prior to actually running an upgrade.
+- **Updated** the `istioctl experimental precheck` command to identify potential upgrade issues prior to actually running an upgrade.
 
 - **Updated** `istioctl kube-inject` to call webhook server to get the injection template by default.
   ([Issue #29270](https://github.com/istio/istio/issues/29270))
@@ -161,7 +161,7 @@ recommended to follow the new [multicluster installation guide](/docs/setup/inst
 - **Added** `istioctl experimental internal-debug` to retrieve istiod debug information via a secured debug interface.
   ([Issue #31338](https://github.com/istio/istio/issues/31338))
 
-- **Added** 'istioctl validate' and the validating webhook now report duplicate or unreachable virtual service matches.
+- **Added** `istioctl validate` and the validating webhook now report duplicate or unreachable virtual service matches.
   ([Issue #31525](https://github.com/istio/istio/issues/31525))
 
 - **Added** `istioctl proxy-config -o yaml` to display in YAML along with the current JSON and short format.

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -4,15 +4,12 @@ description: Istio 1.10.0 release notes.
 weight: 10
 ---
 
-# Release Notes
-
 ## Deprecation Notices
 
-These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/about/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.
+These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/docs/releases/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.
 
 - **Deprecated** installation flags `values.global.arch` in favor of the affinity Kubernetes settings.
   ([Issue #30027](https://github.com/istio/istio/issues/30027))
-
 
 ## Traffic Management
 
@@ -21,7 +18,7 @@ These notices describe functionality that will be removed in a future release ac
 
 - **Added** `meshConfig.discoverySelectors` to dynamically restrict the set of namespaces for `Services`, `Pods`, and `Endpoints` that istiod processes when pushing xDS updates to improve performance on the data plane.
   ([Issue #26679](https://github.com/istio/istio/issues/26679))
-  
+
 - **Fixed** configuration of TLS parameters (TLS version, TLS cipher suites, curves, etc.) with `EnvoyFilter`.
   ([Issue #28996](https://github.com/istio/istio/issues/28996))
 
@@ -33,7 +30,7 @@ These notices describe functionality that will be removed in a future release ac
 - **Improved** virtual machine integration to clean up `iptables` rules when the service is stopped.
   ([Issue #29556](https://github.com/istio/istio/issues/29556))
 
-- **Updated** istio-proxy drain notification strategy to immediate from gradual. 
+- **Updated** istio-proxy drain notification strategy to immediate from gradual.
   ([Issue #31403](https://github.com/istio/istio/issues/31403))
 
 - **Added** CNI metrics counting repair operations.
@@ -45,12 +42,12 @@ These notices describe functionality that will be removed in a future release ac
 - **Added** SDS secrets fetch failure metric `pilot_sds_certificate_errors_total`.
   ([Issue #31779](https://github.com/istio/istio/issues/31779))
 
-- **Added** metrics for istiod informer errors.  
+- **Added** metrics for istiod informer errors.
 
 - **Added** 'istioctl validate' and the validating webhook now report duplicate or unreachable virtual service matches.
   ([Issue #31525](https://github.com/istio/istio/issues/31525))
 
-- **Fixed** a bug where `ISTIO_META_IDLE_TIMEOUT` is not reflected when set to "0s".
+- **Fixed** a bug where `ISTIO_META_IDLE_TIMEOUT` is not reflected when set to `0s`.
   ([Issue #30067](https://github.com/istio/istio/issues/30067))
 
 - **Fixed** avoid unnecessary full push in service entry store.
@@ -63,7 +60,6 @@ These notices describe functionality that will be removed in a future release ac
   ([Issue #23494](https://github.com/istio/istio/issues/23494))
 
 - **Fixed** a bug where `EnvoyFilter` with service match did not work for inbound clusters.
-  
 
 ## Security
 
@@ -71,34 +67,33 @@ These notices describe functionality that will be removed in a future release ac
 clusters with version 1.22 and greater.
   ([Issue #22161](https://github.com/istio/istio/issues/22161))
 
-- **Added** experimental option to configure Envoy to fetch the JWKS by itself. This should be enabled if the `jwks_uri` is a mesh cluster URL for mTLS and has other benefits like retries, JWKS caching etc. 
+- **Added** experimental option to configure Envoy to fetch the JWKS by itself. This should be enabled if the `jwks_uri` is a mesh cluster URL for mTLS and has other benefits like retries, JWKS caching etc.
 This is disabled by default and can be enabled by setting `PILOT_JWT_ENABLE_REMOTE_JWKS` to true.
   ([Issue #28742](https://github.com/istio/istio/issues/28742))
 
 - **Added** an environment variable `PILOT_JWT_PUB_KEY_REFRESH_INTERVAL` to configure the interval of
-istiod fetching the `jwks_uri` for the JWKS public key. Users can set the refresh interval with 
+istiod fetching the `jwks_uri` for the JWKS public key. Users can set the refresh interval with
 `--set values.pilot.env.PILOT_JWT_PUB_KEY_REFRESH_INTERVAL=<duration>` during installation.
-The default interval is 20m. Valid time units are "ns", "us", "ms", "s", "m", "h".
+The default interval is `20m`. Valid time units are "ns", "us", "ms", "s", "m", "h".
 
 - **Added**  istiod JWT public key refresh job will now retry the failed fetch of the `jwks_uri` with exponential backoff.
   ([Issue #30261](https://github.com/istio/istio/issues/30261))
 
 - **Added** an experimental feature to allow dry-run of an `AuthorizationPolicy` without actually enforcing the policy.
- ([Usage](https://istio.io/latest/docs/tasks/security/authorization/authz-dry-run/), [Design](https://docs.google.com/document/d/1xQdZsEgJ3Ld2qebfT3EJkg2COTtCR1TqBVojmnvI78g), [PR](https://github.com/istio/api/pull/1933))
+ ([Usage](/docs/tasks/security/authorization/authz-dry-run/), [Design](https://docs.google.com/document/d/1xQdZsEgJ3Ld2qebfT3EJkg2COTtCR1TqBVojmnvI78g), [PR](https://github.com/istio/api/pull/1933))
 
-- Improved the experimental [External Authorization](https://istio.io/latest/docs/tasks/security/authorization/authz-custom/) feature with new capabilities:
-- **Added** the `timeout` field to configure the timeout (default is 10m) between the ext_authz filter and the external service.
+- Improved the experimental [External Authorization](/docs/tasks/security/authorization/authz-custom/) feature with new capabilities:
+- **Added** the `timeout` field to configure the timeout (default is `10m`) between the `ext_authz` filter and the external service.
 - **Added** the `include_additional_headers_in_check` field to send additional headers to the external service.
 - **Added** the `include_request_body_in_check` field to send the body to the external service.
 - **Supported** prefix and suffix match in the `include_request_headers_in_check`, `headers_to_upstream_on_allow` and `headers_to_downstream_on_deny` field.
 - **Deprecated** the `include_headers_in_check` field with the new `include_request_headers_in_check` field for better naming.
- ([Reference](https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR](https://github.com/istio/api/pull/1926))
+ ([Reference](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ExtensionProvider-EnvoyExternalAuthorizationHttpProvider), [PR](https://github.com/istio/api/pull/1926))
 
 - **Fixed** removed ability to configure `trustDomain` from Helm `global.values`. Now it is configured through `meshConfig.trustDomain` ([Issue #27734](https://github.com/istio/istio/issues/27734))
 
 - **Fixed** an issue causing simple TLS traffic to ports not exposed by a `Service` to be rejected by servers when in `PERMISSIVE` mTLS mode.
   ([Issue #31297](https://github.com/istio/istio/issues/31297))
-  
 
 ## Telemetry
 
@@ -111,12 +106,10 @@ The default interval is 20m. Valid time units are "ns", "us", "ms", "s", "m", "h
 - **Fixed** an issue where Envoy did not start up properly when duplicate stats tags were configured.
   ([Issue #31270](https://github.com/istio/istio/issues/31270))
 
-
 ## Extensibility
 
 - **Added** reliable Wasm module remote load with istio-agent.
   ([Issue #29989](https://github.com/istio/istio/issues/29989))
-
 
 ## Installation
 
@@ -149,14 +142,13 @@ under the hood.
   ([Issue #31186](https://github.com/istio/istio/issues/31186))
 
 - **Removed** the `15012` and `15443` ports from the default gateway installation. These can be explicitly
-[added](https://istio.io/latest/docs/setup/install/istioctl/#configure-gateways) if desired, although it is
-recommended to follow the new [multicluster installation guide](https://istio.io/latest/docs/setup/install/multicluster/) instead.
-  
-  
+[added](/docs/setup/install/istioctl/#configure-gateways) if desired, although it is
+recommended to follow the new [multicluster installation guide](/docs/setup/install/multicluster/) instead.
+
 ## istioctl
 
 - **Updated** the experimental `precheck` command to identify potential upgrade issues prior to actually running an upgrade.
-  
+
 - **Updated** `istioctl kube-inject` to call webhook server to get the injection template by default.
   ([Issue #29270](https://github.com/istio/istio/issues/29270))
 
@@ -164,14 +156,14 @@ recommended to follow the new [multicluster installation guide](https://istio.io
   ([Issue #31338](https://github.com/istio/istio/issues/31338))
 
 - **Added** `istioctl proxy-config -o yaml` to display in YAML along with the current JSON and short format.
- ([Usage]( https://istio.io/latest/docs/reference/commands/istioctl/#istioctl-proxy-config), [Issue #31695](https://github.com/istio/istio/issues/31695))
+ ([Usage](/docs/reference/commands/istioctl/#istioctl-proxy-config), [Issue #31695](https://github.com/istio/istio/issues/31695))
 
 - **Added** the `istioctl proxy-config all` command to view the full proxy configuration.
 
 - **Added** tooling for revision-centric view of current Istio deployments in a cluster. This is to
-provide a better understanding of deployments- such as the number of istiod, gateway pods, `IstioOperator` CRs-
+provide a better understanding of deployments- such as the number of istiod, gateway pods, `IstioOperator` custom resources-
 defining a particular revision, and the number of pods with sidecars pointing to a particular revision. ([Issue #23892](https://github.com/istio/istio/issues/23892))
 
-- **Added** a new analyzer for invalid webhook configurations.  
+- **Added** a new analyzer for invalid webhook configurations.
 
 - **Fixed** fail correctly when `istioctl x create-remote-secret --secret-name` points to a non-existent secret in the remote cluster.  ([Issue #30723](https://github.com/istio/istio/issues/30723))

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -13,11 +13,11 @@ aliases:
 
 These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/docs/releases/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.
 
-- **Deprecated** the values.global.jwtPolicy=first-party-jwt option. This option is less secure and intended for backwards compatibility
+- **Deprecated** the `values.global.jwtPolicy=first-party-jwt` option. This option is less secure and intended for backwards compatibility
 with older Kubernetes clusters without support for more secure token authentication, but is now enabled by default in new Kubernetes versions.
 The option will be removed in future releases. See [this documentation](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) for more information.
 
-- **Deprecated** installation flags `values.global.arch` in favor of the affinity Kubernetes settings.
+- **Deprecated** the `values.global.arch` option in favor of the affinity Kubernetes settings.
   ([Issue #30027](https://github.com/istio/istio/issues/30027))
 
 ## Traffic Management

--- a/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/change-notes/index.md
@@ -1,7 +1,12 @@
 ---
 title: Change Notes
+linktitle: 1.10
 description: Istio 1.10.0 release notes.
+publishdate: 2021-05-18
+release: 1.10
 weight: 10
+aliases:
+    - /news/announcing-1.10
 ---
 
 ## Deprecation Notices
@@ -13,8 +18,8 @@ These notices describe functionality that will be removed in a future release ac
 
 ## Traffic Management
 
-- **Added** the `ISTIO_GATEWAY_STRIP_HOST_PORT` environment variable to control whether gateways strip host port before any processing of request by HTTP filters or routing.
-  ([Issue #25350](https://github.com/istio/istio/issues/25350))
+- **Added** the `ISTIO_GATEWAY_STRIP_HOST_PORT` environment variable to control whether gateways strip host port before any processing of request by HTTP filters or routing. This option is disabled by default.
+  ([Blog](/blog/2021/discovery-selectors/), [Issue #25350](https://github.com/istio/istio/issues/25350))
 
 - **Added** `meshConfig.discoverySelectors` to dynamically restrict the set of namespaces for `Services`, `Pods`, and `Endpoints` that istiod processes when pushing xDS updates to improve performance on the data plane.
   ([Issue #26679](https://github.com/istio/istio/issues/26679))

--- a/content/en/news/releases/1.10.x/announcing-1.10/upgrade-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/upgrade-notes/index.md
@@ -9,7 +9,6 @@ These notes detail the changes which purposefully break backwards compatibility 
 The notes also mention changes which preserve backwards compatibility while introducing new behavior.
 Changes are only included if the new behavior would be unexpected to a user of Istio 1.9.
 
-
 ## Inbound Forwarding Configuration
 
 The behavior of inbound forwarding will be modified in the near future. While this change is not enabled
@@ -31,18 +30,18 @@ To help detect these situations, we have added a check to find pods that will be
 experimental precheck command to get a report of any pods binding to lo on a port exposed in a Service. This command is
 available in Istio 1.10+. Without action, these ports will no longer be accessible upon upgrade.
 
-```sh
+{{< text bash >}}
 $ istioctl experimental precheck
 Error [IST0143] (Pod echo-local-849647c5bd-g9wxf.default) Port 443 is exposed in a Service but listens on localhost. It will not be exposed to other pods.
 Error [IST0143] (Pod echo-local-849647c5bd-g9wxf.default) Port 7070 is exposed in a Service but listens on localhost. It will not be exposed to other pods.
 Error: Issues found when checking the cluster. Istio may not be safe to install or upgrade.
 See https://istio.io/latest/docs/reference/config/analysis for more information about causes and resolutions.
-```
+{{< /text >}}
 
 Regardless of Istio version, the behavior can be explicitly controlled by the `Sidecar`.
 For example, to configure the 9080 port to explicitly be sent to localhost:
 
-```yaml
+{{< text yaml >}}
 apiVersion: networking.istio.io/v1beta1
 kind: Sidecar
 metadata:
@@ -57,8 +56,7 @@ spec:
       protocol: HTTP
       name: http
     defaultEndpoint: 127.0.0.1:9080
-```
-
+{{< /text >}}
 
 ## Sidecar Injector Changes
 
@@ -83,4 +81,3 @@ If this behavior is not desired, it can be temporarily disabled with `--set valu
 This option will be removed in future releases.
 
 See the updated [Automatic sidecar injection](/docs/setup/additional-setup/sidecar-injection/) documentation for more information.
-

--- a/content/en/news/releases/1.10.x/announcing-1.10/upgrade-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/upgrade-notes/index.md
@@ -1,7 +1,8 @@
 ---
-title: Upgrade Notes
+title: Istio 1.10 Upgrade Notes
 description: Important changes to consider when upgrading to Istio 1.10.0.
 publishdate: 2021-05-18
+linktitle: 1.10 Upgrade Notes
 weight: 20
 ---
 

--- a/content/en/news/releases/1.10.x/announcing-1.10/upgrade-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/upgrade-notes/index.md
@@ -1,0 +1,86 @@
+---
+title: Upgrade Notes
+description: Important changes to consider when upgrading to Istio 1.10.0.
+weight: 20
+---
+
+When you upgrade from Istio 1.9 to Istio 1.10, you need to consider the changes on this page.
+These notes detail the changes which purposefully break backwards compatibility with Istio 1.9.
+The notes also mention changes which preserve backwards compatibility while introducing new behavior.
+Changes are only included if the new behavior would be unexpected to a user of Istio 1.9.
+
+
+## Inbound Forwarding Configuration
+
+The behavior of inbound forwarding will be modified in the near future. While this change is not enabled
+by default in Istio 1.10, it can be enabled today by configuring the `PILOT_ENABLE_INBOUND_PASSTHROUGH=true` environment
+variable in Istiod.
+
+Previously, requests would be forwarded to `localhost`. This leads to two important differences compared to running applications
+without Istio:
+
+* Applications that bind to `localhost` will be exposed to external pods.
+* Applications that bind to `<POD_IP>` will not be exposed to external pods.
+
+The latter is a common source of friction when adopting Istio, in particular with stateful services where this is common.
+
+The new behavior instead forwards the request as is. This matches the behavior a user would see without Istio installed.
+However, as a result, applications that have come to rely on `localhost` being exposed externally by Istio may stop working.
+
+To help detect these situations, we have added a check to find pods that will be impacted. You can run the istioctl
+experimental precheck command to get a report of any pods binding to lo on a port exposed in a Service. This command is
+available in Istio 1.10+. Without action, these ports will no longer be accessible upon upgrade.
+
+```sh
+$ istioctl experimental precheck
+Error [IST0143] (Pod echo-local-849647c5bd-g9wxf.default) Port 443 is exposed in a Service but listens on localhost. It will not be exposed to other pods.
+Error [IST0143] (Pod echo-local-849647c5bd-g9wxf.default) Port 7070 is exposed in a Service but listens on localhost. It will not be exposed to other pods.
+Error: Issues found when checking the cluster. Istio may not be safe to install or upgrade.
+See https://istio.io/latest/docs/reference/config/analysis for more information about causes and resolutions.
+```
+
+Regardless of Istio version, the behavior can be explicitly controlled by the `Sidecar`.
+For example, to configure the 9080 port to explicitly be sent to localhost:
+
+```yaml
+apiVersion: networking.istio.io/v1beta1
+kind: Sidecar
+metadata:
+  name: ratings
+spec:
+  workloadSelector:
+    labels:
+      app: ratings
+  ingress:
+  - port:
+      number: 9080
+      protocol: HTTP
+      name: http
+    defaultEndpoint: 127.0.0.1:9080
+```
+
+
+## Sidecar Injector Changes
+
+The logic to determine if a pod requires sidecar injection or not has been updated to make use of
+new Kubernetes features. Previously, the webhook was triggered at a coarse grain level, selecting any
+pods in a namespace with a matching `istio-injection=enabled` label.
+
+This has two limitations:
+
+* Opting out individual pods with the `sidecar.istio.io/inject` label would still trigger the webhook,
+  only to be filtered out by Istio. This can have the unexpected impact of adding a dependency on Istio
+  when one is not expected.
+
+* There is no way to opt-in an individual pod, with `sidecar.istio.io/inject`, without enabling injection
+  for the entire namespace.
+
+These limitations have both been resolved. As a result, additional pods may be injected that were not in previous versions,
+if they exist in a namespace without an `istio-injection` label set but have the `sidecar.istio.io/inject` label set on the pod.
+This is expected to be an uncommon case, so for most users there will be no behavioral changes to existing pods.
+
+If this behavior is not desired, it can be temporarily disabled with `--set values.sidecarInjectorWebhook.useLegacySelectors=true`.
+This option will be removed in future releases.
+
+See the updated [Automatic sidecar injection](/docs/setup/additional-setup/sidecar-injection/) documentation for more information.
+

--- a/content/en/news/releases/1.10.x/announcing-1.10/upgrade-notes/index.md
+++ b/content/en/news/releases/1.10.x/announcing-1.10/upgrade-notes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Upgrade Notes
 description: Important changes to consider when upgrading to Istio 1.10.0.
+publishdate: 2021-05-18
 weight: 20
 ---
 
@@ -11,8 +12,8 @@ Changes are only included if the new behavior would be unexpected to a user of I
 
 ## Inbound Forwarding Configuration
 
-The behavior of inbound forwarding will be modified in the near future. While this change is not enabled
-by default in Istio 1.10, it can be enabled today by configuring the `PILOT_ENABLE_INBOUND_PASSTHROUGH=true` environment
+The behavior of inbound forwarding has been modified for Istio 1.10. This change is enabled
+by default in Istio 1.10 and it can be disabled by configuring the `PILOT_ENABLE_INBOUND_PASSTHROUGH=false` environment
 variable in Istiod.
 
 Previously, requests would be forwarded to `localhost`. This leads to two important differences compared to running applications
@@ -26,8 +27,8 @@ The latter is a common source of friction when adopting Istio, in particular wit
 The new behavior instead forwards the request as is. This matches the behavior a user would see without Istio installed.
 However, as a result, applications that have come to rely on `localhost` being exposed externally by Istio may stop working.
 
-To help detect these situations, we have added a check to find pods that will be impacted. You can run the istioctl
-experimental precheck command to get a report of any pods binding to lo on a port exposed in a Service. This command is
+To help detect these situations, we have added a check to find pods that will be impacted. You can run the `istioctl
+experimental precheck` command to get a report of any pods binding to `localhost` on a port exposed in a Service. This command is
 available in Istio 1.10+. Without action, these ports will no longer be accessible upon upgrade.
 
 {{< text bash >}}
@@ -66,7 +67,7 @@ pods in a namespace with a matching `istio-injection=enabled` label.
 
 This has two limitations:
 
-* Opting out individual pods with the `sidecar.istio.io/inject` label would still trigger the webhook,
+* Opting out individual pods with the `sidecar.istio.io/inject` annotation would still trigger the webhook,
   only to be filtered out by Istio. This can have the unexpected impact of adding a dependency on Istio
   when one is not expected.
 
@@ -74,7 +75,7 @@ This has two limitations:
   for the entire namespace.
 
 These limitations have both been resolved. As a result, additional pods may be injected that were not in previous versions,
-if they exist in a namespace without an `istio-injection` label set but have the `sidecar.istio.io/inject` label set on the pod.
+if they exist in a namespace without an `istio-injection` label set but have the `sidecar.istio.io/inject` annotation set to `true` on the pod.
 This is expected to be an uncommon case, so for most users there will be no behavioral changes to existing pods.
 
 If this behavior is not desired, it can be temporarily disabled with `--set values.sidecarInjectorWebhook.useLegacySelectors=true`.


### PR DESCRIPTION
[Change notes](https://deploy-preview-9661--preliminary-istio.netlify.app/latest/news/releases/1.10.x/announcing-1.10/change-notes/), [upgrade notes](https://deploy-preview-9661--preliminary-istio.netlify.app/latest/news/releases/1.10.x/announcing-1.10/upgrade-notes/), [release announcement](https://deploy-preview-9661--preliminary-istio.netlify.app/latest/news/releases/1.10.x/announcing-1.10/)

Noticed a few things when generating these notes:

1) Lots of release notes using wrong `area:` leading to them getting left out of generation (manually went back and fixed a few of these, lots use `networking` instead of `traffic-management` which isn't on the `minorReleaseNotes.md` template), maybe we need validation on these
2) Release announcement does not show on "release announcements" in `News` (saw this was already noticed on `docs` Slack channel)