### PR TITLE
Use zipkin collector address instead of jaeger to avoid confusion.

### DIFF
--- a/content/en/docs/ops/integrations/jaeger/index.md
+++ b/content/en/docs/ops/integrations/jaeger/index.md
@@ -25,7 +25,7 @@ This will deploy Jaeger into your cluster. This is intended for demonstration on
 
 Consult the [Jaeger documentation](https://www.jaegertracing.io/) to get started. No special changes are needed for Jaeger to work with Istio.
 
-Once Jaeger is installed, you will need to point Istio proxies to send traces to the deployment. This can be configured with `--set values.global.tracer.zipkin.address=<jaeger-collector-address>:9411` at installation time. See the [`ProxyConfig.Tracing`](/docs/reference/config/istio.mesh.v1alpha1/#Tracing) for advanced configuration such as TLS settings.
+Once Jaeger is installed, you will need to point Istio proxies to send traces to the deployment. This can be configured with `--set values.global.tracer.zipkin.address=<jaeger-collector-address>` at installation time. See the [`ProxyConfig.Tracing`](/docs/reference/config/istio.mesh.v1alpha1/#Tracing) for advanced configuration such as TLS settings.
 
 ## Usage
 

--- a/content/en/docs/ops/integrations/jaeger/index.md
+++ b/content/en/docs/ops/integrations/jaeger/index.md
@@ -25,7 +25,7 @@ This will deploy Jaeger into your cluster. This is intended for demonstration on
 
 Consult the [Jaeger documentation](https://www.jaegertracing.io/) to get started. No special changes are needed for Jaeger to work with Istio.
 
-Once Jaeger is installed, you will need to point Istio proxies to send traces to the deployment. This can be configured with `--set values.global.tracer.zipkin.address=<jaeger-collector-address>:9411` at installation time. See the [`ProxyConfig.Tracing`](/docs/reference/config/istio.mesh.v1alpha1/#Tracing) for advanced configuration such as TLS settings.
+Once Jaeger is installed, you will need to point Istio proxies to send traces to the deployment. This can be configured with `--set values.global.tracer.zipkin.address=<zipkin-collector-address>:9411` at installation time. See the [`ProxyConfig.Tracing`](/docs/reference/config/istio.mesh.v1alpha1/#Tracing) for advanced configuration such as TLS settings.
 
 ## Usage
 

--- a/content/en/docs/ops/integrations/jaeger/index.md
+++ b/content/en/docs/ops/integrations/jaeger/index.md
@@ -25,7 +25,7 @@ This will deploy Jaeger into your cluster. This is intended for demonstration on
 
 Consult the [Jaeger documentation](https://www.jaegertracing.io/) to get started. No special changes are needed for Jaeger to work with Istio.
 
-Once Jaeger is installed, you will need to point Istio proxies to send traces to the deployment. This can be configured with `--set values.global.tracer.zipkin.address=<jaeger-collector-address>` at installation time. See the [`ProxyConfig.Tracing`](/docs/reference/config/istio.mesh.v1alpha1/#Tracing) for advanced configuration such as TLS settings.
+Once Jaeger is installed, you will need to point Istio proxies to send traces to the deployment. This can be configured with `--set values.global.tracer.zipkin.address=<jaeger-collector-address>:9411` at installation time. See the [`ProxyConfig.Tracing`](/docs/reference/config/istio.mesh.v1alpha1/#Tracing) for advanced configuration such as TLS settings.
 
 ## Usage
 

--- a/content/en/docs/ops/integrations/zipkin/index.md
+++ b/content/en/docs/ops/integrations/zipkin/index.md
@@ -25,7 +25,7 @@ This will deploy Zipkin into your cluster. This is intended for demonstration on
 
 Consult the [Zipkin documentation](https://zipkin.io/) to get started. No special changes are needed for Zipkin to work with Istio.
 
-Once Zipkin is installed, you will need to point Istio proxies to send traces to the deployment. This can be configured with `--set values.global.tracer.zipkin.address=<zipkin-collector-address>:9411` at installation time. See the [`ProxyConfig.Tracing`](/docs/reference/config/istio.mesh.v1alpha1/#Tracing) for advanced configuration such as TLS settings.
+Once Zipkin is installed, you will need to point Istio proxies to send traces to the deployment. This can be configured with `--set values.global.tracer.zipkin.address=<zipkin-collector-address>` at installation time. See the [`ProxyConfig.Tracing`](/docs/reference/config/istio.mesh.v1alpha1/#Tracing) for advanced configuration such as TLS settings.
 
 ## Usage
 

--- a/content/en/docs/ops/integrations/zipkin/index.md
+++ b/content/en/docs/ops/integrations/zipkin/index.md
@@ -25,7 +25,7 @@ This will deploy Zipkin into your cluster. This is intended for demonstration on
 
 Consult the [Zipkin documentation](https://zipkin.io/) to get started. No special changes are needed for Zipkin to work with Istio.
 
-Once Zipkin is installed, you will need to point Istio proxies to send traces to the deployment. This can be configured with `--set values.global.tracer.zipkin.address=<zipkin-collector-address>` at installation time. See the [`ProxyConfig.Tracing`](/docs/reference/config/istio.mesh.v1alpha1/#Tracing) for advanced configuration such as TLS settings.
+Once Zipkin is installed, you will need to point Istio proxies to send traces to the deployment. This can be configured with `--set values.global.tracer.zipkin.address=<zipkin-collector-address>:9411` at installation time. See the [`ProxyConfig.Tracing`](/docs/reference/config/istio.mesh.v1alpha1/#Tracing) for advanced configuration such as TLS settings.
 
 ## Usage
 


### PR DESCRIPTION
There is no need to mention port number. Operator should know which port they should be using for zipkin and jaeger trace report. It has caused some confusions: https://github.com/istio/istio.io/issues/9668 and https://github.com/istio/istio/issues/32026#issuecomment-831561949