### PR TITLE
DOCS: workaround of kubectl apply: delete istio.io/rev label from main istiod svc

### DIFF
--- a/content/en/docs/setup/upgrade/canary/index.md
+++ b/content/en/docs/setup/upgrade/canary/index.md
@@ -62,7 +62,7 @@ Due to [a bug](https://github.com/istio/istio/issues/28880) in the creation of t
 One way to accomplish this is to manually create a service called `istiod` pointing to the target revision using [this service]({{< github_blob >}}/manifests/charts/istio-control/istio-discovery/templates/service.yaml) as a template. Another option is to run the command below, where `<REVISION>` is the name of the revision that should handle validation. This command creates an `istiod` service pointed to the target revision.
 
 {{< text bash >}}
-$ kubectl get service -n istio-system -o json istiod-<REVISION> | jq '.metadata.name = "istiod" | del(.spec.clusterIP) | del(.spec.clusterIPs)' | kubectl apply -f -
+$ kubectl get service -n istio-system -o json istiod-<REVISION> | jq '.metadata.name = "istiod" | del(.spec.clusterIP) | del(.spec.clusterIPs) | del (.metadata.labels."istio.io/rev")' | kubectl apply -f -
 {{< /text >}}
 
 {{</ warning >}}

--- a/content/en/docs/setup/upgrade/canary/index.md
+++ b/content/en/docs/setup/upgrade/canary/index.md
@@ -62,7 +62,7 @@ Due to [a bug](https://github.com/istio/istio/issues/28880) in the creation of t
 One way to accomplish this is to manually create a service called `istiod` pointing to the target revision using [this service]({{< github_blob >}}/manifests/charts/istio-control/istio-discovery/templates/service.yaml) as a template. Another option is to run the command below, where `<REVISION>` is the name of the revision that should handle validation. This command creates an `istiod` service pointed to the target revision.
 
 {{< text bash >}}
-$ kubectl get service -n istio-system -o json istiod-<REVISION> | jq '.metadata.name = "istiod" | del(.spec.clusterIP) | del(.spec.clusterIPs) | del (.metadata.labels."istio.io/rev")' | kubectl apply -f -
+$ kubectl get service -n istio-system -o json istiod-<REVISION> | jq '.metadata.name = "istiod" | del(.spec.clusterIP, .spec.clusterIPs, .metadata.labels."istio.io/rev")' | kubectl apply -f -
 {{< /text >}}
 
 {{</ warning >}}


### PR DESCRIPTION
delete istio.io/rev label from main istiod svc  in workaround.

This labels causes "istio install" on the same revision (and I guess also uninstall) to remove the service.

Example:
istioctl install --readiness-timeout 10m -y  --revision 1-8-3
...
kubectl get service -n istio-system -o json istiod-1-8-3 | jq '.metadata.name = "istiod" | del(.spec.clusterIP) | del(.spec.clusterIPs)'  | kubectl apply -f -
service/istiod created
 kubectl get svc -n istio-system istiod
istiod   ClusterIP   X <none>        X/TCP,Y/TCP,Z/TCP,A/TCP   TIMEs

istioctl install --readiness-timeout 10m -y  --revision 1-8-3
kubectl get svc -n istio-system istiod

No service anymore :-(

As the main service is not a part of the revision, it shouldn't contain the label.



[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure