### PR TITLE
Update istio test refererence for 1.10

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -296,13 +296,13 @@ In this example, you set a timeout rule on calls to the `httpbin.org` service.
 
     {{< text bash >}}
     $ kubectl exec "$SOURCE_POD" -c sleep -- time curl -o /dev/null -sS -w "%{http_code}\n" http://httpbin.org/delay/5
-    408
+    504
     real    0m3.149s
     user    0m0.004s
     sys     0m0.004s
     {{< /text >}}
 
-    This time a 408 (Request Timeout) appears after 3 seconds.
+    This time a 504 (Gateway Timeout) appears after 3 seconds.
     Although httpbin.org was waiting 5 seconds, Istio cut off the request at 3 seconds.
 
 ### Cleanup the controlled access to external services

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/snips.sh
@@ -175,7 +175,7 @@ kubectl exec "$SOURCE_POD" -c sleep -- time curl -o /dev/null -sS -w "%{http_cod
 }
 
 ! read -r -d '' snip_manage_traffic_to_external_services_3_out <<\ENDSNIP
-408
+504
 real    0m3.149s
 user    0m0.004s
 sys     0m0.004s

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v0.0.0-20
 require (
 	github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f
 	github.com/pmezard/go-difflib v1.0.0
-	istio.io/istio v0.0.0-20210501204141-b660c2e424e6
+	istio.io/istio v0.0.0-20210504183933-46cd72f48a4e
 	istio.io/pkg v0.0.0-20210420153545-2c6acb5fef3c
 	k8s.io/apimachinery v0.20.5
 	k8s.io/client-go v0.20.5

--- a/go.sum
+++ b/go.sum
@@ -1481,8 +1481,8 @@ istio.io/client-go v1.10.0-alpha.1.0.20210420154934-5b0be5983930/go.mod h1:e61Tm
 istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
 istio.io/gogo-genproto v0.0.0-20210420153714-0c2931135d30 h1:c7AZ0LR25VUWnGxYEf5JN+CmeQc3Ahg/d3fJgmmmuiE=
 istio.io/gogo-genproto v0.0.0-20210420153714-0c2931135d30/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
-istio.io/istio v0.0.0-20210501204141-b660c2e424e6 h1:tv//Lx6DOKADNs6U97ihsHEUwdgNKtEP2SyLgT2wX40=
-istio.io/istio v0.0.0-20210501204141-b660c2e424e6/go.mod h1:NPuZ5PRFvyIx+2xHQx8qFE8zZm4xmnO4mxTvCXIyA7Y=
+istio.io/istio v0.0.0-20210504183933-46cd72f48a4e h1:od1cqlRz/wBSAoS7wgSfw5Z8Yj5XaFe7fre4LwknUoE=
+istio.io/istio v0.0.0-20210504183933-46cd72f48a4e/go.mod h1:NPuZ5PRFvyIx+2xHQx8qFE8zZm4xmnO4mxTvCXIyA7Y=
 istio.io/pkg v0.0.0-20210420153545-2c6acb5fef3c h1:rU3ogBd9yZCdhjuRzblyZ99CjxbnPNdpK2z2Rnk8lAw=
 istio.io/pkg v0.0.0-20210420153545-2c6acb5fef3c/go.mod h1:U14DF4p1AViKhOwpVv1UPEWtknGytJyfJw6hqVi0TmM=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/31616

With the upstream Envoy change we can now change the docs back to the prior, pre-regression, return codes.

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure