### PR TITLE
Add doc test for IstioOperator install

### DIFF
--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -303,7 +303,7 @@ If you omit the `revision` flag, then all revisions of Istio operator will be re
 Note that deleting the operator before the `IstioOperator` CR and corresponding Istio revision are fully removed may result in leftover Istio resources.
 To clean up anything not removed by the operator:
 
-{{< text syntax=bash snip_id=none >}}
+{{< text syntax=bash snip_id=cleanup >}}
 $ istioctl manifest generate | kubectl delete -f -
 $ kubectl delete ns istio-system --grace-period=0 --force
  {{< /text >}}

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -6,7 +6,7 @@ keywords: [kubernetes, operator]
 aliases:
     - /docs/setup/install/standalone-operator
 owner: istio/wg-environments-maintainers
-test: no
+test: yes
 ---
 
 Instead of manually installing, upgrading, and uninstalling Istio in a production environment,
@@ -23,7 +23,7 @@ checks are performed.
 
 {{< warning >}}
 Using an operator does have a security implication.
-With the `istioctl install` command, the operation will run in the admin user’s security context,
+With the `istioctl install` command, the operation will run in the admin user’s security context,
 whereas with an operator, an in-cluster pod will run the operation in its security context.
 To avoid a vulnerability, ensure that the operator deployment is sufficiently secured.
 {{< /warning >}}
@@ -38,7 +38,7 @@ To avoid a vulnerability, ensure that the operator deployment is sufficiently se
 
 1. Deploy the Istio operator:
 
-    {{< text bash >}}
+    {{< text syntax=bash snip_id=create_istio_operator >}}
     $ istioctl operator init
     {{< /text >}}
 
@@ -77,7 +77,7 @@ To avoid a vulnerability, ensure that the operator deployment is sufficiently se
 To install the Istio `demo` [configuration profile](/docs/setup/additional-setup/config-profiles/)
 using the operator, run the following command:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=create_demo_profile >}}
 $ kubectl apply -f - <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -117,7 +117,7 @@ seconds.
 
 You can confirm the Istio control plane services have been deployed with the following commands:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=kubectl_get_svc >}}
 $ kubectl get svc -n istio-system
 NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                                                                      AGE
 istio-egressgateway         ClusterIP      10.103.243.113   <none>        80/TCP,443/TCP,15443/TCP                                                     17s
@@ -125,7 +125,7 @@ istio-ingressgateway        LoadBalancer   10.101.204.227   <pending>     15020:
 istiod                      ClusterIP      10.96.237.249    <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,53/UDP,853/TCP                         30s                                                              13s
 {{< /text >}}
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=kubectl_get_pods >}}
 $ kubectl get pods -n istio-system
 NAME                                   READY   STATUS    RESTARTS   AGE
 istio-egressgateway-5444c68db8-9h6dz   1/1     Running   0          87s
@@ -142,7 +142,7 @@ the Istio installation correspondingly.
 For example, you can switch the installation to the `default`
 profile with the following command:
 
-{{< text bash >}}
+{{< text syntax=bash >}}
 $ kubectl apply -f - <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -182,7 +182,7 @@ You can observe the changes that the controller makes in the cluster in response
 checking the operator controller logs:
 
 {{< text bash >}}
-$ kubectl logs -f -n istio-operator $(kubectl get pods -n istio-operator -lname=istio-operator -o jsonpath='{.items[0].metadata.name}')
+$ kubectl logs -f -n istio-operator "$(kubectl get pods -n istio-operator -lname=istio-operator -o jsonpath='{.items[0].metadata.name}')"
 {{< /text >}}
 
 Refer to the [`IstioOperator` API](/docs/reference/config/istio.operator.v1alpha1/#IstioOperatorSpec)
@@ -286,7 +286,7 @@ explained in the [Data plane upgrade](/docs/setup/upgrade/canary/#data-plane) do
 
 If you used the operator to perform a canary upgrade of the control plane, you can uninstall the old control plane and keep the new one by deleting the old in-cluster `IstioOperator` CR, which will uninstall the old revision of Istio:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ kubectl delete istiooperators.install.istio.io -n istio-system example-istiocontrolplane
 {{< /text >}}
 
@@ -294,7 +294,7 @@ Wait until Istio is uninstalled - this may take some time.
 
 Then you can remove the Istio operator for the old revision by running the following command:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ istioctl operator remove --revision <revision>
 {{< /text >}}
 
@@ -303,7 +303,7 @@ If you omit the `revision` flag, then all revisions of Istio operator will be re
 Note that deleting the operator before the `IstioOperator` CR and corresponding Istio revision are fully removed may result in leftover Istio resources.
 To clean up anything not removed by the operator:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ istioctl manifest generate | kubectl delete -f -
 $ kubectl delete ns istio-system --grace-period=0 --force
  {{< /text >}}

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -121,7 +121,7 @@ You can confirm the Istio control plane services have been deployed with the fol
 $ kubectl get services -n istio-system
 NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)   AGE
 istio-egressgateway    ClusterIP      10.96.65.145    <none>           ...       30s
-istio-ingressgateway   LoadBalancer   10.96.189.244   <none>           ...       30s
+istio-ingressgateway   LoadBalancer   10.96.189.244   192.168.11.156   ...       30s
 istiod                 ClusterIP      10.96.189.20    <none>           ...       37s
 {{< /text >}}
 

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -119,10 +119,10 @@ You can confirm the Istio control plane services have been deployed with the fol
 
 {{< text syntax=bash snip_id=kubectl_get_svc >}}
 $ kubectl get svc -n istio-system
-NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                                                                      AGE
-istio-egressgateway         ClusterIP      10.103.243.113   <none>        80/TCP,443/TCP,15443/TCP                                                     17s
-istio-ingressgateway        LoadBalancer   10.101.204.227   <pending>     15020:31077/TCP,80:30689/TCP,443:32419/TCP,31400:31411/TCP,15443:30176/TCP   17s
-istiod                      ClusterIP      10.96.237.249    <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,53/UDP,853/TCP                         30s                                                              13s
+NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP      PORT(S)                                                                      AGE
+istio-egressgateway         ClusterIP      10.103.243.113   <none>           80/TCP,443/TCP,15443/TCP                                                     17s
+istio-ingressgateway        LoadBalancer   10.101.204.227   192.168.11.166   15020:31077/TCP,80:30689/TCP,443:32419/TCP,31400:31411/TCP,15443:30176/TCP   17s
+istiod                      ClusterIP      10.96.237.249    <none>           15010/TCP,15012/TCP,443/TCP,15014/TCP,53/UDP,853/TCP                         30s                                                              13s
 {{< /text >}}
 
 {{< text syntax=bash snip_id=kubectl_get_pods >}}

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -119,18 +119,20 @@ You can confirm the Istio control plane services have been deployed with the fol
 
 {{< text syntax=bash snip_id=kubectl_get_svc >}}
 $ kubectl get svc -n istio-system
-NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP      PORT(S)                                                                      AGE
-istio-egressgateway         ClusterIP      10.103.243.113   <none>           80/TCP,443/TCP,15443/TCP                                                     17s
-istio-ingressgateway        LoadBalancer   10.101.204.227   192.168.11.166   15020:31077/TCP,80:30689/TCP,443:32419/TCP,31400:31411/TCP,15443:30176/TCP   17s
-istiod                      ClusterIP      10.96.237.249    <none>           15010/TCP,15012/TCP,443/TCP,15014/TCP,53/UDP,853/TCP                         30s                                                              13s
+NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                                                                      AGE
+istio-egressgateway    ClusterIP      10.96.65.145    <none>           80/TCP,443/TCP                                                               30s
+istio-ingressgateway   LoadBalancer   10.96.189.244   192.168.11.156   15021:32187/TCP,80:32320/TCP,443:32244/TCP,31400:31458/TCP,15443:31196/TCP   30s
+istiod                 ClusterIP      10.96.189.20    <none>           15010/TCP,15012/TCP,443/TCP,15014/TCP                                        37s
+
 {{< /text >}}
 
 {{< text syntax=bash snip_id=kubectl_get_pods >}}
 $ kubectl get pods -n istio-system
-NAME                                   READY   STATUS    RESTARTS   AGE
-istio-egressgateway-5444c68db8-9h6dz   1/1     Running   0          87s
-istio-ingressgateway-5c68cb968-x7qv9   1/1     Running   0          87s
-istiod-598984548d-wjq9j                1/1     Running   0          99s
+NAME                                    READY   STATUS    RESTARTS   AGE
+istio-egressgateway-696cccb5-m8ndk      1/1     Running   0          68s
+istio-ingressgateway-86cb4b6795-9jlrk   1/1     Running   0          68s
+istiod-b47586647-sf6sw                  1/1     Running   0          74s
+
 {{< /text >}}
 
 ## Update

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -157,7 +157,7 @@ EOF
 You can also enable or disable components and modify resource settings.
 For example, to enable the `istio-egressgateway` component and increase pilot memory requests:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=update_operator >}}
 $ kubectl apply -f - <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -6,7 +6,7 @@ keywords: [kubernetes, operator]
 aliases:
     - /docs/setup/install/standalone-operator
 owner: istio/wg-environments-maintainers
-test: yes
+test: no
 ---
 
 Instead of manually installing, upgrading, and uninstalling Istio in a production environment,

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -118,12 +118,11 @@ seconds.
 You can confirm the Istio control plane services have been deployed with the following commands:
 
 {{< text syntax=bash snip_id=kubectl_get_svc >}}
-$ kubectl get svc -n istio-system
-NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                                                                      AGE
-istio-egressgateway    ClusterIP      10.96.65.145    <none>           80/TCP,443/TCP                                                               30s
-istio-ingressgateway   LoadBalancer   10.96.189.244   192.168.11.156   15021:32187/TCP,80:32320/TCP,443:32244/TCP,31400:31458/TCP,15443:31196/TCP   30s
-istiod                 ClusterIP      10.96.189.20    <none>           15010/TCP,15012/TCP,443/TCP,15014/TCP                                        37s
-
+$ kubectl get services -n istio-system
+NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)   AGE
+istio-egressgateway    ClusterIP      10.96.65.145    <none>           ...       30s
+istio-ingressgateway   LoadBalancer   10.96.189.244   <none>           ...       30s
+istiod                 ClusterIP      10.96.189.20    <none>           ...       37s
 {{< /text >}}
 
 {{< text syntax=bash snip_id=kubectl_get_pods >}}
@@ -132,7 +131,6 @@ NAME                                    READY   STATUS    RESTARTS   AGE
 istio-egressgateway-696cccb5-m8ndk      1/1     Running   0          68s
 istio-ingressgateway-86cb4b6795-9jlrk   1/1     Running   0          68s
 istiod-b47586647-sf6sw                  1/1     Running   0          74s
-
 {{< /text >}}
 
 ## Update
@@ -275,7 +273,7 @@ istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
 {{< /text >}}
 
 {{< text bash >}}
-$ kubectl get svc -n istio-system -l app=istiod
+$ kubectl get services -n istio-system -l app=istiod
 NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
 istiod         ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
 istiod-1-8-1   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -62,10 +62,10 @@ kubectl get svc -n istio-system
 }
 
 ! read -r -d '' snip_kubectl_get_svc_out <<\ENDSNIP
-NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                                                                      AGE
-istio-egressgateway         ClusterIP      10.103.243.113   <none>        80/TCP,443/TCP,15443/TCP                                                     17s
-istio-ingressgateway        LoadBalancer   10.101.204.227   <pending>     15020:31077/TCP,80:30689/TCP,443:32419/TCP,31400:31411/TCP,15443:30176/TCP   17s
-istiod                      ClusterIP      10.96.237.249    <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,53/UDP,853/TCP                         30s                                                              13s
+NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP      PORT(S)                                                                      AGE
+istio-egressgateway         ClusterIP      10.103.243.113   <none>           80/TCP,443/TCP,15443/TCP                                                     17s
+istio-ingressgateway        LoadBalancer   10.101.204.227   192.168.11.166   15020:31077/TCP,80:30689/TCP,443:32419/TCP,31400:31411/TCP,15443:30176/TCP   17s
+istiod                      ClusterIP      10.96.237.249    <none>           15010/TCP,15012/TCP,443/TCP,15014/TCP,53/UDP,853/TCP                         30s                                                              13s
 ENDSNIP
 
 snip_kubectl_get_pods() {

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -91,7 +91,7 @@ spec:
 EOF
 }
 
-snip_update_2() {
+snip_update_operator() {
 kubectl apply -f - <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2153,SC2155,SC2164
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          docs/setup/install/operator/index.md
+####################################################################################################
+
+snip_create_istio_operator() {
+istioctl operator init
+}
+
+snip_prerequisites_2() {
+istioctl operator init --watchedNamespaces=istio-namespace1,istio-namespace2
+}
+
+snip_prerequisites_3() {
+helm install istio-operator manifests/charts/istio-operator \
+  --set operatorNamespace=istio-operator \
+  --set watchedNamespaces="istio-namespace1\,istio-namespace2"
+}
+
+snip_create_demo_profile() {
+kubectl apply -f - <<EOF
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+  name: example-istiocontrolplane
+spec:
+  profile: demo
+EOF
+}
+
+! read -r -d '' snip_install_2 <<\ENDSNIP
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+...
+spec:
+  profile: demo
+  values:
+    global:
+      istioNamespace: istio-namespace1
+ENDSNIP
+
+snip_kubectl_get_svc() {
+kubectl get svc -n istio-system
+}
+
+! read -r -d '' snip_kubectl_get_svc_out <<\ENDSNIP
+NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                                                                      AGE
+istio-egressgateway         ClusterIP      10.103.243.113   <none>        80/TCP,443/TCP,15443/TCP                                                     17s
+istio-ingressgateway        LoadBalancer   10.101.204.227   <pending>     15020:31077/TCP,80:30689/TCP,443:32419/TCP,31400:31411/TCP,15443:30176/TCP   17s
+istiod                      ClusterIP      10.96.237.249    <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,53/UDP,853/TCP                         30s                                                              13s
+ENDSNIP
+
+snip_kubectl_get_pods() {
+kubectl get pods -n istio-system
+}
+
+! read -r -d '' snip_kubectl_get_pods_out <<\ENDSNIP
+NAME                                   READY   STATUS    RESTARTS   AGE
+istio-egressgateway-5444c68db8-9h6dz   1/1     Running   0          87s
+istio-ingressgateway-5c68cb968-x7qv9   1/1     Running   0          87s
+istiod-598984548d-wjq9j                1/1     Running   0          99s
+ENDSNIP
+
+snip_update_1() {
+kubectl apply -f - <<EOF
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+  name: example-istiocontrolplane
+spec:
+  profile: default
+EOF
+}
+
+snip_update_2() {
+kubectl apply -f - <<EOF
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+  name: example-istiocontrolplane
+spec:
+  profile: default
+  components:
+    pilot:
+      k8s:
+        resources:
+          requests:
+            memory: 3072Mi
+    egressGateways:
+    - name: istio-egressgateway
+      enabled: true
+EOF
+}
+
+snip_update_3() {
+kubectl logs -f -n istio-operator "$(kubectl get pods -n istio-operator -lname=istio-operator -o jsonpath='{.items[0].metadata.name}')"
+}
+
+snip_inplace_upgrade_1() {
+<extracted-dir>/bin/istioctl operator init
+}
+
+snip_inplace_upgrade_2() {
+kubectl get pods --namespace istio-operator \
+  -o=jsonpath='{range .items[*]}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{"\n"}{end}'
+}
+
+snip_inplace_upgrade_3() {
+kubectl get pods --namespace istio-system \
+  -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{"\n"}{end}'
+}
+
+snip_canary_upgrade_1() {
+kubectl get iop --all-namespaces
+}
+
+! read -r -d '' snip_canary_upgrade_1_out <<\ENDSNIP
+NAMESPACE      NAME                        REVISION   STATUS    AGE
+istio-system   example-istiocontrolplane              HEALTHY   11m
+ENDSNIP
+
+snip_canary_upgrade_2() {
+istio-1.8.1/bin/istioctl operator init --revision 1-8-1
+}
+
+snip_canary_upgrade_3() {
+helm install istio-operator manifests/charts/istio-operator \
+  --set operatorNamespace=istio-operator \
+  --set watchedNamespaces=istio-system \
+  --set revision=1-9-0
+}
+
+snip_canary_upgrade_4() {
+cat example-istiocontrolplane-1-8-1.yaml
+}
+
+! read -r -d '' snip_canary_upgrade_4_out <<\ENDSNIP
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+  name: example-istiocontrolplane-1-8-1
+spec:
+  revision: 1-8-1
+  profile: demo
+ENDSNIP
+
+snip_canary_upgrade_5() {
+kubectl get pod -n istio-system -l app=istiod
+}
+
+! read -r -d '' snip_canary_upgrade_5_out <<\ENDSNIP
+NAME                            READY   STATUS    RESTARTS   AGE
+istiod-1-8-1-597475f4f6-bgtcz   1/1     Running   0          64s
+istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
+ENDSNIP
+
+snip_canary_upgrade_6() {
+kubectl get svc -n istio-system -l app=istiod
+}
+
+! read -r -d '' snip_canary_upgrade_6_out <<\ENDSNIP
+NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
+istiod         ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
+istiod-1-8-1   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
+ENDSNIP

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -184,3 +184,8 @@ NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)               
 istiod         ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
 istiod-1-8-1   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
 ENDSNIP
+
+snip_cleanup() {
+istioctl manifest generate | kubectl delete -f -
+kubectl delete ns istio-system --grace-period=0 --force
+}

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -62,10 +62,11 @@ kubectl get svc -n istio-system
 }
 
 ! read -r -d '' snip_kubectl_get_svc_out <<\ENDSNIP
-NAME                        TYPE           CLUSTER-IP       EXTERNAL-IP      PORT(S)                                                                      AGE
-istio-egressgateway         ClusterIP      10.103.243.113   <none>           80/TCP,443/TCP,15443/TCP                                                     17s
-istio-ingressgateway        LoadBalancer   10.101.204.227   192.168.11.166   15020:31077/TCP,80:30689/TCP,443:32419/TCP,31400:31411/TCP,15443:30176/TCP   17s
-istiod                      ClusterIP      10.96.237.249    <none>           15010/TCP,15012/TCP,443/TCP,15014/TCP,53/UDP,853/TCP                         30s                                                              13s
+NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                                                                      AGE
+istio-egressgateway    ClusterIP      10.96.65.145    <none>           80/TCP,443/TCP                                                               30s
+istio-ingressgateway   LoadBalancer   10.96.189.244   192.168.11.156   15021:32187/TCP,80:32320/TCP,443:32244/TCP,31400:31458/TCP,15443:31196/TCP   30s
+istiod                 ClusterIP      10.96.189.20    <none>           15010/TCP,15012/TCP,443/TCP,15014/TCP                                        37s
+
 ENDSNIP
 
 snip_kubectl_get_pods() {
@@ -73,10 +74,11 @@ kubectl get pods -n istio-system
 }
 
 ! read -r -d '' snip_kubectl_get_pods_out <<\ENDSNIP
-NAME                                   READY   STATUS    RESTARTS   AGE
-istio-egressgateway-5444c68db8-9h6dz   1/1     Running   0          87s
-istio-ingressgateway-5c68cb968-x7qv9   1/1     Running   0          87s
-istiod-598984548d-wjq9j                1/1     Running   0          99s
+NAME                                    READY   STATUS    RESTARTS   AGE
+istio-egressgateway-696cccb5-m8ndk      1/1     Running   0          68s
+istio-ingressgateway-86cb4b6795-9jlrk   1/1     Running   0          68s
+istiod-b47586647-sf6sw                  1/1     Running   0          74s
+
 ENDSNIP
 
 snip_update_1() {

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -58,15 +58,14 @@ spec:
 ENDSNIP
 
 snip_kubectl_get_svc() {
-kubectl get svc -n istio-system
+kubectl get services -n istio-system
 }
 
 ! read -r -d '' snip_kubectl_get_svc_out <<\ENDSNIP
-NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)                                                                      AGE
-istio-egressgateway    ClusterIP      10.96.65.145    <none>           80/TCP,443/TCP                                                               30s
-istio-ingressgateway   LoadBalancer   10.96.189.244   192.168.11.156   15021:32187/TCP,80:32320/TCP,443:32244/TCP,31400:31458/TCP,15443:31196/TCP   30s
-istiod                 ClusterIP      10.96.189.20    <none>           15010/TCP,15012/TCP,443/TCP,15014/TCP                                        37s
-
+NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)   AGE
+istio-egressgateway    ClusterIP      10.96.65.145    <none>           ...       30s
+istio-ingressgateway   LoadBalancer   10.96.189.244   <none>           ...       30s
+istiod                 ClusterIP      10.96.189.20    <none>           ...       37s
 ENDSNIP
 
 snip_kubectl_get_pods() {
@@ -78,7 +77,6 @@ NAME                                    READY   STATUS    RESTARTS   AGE
 istio-egressgateway-696cccb5-m8ndk      1/1     Running   0          68s
 istio-ingressgateway-86cb4b6795-9jlrk   1/1     Running   0          68s
 istiod-b47586647-sf6sw                  1/1     Running   0          74s
-
 ENDSNIP
 
 snip_update_1() {
@@ -178,7 +176,7 @@ istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
 ENDSNIP
 
 snip_canary_upgrade_6() {
-kubectl get svc -n istio-system -l app=istiod
+kubectl get services -n istio-system -l app=istiod
 }
 
 ! read -r -d '' snip_canary_upgrade_6_out <<\ENDSNIP

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -64,7 +64,7 @@ kubectl get services -n istio-system
 ! read -r -d '' snip_kubectl_get_svc_out <<\ENDSNIP
 NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)   AGE
 istio-egressgateway    ClusterIP      10.96.65.145    <none>           ...       30s
-istio-ingressgateway   LoadBalancer   10.96.189.244   <none>           ...       30s
+istio-ingressgateway   LoadBalancer   10.96.189.244   192.168.11.156   ...       30s
 istiod                 ClusterIP      10.96.189.20    <none>           ...       37s
 ENDSNIP
 

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -52,3 +52,4 @@ _verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
 istioctl operator remove
 istioctl x uninstall --purge -y
 kubectl delete ns istio-system --grace-period=0 --force
+kubectl delete ns istio-operator --grace-period=0 --force

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -31,7 +31,10 @@ snip_create_demo_profile
 
 echo "Waiting for dep..."
 sleep 20s
-kubectl logs -n istio-operator istio-operator
+echo "Operator logs"
+kubectl logs -n istio-operator -l name=istio-operator
+echo "Pod dump"
+kubectl get pods --all-namespaces
 _wait_for_deployment istio-system istiod
 
 echo "Verifying services..."

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+
+set -o pipefail
+
+# @setup profile=none
+
+snip_create_istio_operator
+snip_create_demo_profile
+
+_wait_for_deployment istio-system istiod
+
+# shellcheck disable=SC2154
+_verify_like snip_kubectl_get_svc "$snip_kubectl_get_svc_out"
+# shellcheck disable=SC2154
+_verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
+
+# @cleanup
+istioctl operator remove
+kubectl delete ns istio-operator
+kubectl delete ns istio-system

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -42,7 +42,7 @@ _wait_for_deployment istio-system istiod
 
 echo "Verifying services..."
 # shellcheck disable=SC2154
-_verify_contains snip_kubectl_get_svc "$snip_kubectl_get_svc_out"
+_verify_like snip_kubectl_get_svc "$snip_kubectl_get_svc_out"
 
 echo "Verifying pods..."
 # shellcheck disable=SC2154
@@ -50,5 +50,4 @@ _verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
 
 # @cleanup
 istioctl operator remove
-snip_cleanup
 istiotl x uninstall --purge -y

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -30,16 +30,17 @@ echo "Creating demo profile..."
 snip_create_demo_profile
 
 echo "Waiting for dep..."
+sleep 20s
+kubectl logs -n istio-operator istio-operator
 _wait_for_deployment istio-system istiod
 
 echo "Verifying services..."
 # shellcheck disable=SC2154
-_verify_like snip_kubectl_get_svc "$snip_kubectl_get_svc_out"
+#_verify_like snip_kubectl_get_svc "$snip_kubectl_get_svc_out"
 echo "Verifying services..."
 # shellcheck disable=SC2154
-_verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
+#_verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
 
 # @cleanup
 istioctl operator remove
 kubectl delete ns istio-operator
-kubectl delete ns istio-system

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -50,4 +50,5 @@ _verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
 
 # @cleanup
 istioctl operator remove
-istiotl x uninstall --purge -y
+istioctl x uninstall --purge -y
+kubectl delete ns istio-system --grace-period=0 --force

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -51,4 +51,4 @@ _verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
 # @cleanup
 istioctl operator remove
 kubectl delete ns istio-operator
-kubectl delete ns istio-system
+istiotl x uninstall --purge -y

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -20,13 +20,22 @@ set -o pipefail
 
 # @setup profile=none
 
+echo "Creating operator..."
 snip_create_istio_operator
+
+echo "Waiting for operator..."
+_wait_for_deployment istio-operator istio-operator
+
+echo "Creating demo profile..."
 snip_create_demo_profile
 
+echo "Waiting for dep..."
 _wait_for_deployment istio-system istiod
 
+echo "Verifying services..."
 # shellcheck disable=SC2154
 _verify_like snip_kubectl_get_svc "$snip_kubectl_get_svc_out"
+echo "Verifying services..."
 # shellcheck disable=SC2154
 _verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
 

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -30,20 +30,25 @@ echo "Creating demo profile..."
 snip_create_demo_profile
 
 echo "Waiting for dep..."
-sleep 20s
+sleep 30s
+
 echo "Operator logs"
 kubectl logs -n istio-operator -l name=istio-operator
+
 echo "Pod dump"
 kubectl get pods --all-namespaces
+
 _wait_for_deployment istio-system istiod
 
 echo "Verifying services..."
 # shellcheck disable=SC2154
-#_verify_like snip_kubectl_get_svc "$snip_kubectl_get_svc_out"
-echo "Verifying services..."
+_verify_contains snip_kubectl_get_svc "$snip_kubectl_get_svc_out"
+
+echo "Verifying pods..."
 # shellcheck disable=SC2154
-#_verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
+_verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
 
 # @cleanup
 istioctl operator remove
 kubectl delete ns istio-operator
+kubectl delete ns istio-system

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -50,5 +50,5 @@ _verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
 
 # @cleanup
 istioctl operator remove
-kubectl delete ns istio-operator
+snip_cleanup
 istiotl x uninstall --purge -y

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -20,33 +20,22 @@ set -o pipefail
 
 # @setup profile=none
 
-echo "Creating operator..."
 snip_create_istio_operator
-
-echo "Waiting for operator..."
 _wait_for_deployment istio-operator istio-operator
 
-echo "Creating demo profile..."
 snip_create_demo_profile
-
-echo "Waiting for dep..."
 sleep 30s
-
-echo "Operator logs"
-kubectl logs -n istio-operator -l name=istio-operator
-
-echo "Pod dump"
-kubectl get pods --all-namespaces
-
 _wait_for_deployment istio-system istiod
 
-echo "Verifying services..."
 # shellcheck disable=SC2154
 _verify_like snip_kubectl_get_svc "$snip_kubectl_get_svc_out"
 
-echo "Verifying pods..."
 # shellcheck disable=SC2154
 _verify_like snip_kubectl_get_pods "$snip_kubectl_get_pods_out"
+
+snip_update_operator
+sleep 30s
+_verify_contains snip_kubectl_get_svc "egressgateway"
 
 # @cleanup
 istioctl operator remove

--- a/pkg/test/istioio/script.go
+++ b/pkg/test/istioio/script.go
@@ -17,6 +17,7 @@ package istioio
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -116,8 +117,8 @@ func (s Script) run(ctx framework.TestContext) {
 		_ = writer.Flush()
 		_ = outputFile.Close()
 	}()
-	cmd.Stdout = writer
-	cmd.Stderr = writer
+	cmd.Stdout = io.MultiWriter(writer, os.Stdout)
+	cmd.Stderr = io.MultiWriter(writer, os.Stderr)
 
 	// Run the command.
 	if err := cmd.Run(); err != nil {

--- a/pkg/test/istioio/script.go
+++ b/pkg/test/istioio/script.go
@@ -17,7 +17,6 @@ package istioio
 import (
 	"bufio"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -117,8 +116,8 @@ func (s Script) run(ctx framework.TestContext) {
 		_ = writer.Flush()
 		_ = outputFile.Close()
 	}()
-	cmd.Stdout = io.MultiWriter(writer, os.Stdout)
-	cmd.Stderr = io.MultiWriter(writer, os.Stderr)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
 
 	// Run the command.
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
Test the install and update sections of the `istioctl operator` install docs. Doesn't test the upgrade portions since that requires older istioctls

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
