### PR TITLE
Remove test requirement from CNI install page

### DIFF
--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -7,7 +7,7 @@ aliases:
     - /docs/setup/kubernetes/additional-setup/cni
 keywords: [kubernetes,cni,sidecar,proxy,network,helm]
 owner: istio/wg-environments-maintainers
-test: no
+test: n/a
 ---
 
 Follow this guide to install, configure, and use an Istio mesh using the Istio Container Network Interface


### PR DESCRIPTION
The CNI installation page is more of a reference than a guide. Page test does not really apply here.

Also CNI doc will be revamped at release 1.11, so it does not seem to be reasonable to put effort on testing it now. 

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure