### PR TITLE
[release-1.9] Clean up documentation

### DIFF
--- a/content/en/blog/2021/patch-tuesdays/index.md
+++ b/content/en/blog/2021/patch-tuesdays/index.md
@@ -1,6 +1,6 @@
 ---
-title: How security releases (patch tuesday, embargoes, 0-days) are handled by the Product Security working group
-description: Announcing patch Tuesdays, how 0-days and embargoes are handled, updates to the security best practices page and the notification of the early disclosure list.
+title: How security releases (patch Tuesdays, embargoes, 0-days) are handled by the Product Security working group
+description: Announcing patch Tuesdays, how 0-days and embargoes are handled, updates to the security best practices page and the membership to the early disclosure list.
 publishdate: 2021-05-11
 attribution: "Jacob Delgado (Aspen Mesh)"
 keywords: [cve,product security]
@@ -25,9 +25,13 @@ by having routine security release days so that upgrade operations can be planne
 
 ## Patch Tuesdays
 
-The Product Security working group is intending to ship a security release the 2nd Tuesday of each month. These security
-releases may contain fixes for multiple CVEs. It is the intent of the Product Security working group to have these
-security releases do not contain any other fixes, although that may not always be possible.
+The Product Security working group is intending to ship a security release the 2nd Tuesday of each month when security
+issues have been identified and are being worked on. For such an event, the Product Security Working Group will announce on
+[Discuss](https://discuss.istio.io/c/announcements/5) 2 weeks prior to the 2nd Tuesday of the pending security release.
+If no such announcement is made there will not be a security release for that month, barring some exceptions (see below).
+
+These security releases may contain fixes for multiple CVEs. It is the intent of the Product Security working group to
+have these security releases do not contain any other fixes, although that may not always be possible.
 
 ### First Patch Tuesday
 

--- a/content/en/news/releases/1.8.x/announcing-1.8.6/index.md
+++ b/content/en/news/releases/1.8.x/announcing-1.8.6/index.md
@@ -19,7 +19,7 @@ This is the final release of 1.8. Please upgrade your Istio installation to a su
 
 ## Security update
 
-The following 2 CVEs are highly related.
+The first 2 CVEs are highly related.
 
 - __[CVE-2021-31920](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31920)__:
 Istio contains a remotely exploitable vulnerability where an HTTP request path with multiple slashes or escaped slash characters (`%2F` or `%5C`) could potentially bypass an Istio authorization policy when path based authorization rules are used. See the [ISTIO-SECURITY-2021-005 bulletin](/news/security/istio-security-2021-005) for more details.
@@ -33,16 +33,16 @@ Istio contains a remotely exploitable vulnerability where an HTTP request path w
 
 ## Changes
 
-**Added** [security best practice for authorization policies](/docs/ops/best-practices/security/#authorization-policies)
+- **Added** [security best practice for authorization policies](/docs/ops/best-practices/security/#authorization-policies)
 
-**Fixed** istiod so it will no longer generate listeners for privileged gateway ports (<1024) if the gateway Pod does not have sufficient permissions. [Issue 27566](https://github.com/istio/istio/issues/27566)
+- **Fixed** istiod so it will no longer generate listeners for privileged gateway ports (<1024) if the gateway Pod does not have sufficient permissions. [Issue 27566](https://github.com/istio/istio/issues/27566)
 
-**Fixed** an issue where transport socket parameters are now taken into account when configured in `EnvoyFilter`. [Issue 28996](https://github.com/istio/istio/issues/28996)
+- **Fixed** an issue where transport socket parameters are now taken into account when configured in `EnvoyFilter`. [Issue 28996](https://github.com/istio/istio/issues/28996)
 
-**Fixed** `PeerAuthentication` to not turn off mTLS while using multi-network, non-mTLS endpoints from the cross-network load-balancing endpoints to prevent 500 errors. [Issue 28798](https://github.com/istio/istio/issues/28798)
+- **Fixed** `PeerAuthentication` to not turn off mTLS while using multi-network, non-mTLS endpoints from the cross-network load-balancing endpoints to prevent 500 errors. [Issue 28798](https://github.com/istio/istio/issues/28798)
 
-**Fixed** a bug causing runaway logs in istiod after disabling the default ingress controller. [Issue 31336](https://github.com/istio/istio/issues/31336)
+- **Fixed** a bug causing runaway logs in istiod after disabling the default ingress controller. [Issue 31336](https://github.com/istio/istio/issues/31336)
 
-**Fixed** the Kubernetes API server so it is now considered to be cluster-local by default . This means that any pod attempting to reach `kubernetes.default.svc` will always be directed to the in-cluster server. [Issue 31340](https://github.com/istio/istio/issues/31340)
+- **Fixed** the Kubernetes API server so it is now considered to be cluster-local by default . This means that any pod attempting to reach `kubernetes.default.svc` will always be directed to the in-cluster server. [Issue 31340](https://github.com/istio/istio/issues/31340)
 
-**Fixed** Istio operator to prune resources that do not belong to the specific Istio operator CR. [Issue 30833](https://github.com/istio/istio/issues/30833)
+- **Fixed** Istio operator to prune resources that do not belong to the specific Istio operator CR. [Issue 30833](https://github.com/istio/istio/issues/30833)

--- a/content/en/news/releases/1.9.x/announcing-1.9.5/index.md
+++ b/content/en/news/releases/1.9.x/announcing-1.9.5/index.md
@@ -15,7 +15,7 @@ This release fixes the security vulnerabilities described in our May 11th posts,
 
 ## Security update
 
-The following 2 CVEs are highly related.
+The first 2 CVEs are highly related.
 
 - __[CVE-2021-31920](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31920)__:
 Istio contains a remotely exploitable vulnerability where an HTTP request path with multiple slashes or escaped slash characters (`%2F` or `%5C`) could potentially bypass an Istio authorization policy when path based authorization rules are used. See the [ISTIO-SECURITY-2021-005 bulletin](/news/security/istio-security-2021-005) for more details.


### PR DESCRIPTION
Address nits from https://github.com/istio/istio.io/pull/9714. Clarify when a security release will be patched. Not every month will have a CVE fix on the 2nd Tuesday.


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure