### PR TITLE
make release-1.10.0-dry-run fails finding remote branch

### DIFF
--- a/scripts/create_version.sh
+++ b/scripts/create_version.sh
@@ -138,7 +138,10 @@ create_branch_for_new_release() {
         s/^doc_branch_name: .*$/doc_branch_name: ${NEW_RELEASE_BRANCH}/;
     " data/args.yml
 
-    UPDATE_BRANCH=${NEW_RELEASE_BRANCH} make update-common
+    # Can only do an update-common against a non dry-run branch
+    if [ "${DRY_RUN}" != '1' ]; then
+        UPDATE_BRANCH=${NEW_RELEASE_BRANCH} make update-common
+    fi
 
     if [[ $(git status --porcelain) ]]; then
         git add -A


### PR DESCRIPTION

Failure:
```
warning: Could not find remote branch release-1.10-dry-run to clone.
fatal: Remote branch release-1.10-dry-run not found in upstream origin
common/Makefile.common.mk:103: recipe for target 'update-common' failed
make[2]: *** [update-common] Error 128
make[2]: Leaving directory '/work'
Makefile.core.mk:156: recipe for target 'release-1.10.0-dry-run' failed
```

Could change this it having DRY_RUN being unassigned, but not sure what developers might expect.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure