### PR TITLE
fix example content `mirrorPercent` to `mirrorPercentage`

### DIFF
--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -231,7 +231,8 @@ log entries for `v1` and none for `v2`:
         mirror:
           host: httpbin
           subset: v2
-        mirrorPercent: 100
+        mirrorPercentage:
+          value: 100.0
     EOF
     {{< /text >}}
 
@@ -244,7 +245,7 @@ log entries for `v1` and none for `v2`:
     Also, it is important to note that these requests are mirrored as "fire and
     forget", which means that the responses are discarded.
 
-    You can use the `mirrorPercent` field to mirror a fraction of the traffic,
+    You can use the `value` field under the `mirrorPercentage` field to mirror a fraction of the traffic,
     instead of mirroring all requests. If this field is absent, all traffic will be mirrored.
 
 1. Send in traffic:

--- a/content/en/docs/tasks/traffic-management/mirroring/snips.sh
+++ b/content/en/docs/tasks/traffic-management/mirroring/snips.sh
@@ -208,7 +208,8 @@ spec:
     mirror:
       host: httpbin
       subset: v2
-    mirrorPercent: 100
+    mirrorPercentage:
+      value: 100.0
 EOF
 }
 


### PR DESCRIPTION
Fix example content `mirrorPercent` to `mirrorPercentage`.

Related issue [istio#32884](https://github.com/istio/istio/issues/32884)


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure