### PR TITLE
Remove page icons

### DIFF
--- a/content/en/about/faq/_index.md
+++ b/content/en/about/faq/_index.md
@@ -9,7 +9,6 @@ aliases:
   - /docs/reference/faq.html
   - /help/faq/
   - /faq.html
-icon: faq
 skip_toc: false
 skip_byline: true
 skip_pagenav: true

--- a/content/en/about/faq/applications/index.md
+++ b/content/en/about/faq/applications/index.md
@@ -4,5 +4,4 @@ linktitle: Applications
 description: Application Specific Q & A.
 weight: 30
 layout: faq
-icon: faq
 ---

--- a/content/en/about/faq/distributed-tracing/index.md
+++ b/content/en/about/faq/distributed-tracing/index.md
@@ -4,7 +4,6 @@ linktitle: Distributed Tracing
 description: Distributed Tracing Q & A.
 weight: 46
 layout: faq
-icon: faq
 aliases:
   - /help/faq/distributed-tracing
 ---

--- a/content/en/about/faq/general/index.md
+++ b/content/en/about/faq/general/index.md
@@ -4,7 +4,6 @@ linktitle: General
 description: General Q & A.
 weight: 10
 layout: faq
-icon: faq
 aliases:
   - /help/faq/general
 ---

--- a/content/en/about/faq/metrics-and-logs/index.md
+++ b/content/en/about/faq/metrics-and-logs/index.md
@@ -4,7 +4,6 @@ linktitle: Metrics and Logs
 description: Metrics and Logs Q & A.
 weight: 45
 layout: faq
-icon: faq
 aliases:
  - /help/faq/telemetry
  - /help/faq/metrics-and-logs

--- a/content/en/about/faq/security/index.md
+++ b/content/en/about/faq/security/index.md
@@ -4,7 +4,6 @@ linktitle: Security
 description: Security Q & A.
 weight: 30
 layout: faq
-icon: faq
 aliases:
   - /help/faq/security
 ---

--- a/content/en/about/faq/setup/index.md
+++ b/content/en/about/faq/setup/index.md
@@ -4,7 +4,6 @@ linktitle: Setup
 description: Setup Q & A.
 weight: 20
 layout: faq
-icon: faq
 aliases:
   - /help/faq/setup
 ---

--- a/content/en/about/faq/traffic-management/index.md
+++ b/content/en/about/faq/traffic-management/index.md
@@ -4,7 +4,6 @@ linktitle: Traffic Management
 description: Traffic Management Q & A.
 weight: 50
 layout: faq
-icon: faq
 aliases:
   - /help/faq/traffic-management
 ---

--- a/content/en/about/media-resources/index.md
+++ b/content/en/about/media-resources/index.md
@@ -2,7 +2,6 @@
 title: Media Resources
 description: Official Istio resources for digital and printed materials.
 weight: 90
-icon: istio-blue-logo
 ---
 
 Here are a few assets in case you want to show off your support for Istio, integration to Istio, or want to link back to

--- a/content/en/blog/2017/_index.md
+++ b/content/en/blog/2017/_index.md
@@ -2,7 +2,6 @@
 title: 2017 Posts
 description: Blog posts for 2017.
 weight: 20
-icon: blog
 decoration: dot
 list_by_publishdate: true
 ---

--- a/content/en/blog/2018/_index.md
+++ b/content/en/blog/2018/_index.md
@@ -2,7 +2,6 @@
 title: 2018 Posts
 description: Blog posts for 2018.
 weight: 10
-icon: blog
 decoration: dot
 list_by_publishdate: true
 ---

--- a/content/en/blog/2019/_index.md
+++ b/content/en/blog/2019/_index.md
@@ -2,7 +2,6 @@
 title: 2019 Posts
 description: Blog posts for 2019.
 weight: 9
-icon: blog
 decoration: dot
 list_by_publishdate: true
 ---

--- a/content/en/blog/2020/_index.md
+++ b/content/en/blog/2020/_index.md
@@ -2,7 +2,6 @@
 title: 2020 Posts
 description: Blog posts for 2020.
 weight: 8
-icon: blog
 decoration: dot
 list_by_publishdate: true
 ---

--- a/content/en/blog/2021/_index.md
+++ b/content/en/blog/2021/_index.md
@@ -2,7 +2,6 @@
 title: 2021 Posts
 description: Blog posts for 2021.
 weight: 7
-icon: blog
 decoration: dot
 list_by_publishdate: true
 ---

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -3,7 +3,6 @@ title: Blog
 description: Read articles from contributors and users on all things Istio.
 linktitle: Blog
 sidebar_multicard: true
-icon: blog
 decoration: pill
 aliases:
     - /blog/posts/index.html

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -5,7 +5,6 @@ description: Learn how to deploy, use, and operate Istio.
 weight: 1
 skip_toc: true
 skip_sidebar: true
-icon: docs
 test: n/a
 doc_type: docs
 ---

--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -2,6 +2,5 @@
 title: Concepts
 description: Learn about the different parts of the Istio system and the abstractions it uses.
 weight: 10
-icon: concepts
 test: n/a
 ---

--- a/content/en/docs/examples/_index.md
+++ b/content/en/docs/examples/_index.md
@@ -5,6 +5,5 @@ weight: 30
 aliases:
     - /docs/samples/index.html
     - /docs/guides/index.html
-icon: examples
 test: n/a
 ---

--- a/content/en/docs/examples/microservices-istio/_index.md
+++ b/content/en/docs/examples/microservices-istio/_index.md
@@ -2,7 +2,6 @@
 title: Learn Microservices using Kubernetes and Istio
 description: This modular tutorial provides new users with hands-on experience using Istio for common microservices scenarios, one step at a time.   
 weight: 100
-icon: classroom
 simple_list: true
 content_above: true
 test: n/a

--- a/content/en/docs/ops/_index.md
+++ b/content/en/docs/ops/_index.md
@@ -8,6 +8,5 @@ aliases:
     - /help/troubleshooting/index.html
     - /help/ops
     - /help
-icon: guide
 test: n/a
 ---

--- a/content/en/docs/reference/_index.md
+++ b/content/en/docs/reference/_index.md
@@ -2,6 +2,5 @@
 title: Reference
 description: Detailed authoritative reference material such as command-line options, configuration options, and API calling parameters.
 weight: 60
-icon: reference
 test: n/a
 ---

--- a/content/en/docs/reference/glossary/index.md
+++ b/content/en/docs/reference/glossary/index.md
@@ -7,7 +7,6 @@ aliases:
   - /glossary
   - /docs/welcome/glossary.html
   - /help/glossary
-icon: glossary
 owner: istio/wg-docs-maintainers
 test: n/a
 ---

--- a/content/en/docs/releases/_index.md
+++ b/content/en/docs/releases/_index.md
@@ -2,7 +2,6 @@
 title: Releases
 description: Information relating to Istio releases.
 weight: 40
-icon: releases
 aliases:
 keywords: [releases]
 test: n/a

--- a/content/en/docs/releases/bugs/index.md
+++ b/content/en/docs/releases/bugs/index.md
@@ -8,7 +8,6 @@ aliases:
     - /help/bugs/
     - /about/bugs
     - /latest/about/bugs
-icon: bugs
 owner: istio/wg-docs-maintainers
 test: n/a
 ---

--- a/content/en/docs/releases/contribute/_index.md
+++ b/content/en/docs/releases/contribute/_index.md
@@ -13,7 +13,6 @@ aliases:
     - /latest/about/contribute
 keywords: [contribute, github, docs, shortcodes, code-blocks, website]
 list_below: true
-icon: contribute
 owner: istio/wg-docs-maintainers
 test: n/a
 ---

--- a/content/en/docs/releases/feature-stages/index.md
+++ b/content/en/docs/releases/feature-stages/index.md
@@ -9,7 +9,6 @@ aliases:
     - /docs/home/roadmap.html
     - /about/feature-stages
     - /latest/about/feature-stages
-icon: feature-status
 owner: istio/wg-docs-maintainers
 test: n/a
 ---

--- a/content/en/docs/releases/log/index.md
+++ b/content/en/docs/releases/log/index.md
@@ -5,7 +5,6 @@ weight: 110
 aliases:
     - /about/log
     - /latest/about/log
-icon: log
 skip_seealso: true
 skip_byline: true
 owner: istio/wg-docs-maintainers

--- a/content/en/docs/releases/security-vulnerabilities/index.md
+++ b/content/en/docs/releases/security-vulnerabilities/index.md
@@ -5,7 +5,6 @@ weight: 35
 aliases:
     - /about/security-vulnerabilities
     - /latest/about/security-vulnerabilities
-icon: vulnerabilities
 owner: istio/wg-docs-maintainers
 test: n/a
 ---

--- a/content/en/docs/releases/supported-releases/index.md
+++ b/content/en/docs/releases/supported-releases/index.md
@@ -5,7 +5,6 @@ weight: 35
 aliases:
     - /about/supported-releases
     - /latest/about/supported-releases
-icon: cadence
 owner: istio/wg-docs-maintainers
 test: n/a
 ---

--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -2,7 +2,6 @@
 title: Setup
 description: Instructions for installing the Istio control plane on Kubernetes.
 weight: 15
-icon: setup
 aliases:
     - /docs/tasks/installing-istio.html
     - /docs/setup/install-kubernetes.html

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -5,7 +5,6 @@ description: Install and configure Istio for in-depth evaluation.
 weight: 30
 keywords: [kubernetes,helm]
 owner: istio/wg-environments-maintainers
-icon: helm
 test: yes
 ---
 

--- a/content/en/docs/setup/install/multicluster/before-you-begin/index.md
+++ b/content/en/docs/setup/install/multicluster/before-you-begin/index.md
@@ -2,7 +2,6 @@
 title: Before you begin
 description: Initial steps before installing Istio on multiple clusters.
 weight: 1
-icon: setup
 keywords: [kubernetes,multicluster]
 test: n/a
 owner: istio/wg-environments-maintainers

--- a/content/en/docs/setup/install/multicluster/multi-primary/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary/index.md
@@ -2,7 +2,6 @@
 title: Install Multi-Primary
 description: Install an Istio mesh across multiple primary clusters.
 weight: 10
-icon: setup
 keywords: [kubernetes,multicluster]
 test: yes
 owner: istio/wg-environments-maintainers

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -2,7 +2,6 @@
 title: Install Multi-Primary on different networks
 description: Install an Istio mesh across multiple primary clusters on different networks.
 weight: 30
-icon: setup
 keywords: [kubernetes,multicluster]
 test: yes
 owner: istio/wg-environments-maintainers

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -2,7 +2,6 @@
 title: Install Primary-Remote
 description: Install an Istio mesh across primary and remote clusters.
 weight: 20
-icon: setup
 keywords: [kubernetes,multicluster]
 test: yes
 owner: istio/wg-environments-maintainers

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -2,7 +2,6 @@
 title: Install Primary-Remote on different networks
 description: Install an Istio mesh across primary and remote clusters on different networks.
 weight: 40
-icon: setup
 keywords: [kubernetes,multicluster]
 test: yes
 owner: istio/wg-environments-maintainers

--- a/content/en/docs/setup/install/multicluster/verify/index.md
+++ b/content/en/docs/setup/install/multicluster/verify/index.md
@@ -2,7 +2,6 @@
 title: Verify the installation
 description: Verify that Istio has been installed properly on multiple clusters.
 weight: 50
-icon: setup
 keywords: [kubernetes,multicluster]
 test: yes
 owner: istio/wg-environments-maintainers

--- a/content/en/docs/setup/upgrade/helm/index.md
+++ b/content/en/docs/setup/upgrade/helm/index.md
@@ -5,7 +5,6 @@ description: Upgrade and configure Istio for in-depth evaluation.
 weight: 27
 keywords: [kubernetes,helm]
 owner: istio/wg-environments-maintainers
-icon: helm
 test: no
 ---
 

--- a/content/en/docs/tasks/_index.md
+++ b/content/en/docs/tasks/_index.md
@@ -2,6 +2,5 @@
 title: Tasks
 description: How to do single specific targeted activities with the Istio system.
 weight: 20
-icon: tasks
 test: n/a
 ---

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/before-you-begin/index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/before-you-begin/index.md
@@ -2,7 +2,6 @@
 title: Before you begin
 description: Initial steps before configuring locality load balancing.
 weight: 1
-icon: tasks
 keywords: [locality,load balancing,priority,prioritized,kubernetes,multicluster]
 test: yes
 owner: istio/wg-networking-maintainers

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/cleanup/index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/cleanup/index.md
@@ -2,7 +2,6 @@
 title: Cleanup
 description: Cleanup steps for locality load balancing.
 weight: 30
-icon: tasks
 keywords: [locality,load balancing]
 test: yes
 owner: istio/wg-networking-maintainers

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/distribute/index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/distribute/index.md
@@ -2,7 +2,6 @@
 title: Locality weighted distribution
 description: This guide demonstrates how to configure locality distribution.
 weight: 20
-icon: tasks
 keywords: [locality,load balancing,kubernetes,multicluster]
 test: yes
 owner: istio/wg-networking-maintainers

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/index.md
@@ -2,7 +2,6 @@
 title: Locality failover
 description: This task demonstrates how to configure your mesh for locality failover.
 weight: 10
-icon: tasks
 keywords: [locality,load balancing,priority,prioritized,kubernetes,multicluster]
 test: yes
 owner: istio/wg-networking-maintainers

--- a/content/en/news/_index.md
+++ b/content/en/news/_index.md
@@ -3,7 +3,6 @@ title: News
 description: Select security bulletins, release announcements, or support announcements to stay up to date.
 linktitle: News
 sidebar_multicard: true
-icon: bullhorn
 decoration: pill
 layout: news-feed
 outputs:

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -76,7 +76,7 @@
                     <div class="entry" title="{{ $info }}">
                         <h5>
                             <a href="{{ .Permalink }}">
-                                {{- if .Params.icon -}}<i class="page-icon">{{- partial "icon.html" .Params.icon -}}</i>{{- end -}}{{- .Title -}}
+                                {{- .Title -}}
 
                                 {{- if $decoration -}}
                                     <i class="{{ $decoration }}" data-prefix="{{ .RelPermalink }}"></i>


### PR DESCRIPTION
The new design doesn't include icons in news, blog or FAQ; this PR removes a small number of them that remain in the docs, and the layout.

[X] Docs