### PR TITLE
Use cert-manager.io/v1 instead of v1alpha2 in docs.

### DIFF
--- a/content/en/docs/ops/integrations/certmanager/index.md
+++ b/content/en/docs/ops/integrations/certmanager/index.md
@@ -23,7 +23,7 @@ Consult the [cert-manager installation documentation](https://cert-manager.io/do
 cert-manager can be used to write a secret to Kubernetes, which can then be referenced by a Gateway. To get started, configure a `Certificate` resource, following the [cert-manager documentation](https://cert-manager.io/docs/usage/certificate/). The `Certificate` should be created in the same namespace as the `istio-ingressgateway` deployment. For example, a `Certificate` may look like:
 
 {{< text yaml >}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ingress-cert

--- a/content/zh/docs/ops/integrations/certmanager/index.md
+++ b/content/zh/docs/ops/integrations/certmanager/index.md
@@ -23,7 +23,7 @@ test: no
 cert-manager 可用于向 Kubernetes 写入 Secret 秘钥，Gateway 可以引用该秘钥。首先，请按照 [cert-manager 文档](https://cert-manager.io/docs/usage/certificate/)中的说明配置 `Certificate` 资源。`Certificate` 应该创建在与 `istio-ingressgateway` Deployment 相同的命名空间。例如， 一个 `Certificate` 可能看起来像下边这样：
 
 {{< text yaml >}}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: ingress-cert


### PR DESCRIPTION
We are deprecating all pre-v1 API versions in cert-manager, as v1 has been out for roughly a year (https://github.com/jetstack/cert-manager/issues/3944). This updates the current docs to change v1alpha2 to v1.
 

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure