### PR TITLE
Experimental tidy-ups

### DIFF
--- a/content/en/docs/ops/configuration/extensibility/wasm-module-distribution/index.md
+++ b/content/en/docs/ops/configuration/extensibility/wasm-module-distribution/index.md
@@ -1,6 +1,6 @@
 ---
-title: Distributing WebAssembly Modules [Experimental]
-description: Describes how to make remote WebAssembly modules available in the mesh (experimental).
+title: Distributing WebAssembly Modules (Experimental)
+description: Describes how to make remote WebAssembly modules available in the mesh.
 weight: 10
 aliases:
   - /help/ops/extensibility/distribute-remote-wasm-module

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -1,6 +1,6 @@
 ---
-title: Configuring Gateway Network Topology [Alpha]
-description: How to configure gateway network topology (alpha).
+title: Configuring Gateway Network Topology (Alpha)
+description: How to configure gateway network topology.
 weight: 60
 keywords: [traffic-management,ingress,gateway]
 owner: istio/wg-networking-maintainers

--- a/content/en/docs/reference/config/proxy_extensions/wasm_telemetry/index.md
+++ b/content/en/docs/reference/config/proxy_extensions/wasm_telemetry/index.md
@@ -1,6 +1,6 @@
 ---
-title: Wasm-based Telemetry [Experimental]
-description: How to enable telemetry generation with the Wasm runtime (experimental).
+title: Wasm-based Telemetry (Experimental)
+description: How to enable telemetry generation with the Wasm runtime.
 weight: 60
 owner: istio/wg-policies-and-telemetry-maintainers
 test: no

--- a/content/en/docs/setup/additional-setup/sidecar-injection/index.md
+++ b/content/en/docs/setup/additional-setup/sidecar-injection/index.md
@@ -221,7 +221,7 @@ In general, any field in a pod can be set. However, care must be taken for certa
 
 Additionally, certain fields are configurable by [annotations](/docs/reference/config/annotations/) on the pod, although it is recommended to use the above approach to customizing settings.
 
-### Custom templates [experimental]
+### Custom templates (experimental)
 
 {{< warning >}}
 This feature is experimental and subject to change, or removal, at any time.

--- a/content/en/docs/setup/upgrade/gateways/index.md
+++ b/content/en/docs/setup/upgrade/gateways/index.md
@@ -1,6 +1,6 @@
 ---
-title: Managing Gateways with Multiple Revisions [Experimental]
-description: Configuring and upgrading Istio with gateways (experimental).
+title: Managing Gateways with Multiple Revisions (Experimental)
+description: Configuring and upgrading Istio with gateways.
 weight: 30
 keywords: [kubernetes,upgrading,gateway]
 owner: istio/wg-environments-maintainers

--- a/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
@@ -1,5 +1,5 @@
 ---
-title: Classifying Metrics Based on Request or Response (Experimental)
+title: Classifying Metrics Based on Request or Response
 description: This task shows you how to improve telemetry by grouping requests and responses by their type.
 weight: 27
 keywords: [telemetry,metrics,classify,request-based,openapispec,swagger]

--- a/content/en/docs/tasks/security/authorization/authz-dry-run/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-dry-run/index.md
@@ -1,5 +1,5 @@
 ---
-title: Dry Run [Experimental]
+title: Dry Run (Experimental)
 description: Shows how to dry-run an authorization policy without enforcing it.
 weight: 65
 keywords: [security,access-control,rbac,authorization,dry-run]

--- a/content/en/docs/tasks/security/cert-management/custom-ca-k8s/index.md
+++ b/content/en/docs/tasks/security/cert-management/custom-ca-k8s/index.md
@@ -1,6 +1,6 @@
 ---
-title: Custom CA Integration using Kubernetes CSR [Experimental]
-description: Shows how to use a Custom Certificate Authority (that integrates with the Kubernetes CSR API) to provision Istio workload certificates (experimental).
+title: Custom CA Integration using Kubernetes CSR (Experimental)
+description: Shows how to use a Custom Certificate Authority (that integrates with the Kubernetes CSR API) to provision Istio workload certificates.
 weight: 100
 keywords: [security,certificate]
 aliases:


### PR DESCRIPTION
- change `[Experimental]` to `(Experimental)` in headings
- remove from page descriptions, as it's already in the headings
- remove `[Experimental]` from /docs/tasks/observability/metrics/classify-metrics as it was [promoted to Beta in 1.9](https://istio.io/latest/news/releases/1.9.x/announcing-1.9/#request-classification-beta) 

[X] Docs
