### PR TITLE
move docs menu to the 2nd item

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -165,31 +165,31 @@ disableAliases = true
       weight = 6
 
   [[menu.main]]
+    identifier = "docs"
+    name = "Documentation"
+    title = "Documentation"
+    url = "/docs/"
+    weight = 2
+
+  [[menu.main]]
     identifier = "blog"
     name = "Blog"
     title = "Istio Blog"
     url = "/blog/"
-    weight = 2
+    weight = 3
 
   [[menu.main]]
     identifier = "news"
     name = "News"
     title = "News"
     url = "/news/"
-    weight = 3
+    weight = 4
 
   [[menu.main]]
     identifier = "get-involved"
     name = "Get involved"
     title = "Get involved"
     url = "/get-involved/"
-    weight = 4
-
-  [[menu.main]]
-    identifier = "docs"
-    name = "Documentation"
-    title = "Documentation"
-    url = "/docs/"
     weight = 5
 
   # i18n for Chinese


### PR DESCRIPTION
I think documentation is the most widely used menu item on the list and it should be moved as early as possible to quickly access it. Not sure if there is a standard way to keep it at the end of the menu, but I saw most of the websites keep it at the start of the menu list.
 
Old menu items:

![old-menu](https://user-images.githubusercontent.com/2920003/118641357-aea84300-b7f7-11eb-8a81-c71beb9235fa.png)


New menu items

![new-menu](https://user-images.githubusercontent.com/2920003/118641375-b4058d80-b7f7-11eb-921f-4c819055f46d.png)
