### PR TITLE
Restore external authorization tests

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-custom/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-custom/test.sh
@@ -51,18 +51,19 @@ snip_define_the_external_authorizer_4
 _wait_for_deployment istio-system istiod
 
 # create the authorization policy and verify the ext-authz response.
+echo "Before enable"
 snip_enable_with_external_authorization_1
+echo "After enable"
 
-# Comment out the next lines as the tests seems to be failing. Release blocker issue created for this test: https://github.com/istio/istio/issues/32926
-#_verify_same snip_enable_with_external_authorization_2 "$snip_enable_with_external_authorization_2_out"
-#_verify_lines snip_enable_with_external_authorization_3 "
-#+ \"X-Ext-Authz-Check-Result\": \"allowed\",
-#"
+_verify_same snip_enable_with_external_authorization_2 "$snip_enable_with_external_authorization_2_out"
+_verify_lines snip_enable_with_external_authorization_3 "
++ \"X-Ext-Authz-Check-Result\": \"allowed\",
+"
 _verify_same snip_enable_with_external_authorization_4 "$snip_enable_with_external_authorization_4_out"
-#_verify_lines snip_enable_with_external_authorization_5 "
-#+ [gRPCv3][allowed]
-#+ [gRPCv3][denied]
-#"
+_verify_lines snip_enable_with_external_authorization_5 "
++ [gRPCv3][allowed]
++ [gRPCv3][denied]
+"
 
 # @cleanup
 snip_clean_up_1

--- a/content/en/docs/tasks/security/authorization/authz-custom/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-custom/test.sh
@@ -51,9 +51,7 @@ snip_define_the_external_authorizer_4
 _wait_for_deployment istio-system istiod
 
 # create the authorization policy and verify the ext-authz response.
-echo "Before enable"
 snip_enable_with_external_authorization_1
-echo "After enable"
 
 _verify_same snip_enable_with_external_authorization_2 "$snip_enable_with_external_authorization_2_out"
 _verify_lines snip_enable_with_external_authorization_3 "

--- a/go.mod
+++ b/go.mod
@@ -27,8 +27,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	istio.io/client-go v1.10.0-rc.1.0.20210512214749-e6f28edf3fce // indirect
 	istio.io/gogo-genproto v0.0.0-20210511212328-954676fb66ee // indirect
-	istio.io/istio v0.0.0-20210518140137-7a4c1a8db702
-	istio.io/pkg v0.0.0-20210511212328-a723cf65d468
+	istio.io/istio v0.0.0-20210519112312-cdaf3848a0e7
+	istio.io/pkg v0.0.0-20210519012641-d57c32f9ee9c
 	k8s.io/apimachinery v0.21.0
 	k8s.io/client-go v0.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1528,11 +1528,10 @@ istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f/go.mod h1:6BwTZRNbWS57
 istio.io/gogo-genproto v0.0.0-20210405163638-fcb891f20a5a/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
 istio.io/gogo-genproto v0.0.0-20210511212328-954676fb66ee h1:fFWfuxPvp6lYlbtggUs1PkQQCfsfK2AbhWUXpE88fHM=
 istio.io/gogo-genproto v0.0.0-20210511212328-954676fb66ee/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
-istio.io/istio v0.0.0-20210518140137-7a4c1a8db702 h1:k8cNz23D8eZOUuG8UIKVlsWalH6jjNd6c1nzuBjHJ0I=
-istio.io/istio v0.0.0-20210518140137-7a4c1a8db702/go.mod h1:MoIgw2eqlTi+czrHoR43Domhh2BXiX8AqYEHvsSUCxQ=
-istio.io/pkg v0.0.0-20210405163638-bd457cbec517/go.mod h1:U14DF4p1AViKhOwpVv1UPEWtknGytJyfJw6hqVi0TmM=
-istio.io/pkg v0.0.0-20210511212328-a723cf65d468 h1:oJR9UZTHhsxOzx6DxJS4MZBwZ22SmzOw+DFODg6ovWs=
-istio.io/pkg v0.0.0-20210511212328-a723cf65d468/go.mod h1:U14DF4p1AViKhOwpVv1UPEWtknGytJyfJw6hqVi0TmM=
+istio.io/istio v0.0.0-20210519112312-cdaf3848a0e7 h1:EHlIPyrPjsI24xU9T2eVfiKH/WswJIO/FjusGqdVy24=
+istio.io/istio v0.0.0-20210519112312-cdaf3848a0e7/go.mod h1:FlgDi8xe8wR+F93Tddwjin8kwFgvLHmOQw+UJEAbLWE=
+istio.io/pkg v0.0.0-20210519012641-d57c32f9ee9c h1:s3a8zBhbgugTISLVLLUXbvruTFMRgHS/JuapYY3MPoA=
+istio.io/pkg v0.0.0-20210519012641-d57c32f9ee9c/go.mod h1:U14DF4p1AViKhOwpVv1UPEWtknGytJyfJw6hqVi0TmM=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=
 k8s.io/api v0.18.3/go.mod h1:UOaMwERbqJMfeeeHc8XJKawj4P9TgDRnViIqqBeH2QA=
 k8s.io/api v0.18.4/go.mod h1:lOIQAKYgai1+vz9J7YcDZwC26Z0zQewYOGWdyIPUUQ4=


### PR DESCRIPTION
Fixes https://github.com/istio/istio/issues/32926

The tests are failing to create the AuthorizationPolicy with a 
```
Error from server (InternalError): error when creating "STDIN": Internal error occurred: failed calling webhook "validation.istio.io": Post "https://istiod.istio-system.svc:443/validate?timeout=10s": dial tcp 10.96.149.86:443: i/o timeout
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure