### PR TITLE
Update the Community Drive URL in ZH

### DIFF
--- a/content/en/blog/2018/egress-monitoring-access-control/index.md
+++ b/content/en/blog/2018/egress-monitoring-access-control/index.md
@@ -593,7 +593,7 @@ demonstrated a simple policy that allowed certain URL paths only. We also showed
 ## Cleanup
 
 1.  Perform the instructions in [Cleanup](/docs/tasks/traffic-management/egress/egress-gateway//#cleanup) section of the
-[Configure an Egress Gateway](/docs/tasks/traffic-management/egress/egress-gateway//) example.
+[Configure an Egress Gateway](/docs/tasks/traffic-management/egress/egress-gateway/) example.
 
 1.  Delete the logging and policy checks configuration:
 

--- a/content/en/blog/2019/evolving-istios-apis/index.md
+++ b/content/en/blog/2019/evolving-istios-apis/index.md
@@ -60,4 +60,4 @@ Oh, and if for some reason you judge a toolbox by the list of CRDs it installs, 
 
 All service meshes and, by extension, Istio seeks to automate complex infrastructure operations, like networking and security. That means there will always be complexity in its APIs, but Istio will always aim to solve the needs of operators, while continuing to evolve the API to provide robust building blocks and prioritize flexibility through role-centric abstractions.
 
-We can't wait for you to join our [community](/get-involved//) to see what you build with Istio next!
+We can't wait for you to join our [community](/get-involved/) to see what you build with Istio next!

--- a/content/en/blog/2020/large-scale-security-policy-performance-tests/index.md
+++ b/content/en/blog/2020/large-scale-security-policy-performance-tests/index.md
@@ -155,4 +155,4 @@ The overall trends of both graphs are similar. This is consistent to the paths v
 
 If you are interested in creating your own large scale security policies and running performance tests with them, see the [performance benchmarking tool README](https://github.com/istio/tools/tree/master/perf/benchmark/security/generate_policies).
 
-If you are interested in reading more about the security policies tests, see [our design doc](https://docs.google.com/document/d/1ZP9eQ_2EJEG12xnfsoo7125FDN38r62iqY1PUn9Dz-0/edit?usp=sharing). If you don't already have access, you can [join the Istio team drive](/get-involved//).
+If you are interested in reading more about the security policies tests, see [our design doc](https://docs.google.com/document/d/1ZP9eQ_2EJEG12xnfsoo7125FDN38r62iqY1PUn9Dz-0/edit?usp=sharing). If you don't already have access, you can [join the Istio team drive](/get-involved/).

--- a/content/en/docs/examples/microservices-istio/logs-istio/index.md
+++ b/content/en/docs/examples/microservices-istio/logs-istio/index.md
@@ -81,4 +81,4 @@ Before you customize Istio for production use, see these resources:
 ## Join the Istio community
 
 We welcome you to ask questions and give us feedback by joining the
-[Istio community](/get-involved//).
+[Istio community](/get-involved/).

--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -412,7 +412,7 @@ Before you customize Istio for production use, see these resources:
 ## Join the Istio community
 
 We welcome you to ask questions and give us feedback by joining the
-[Istio community](/get-involved//).
+[Istio community](/get-involved/).
 
 ## Uninstall
 

--- a/content/en/get-involved/_index.md
+++ b/content/en/get-involved/_index.md
@@ -40,7 +40,7 @@ doc_type: get-involved
 {{% involve_block title="Become a contributor" subtitle="Code, documentation, community: Istio welcomes your contribution! Use these links as your entry point." icon="contribution" %}}
 1. Familiarize yourself with the Istio [code of conduct](https://github.com/istio/community/blob/master/CONTRIBUTING.md#code-of-conduct) and [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md).
 2. The [Istio Community README](https://github.com/istio/community/blob/master/README.md) is the **starting point for contributors** who want to work on code, docs or other parts of Istio.
-3. You can access our [**trove of technical content and working documents**](https://drive.google.com/corp/drive/u/0/folders/0AIS5p3eW9BCtUk9PVA) joining the [istio-team-drive-access@ Google Group](https://groups.google.com/forum/#!forum/istio-team-drive-access).
+3. You can access our [**trove of technical content and working documents**](https://drive.google.com/corp/drive/folders/0ADmbrU7ueGOUUk9PVA) by joining the [istio-team-drive-access@ Google Group](https://groups.google.com/forum/#!forum/istio-team-drive-access).
 4. You can participate in the [**working groups**](https://github.com/istio/community/blob/master/WORKING-GROUPS.md) which focus on particular areas of interest, such as docs, security, and networking.
 5. Interested in helping with **Chinese language documentation**? Join the [ServiceMesher community](https://www.servicemesher.com/).
 {{% /involve_block %}}

--- a/content/zh/about/community/join/index.md
+++ b/content/zh/about/community/join/index.md
@@ -37,7 +37,7 @@ Istio 是一个开源项目，拥有一个活跃的社区支持它的使用和�
 如果您想深入了解 Istio 的具体细节，请查看我们不断丰富的设计文档集。如需要访问这些文档，只需加入
 [istio-team-drive-access@](https://groups.google.com/forum/#!forum/istio-team-drive-access) 讨论组。
 加入之后，您就可以直接前往
-[文件夹（这里有很多技术文档）](https://drive.google.com/corp/drive/u/0/folders/0AIS5p3eW9BCtUk9PVA) 查看。
+[文件夹（这里有很多技术文档）](https://drive.google.com/corp/drive/folders/0ADmbrU7ueGOUUk9PVA) 查看。
 {{< /community_item >}}
 
 {{< community_item logo="./group.svg" alt="Working Groups" >}}

--- a/content/zh/get-involved/_index.md
+++ b/content/zh/get-involved/_index.md
@@ -31,7 +31,7 @@ doc_type: get-involved
 {{% involve_block title="成为贡献者" subtitle="代码、文档、社区：Istio 欢迎您的贡献！ 请点击这些链接开始吧。" icon="contribution" %}}
 1. 熟悉 Istio 的 [代码规范](https://github.com/istio/community/blob/master/CONTRIBUTING.md#code-of-conduct) 与 [贡献指南](https://github.com/istio/community/blob/master/CONTRIBUTING.md)。
 2. 无论谁想要通过代码，文档还是其他部分进行贡献 [Istio 社区自述](https://github.com/istio/community/blob/master/README.md) 都是 **贡献者的起点** 。
-3. 您可以加入 [istio-team-drive-access@ Google Group](https://groups.google.com/forum/#！forum/istio-team-drive-access) 来 [**访问我们的技术内容和工作文档**](https://drive.google.com/corp/drive/u/0/folders/0AIS5p3eW9BCtUk9PVA)。
+3. 您可以加入 [istio-team-drive-access@ Google Group](https://groups.google.com/forum/#！forum/istio-team-drive-access) 来 [**访问我们的技术内容和工作文档**](https://drive.google.com/corp/drive/folders/0ADmbrU7ueGOUUk9PVA)。
 4. 您可以加入 [**工作组**](https://github.com/istio/community/blob/master/WORKING-GROUPS.md) 这些工作组专注于您感兴趣的特定领域，如文档，安全和网络。
 5. 有兴趣帮忙翻译 **中文文档** 吗？欢迎加入 [ServiceMesher 社区](https://i.cloudnative.to/istio/event/istio-doc-translation)。
 {{% /involve_block %}}


### PR DESCRIPTION
The Istio Community Drive has moved; this PR changes the path to it in the /zh/ pages.
[X] Docs

(See also #9813)