### PR TITLE
Fix image used by sleep sample (doesn't use istio/istio sleep)

### DIFF
--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -126,8 +126,8 @@ you will apply a rule to mirror a portion of traffic to `v2`.
         spec:
           containers:
           - name: sleep
-            image: tutum/curl
-            command: ["/bin/sleep","infinity"]
+            image: curlimages/curl
+            command: ["/bin/sleep","3650d"]
             imagePullPolicy: IfNotPresent
     EOF
     {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/mirroring/snips.sh
+++ b/content/en/docs/tasks/traffic-management/mirroring/snips.sh
@@ -112,8 +112,8 @@ spec:
     spec:
       containers:
       - name: sleep
-        image: tutum/curl
-        command: ["/bin/sleep","infinity"]
+        image: curlimages/curl
+        command: ["/bin/sleep","3650d"]
         imagePullPolicy: IfNotPresent
 EOF
 }


### PR DESCRIPTION
This fixes the mirror test as the image specified on the page is no longer available. Switched to using the image used by the sleep sample.

Later we may switch to using the samples from istio/istio.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure