### PR TITLE
Fix a warning message

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -73,7 +73,6 @@ export ISTIO_VERSION=${TAG}
 echo "TAG=${TAG}"
 echo "VERSION=${VERSION}"
 echo "ISTIO_VERSION=${ISTIO_VERSION}"
-make gen-charts
 if [ -z "$IN_BUILD_CONTAINER" ]
 then
   make "$ISTIOCTL_ARTIFACT"


### PR DESCRIPTION

Remove the target from the script:
```
VERSION=1.11-alpha.cdaf3848a0e73eea6a0669a3423c16db1555eebb
ISTIO_VERSION=1.11-alpha.cdaf3848a0e73eea6a0669a3423c16db1555eebb
This target is no longer required and will be removed in the future
mkdir -p /work/out/darwin_amd64/logs
mkdir -p /work/out/darwin_amd64/release
```


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure