### PR TITLE
Replace deprecated filters values with latest and correct values

### DIFF
--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -92,9 +92,9 @@ backend, is used below.
             listener:
               filterChain:
                 filter:
-                  name: "envoy.http_connection_manager"
+                  name: "envoy.filters.network.http_connection_manager"
                   subFilter:
-                    name: "envoy.router"
+                    name: "envoy.filters.http.router"
           patch:
             operation: INSERT_BEFORE
             # Adds the Envoy Rate Limit Filter in HTTP filter chain.
@@ -199,7 +199,7 @@ spec:
       listener:
         filterChain:
           filter:
-            name: "envoy.http_connection_manager"
+            name: "envoy.filters.network.http_connection_manager"
       patch:
         operation: INSERT_BEFORE
         value:
@@ -254,7 +254,7 @@ spec:
       listener:
         filterChain:
           filter:
-            name: "envoy.http_connection_manager"
+            name: "envoy.filters.network.http_connection_manager"
       patch:
         operation: INSERT_BEFORE
         value:


### PR DESCRIPTION

On deploying the existing provided configuration, the system throws a warning message stating the filters "envoy.http_connection_manager" and "envoy.router" is deprecated. I have updated the filters with the right values to avoid showing these warning messages.


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure