### PR TITLE
Add wait to allow sleep pod to start

### DIFF
--- a/content/en/docs/ops/configuration/telemetry/envoy-stats/test.sh
+++ b/content/en/docs/ops/configuration/telemetry/envoy-stats/test.sh
@@ -67,6 +67,7 @@ echo "${snip_proxyIstioConfig}" > proxyConfig.yaml
 unset IFS
 yq m -d2 samples/sleep/sleep.yaml proxyConfig.yaml > sleep_istioconfig.yaml
 kubectl apply -f sleep_istioconfig.yaml
+_wait_for_deployment default sleep
 POD="$(kubectl get pod -l app=sleep -o jsonpath='{.items[0].metadata.name}')"
 export POD
 _verify_contains snip_get_stats "circuit_breakers"


### PR DESCRIPTION
Noting the following test failed and it looks like the test tried to get the pod before it was started. https://prow.istio.io/view/gs/istio-prow/pr-logs/pull/istio_istio.io/9863/doc.test.profile_none_istio.io_release-1.10/1399719257855496192
shows an error where it seems sleep wasn't allowed to start:
```
deployment.apps/sleep created
error: error executing jsonpath "{.items[0].metadata.name}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
	template was:
		{.items[0].metadata.name}
	object given to jsonpath engine was:
		map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":"", "selfLink":""}}
```

[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure