### PR TITLE
[release-1.10] Update reference docs 1.10.1

### DIFF
--- a/content/en/docs/reference/config/annotations/index.html
+++ b/content/en/docs/reference/config/annotations/index.html
@@ -45,6 +45,19 @@ Istio supports to control its behavior.
 				
 					<tr>
 				
+					<td><code>inject.istio.io/templates</code></td>
+				
+					<td>Alpha</td>
+				
+					<td>[Pod]</td>
+					<td>The name of the inject template(s) to use, as a comma separate list. See https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#custom-templates-experimental for more information.</td>
+				</tr>
+			
+		
+			
+				
+					<tr>
+				
 					<td><code>install.operator.istio.io/chart-owner</code></td>
 				
 					<td>Alpha</td>
@@ -132,6 +145,8 @@ Istio supports to control its behavior.
 					<td>[Pod]</td>
 					<td>Overrides for the proxy configuration for this specific proxy. Available options can be found at https://istio.io/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig.</td>
 				</tr>
+			
+		
 			
 		
 			


### PR DESCRIPTION

Ran as there was a 1.10.1 build entering long running tests. Will hold until that ships, or possibly there will be a delay for some other issues.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure