### PR TITLE
missing a space after "kubectl get pods -l"

### DIFF
--- a/content/en/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/en/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -108,7 +108,7 @@ governed by Istio.
 Pass in `curl` to indicate that you just want to make one call:
 
     {{< text bash >}}
-    $ export FORTIO_POD=$(kubectl get pods -lapp=fortio -o 'jsonpath={.items[0].metadata.name}')
+    $ export FORTIO_POD=$(kubectl get pods -l app=fortio -o 'jsonpath={.items[0].metadata.name}')
     $ kubectl exec "$FORTIO_POD" -c fortio -- /usr/bin/fortio curl -quiet http://httpbin:8000/get
     HTTP/1.1 200 OK
     server: envoy

--- a/content/en/docs/tasks/traffic-management/circuit-breaking/snips.sh
+++ b/content/en/docs/tasks/traffic-management/circuit-breaking/snips.sh
@@ -77,7 +77,7 @@ kubectl apply -f <(istioctl kube-inject -f samples/httpbin/sample-client/fortio-
 }
 
 snip_adding_a_client_3() {
-export FORTIO_POD=$(kubectl get pods -lapp=fortio -o 'jsonpath={.items[0].metadata.name}')
+export FORTIO_POD=$(kubectl get pods -l app=fortio -o 'jsonpath={.items[0].metadata.name}')
 kubectl exec "$FORTIO_POD" -c fortio -- /usr/bin/fortio curl -quiet http://httpbin:8000/get
 }
 


### PR DESCRIPTION
missing a space after the command

[ ] Configuration Infrastructure
[X]Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
