### PR TITLE
fix for nginx deployment yaml

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination-sds/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination-sds/index.md
@@ -182,11 +182,19 @@ to hold the configuration of the NGINX server:
           containers:
           - name: my-nginx
             image: nginx
+            lifecycle:
+              postStart:
+                exec:
+                  command:
+                    - /bin/sh
+                    - -c
+                    - |
+                      cp /etc/nginxconf/nginx.conf /etc/nginx/nginx.conf; nginx -s reload;                   
             ports:
             - containerPort: 443
             volumeMounts:
             - name: nginx-config
-              mountPath: /etc/nginx
+              mountPath: /etc/nginxconf
               readOnly: true
             - name: nginx-server-certs
               mountPath: /etc/nginx-server-certs


### PR DESCRIPTION
Egress Gateways with TLS Origination

As the path /etc/nginx already exists in the container the volume mount to the same location fails and the pod goes to crashloop. To get rid of this issue, mount the nginx.config to a separate location and copy the it to the nginx folder during the pod start followed by a nginx reload.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
