### PR TITLE
add direct pod IP troubleshooting guide for multicluster

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/multicluster/index.md
+++ b/content/en/docs/ops/diagnostic-tools/multicluster/index.md
@@ -40,7 +40,7 @@ upstream connect error or disconnect/reset before headers. reset reason: local r
 
 While Istio provides service discovery capabilities to make it easier, cross-cluster traffic should still succeed
 if pods in each cluster are on a single network without Istio. To rule out issues with TLS/mTLS, we can do a manual
-traffic test on non-sidecared pods.
+traffic test using pods without an Istio sidecar.
 
 In each cluster, create a new namespace for this test. Do _not_ enable sidecar injection:
 

--- a/content/en/docs/ops/diagnostic-tools/multicluster/index.md
+++ b/content/en/docs/ops/diagnostic-tools/multicluster/index.md
@@ -39,8 +39,8 @@ upstream connect error or disconnect/reset before headers. reset reason: local r
 {{< /text >}}
 
 While Istio provides service discovery capabilities to make it easier, cross-cluster traffic should still succeed
-if pods in each cluster are on a single network without Istio. To rule out issues with TLS/mTLS, we can do a manual
-traffic test using pods without an Istio sidecar.
+if pods in each cluster are on a single network without Istio. To rule out issues with TLS/mTLS, you can do a manual
+traffic test using pods without Istio sidecars.
 
 In each cluster, create a new namespace for this test. Do _not_ enable sidecar injection:
 

--- a/content/en/docs/ops/diagnostic-tools/multicluster/index.md
+++ b/content/en/docs/ops/diagnostic-tools/multicluster/index.md
@@ -34,7 +34,7 @@ In some environments it may not be apparent that a firewall is blocking traffic 
 that `ICMP` (ping) traffic may succeed, but HTTP and other types of traffic do not. This can appear as a timeout, or 
 in some cases a more confusing error such as:
 
-{{< text >}}
+{{< text plain >}}
 upstream connect error or disconnect/reset before headers. reset reason: local reset, transport failure reason: TLS error: 268435612:SSL routines:OPENSSL_internal:HTTP_REQUEST
 {{< /text >}}
 
@@ -52,21 +52,18 @@ $ kubectl create --context="${CTX_CLUSTER2}" namespace uninjected-sample
 Then deploy the same apps used in [verify multicluster installation](/docs/setup/install/multicluster/verify/):
 
 {{< text bash >}}
-# hello world service
 $ kubectl apply --context="${CTX_CLUSTER1}" \
     -f samples/helloworld/helloworld.yaml \
     -l service=helloworld -n uninjected-sample
 $ kubectl apply --context="${CTX_CLUSTER2}" \
     -f samples/helloworld/helloworld.yaml \
     -l service=helloworld -n uninjected-sample
-# hello world deployment
 $ kubectl apply --context="${CTX_CLUSTER1}" \
     -f samples/helloworld/helloworld.yaml \
     -l version=v1 -n uninjected-sample
 $ kubectl apply --context="${CTX_CLUSTER2}" \
     -f samples/helloworld/helloworld.yaml \
     -l version=v2 -n uninjected-sample
-# sleep deployment
 $ kubectl apply --context="${CTX_CLUSTER1}" \
     -f samples/sleep/sleep.yaml -n uninjected-sample
 $ kubectl apply --context="${CTX_CLUSTER2}" \

--- a/content/en/docs/ops/diagnostic-tools/multicluster/index.md
+++ b/content/en/docs/ops/diagnostic-tools/multicluster/index.md
@@ -68,7 +68,7 @@ $ kubectl apply --context="${CTX_CLUSTER1}" \
     -f samples/sleep/sleep.yaml -n uninjected-sample
 $ kubectl apply --context="${CTX_CLUSTER2}" \
     -f samples/sleep/sleep.yaml -n uninjected-sample
-{{ < /text >}}
+{{< /text >}}
 
 
 Verify that there is a helloworld pod running in `cluster2`, using the `-o wide` flag, so we can get the Pod IP:

--- a/content/en/docs/ops/diagnostic-tools/multicluster/index.md
+++ b/content/en/docs/ops/diagnostic-tools/multicluster/index.md
@@ -31,7 +31,7 @@ There are many possible causes to the problem:
 ### Connectivity and firewall issues
 
 In some environments it may not be apparent that a firewall is blocking traffic between your clusters. It's possible
-that `ICMP` (ping) traffic may succeed, but HTTP and other types of traffic do not. This can appear as a timeout, or 
+that `ICMP` (ping) traffic may succeed, but HTTP and other types of traffic do not. This can appear as a timeout, or
 in some cases a more confusing error such as:
 
 {{< text plain >}}
@@ -70,7 +70,6 @@ $ kubectl apply --context="${CTX_CLUSTER2}" \
     -f samples/sleep/sleep.yaml -n uninjected-sample
 {{< /text >}}
 
-
 Verify that there is a helloworld pod running in `cluster2`, using the `-o wide` flag, so we can get the Pod IP:
 
 {{< text bash >}}
@@ -97,10 +96,10 @@ Hello version: v2, instance: helloworld-v2-54df5f84b-z28p5
 {{< /text >}}
 
 If successful, there should responses only from `helloworld-v2`. Repeat the steps, but send traffic from `cluster2`
-to `cluster1`. 
+to `cluster1`.
 
 If this succeeds, you can rule out connectivity issues. If it does not, the cause of the problem may lie outside your
-Istio configuration. 
+Istio configuration.
 
 ### Locality Load Balancing
 

--- a/content/en/docs/ops/diagnostic-tools/multicluster/index.md
+++ b/content/en/docs/ops/diagnostic-tools/multicluster/index.md
@@ -28,6 +28,83 @@ we would expect both `v1` and `v2` responses, indicating traffic is going to bot
 
 There are many possible causes to the problem:
 
+### Connectivity and firewall issues
+
+In some environments it may not be apparent that a firewall is blocking traffic between your clusters. It's possible
+that `ICMP` (ping) traffic may succeed, but HTTP and other types of traffic do not. This can appear as a timeout, or 
+in some cases a more confusing error such as:
+
+{{< text >}}
+upstream connect error or disconnect/reset before headers. reset reason: local reset, transport failure reason: TLS error: 268435612:SSL routines:OPENSSL_internal:HTTP_REQUEST
+{{< /text >}}
+
+While Istio provides service discovery capabilities to make it easier, cross-cluster traffic should still succeed
+if pods in each cluster are on a single network without Istio. To rule out issues with TLS/mTLS, we can do a manual
+traffic test on non-sidecared pods.
+
+In each cluster, create a new namespace for this test. Do _not_ enable sidecar injection:
+
+{{< text bash >}}
+$ kubectl create --context="${CTX_CLUSTER1}" namespace uninjected-sample
+$ kubectl create --context="${CTX_CLUSTER2}" namespace uninjected-sample
+{{< /text >}}
+
+Then deploy the same apps used in [verify multicluster installation](/docs/setup/install/multicluster/verify/):
+
+{{< text bash >}}
+# hello world service
+$ kubectl apply --context="${CTX_CLUSTER1}" \
+    -f samples/helloworld/helloworld.yaml \
+    -l service=helloworld -n uninjected-sample
+$ kubectl apply --context="${CTX_CLUSTER2}" \
+    -f samples/helloworld/helloworld.yaml \
+    -l service=helloworld -n uninjected-sample
+# hello world deployment
+$ kubectl apply --context="${CTX_CLUSTER1}" \
+    -f samples/helloworld/helloworld.yaml \
+    -l version=v1 -n uninjected-sample
+$ kubectl apply --context="${CTX_CLUSTER2}" \
+    -f samples/helloworld/helloworld.yaml \
+    -l version=v2 -n uninjected-sample
+# sleep deployment
+$ kubectl apply --context="${CTX_CLUSTER1}" \
+    -f samples/sleep/sleep.yaml -n uninjected-sample
+$ kubectl apply --context="${CTX_CLUSTER2}" \
+    -f samples/sleep/sleep.yaml -n uninjected-sample
+{{ < /text >}}
+
+
+Verify that there is a helloworld pod running in `cluster2`, using the `-o wide` flag, so we can get the Pod IP:
+
+{{< text bash >}}
+$ kubectl --context="${CTX_CLUSTER2}" -n uninjected-sample get pod -o wide
+NAME                             READY   STATUS    RESTARTS   AGE   IP           NODE     NOMINATED NODE   READINESS GATES
+helloworld-v2-54df5f84b-z28p5    1/1     Running   0          43s   10.100.0.1   node-1   <none>           <none>
+sleep-557747455f-jdsd8           1/1     Running   0          41s   10.100.0.2   node-2   <none>           <none>
+{{< /text >}}
+
+Take note of the `IP` column for `helloworld`. In this case, it is `10.100.0.1`:
+
+{{< text bash >}}
+$ REMOTE_POD_IP=10.100.0.1
+{{< /text >}}
+
+Next, attempt to send traffic from the `sleep` pod in `cluster1` directly to this Pod IP:
+
+{{< text bash >}}
+$ kubectl exec --context="${CTX_CLUSTER1}" -n uninjected-sample -c sleep \
+    "$(kubectl get pod --context="${CTX_CLUSTER1}" -n uninjected-sample -l \
+    app=sleep -o jsonpath='{.items[0].metadata.name}')" \
+    -- curl -sS $REMOTE_POD_IP:5000/hello
+Hello version: v2, instance: helloworld-v2-54df5f84b-z28p5
+{{< /text >}}
+
+If successful, you should get only responsed from `helloworld-v2`. Repeat the steps, but send traffic from `cluster2`
+to `cluster1`. 
+
+If this succeeds, you can rule out connectivity issues. If it does not, the cause of the problem may lie outside your
+Istio configuration. 
+
 ### Locality Load Balancing
 
 [Locality load balancing](/docs/tasks/traffic-management/locality-load-balancing/failover/#configure

--- a/content/en/docs/ops/diagnostic-tools/multicluster/index.md
+++ b/content/en/docs/ops/diagnostic-tools/multicluster/index.md
@@ -95,7 +95,7 @@ $ kubectl exec --context="${CTX_CLUSTER1}" -n uninjected-sample -c sleep \
 Hello version: v2, instance: helloworld-v2-54df5f84b-z28p5
 {{< /text >}}
 
-If successful, there should responses only from `helloworld-v2`. Repeat the steps, but send traffic from `cluster2`
+If successful, there should be responses only from `helloworld-v2`. Repeat the steps, but send traffic from `cluster2`
 to `cluster1`.
 
 If this succeeds, you can rule out connectivity issues. If it does not, the cause of the problem may lie outside your

--- a/content/en/docs/ops/diagnostic-tools/multicluster/index.md
+++ b/content/en/docs/ops/diagnostic-tools/multicluster/index.md
@@ -96,7 +96,7 @@ $ kubectl exec --context="${CTX_CLUSTER1}" -n uninjected-sample -c sleep \
 Hello version: v2, instance: helloworld-v2-54df5f84b-z28p5
 {{< /text >}}
 
-If successful, you should get only responsed from `helloworld-v2`. Repeat the steps, but send traffic from `cluster2`
+If successful, there should responses only from `helloworld-v2`. Repeat the steps, but send traffic from `cluster2`
 to `cluster1`. 
 
 If this succeeds, you can rule out connectivity issues. If it does not, the cause of the problem may lie outside your


### PR DESCRIPTION
This adds a short test users can do to determine if their networking setup meets the basic requirements for cross-cluster communication.

I include the error message seen in https://github.com/istio/istio/issues/32523 because I've seen this error due to a connectivity issue. 