### PR TITLE
add mitigation for unsupported normalization in security best practice

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -508,6 +508,7 @@ misconfiguration
 misconfigurations
 misconfigured
 misordered
+mitigations
 Mitigations
 MongoDB
 mongodb

--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -75,7 +75,7 @@ The above policy explicitly lists the allowed path (`/public`). This means the r
 `/public` to let the request allowed by the policy. Any other requests will be rejected by default eliminating the risk
 of unknown normalization behavior causing policy bypass.
 
-The following is another example using the `DENY-with-negative-matching` pattern to achieve the same result:
+The following is an example using the `DENY-with-negative-matching` pattern to achieve the same result:
 
 {{< text yaml >}}
 apiVersion: security.istio.io/v1beta1
@@ -187,7 +187,7 @@ out the scope of Istio and also not supported by Istio.
 
 #### Custom normalization logic
 
-You can apply custom normalization logic using the WASM or Lua filter. It is recommended to use the WAM filter because
+You can apply custom normalization logic using the WASM or Lua filter. It is recommended to use the WASM filter because
 it's officially supported and also used by Istio. You could use the Lua filter for a quick proof-of-concept DEMO but we do
 not recommend using the Lua filter in production because it is not supported by Istio.
 
@@ -235,13 +235,13 @@ on the normalized requests. Please refer to your specific WAF product for config
 
 #### Feature request to Istio
 
-If you believe Istio should officially support a specific normalization, you could follow the [reporting a vulnerability](/docs/releases/security-vulnerabilities/#reporting-a-vulnerability)
+If you believe Istio should officially support a specific normalization, you can follow the [reporting a vulnerability](/docs/releases/security-vulnerabilities/#reporting-a-vulnerability)
 page to send a feature request about the specific normalization to the Istio Product Security Work Group for initial evaluation.
 
 Please do not open any issues in public without first contacting the Istio Product Security Work Group because the
-issue might be considered as a security vulnerability that needs to be fixed in private.
+issue might be considered a security vulnerability that needs to be fixed in private.
 
-If the Istio Product Security Work Group evaluates the feature request to not be a security vulnerability, an issue will
+If the Istio Product Security Work Group evaluates the feature request as not a security vulnerability, an issue will
 be opened in public for further discussions of the feature request.
 
 ## Understand traffic capture limitations

--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -72,7 +72,7 @@ spec:
 {{< /text >}}
 
 The above policy explicitly lists the allowed path (`/public`). This means the request path must be exactly the same as
-`/public` to let the request allowed by the policy. Any other requests will be rejected by default eliminating the risk
+`/public` to allow the request. Any other requests will be rejected by default eliminating the risk
 of unknown normalization behavior causing policy bypass.
 
 The following is an example using the `DENY-with-negative-matching` pattern to achieve the same result:

--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -31,9 +31,9 @@ It takes effort to configure the correct authorization policies to best protect 
 It is important to understand the implications of these configurations as Istio cannot determine the proper authorization for all users.
 Please follow this section in its entirety.
 
-### Safer Authorization Policy Pattern
+### Safer Authorization Policy Patterns
 
-#### Apply default-deny authorization policies
+#### Use default-deny patterns
 
 We recommend you define your Istio authorization policies following the default-deny pattern to enhance your cluster's security posture.
 The default-deny authorization pattern means your system denies all requests by default, and you define the conditions in which the requests are allowed.
@@ -56,7 +56,7 @@ and do not use any of the **negative** matching fields (e.g. `notPaths`, `notVal
 The `DENY-with-negative-matching` pattern is to use the `DENY` action only with **negative** matching fields (e.g. `notPaths`, `notValues`)
 and do not use any of the **positive** matching fields (e.g. `paths`, `values`).
 
-For example, the authorization policy below uses the `ALLOW-with-positive-matching` pattern to allow requests at path `/public`:
+For example, the authorization policy below uses the `ALLOW-with-positive-matching` pattern to allow requests to path `/public`:
 
 {{< text yaml >}}
 apiVersion: security.istio.io/v1beta1

--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -179,16 +179,16 @@ apiVersion: v1
 
 ### Mitigation for unsupported normalization
 
-This section describes various mitigations for unsupported normalization. These could be useful when you find a specific
+This section describes various mitigations for unsupported normalization. These could be useful when you need a specific
 normalization that is not supported by Istio.
 
-Please make sure you understand the mitigation thoroughly and use it carefully. Some mitigation is just best-effort workaround
-that is not well tested or rely on things that are not supported by Istio.
+Please make sure you understand the mitigation thoroughly and use it carefully as some mitigations rely on things that are
+out the scope of Istio and also not supported by Istio.
 
 #### Custom normalization logic
 
 You can apply custom normalization logic using the WASM or Lua filter. It is recommended to use the WAM filter because
-it's officially supported and also used by Istio. You could use the Lua filter for quick proof-of-concept DEMO but we do
+it's officially supported and also used by Istio. You could use the Lua filter for a quick proof-of-concept DEMO but we do
 not recommend using the Lua filter in production because it is not supported by Istio.
 
 ##### Example custom normalization (case normalization)
@@ -229,8 +229,8 @@ spec:
 
 #### Specialized Web Application Firewall (WAF)
 
-Many specialized Web Application Firewall (WAF) products provide more normalization options. It can be deployed in
-front of the Istio ingress gateway to normalize requests entering the mesh, the authorization policy will then be enforced
+Many specialized Web Application Firewall (WAF) products provide additional normalization options. They can be deployed in
+front of the Istio ingress gateway to normalize requests entering the mesh. The authorization policy will then be enforced
 on the normalized requests. Please refer to your specific WAF product for configuring the normalization options.
 
 #### Feature request to Istio
@@ -241,8 +241,8 @@ page to send a feature request about the specific normalization to the Istio Pro
 Please do not open any issues in public without first contacting the Istio Product Security Work Group because the
 issue might be considered as a security vulnerability that needs to be fixed in private.
 
-If Istio Product Security Work Group evaluates the feature request not a security vulnerability, an issue will be opened
-in public for further discussions of the feature request.
+If the Istio Product Security Work Group evaluates the feature request to not be a security vulnerability, an issue will
+be opened in public for further discussions of the feature request.
 
 ## Understand traffic capture limitations
 


### PR DESCRIPTION
This PR adds the initial guidance on unsupported normalization in authorization policy, more mitigation could be added when supported.

cc @myidpt @justinpettit 



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure