### PR TITLE
update zh enableAutoMtls default true

### DIFF
--- a/content/zh/docs/reference/config/istio.mesh.v1alpha1/index.html
+++ b/content/zh/docs/reference/config/istio.mesh.v1alpha1/index.html
@@ -667,7 +667,7 @@ No
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#boolvalue">BoolValue</a></code></td>
 <td>
 <p>This flag is used to enable mutual TLS automatically for service to service communication
-within the mesh, default false.
+within the mesh, default true.
 If set to true, and a given service does not have a corresponding DestinationRule configured,
 or its DestinationRule does not have TLSSettings specified, Istio configures client side
 TLS configuration appropriately. More specifically,


### PR DESCRIPTION


https://github.com/istio/istio.io/blob/296c1ba498af93e9fe41f0b3fa8fe1e73e176846/content/en/docs/reference/config/istio.mesh.v1alpha1/index.html#L277
in en docs, enableAutoMtls default is true.

[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure