### PR TITLE
remove Mixer dashboard from the Grafana setup script

### DIFF
--- a/content/en/docs/ops/integrations/grafana/index.md
+++ b/content/en/docs/ops/integrations/grafana/index.md
@@ -47,7 +47,7 @@ $ GRAFANA_DATASOURCE="Prometheus"
 $ # The version of Istio to deploy
 $ VERSION={{< istio_full_version >}}
 $ # Import all Istio dashboards
-$ for DASHBOARD in 7639 11829 7636 7630 7642 7645; do
+$ for DASHBOARD in 7639 11829 7636 7630 7645; do
 $     REVISION="$(curl -s https://grafana.com/api/dashboards/${DASHBOARD}/revisions -s | jq ".items[] | select(.description | contains(\"${VERSION}\")) | .revision")"
 $     curl -s https://grafana.com/api/dashboards/${DASHBOARD}/revisions/${REVISION}/download > /tmp/dashboard.json
 $     echo "Importing $(cat /tmp/dashboard.json | jq -r '.title') (revision ${REVISION}, id ${DASHBOARD})..."


### PR DESCRIPTION
7642 is https://grafana.com/grafana/dashboards/7642, the Istio mixer dashboard.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
