### PR TITLE
Add traffic management concept alias

### DIFF
--- a/content/en/docs/concepts/traffic-management/index.md
+++ b/content/en/docs/concepts/traffic-management/index.md
@@ -11,6 +11,7 @@ aliases:
     - /docs/concepts/traffic-management/load-balancing
     - /docs/concepts/traffic-management/request-routing
     - /docs/concepts/traffic-management/pilot.html
+    - /docs/concepts/traffic-management/overview.html
 owner: istio/wg-networking-maintainers
 test: no
 ---


### PR DESCRIPTION
The [Istio mesh dashboard for Grafana](https://grafana.com/grafana/dashboards/7639) includes a link to https://istio.io/docs/concepts/traffic-management/overview.html which is 404.

(TODO: update the dashboard URLs)

[X] Docs
