### PR TITLE
Add comments to the user and vendor pages

### DIFF
--- a/BUGS-AND-FEATURE-REQUESTS.md
+++ b/BUGS-AND-FEATURE-REQUESTS.md
@@ -7,4 +7,4 @@ You can report bugs and feature requests to the Istio team in one of three place
 - [Community and Governance Issues](https://github.com/istio/community/issues)
 
 For security vulnerabilities, please don't report a bug (which is public) and instead follow
-[these procedures](https://istio.io/about/security-vulnerabilities/).
+[these procedures](https://istio.io/latest/docs/releases/security-vulnerabilities/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ to their customers), *professional services* (who offer implementation support
 or consulting for Istio) and *integrations* (commercial or open source products
 that work with Istio).
 
-To add an entry to this page, edit [data/companies.yaml](data/companies.yaml)
+To add an entry to this page, edit [data/companies.yml](data/companies.yml)
 and add your information in the `providers`, `pro_services` or `integrations`
 section, as appropriate. Please add your company logo, preferably in SVG
 format, to [static/logos](static/logos).
@@ -25,7 +25,7 @@ are not demeed to be in good standing in the community.
 Are you running Istio in production?  List yourself on our [Case Studies](https://istio.io/latest/about/case-studies/) page.
 
 If you want to add your logo to our wall of users, add an entry to the `users`
-section in [data/companies.yaml](data/companies.yaml), and add your logo,
+section in [data/companies.yml](data/companies.yml), and add your logo,
 preferably in SVG format, to [static/logos](static/logos).
 
 If you'd like to be interviewed for a full case study, please [create an issue](https://github.com/istio/istio.io/issues/new),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,3 +3,30 @@
 So you want to hack on Istio? Yay! Please refer to Istio's overall
 [contribution guidelines](https://github.com/istio/community/blob/master/CONTRIBUTING.md)
 to find out how you can help.
+
+## Promote your company on istio.io
+
+If your company supports Istio, you can list it on our [Ecosystem page](https://istio.io/latest/about/ecosystem/).
+We have categories for *providers* (who offer hosted or managed Istio services
+to their customers), *professional services* (who offer implementation support
+or consulting for Istio) and *integrations* (commercial or open source products
+that work with Istio).
+
+To add an entry to this page, edit [data/companies.yaml](data/companies.yaml)
+and add your information in the `providers`, `pro_services` or `integrations`
+section, as appropriate. Please add your company logo, preferably in SVG
+format, to [static/logos](static/logos).
+
+The Istio steering committee reserves the right to remove logos of companies that
+are not demeed to be in good standing in the community.
+
+## Tell the world you're using Istio
+
+Are you running Istio in production?  List yourself on our [Case Studies](https://istio.io/latest/about/case-studies/) page.
+
+If you want to add your logo to our wall of users, add an entry to the `users`
+section in [data/companies.yaml](data/companies.yaml), and add your logo,
+preferably in SVG format, to [static/logos](static/logos).
+
+If you'd like to be interviewed for a full case study, please [create an issue](https://github.com/istio/istio.io/issues/new),
+and we'll be in touch!

--- a/content/en/about/case-studies/_index.md
+++ b/content/en/about/case-studies/_index.md
@@ -8,3 +8,5 @@ doc_type: about
 type: case-studies
 sidebar_none: true
 ---
+
+[comment]: <> (To add yourself as an Istio user, please edit /data/companies.yaml and add your logo to /static/logos.)

--- a/content/en/about/case-studies/_index.md
+++ b/content/en/about/case-studies/_index.md
@@ -9,4 +9,4 @@ type: case-studies
 sidebar_none: true
 ---
 
-[comment]: <> (To add yourself as an Istio user, please edit /data/companies.yaml and add your logo to /static/logos.)
+[comment]: <> (To add yourself as an Istio user, please see https://github.com/istio/istio.io/blob/master/CONTRIBUTING.md.)

--- a/content/en/about/ecosystem/index.md
+++ b/content/en/about/ecosystem/index.md
@@ -12,7 +12,7 @@ aliases:
 doc_type: about
 ---
 
-[comment]: <> (To add an Istio provider, professional services consultancy or integration, please edit /data/companies.yaml and add your logo to /static/logos.)
+[comment]: <> (To add an Istio provider, professional services consultancy or integration, please see https://github.com/istio/istio.io/blob/master/CONTRIBUTING.md.)
 
 {{< tabset category-name="ecosystem-type" class="tabset--ecosystem" forget-tab=true >}}
 

--- a/content/en/about/ecosystem/index.md
+++ b/content/en/about/ecosystem/index.md
@@ -12,6 +12,8 @@ aliases:
 doc_type: about
 ---
 
+[comment]: <> (To add an Istio provider, professional services consultancy or integration, please edit /data/companies.yaml and add your logo to /static/logos.)
+
 {{< tabset category-name="ecosystem-type" class="tabset--ecosystem" forget-tab=true >}}
 
     {{< tab

--- a/data/companies.yml
+++ b/data/companies.yml
@@ -1,3 +1,5 @@
+# Please see [CONTRIBUTING.md](/CONTRIBUTING.md) to learn more about editing this file.
+
 providers:
   - name: "Google Cloud's Anthos Service Mesh"
     logo: "/logos/google-cloud.png"


### PR DESCRIPTION
Add comments to the markdown for /about/case-studies and /about/ecosystem to tell people who hit "Edit this page", or otherwise find it, that they should edit the companies.yaml file.

[X] Docs
