### PR TITLE
Add table of contents test status

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -5,7 +5,7 @@ description: Learn how to deploy, use, and operate Istio.
 weight: 1
 skip_toc: true
 skip_sidebar: true
-test: n/a
+test: table-of-contents
 doc_type: docs
 ---
 

--- a/content/en/docs/concepts/_index.md
+++ b/content/en/docs/concepts/_index.md
@@ -2,5 +2,5 @@
 title: Concepts
 description: Learn about the different parts of the Istio system and the abstractions it uses.
 weight: 10
-test: n/a
+test: table-of-contents
 ---

--- a/content/en/docs/examples/_index.md
+++ b/content/en/docs/examples/_index.md
@@ -5,5 +5,5 @@ weight: 30
 aliases:
     - /docs/samples/index.html
     - /docs/guides/index.html
-test: n/a
+test: table-of-contents
 ---

--- a/content/en/docs/examples/microservices-istio/_index.md
+++ b/content/en/docs/examples/microservices-istio/_index.md
@@ -4,7 +4,7 @@ description: This modular tutorial provides new users with hands-on experience u
 weight: 100
 simple_list: true
 content_above: true
-test: n/a
+test: table-of-contents
 ---
 
 It is intended for self-guided users or instructors who train

--- a/content/en/docs/reference/config/_index.md
+++ b/content/en/docs/reference/config/_index.md
@@ -2,5 +2,5 @@
 title: Configuration
 description: Detailed information on configuration options.
 weight: 10
-test: n/a
+test: table-of-contents
 ---

--- a/content/en/docs/reference/config/networking/_index.md
+++ b/content/en/docs/reference/config/networking/_index.md
@@ -5,5 +5,5 @@ weight: 30
 aliases:
     - /docs/reference/config/istio.routing.v1alpha1/
     - /docs/reference/config/networking/
-test: n/a
+test: table-of-contents
 ---

--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -9,5 +9,5 @@ aliases:
     - /docs/setup/kubernetes/download-release/
     - /docs/setup/kubernetes/download/
 keywords: [kubernetes,install,quick-start,setup,installation]
-test: n/a
+test: table-of-contents
 ---

--- a/content/en/docs/setup/install/_index.md
+++ b/content/en/docs/setup/install/_index.md
@@ -6,7 +6,7 @@ weight: 20
 content_above: true
 aliases:
     - /docs/setup/kubernetes/install/
-test: n/a
+test: table-of-contents
 ---
 
 If you need help choosing, refer to our

--- a/content/en/docs/setup/install/multicluster/_index.md
+++ b/content/en/docs/setup/install/multicluster/_index.md
@@ -11,7 +11,7 @@ aliases:
 keywords: [kubernetes,multicluster]
 simple_list: true
 content_above: true
-test: n/a
+test: table-of-contents
 owner: istio/wg-environments-maintainers
 ---
 Follow this guide to install an Istio {{< gloss >}}service mesh{{< /gloss >}}

--- a/content/en/docs/setup/platform-setup/_index.md
+++ b/content/en/docs/setup/platform-setup/_index.md
@@ -5,7 +5,7 @@ weight: 10
 aliases:
     - /docs/setup/kubernetes/platform-setup/
 keywords: [platform-setup]
-test: n/a
+test: table-of-contents
 ---
 
 {{< tip >}}

--- a/content/en/docs/tasks/observability/distributed-tracing/_index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/_index.md
@@ -5,5 +5,5 @@ weight: 30
 keywords: [telemetry,tracing]
 aliases:
  - /docs/tasks/telemetry/distributed-tracing/
-test: n/a
+test: table-of-contents
 ---

--- a/content/en/docs/tasks/security/_index.md
+++ b/content/en/docs/tasks/security/_index.md
@@ -5,5 +5,5 @@ weight: 19
 aliases:
     - /docs/tasks/istio-auth.html
     - /docs/tasks/security/authz-permissive
-test: n/a
+test: table-of-contents
 ---

--- a/content/en/docs/tasks/traffic-management/_index.md
+++ b/content/en/docs/tasks/traffic-management/_index.md
@@ -4,5 +4,5 @@ description: Tasks that demonstrate Istio's traffic routing features.
 weight: 15
 aliases:
     - /docs/examples/intelligent-routing/
-test: n/a
+test: table-of-contents
 ---

--- a/content/en/docs/tasks/traffic-management/ingress/_index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/_index.md
@@ -2,5 +2,5 @@
 title: Ingress
 description: Controlling ingress traffic for an Istio service mesh.
 weight: 70
-test: n/a
+test: table-of-contents
 ---

--- a/content/zh/docs/_index.md
+++ b/content/zh/docs/_index.md
@@ -5,7 +5,7 @@ description: 了解如何部署、使用和运维 Istio。
 weight: 1
 skip_toc: true
 skip_sidebar: true
-test: n/a
+test: table-of-contents
 doc_type: docs
 ---
 

--- a/content/zh/docs/concepts/what-is-istio/index.md
+++ b/content/zh/docs/concepts/what-is-istio/index.md
@@ -7,7 +7,7 @@ aliases:
     - /zh/docs/concepts/what-is-istio/goals
     - /zh/about/intro
 owner: istio/wg-docs-maintainers
-test: n/a
+test: table-of-contents
 ---
 
 云平台令使用它们的公司受益匪浅。但不可否认的是，上云会给 DevOps 团队带来压力。为了可移植性，开发人员必须使用微服务来构建应用，同时运维人员也正在管理着极端庞大的混合云和多云的部署环境。

--- a/scripts/test_status.sh
+++ b/scripts/test_status.sh
@@ -26,6 +26,7 @@ echo "Istio Documents Summary: \
    $(find "${docs}" -name '*.md' -exec grep --quiet '^test: yes$' {} \; -print | wc -l) (tested) \
    $(find "${docs}" -name '*.md' -exec grep --quiet '^test: no$' {} \; -print | wc -l) (untested) \
    $(find "${docs}" -name '*.md' -exec grep --quiet '^test: n/a$' {} \; -print | wc -l) (n/a) \
+   $(find "${docs}" -name '*.md' -exec grep --quiet '^test: table-of-contents$' {} \; -print | wc -l) (table-of-contents) \
    $(find "${docs}" -name '*.md' -print | wc -l) (total)"
 
 echo ""
@@ -35,6 +36,7 @@ echo "=========="
 echo "Summary: \
    $(find "${docs}/tasks" -name '*.md' -exec grep --quiet '^test: yes$' {} \; -print | wc -l) (tested) \
    $(find "${docs}/tasks" -name '*.md' -exec grep --quiet '^test: no$' {} \; -print | wc -l) (untested) \
+   $(find "${docs}/tasks" -name '*.md' -exec grep --quiet '^test: table-of-contents$' {} \; -print | wc -l) (table-of-contents) \
    $(find "${docs}/tasks" -name '*.md' -exec grep --quiet '^test: n/a$' {} \; -print | wc -l) (n/a)"
 
 echo ""
@@ -54,6 +56,7 @@ echo "============="
 echo "Summary: \
    $(find "${docs}/examples" -name '*.md' -exec grep --quiet '^test: yes$' {} \; -print | wc -l) (tested) \
    $(find "${docs}/examples" -name '*.md' -exec grep --quiet '^test: no$' {} \; -print | wc -l) (untested) \
+   $(find "${docs}/examples" -name '*.md' -exec grep --quiet '^test: table-of-contents$' {} \; -print | wc -l) (table-of-contents) \
    $(find "${docs}/examples" -name '*.md' -exec grep --quiet '^test: n/a$' {} \; -print | wc -l) (n/a)"
 
 echo ""
@@ -73,6 +76,7 @@ echo "=========="
 echo "Summary: \
    $(find "${docs}/setup" -name '*.md' -exec grep --quiet '^test: yes$' {} \; -print | wc -l) (tested) \
    $(find "${docs}/setup" -name '*.md' -exec grep --quiet '^test: no$' {} \; -print | wc -l) (untested) \
+   $(find "${docs}/setup" -name '*.md' -exec grep --quiet '^test: table-of-contents$' {} \; -print | wc -l) (table-of-contents) \
    $(find "${docs}/setup" -name '*.md' -exec grep --quiet '^test: n/a$' {} \; -print | wc -l) (n/a)"
 
 echo ""
@@ -92,6 +96,7 @@ echo "==============="
 echo "Summary: \
    $(find "${docs}/ops" -name '*.md' -exec grep --quiet '^test: yes$' {} \; -print | wc -l) (tested) \
    $(find "${docs}/ops" -name '*.md' -exec grep --quiet '^test: no$' {} \; -print | wc -l) (untested) \
+   $(find "${docs}/ops" -name '*.md' -exec grep --quiet '^test: table-of-contents$' {} \; -print | wc -l) (table-of-contents) \
    $(find "${docs}/ops" -name '*.md' -exec grep --quiet '^test: n/a$' {} \; -print | wc -l) (n/a)"
 
 echo ""


### PR DESCRIPTION
This adds a table of contents test type to indicate documentation that contains only a table of contents and no other documentation (i.e. top level document listings for a section). It also extends `make test_status` in order to account for these documents.

This is useful in figuring out which tests we can skip in testing.