### PR TITLE
routeConfiguration.vhost.name use empty string as wildcard

### DIFF
--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -157,7 +157,7 @@ backend, is used below.
             context: GATEWAY
             routeConfiguration:
               vhost:
-                name: "*:80"
+                name: ""
                 route:
                   action: ANY
           patch:


### PR DESCRIPTION

Same as [PR 33690](https://github.com/istio/istio/pull/33690)

According to [routeMatch](https://github.com/istio/istio/blob/767767161b3b3350a30a4b7bb6b337857405c0ed/pilot/pkg/networking/core/v1alpha3/envoyfilter/rc_patch.go#L364), `routeConfiguration.vhost.name` use empty string as wildcard, not `"*:80`.

```go
func routeMatch(httpRoute *route.Route, rp *model.EnvoyFilterConfigPatchWrapper) bool {
...
	// check if httpRoute names match
	if match.Name != "" && match.Name != httpRoute.Name {
		return false
	}
```

If we specify it to `"*:80`, `routeMatch` will do exactly string check, which will failed all the time.

As this is used by gateway, we could set empty string to `routeConfiguration.vhost.name`, to match all `vhost.name`.


[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[X] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure