### PR TITLE
add explicit call out about the subtle difference between empty vs omitted

### DIFF
--- a/content/en/docs/reference/config/security/authorization-policy/index.html
+++ b/content/en/docs/reference/config/security/authorization-policy/index.html
@@ -234,6 +234,9 @@ one rule matches the request.</p>
 <p>If not set, the match will never occur. This is equivalent to setting a
 default of deny for the target workloads.</p>
 
+<p>If set but left empty, the match will always occur. This is equivalent to
+setting a default of allow for the target workloads.</p>
+
 </td>
 <td>
 No


### PR DESCRIPTION


[ ] Configuration Infrastructure
[X ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure

At first glance, a quick reading of this example the highlighted description text below appears to contradict it.

![image](https://user-images.githubusercontent.com/4367945/123826489-cfbb8380-d8cd-11eb-85d0-a6f19d8e5e05.png)

This change adds an explicit call out describing the subtle but crucial difference between "omitted" and "empty".