### PR TITLE
Add the information that you can concatenate CA certs

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -432,7 +432,7 @@ Istio supports reading a few different Secret formats, to support integration wi
 * A TLS Secret with keys `tls.key` and `tls.crt`, as described above. For mutual TLS, a `ca.crt` key can be used.
 * A generic Secret with keys `key` and `cert`. For mutual TLS, a `cacert` key can be used.
 * A generic Secret with keys `key` and `cert`. For mutual TLS, a separate generic Secret named `<secret>-cacert`, with a `cacert` key. For example, `httpbin-credential` has `key` and `cert`, and `httpbin-credential-cacert` has `cacert`.
-* The `cacert` entry can be a CA bundle: concatenated individual CA certificates.
+* The `cacert` can be a CA bundle consisting of concatenated individual CA certificates.
 
 ### SNI Routing
 

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -432,6 +432,7 @@ Istio supports reading a few different Secret formats, to support integration wi
 * A TLS Secret with keys `tls.key` and `tls.crt`, as described above. For mutual TLS, a `ca.crt` key can be used.
 * A generic Secret with keys `key` and `cert`. For mutual TLS, a `cacert` key can be used.
 * A generic Secret with keys `key` and `cert`. For mutual TLS, a separate generic Secret named `<secret>-cacert`, with a `cacert` key. For example, `httpbin-credential` has `key` and `cert`, and `httpbin-credential-cacert` has `cacert`.
+* The `cacert` entry can be a CA bundle: concatenated individual CA certificates.
 
 ### SNI Routing
 

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -432,7 +432,7 @@ Istio supports reading a few different Secret formats, to support integration wi
 * A TLS Secret with keys `tls.key` and `tls.crt`, as described above. For mutual TLS, a `ca.crt` key can be used.
 * A generic Secret with keys `key` and `cert`. For mutual TLS, a `cacert` key can be used.
 * A generic Secret with keys `key` and `cert`. For mutual TLS, a separate generic Secret named `<secret>-cacert`, with a `cacert` key. For example, `httpbin-credential` has `key` and `cert`, and `httpbin-credential-cacert` has `cacert`.
-* The `cacert` can be a CA bundle consisting of concatenated individual CA certificates.
+* The `cacert` key value can be a CA bundle consisting of concatenated individual CA certificates.
 
 ### SNI Routing
 


### PR DESCRIPTION
Add the information that you can concatenate CA certs if you want to accept MTLS from client providing certificate signed by different CAs



[ ] Configuration Infrastructure
[x ] Docs
[ x] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ x] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure