### PR TITLE
Added a section on 503 error while accessing headless services

### DIFF
--- a/content/en/docs/ops/common-problems/network-issues/index.md
+++ b/content/en/docs/ops/common-problems/network-issues/index.md
@@ -287,9 +287,8 @@ When `nginx` is accessed from this `sleep` pod using its Pod IP (this is one of 
 
 {{< text bash >}}
 $ export SOURCE_POD=$(kubectl get pod -l app=sleep -o jsonpath='{.items..metadata.name}')
-$ kubectl exec -it $SOURCE_POD -c sleep -- sh
-/ $ curl 10.1.1.171 -s -o /dev/null -w "%{http_code}"
-  503/
+$ kubectl exec -it $SOURCE_POD -c sleep -- curl 10.1.1.171 -s -o /dev/null -w "%{http_code}"
+  503
 {{< /text >}}
 
 `10.1.1.171` is the Pod IP of one of the replicas of `nginx` and the service is accessed on `containerPort` 80.
@@ -302,9 +301,8 @@ Here are some of the ways to avoid this 503 error:
 
     {{< text bash >}}
     $ export SOURCE_POD=$(kubectl get pod -l app=sleep -o jsonpath='{.items..metadata.name}')
-    $ kubectl exec -it $SOURCE_POD -c sleep -- sh
-    / $ curl -H "Host: nginx.default" 10.1.1.171 -s -o /dev/null -w "%{http_code}"
-      200/
+    $ kubectl exec -it $SOURCE_POD -c sleep -- curl -H "Host: nginx.default" 10.1.1.171 -s -o /dev/null -w "%{http_code}"
+      200
     {{< /text >}}
 
 1. Set port name to `tcp` or `tcp-web` or `tcp-<custom_name>`:
@@ -317,11 +315,13 @@ Here are some of the ways to avoid this 503 error:
 
     {{< text bash >}}
     $ export SOURCE_POD=$(kubectl get pod -l app=sleep -o jsonpath='{.items..metadata.name}')
-    $ kubectl exec -it $SOURCE_POD -c sleep -- sh
-    / $ curl 10.1.1.171 -s -o /dev/null -w "%{http_code}"
-      200/
-    / $ curl -H "Host: nginx.default" 10.1.1.171 -s -o /dev/null -w "%{http_code}"
-      200/
+    $ kubectl exec -it $SOURCE_POD -c sleep -- curl 10.1.1.171 -s -o /dev/null -w "%{http_code}"
+      200
+    {{< /text >}}
+
+    {{< text bash >}}
+    $ kubectl exec -it $SOURCE_POD -c sleep -- curl -H "Host: nginx.default" 10.1.1.171 -s -o /dev/null -w "%{http_code}"
+      200
     {{< /text >}}
 
 1. Use domain name instead of Pod IP:
@@ -330,9 +330,8 @@ Here are some of the ways to avoid this 503 error:
 
     {{< text bash >}}
     $ export SOURCE_POD=$(kubectl get pod -l app=sleep -o jsonpath='{.items..metadata.name}')
-    $ kubectl exec -it $SOURCE_POD -c sleep -- sh
-    / $ curl web-0.nginx.default -s -o /dev/null -w "%{http_code}"
-      200/
+    $ kubectl exec -it $SOURCE_POD -c sleep -- curl web-0.nginx.default -s -o /dev/null -w "%{http_code}"
+      200
     {{< /text >}}
 
     Here `web-0` is the pod name of one of the 3 replicas of `nginx`.

--- a/content/en/docs/ops/common-problems/network-issues/index.md
+++ b/content/en/docs/ops/common-problems/network-issues/index.md
@@ -240,7 +240,7 @@ Assume Istio is installed with the following configuration:
 - `mTLS mode` set to `STRICT` within the mesh
 - `meshConfig.outboundTrafficPolicy.mode` set to `ALLOW_ANY`
 
-Consider `nginx` is deployed as a `StatefulSet` in the default namespace and a corresponding `Headless Service` is defined as shown below: 
+Consider `nginx` is deployed as a `StatefulSet` in the default namespace and a corresponding `Headless Service` is defined as shown below:
 
 {{< text yaml >}}
 apiVersion: v1
@@ -293,67 +293,66 @@ spec:
           storage: 1Gi
 {{< /text >}}
 
-Let us assume we have a [sleep](https://github.com/istio/istio/blob/1.10.2/samples/sleep/sleep.yaml) pod `Deployment` as well in the default namespace.
+Let us assume we have a [sleep]({{< github_tree >}}/samples/sleep) pod `Deployment` as well in the default namespace.
 
 Now, let us consider 3 possible scenarios based on the port `name` defined in the headless service:
 
 1. Port `name` set to `web` (as shown in the example above) or any other custom name
 
-  - Request without Host header:
-      
+    - Request without Host header:
+
         When `nginx` is accessed without the Host header, the sidecar proxy on the client-side fails to find the route entry to `nginx` and fails with `HTTP 404 NR`.
 
         {{< text bash >}}
         $ kubectl exec -it sleep-557747455f-blkgt -c sleep -- sh
         / $ curl 10.1.1.171 -s -o /dev/null -w "%{http_code}"
-          404/ 
+          404/
         {{< /text >}}
 
         Here, `10.1.1.171` is the Pod IP of one of the replicas of `nginx` and the service is accessed on `containerPort` 80.
-
-  - Request with Host header:
+    - Request with Host header:
 
         When `nginx` is accessed with the correct Host header, it successfully returns `HTTP 200 OK`.
 
         {{< text bash >}}
         $ kubectl exec -it sleep-557747455f-blkgt -c sleep -- sh
         / $ curl -H "Host: nginx.default" 10.1.1.171 -s -o /dev/null -w "%{http_code}"
-          200/ 
+          200/
         {{< /text >}}
 
 1. Port `name` set to `http` or `http-web` or `http-<custom_name>`
 
-  - Request without Host header:
+    - Request without Host header:
 
         When `nginx` is accessed without the Host header, the request goes via the `PassthroughCluster` to the server-side, but the sidecar proxy on the server-side fails to find the route entry to `nginx` and fails with `HTTP 503 UC`.
 
         {{< text bash >}}
         $ kubectl exec -it sleep-557747455f-blkgt -c sleep -- sh
         / $ curl 10.1.1.171 -s -o /dev/null -w "%{http_code}"
-          503/ 
+          503/
         {{< /text >}}
 
-  - Request with Host header:
+    - Request with Host header:
 
-        The behaviour is very similar to how it is described for the case with the Host header in the previous scenario. The only difference here is that the HTTP Inspector listener filter is NOT triggerred on the server-side, since the port name already has a prefix `http`. 
-        
+        The behavior is very similar to how it is described for the case with the Host header in the previous scenario. The only difference here is that the HTTP Inspector listener filter is NOT triggered on the server-side, since the port name already has a prefix `http`.
+
         A request to `nginx` with the correct Host header successfully returns `HTTP 200 OK`.
 
 1. Port `name` set to `tcp` or `tcp-web` or `tcp-<custom_name>`
-  
-    With this naming, the Host header is NOT needed to access `nginx`. In this scenario, only the `TCP Proxy` network filter on the sidecar proxy is used, both on the client-side and server-side. HTTP Connection Manager is not used at all and therefore, any kind of header is not expected in the request. 
-    
+
+    With this naming, the Host header is NOT needed to access `nginx`. In this scenario, only the `TCP Proxy` network filter on the sidecar proxy is used, both on the client-side and server-side. HTTP Connection Manager is not used at all and therefore, any kind of header is not expected in the request.
+
     A request to `nginx` with or without the Host header successfully returns `HTTP 200 OK`.
-    
+
     This is useful in certain scenarios where a client may not be able to include header information in the request.
-    
+
     {{< text bash >}}
     $ kubectl exec -it sleep-557747455f-blkgt -c sleep -- sh
     / $ curl 10.1.1.171 -s -o /dev/null -w "%{http_code}"
-      200/ 
+      200/
 
     / $ curl -H "Host: nginx.default" 10.1.1.171 -s -o /dev/null -w "%{http_code}"
-      200/ 
+      200/
     {{< /text >}}
 
 ## TLS configuration mistakes

--- a/content/en/docs/ops/common-problems/network-issues/index.md
+++ b/content/en/docs/ops/common-problems/network-issues/index.md
@@ -272,25 +272,12 @@ spec:
       labels:
         app: nginx
     spec:
-      terminationGracePeriodSeconds: 10
       containers:
       - name: nginx
         image: k8s.gcr.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web
-        volumeMounts:
-        - name: www
-          mountPath: /usr/share/nginx/html
-  volumeClaimTemplates:
-  - metadata:
-      name: www
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: "my-storage-class"
-      resources:
-        requests:
-          storage: 1Gi
 {{< /text >}}
 
 Let us assume we have a [sleep]({{< github_tree >}}/samples/sleep) pod `Deployment` as well in the default namespace.


### PR DESCRIPTION
I observed a few common errors while using StatefulSet with headless services and felt it is good to have it documented under traffic management problems. I have described 3 different scenarios based on the _port name_ specified in the headless service, focusing on the importance of using the Host header while making an HTTP request to a headless service.


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[X] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[X] User Experience
[ ] Developer Infrastructure