### PR TITLE
No longer need this warning about Kiali addon install.

### DIFF
--- a/content/en/docs/ops/integrations/kiali/index.md
+++ b/content/en/docs/ops/integrations/kiali/index.md
@@ -24,11 +24,6 @@ $ kubectl apply -f {{< github_file >}}/samples/addons/kiali.yaml
 
 This will deploy Kiali into your cluster. This is intended for demonstration only, and is not tuned for performance or security.
 
-{{< tip >}}
-If there are errors trying to install the addons, try running the command again. There may
-be some timing issues which will be resolved when the command is run again.
-{{< /tip >}}
-
 ### Option 2: Customizable install
 
 The Kiali project offers its own [quick start guide](https://kiali.io/documentation/latest/quick-start) and [customizable installation methods](https://kiali.io/documentation/latest/installation-guide). We recommend production users follow those instructions to ensure they stay up to date with the latest versions and best practices.


### PR DESCRIPTION
Now that the [Kiali addon has been upgraded to v1.36](https://github.com/istio/istio/pull/33695/files), there is no longer the monitoring dashboard CRD that we have to worry about. This is what caused that timing error (the CRD would fail to be established in time before the dashboards themselves started to get created).

Since this timing error won't happen, we can remove this warning in the docs.

fixes: https://github.com/kiali/kiali/issues/4111



[ ] Configuration Infrastructure
[x] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure