### PR TITLE
Update local rate limit task configuration.

### DIFF
--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -196,10 +196,11 @@ spec:
       app: productpage
   configPatches:
     - applyTo: HTTP_FILTER
-      listener:
-        filterChain:
-          filter:
-            name: "envoy.filters.network.http_connection_manager"
+      match:
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
       patch:
         operation: INSERT_BEFORE
         value:
@@ -251,10 +252,11 @@ spec:
       app: productpage
   configPatches:
     - applyTo: HTTP_FILTER
-      listener:
-        filterChain:
-          filter:
-            name: "envoy.filters.network.http_connection_manager"
+      match:
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
       patch:
         operation: INSERT_BEFORE
         value:
@@ -266,7 +268,7 @@ spec:
               stat_prefix: http_local_rate_limiter
     - applyTo: HTTP_ROUTE
       match:
-        context: SIDECAR_OUTBOUND
+        context: SIDECAR_INBOUND
         routeConfiguration:
           vhost:
             name: "inbound|http|9080"


### PR DESCRIPTION
there is  2 mistakes in this the local limitrate demo，
1.  the match is missed in the configPatches
2. the routeConfiguration is miss configured and it does not works



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure