### PR TITLE
Minor typo in cert-manager documentation

### DIFF
--- a/content/en/docs/ops/integrations/certmanager/index.md
+++ b/content/en/docs/ops/integrations/certmanager/index.md
@@ -66,7 +66,7 @@ Alternatively, a `Certificate` can be created as described in [Istio Gateway](#i
 
 {{< text yaml >}}
 apiVersion: networking.k8s.io/v1beta1
-Kind: Ingress
+kind: Ingress
 metadata:
   name: ingress
   annotations:


### PR DESCRIPTION
Fix minor typo in cert-manager docs


[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure