### PR TITLE
Promote external control plane feature to beta

### DIFF
--- a/data/features.yaml
+++ b/data/features.yaml
@@ -249,7 +249,7 @@ features:
     link: "/docs/setup/install/external-controlplane/"
     level:
       checklist: features/external_istiod.md
-      maturity: Alpha
+      maturity: Beta
       nextExpectedPromotion: ""
     area: Core
   - name: "Kubernetes: Istio In-Place Control Plane Upgrade"


### PR DESCRIPTION

The [external control plane feature](https://github.com/istio/enhancements/pull/93) is functionally ready to be promoted to `Beta`.

The only possible issue is that it's somewhat light on testing, although it does have basic integration testing and doc testing which should be sufficient for `Beta` promotion in release 1.11. More robust and complete testing will be added in 1.12+ in preparation for later promotion to `Stable`.

**Current Test Summary**

1. Doc test for helloworld service and gateway deployment with [single cluster external control plane setup](https://preliminary.istio.io/latest/docs/setup/install/external-controlplane/).
2. Doc test for helloworld running on two clusters (config and remote), i.e., a [multicluster external control plane setup](https://preliminary.istio.io/latest/docs/setup/install/external-controlplane/#adding-clusters).
3. Integration test for single config cluster with external control plane - confirms istiod connectivity including injection webhook is functioning. 
4. Integration test for multicluster reachability using an external control plane (TBD: will be added before 1.11 release) 



[ ] Configuration Infrastructure
[ ] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure