### PR TITLE
Helm can use revision tags

### DIFF
--- a/content/en/boilerplates/revision-tags-default-intro.md
+++ b/content/en/boilerplates/revision-tags-default-intro.md
@@ -1,0 +1,7 @@
+---
+---
+The revision pointed to by the tag `default` is considered the ***default revision*** and has additional semantic meaning.
+
+The `default` revision will inject sidecars for the `istio-injection=enabled` namespace selector and `sidecar.istio.io/inject=true` object
+selector in addition to the `istio.io/rev=default` selectors. This makes it possible to migrate from using non-revisioned Istio to using
+a revision entirely without relabeling namespaces. To make a revision `1-10-0` the default, run:

--- a/content/en/boilerplates/revision-tags-default-outro.md
+++ b/content/en/boilerplates/revision-tags-default-outro.md
@@ -1,0 +1,5 @@
+---
+---
+When using the `default` tag alongside an existing non-revisioned Istio installation it is recommended to remove the old
+`MutatingWebhookConfiguration` (typically called `istio-sidecar-injector`) to avoid having both the older and newer control
+planes attempt injection.

--- a/content/en/boilerplates/revision-tags-middle.md
+++ b/content/en/boilerplates/revision-tags-middle.md
@@ -1,0 +1,21 @@
+---
+---
+The resulting mapping between revisions, tags, and namespaces is as shown below:
+
+{{< image width="70%"
+link="/docs/setup/upgrade/canary/tags.png"
+caption="Two namespaces pointed to prod-stable and one pointed to prod-canary"
+>}}
+
+The cluster operator can view this mapping in addition to tagged namespaces through the `istioctl tag list` command:
+
+{{< text bash >}}
+$ istioctl tag list
+TAG         REVISION NAMESPACES
+prod-canary 1-10-0   ...
+prod-stable 1-9-5    ...
+{{< /text >}}
+
+After the cluster operator is satisfied with the stability of the control plane tagged with `prod-canary`, namespaces labeled
+`istio.io/rev=prod-stable` can be updated with one action by modifying the `prod-stable` revision tag to point to the newer
+`1-10-0` revision.

--- a/content/en/boilerplates/revision-tags-preamble.md
+++ b/content/en/boilerplates/revision-tags-preamble.md
@@ -1,0 +1,5 @@
+---
+---
+Manually relabeling namespaces when moving them to a new revision can be tedious and error-prone.
+[Revision tags](/docs/reference/commands/istioctl/#istioctl-tag) solve this problem.
+[Revision tags](/docs/reference/commands/istioctl/#istioctl-tag) are stable identifiers that point to revisions and can be used to avoid relabeling namespaces. Rather than relabeling the namespace, a mesh operator can simply change the tag to point to a new revision. All namespaces labeled with that tag will be updated at the same time.

--- a/content/en/boilerplates/revision-tags-prologue.md
+++ b/content/en/boilerplates/revision-tags-prologue.md
@@ -1,0 +1,11 @@
+---
+---
+Now, the situation is as below:
+
+{{< image width="70%"
+link="/docs/setup/upgrade/canary/tags-updated.png"
+caption="Namespace labels unchanged but now all namespaces pointed to 1-10-0"
+>}}
+
+Restarting injected workloads in the namespaces marked `prod-stable` will now result in those workloads using the `1-10-0`
+control plane. Notice that no namespace relabeling was required to migrate workloads to the new revision.

--- a/content/en/boilerplates/revision-tags-usage.md
+++ b/content/en/boilerplates/revision-tags-usage.md
@@ -1,0 +1,5 @@
+---
+---
+Consider a cluster with two revisions installed, `1-9-5` and `1-10-0`. The cluster operator creates a revision tag `prod-stable`,
+pointed at the older, stable `1-9-5` version, and a revision tag `prod-canary` pointed at the newer `1-10-0` revision. That
+state could be reached via these commands:

--- a/content/en/boilerplates/snips/revision-tags-middle.sh
+++ b/content/en/boilerplates/snips/revision-tags-middle.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2153,SC2155,SC2164
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          boilerplates/revision-tags-middle.md
+####################################################################################################
+
+bpsnip_revision_tags_middle__1() {
+istioctl tag list
+}
+
+! read -r -d '' bpsnip_revision_tags_middle__1_out <<\ENDSNIP
+TAG         REVISION NAMESPACES
+prod-canary 1-10-0   ...
+prod-stable 1-9-5    ...
+ENDSNIP

--- a/content/en/boilerplates/snips/revision-tags-prologue.sh
+++ b/content/en/boilerplates/snips/revision-tags-prologue.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2153,SC2155,SC2164
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          boilerplates/revision-tags-prologue.md
+####################################################################################################
+
+bpsnip_revision_tags_prologue__1() {
+istioctl tag set prod-stable --revision 1-10-0
+}

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -168,10 +168,10 @@ installed above.
 
 ## Uninstall stable revision label resources
 
-If you decide to continue using the old control plane, instead of completing the upgrade,
+If you decide to continue using the old control plane, instead of completing the update,
 you can uninstall the newer revision and its tag by first issuing
 `helm template istiod manifests/charts/istio-control/istio-discovery -s templates/revision-tags.yaml --set revisionTags={prod-canary} --set revision=canary -n istio-system | kubectl delete -f -`.
-You must them uninstall the version of Istio that it pointed to by following the uninstall procedure above.
+You must them uninstall the revision of Istio that it pointed to by following the uninstall procedure above.
 
 If you installed the gateway(s) for this revision using in-place upgrades, you must also reinstall the gateway(s) for the previous revision manually,
 Removing the previous revision and its tags will not automatically revert the previously in-place upgraded gateway(s).

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -171,7 +171,7 @@ installed above.
 If you decide to continue using the old control plane, instead of completing the upgrade,
 you can uninstall the newer revision and its tag by first issuing
 `helm template istiod manifests/charts/istio-control/istio-discovery -s templates/revision-tags.yaml --set revisionTags={prod-canary} --set revision=canary -n istio-system | kubectl delete -f -`.
-You must them uninstall the version of istio that it pointed to by following the uninstall procedure above.
+You must them uninstall the version of Istio that it pointed to by following the uninstall procedure above.
 
 If you installed the gateway(s) for this revision using in-place upgrades, you must also reinstall the gateway(s) for the previous revision manually,
 Removing the previous revision and its tags will not automatically revert the previously in-place upgraded gateway(s).

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -166,6 +166,15 @@ installed above.
     $ kubectl delete namespace istio-system
     {{< /text >}}
 
+## Uninstall stable revision label resources
+
+If you decide to continue using the old control plane, instead of completing the upgrade,
+you can uninstall the newer revision using
+`helm template istiod manifests/charts/istio-control/istio-discovery -s templates/revision-tags.yaml --set revisionTags={prod-canary} --set revision=canary -n istio-system | kubectl delete -f -`.
+
+However, in this case you must first reinstall the gateway(s) for the previous revision manually,
+because the uninstall command will not automatically revert the previously in-place upgraded ones.
+
 ### (Optional) Deleting CRDs installed by Istio
 
 Deleting CRDs permanently removes any Istio resources you have created in your

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -169,11 +169,12 @@ installed above.
 ## Uninstall stable revision label resources
 
 If you decide to continue using the old control plane, instead of completing the upgrade,
-you can uninstall the newer revision using
+you can uninstall the newer revision and its tag by first issuing
 `helm template istiod manifests/charts/istio-control/istio-discovery -s templates/revision-tags.yaml --set revisionTags={prod-canary} --set revision=canary -n istio-system | kubectl delete -f -`.
+You must them uninstall the version of istio that it pointed to by following the uninstall procedure above.
 
-However, in this case you must first reinstall the gateway(s) for the previous revision manually,
-because the uninstall command will not automatically revert the previously in-place upgraded ones.
+If you installed the gateway(s) for this revision using in-place upgrades, you must also reinstall the gateway(s) for the previous revision manually,
+Removing the previous revision and its tags will not automatically revert the previously in-place upgraded gateway(s).
 
 ### (Optional) Deleting CRDs installed by Istio
 

--- a/content/en/docs/setup/upgrade/canary/index.md
+++ b/content/en/docs/setup/upgrade/canary/index.md
@@ -151,7 +151,7 @@ $ istioctl tag set prod-stable --revision 1-10-0
 $ istioctl tag set default --revision 1-10-0
 {{< /text >}}
 
-{{< boilerplate revision-tags-default-intro >}}
+{{< boilerplate revision-tags-default-outro >}}
 
 ## Uninstall old control plane
 

--- a/content/en/docs/setup/upgrade/canary/index.md
+++ b/content/en/docs/setup/upgrade/canary/index.md
@@ -120,70 +120,38 @@ The output confirms that the pod is using `istiod-canary` revision of the contro
 
 ## Stable revision labels (experimental)
 
-Manually relabeling namespaces when moving them to a new revision can be tedious and error-prone.
-[Revision tags](/docs/reference/commands/istioctl/#istioctl-tag) solve this problem.
-[Revision tags](/docs/reference/commands/istioctl/#istioctl-tag) are stable identifiers that point to revisions and can be used to avoid relabeling namespaces. Rather than relabeling the namespace, a mesh operator can simply change the tag to point to a new revision. All namespaces labeled with that tag will be updated at the same time.
+{{< tip >}}
+If you're using Helm, refer to the [Helm upgrade documentation](/docs/setup/upgrade/helm).
+{{</ tip >}}
+
+{{< boilerplate revision-tags-preamble >}}
 
 ### Usage
 
-Consider a cluster with two revisions installed, `1-9-5` and `1-10-0`. The cluster operator creates a revision tag `prod-stable`,
-pointed at the older, stable `1-9-5` version, and a revision tag `prod-canary` pointed at the newer `1-10-0` revision. That
-state could be reached via these commands:
+{{< boilerplate revision-tags-usage >}}
 
 {{< text bash >}}
 $ istioctl tag set prod-stable --revision 1-9-5
 $ istioctl tag set prod-canary --revision 1-10-0
 {{< /text >}}
 
-The resulting mapping between revisions, tags, and namespaces is as shown below:
-
-{{< image width="70%"
-    link="/docs/setup/upgrade/canary/tags.png"
-    caption="Two namespaces pointed to prod-stable and one pointed to prod-canary"
-    >}}
-
-The cluster operator can view this mapping in addition to tagged namespaces through the `istioctl tag list` command:
-
-{{< text bash >}}
-$ istioctl tag list
-TAG         REVISION NAMESPACES
-prod-canary 1-10-0   ...
-prod-stable 1-9-5    ...
-{{< /text >}}
-
-After the cluster operator is satisfied with the stability of the control plane tagged with `prod-canary`, namespaces labeled
-`istio.io/rev=prod-stable` can be updated with one action by modifying the `prod-stable` revision tag to point to the newer
-`1-10-0` revision.
+{{< boilerplate revision-tags-middle >}}
 
 {{< text bash >}}
 $ istioctl tag set prod-stable --revision 1-10-0
 {{< /text >}}
 
-Now, the situation is as below:
-
-{{< image width="70%"
-    link="/docs/setup/upgrade/canary/tags-updated.png"
-    caption="Namespace labels unchanged but now all namespaces pointed to 1-10-0"
->}}
-
-Restarting injected workloads in the namespaces marked `prod-stable` will now result in those workloads using the `1-10-0`
-control plane. Notice that no namespace relabeling was required to migrate workloads to the new revision.
+{{< boilerplate revision-tags-prologue >}}
 
 ### Default tag
 
-The revision pointed to by the tag `default` is considered the ***default revision*** and has additional semantic meaning.
-
-The `default` revision will inject sidecars for the `istio-injection=enabled` namespace selector and `sidecar.istio.io/inject=true` object
-selector in addition to the `istio.io/rev=default` selectors. This makes it possible to migrate from using non-revisioned Istio to using
-a revision entirely without relabeling namespaces. To make a revision `1-10-0` the default, run:
+{{< boilerplate revision-tags-default-intro >}}
 
 {{< text bash >}}
 $ istioctl tag set default --revision 1-10-0
 {{< /text >}}
 
-When using the `default` tag alongside an existing non-revisioned Istio installation it is recommended to remove the old
-`MutatingWebhookConfiguration` (typically called `istio-sidecar-injector`) to avoid having both the older and newer control
-planes attempt injection.
+{{< boilerplate revision-tags-default-intro >}}
 
 ## Uninstall old control plane
 

--- a/content/en/docs/setup/upgrade/helm/index.md
+++ b/content/en/docs/setup/upgrade/helm/index.md
@@ -10,7 +10,7 @@ test: no
 
 Follow this guide to upgrade and configure an Istio mesh using
 [Helm](https://helm.sh/docs/) for in-depth evaluation.  This guide assumes you have already performed an
-[installation with Helm](../../install/helm) for a previous minor or patch version of Istio.
+[installation with Helm](/docs/setup/install/helm) for a previous minor or patch version of Istio.
 
 {{< boilerplate helm-preamble >}}
 
@@ -95,6 +95,46 @@ gateways is [actively in development](/docs/setup/upgrade/gateways/) and is cons
     {{< text bash >}}
     $ helm upgrade istio-base manifests/charts/base -n istio-system --skip-crds
     {{< /text >}}
+
+### Stable revision labels (experimental)
+
+{{< warning >}}
+This workflow is only supported from Istio versions 1.10 and above.
+{{< /warning >}}
+
+{{< boilerplate revision-tags-preamble >}}
+
+#### Usage
+
+{{< boilerplate revision-tags-usage >}}
+
+{{< text bash >}}
+$ helm template istiod manifests/charts/istio-control/istio-discovery -s templates/revision-tags.yaml --set revisionTags={prod-stable} --set revision=1-9-5 -n istio-system | kubectl apply -f -
+$ helm template istiod manifests/charts/istio-control/istio-discovery -s templates/revision-tags.yaml --set revisionTags={prod-canary} --set revision=1-10-0 -n istio-system | kubectl apply -f -
+{{< /text >}}
+
+{{< warning >}}
+These commands create new `MutatingWebhookConfiguration` resources in your cluster, however, they are not owned by any Helm chart due to `kubectl` manually applying the templates. See the instructions
+below to uninstall revision tags.
+{{< /warning >}}
+
+{{< boilerplate revision-tags-middle >}}
+
+{{< text bash >}}
+$ helm template istiod manifests/charts/istio-control/istio-discovery -s templates/revision-tags.yaml --set revisionTags={prod-stable} --set revision=1-10-0 -n istio-system | kubectl apply -f -
+{{< /text >}}
+
+{{< boilerplate revision-tags-prologue >}}
+
+#### Default tag
+
+{{< boilerplate revision-tags-default-intro >}}
+
+{{< text bash >}}
+$ helm template istiod manifests/charts/istio-control/istio-discovery -s templates/revision-tags.yaml --set revisionTags={default} --set revision=1-10-0 -n istio-system | kubectl apply -f -
+{{< /text >}}
+
+{{< boilerplate revision-tags-default-intro >}}
 
 ### In place upgrade
 

--- a/content/en/docs/setup/upgrade/helm/index.md
+++ b/content/en/docs/setup/upgrade/helm/index.md
@@ -134,7 +134,7 @@ $ helm template istiod manifests/charts/istio-control/istio-discovery -s templat
 $ helm template istiod manifests/charts/istio-control/istio-discovery -s templates/revision-tags.yaml --set revisionTags={default} --set revision=1-10-0 -n istio-system | kubectl apply -f -
 {{< /text >}}
 
-{{< boilerplate revision-tags-default-intro >}}
+{{< boilerplate revision-tags-default-outro >}}
 
 ### In place upgrade
 

--- a/content/en/docs/setup/upgrade/helm/index.md
+++ b/content/en/docs/setup/upgrade/helm/index.md
@@ -99,7 +99,7 @@ gateways is [actively in development](/docs/setup/upgrade/gateways/) and is cons
 ### Stable revision labels (experimental)
 
 {{< warning >}}
-This workflow is only supported from Istio versions 1.10 and above.
+Stable revision labels are only supported when updating Istio from and to Istio versions 1.10+.
 {{< /warning >}}
 
 {{< boilerplate revision-tags-preamble >}}


### PR DESCRIPTION
Helm supports revision tags so we should add the appropriate docs for it.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

[ ] Configuration Infrastructure
[X] Docs
[ ] Installation
[ ] Networking
[ ] Performance and Scalability
[ ] Policies and Telemetry
[ ] Security
[ ] Test and Release
[ ] User Experience
[ ] Developer Infrastructure
