### PR TITLE
Document rewriting of TCP based probes (see istio 33734)

### DIFF
--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -26,6 +26,7 @@ The command approach works with no changes required, but HTTP requests and TCP p
 The health check requests to the `liveness-http` service are sent by Kubelet.
 This becomes a problem when mutual TLS is enabled, because the Kubelet does not have an Istio issued certificate.
 Therefore the health check requests will fail.
+
 TCP probe checks need special handling, because Istio redirects all incoming traffic into the sidecar, and so all TCP ports appear open.  The Kubelet simply checks if some process is listening on the specified port, and so the probe will always succeed as long as the sidecar is running.
 
 Istio solves both these problems by rewriting the application `PodSpec` readiness/liveness probe,
@@ -74,7 +75,7 @@ NAME                             READY     STATUS    RESTARTS   AGE
 liveness-6857c8775f-zdv9r        2/2       Running   0           4m
 {{< /text >}}
 
-## Liveness and readiness probes using the HTTP request approach
+## Liveness and readiness probes using the HTTP or TCP approach {#liveness-and-readiness-probes-using-the-http-request-approach}
 
 As stated previously, Istio uses probe rewrite to implement HTTP/TCP probes by default. You can disable this
 feature either for specific pods, or globally.

--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -26,7 +26,7 @@ The command approach works with no changes required, but HTTP requests and TCP p
 The health check requests to the `liveness-http` service are sent by Kubelet.
 This becomes a problem when mutual TLS is enabled, because the Kubelet does not have an Istio issued certificate.
 Therefore the health check requests will fail.
-TCP probe checks need special handling, because Istio redirects all incoming traffic into the sidecar, and so all TCP ports appear open.  The Kubelet simply checks if some process is listening on the specified port, and so the proble will always succeed as long as the sidecar is running.
+TCP probe checks need special handling, because Istio redirects all incoming traffic into the sidecar, and so all TCP ports appear open.  The Kubelet simply checks if some process is listening on the specified port, and so the probe will always succeed as long as the sidecar is running.
 
 Istio solves both these problems by rewriting the application `PodSpec` readiness/liveness probe,
 so that the probe request is sent to the [sidecar agent](/docs/reference/commands/pilot-agent/).

--- a/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
@@ -50,7 +50,7 @@ NAME                             READY     STATUS    RESTARTS   AGE
 liveness-6857c8775f-zdv9r        2/2       Running   0           4m
 ENDSNIP
 
-! read -r -d '' snip_disable_the_http_probe_rewrite_for_a_pod_1 <<\ENDSNIP
+! read -r -d '' snip_disable_the_probe_rewrite_for_a_pod_disablethehttpproberewriteforapod_1 <<\ENDSNIP
 kubectl apply -f - <<EOF
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Document automatic rewriting of TCP based probes, which was introduced in PR https://github.com/istio/istio/pull/33734


- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
