### PR TITLE
fix apiVersion for gw install

### DIFF
--- a/content/en/docs/setup/additional-setup/gateway/index.md
+++ b/content/en/docs/setup/additional-setup/gateway/index.md
@@ -52,7 +52,7 @@ As a security best practice, it is recommended to deploy the gateway in a differ
 First, setup an `IstioOperator` configuration file, called `ingress.yaml` here:
 
 {{< text yaml >}}
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   name: ingress

--- a/content/en/docs/setup/additional-setup/sidecar-injection/index.md
+++ b/content/en/docs/setup/additional-setup/sidecar-injection/index.md
@@ -231,7 +231,7 @@ Completely custom templates can also be defined at installation time.
 For example, to define a custom template that injects the `GREETING` environment variable into the `istio-proxy` container:
 
 {{< text yaml >}}
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   name: istio

--- a/content/en/docs/setup/install/external-controlplane/index.md
+++ b/content/en/docs/setup/install/external-controlplane/index.md
@@ -426,7 +426,7 @@ including gateways, if needed.
 
     {{< text bash >}}
     $ cat <<EOF > istio-ingressgateway.yaml
-    apiVersion: operator.istio.io/v1alpha1
+    apiVersion: install.istio.io/v1alpha1
     kind: IstioOperator
     spec:
       profile: empty
@@ -447,7 +447,7 @@ including gateways, if needed.
 
     {{< text bash >}}
     $ cat <<EOF > istio-egressgateway.yaml
-    apiVersion: operator.istio.io/v1alpha1
+    apiVersion: install.istio.io/v1alpha1
     kind: IstioOperator
     spec:
       profile: empty

--- a/content/en/docs/setup/install/external-controlplane/snips.sh
+++ b/content/en/docs/setup/install/external-controlplane/snips.sh
@@ -300,7 +300,7 @@ ENDSNIP
 
 snip_enable_gateways_1() {
 cat <<EOF > istio-ingressgateway.yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   profile: empty
@@ -319,7 +319,7 @@ istioctl install -f istio-ingressgateway.yaml --context="${CTX_REMOTE_CLUSTER}"
 
 snip_enable_gateways_2() {
 cat <<EOF > istio-egressgateway.yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   profile: empty

--- a/content/zh/docs/setup/additional-setup/external-controlplane/index.md
+++ b/content/zh/docs/setup/additional-setup/external-controlplane/index.md
@@ -401,7 +401,7 @@ $ export REMOTE_CLUSTER_NAME=<your remote cluster name>
 
     {{< text bash >}}
     $ cat <<EOF > istio-ingressgateway.yaml
-    apiVersion: operator.istio.io/v1alpha1
+    apiVersion: install.istio.io/v1alpha1
     kind: IstioOperator
     spec:
       profile: empty
@@ -422,7 +422,7 @@ $ export REMOTE_CLUSTER_NAME=<your remote cluster name>
 
     {{< text bash >}}
     $ cat <<EOF > istio-egressgateway.yaml
-    apiVersion: operator.istio.io/v1alpha1
+    apiVersion: install.istio.io/v1alpha1
     kind: IstioOperator
     spec:
       profile: empty

--- a/content/zh/docs/setup/additional-setup/external-controlplane/snips.sh
+++ b/content/zh/docs/setup/additional-setup/external-controlplane/snips.sh
@@ -322,7 +322,7 @@ ENDSNIP
 
 snip_enable_gateways_1() {
 cat <<EOF > istio-ingressgateway.yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   profile: empty
@@ -341,7 +341,7 @@ istioctl install -f istio-ingressgateway.yaml --context="${CTX_REMOTE_CLUSTER}"
 
 snip_enable_gateways_2() {
 cat <<EOF > istio-egressgateway.yaml
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   profile: empty

--- a/content/zh/docs/setup/additional-setup/sidecar-injection/index.md
+++ b/content/zh/docs/setup/additional-setup/sidecar-injection/index.md
@@ -216,7 +216,7 @@ spec:
 可以在安装时定义一个自定义模板，例如，将 `GREETING` 环境变量注入到 `istio-proxy` 容器中：
 
 {{< text yaml >}}
-apiVersion: operator.istio.io/v1alpha1
+apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   name: istio


### PR DESCRIPTION
getting an error for current doc if I use this yaml with server side istio-operator.   

```
error: unable to recognize "iop.yaml": no matches for kind "IstioOperator" in version "operator.istio.io/v1alpha1"
```

use `apiVersion: install.istio.io/v1alpha1` would work for both `istioctl install -f` or `kubectl apply -f`


- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure