### PR TITLE
Documentation: change Secret name in Sidecar Injection Problems section

### DIFF
--- a/content/en/docs/ops/common-problems/injection/index.md
+++ b/content/en/docs/ops/common-problems/injection/index.md
@@ -148,7 +148,7 @@ Verify the `caBundle` in the `mutatingwebhookconfiguration` matches the
 {{< text bash >}}
 $ kubectl get mutatingwebhookconfiguration istio-sidecar-injector -o yaml -o jsonpath='{.webhooks[0].clientConfig.caBundle}' | md5sum
 4b95d2ba22ce8971c7c92084da31faf0  -
-$ kubectl -n istio-system get secret istiod-service-account-token -o jsonpath='{.data.root-cert\.pem}' | md5sum
+$ kubectl -n istio-system get secret istio-ca-secret -o jsonpath='{.data.root-cert\.pem}' | md5sum
 4b95d2ba22ce8971c7c92084da31faf0  -
 {{< /text >}}
 

--- a/content/en/docs/ops/common-problems/injection/index.md
+++ b/content/en/docs/ops/common-problems/injection/index.md
@@ -146,9 +146,9 @@ Verify the `caBundle` in the `mutatingwebhookconfiguration` matches the
    root certificate mounted in the `istiod` pod.
 
 {{< text bash >}}
-$ kubectl get mutatingwebhookconfiguration istio-sidecar-injector -o yaml -o jsonpath='{.webhooks[0].clientConfig.caBundle}' | md5sum
+$ kubectl get mutatingwebhookconfiguration istio-sidecar-injector -o jsonpath='{.webhooks[0].clientConfig.caBundle}' | md5sum
 4b95d2ba22ce8971c7c92084da31faf0  -
-$ kubectl -n istio-system get secret istio-ca-secret -o jsonpath='{.data.root-cert\.pem}' | md5sum
+$ kubectl -n istio-system get secret istio-ca-secret -o jsonpath='{.data.ca-cert\.pem}' | md5sum
 4b95d2ba22ce8971c7c92084da31faf0  -
 {{< /text >}}
 


### PR DESCRIPTION
Change Secret name from `istiod-service-account-token` to `istio-ca-secret`.

I guess the latter is the correct Secret to use, as it's the only Secret containing a `root-cert.pem` field. And the former seems to be a ServiceAccount token Secret as created by the [Token Controller](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#token-controller) for every ServiceAccount.

However, I didn't look into the code, so correct me if I'm wrong.

Link to the section in the docs: https://istio.io/latest/docs/ops/common-problems/injection/#x509-certificate-related-errors

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure