### PR TITLE
Fix in attribute "name" on "metadata".

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-custom/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-custom/index.md
@@ -77,7 +77,7 @@ of the application that needs the external authorization.
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-name: external-authz-grpc-local
+  name: external-authz-grpc-local
 spec:
   hosts:
   - "external-authz-grpc.local" # The service name to be used in the extension provider in the mesh config.

--- a/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
@@ -57,7 +57,7 @@ ENDSNIP
 apiVersion: networking.istio.io/v1alpha3
 kind: ServiceEntry
 metadata:
-name: external-authz-grpc-local
+  name: external-authz-grpc-local
 spec:
   hosts:
   - "external-authz-grpc.local" # The service name to be used in the extension provider in the mesh config.


### PR DESCRIPTION
Missing tab in attribute "name" at section "Define the external authorizer" in ServiceEntry example.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
