### PR TITLE
Ensure extra padding when banner is present

### DIFF
--- a/src/sass/misc/_banners.scss
+++ b/src/sass/misc/_banners.scss
@@ -59,6 +59,6 @@
 }
 @media screen AND (min-width: $bp-md) {
     .banner-padding {
-        padding-top: 5rem;
+        padding-top: 5rem !important;
     }
 }


### PR DESCRIPTION

Ensure CSS padding setup is correctly handled when banner is present for pages such as Docs, News and Get Involved.
Some other pages such as FAQ, Docs, etc. seem to have no issue as there is no conflicting padding setup.

Before this change:

Blog
![image](https://user-images.githubusercontent.com/23435099/129370447-2abb8493-74ea-4bea-aa81-d49526fcd732.png)

News
![image](https://user-images.githubusercontent.com/23435099/129370378-ba248707-7abd-4e8f-b3a9-83276aa96911.png)

Get Involved
![image](https://user-images.githubusercontent.com/23435099/129370340-01cd5dc0-c60e-4227-9301-0612e629be81.png)


--


- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure