### PR TITLE
Update contributing links

### DIFF
--- a/content/en/about/case-studies/_index.md
+++ b/content/en/about/case-studies/_index.md
@@ -9,4 +9,4 @@ type: case-studies
 sidebar_none: true
 ---
 
-[comment]: <> (To add yourself as an Istio user, please see https://github.com/istio/istio.io/blob/master/CONTRIBUTING.md.)
+[comment]: <> (To add yourself as an Istio user, please see https://github.com/istio/community/blob/master/CONTRIBUTING.md#tell-the-world-youre-using-istio.)

--- a/content/en/about/ecosystem/index.md
+++ b/content/en/about/ecosystem/index.md
@@ -12,7 +12,7 @@ aliases:
 doc_type: about
 ---
 
-[comment]: <> (To add an Istio provider, professional services consultancy or integration, please see https://github.com/istio/istio.io/blob/master/CONTRIBUTING.md.)
+[comment]: <> (To add an Istio provider, professional services consultancy or integration, please see https://github.com/istio/community/blob/master/CONTRIBUTING.md#promote-your-company-on-istioio.)
 
 {{< tabset category-name="ecosystem-type" class="tabset--ecosystem" forget-tab=true >}}
 

--- a/data/companies.yml
+++ b/data/companies.yml
@@ -1,4 +1,4 @@
-# Please see [CONTRIBUTING.md](/CONTRIBUTING.md) to learn more about editing this file.
+# Please see [CONTRIBUTING.md](https://github.com/istio/community/blob/master/CONTRIBUTING.md) to learn more about editing this file.
 
 providers:
   - name: "Google Cloud's Anthos Service Mesh"


### PR DESCRIPTION
An automatic update stomped my changes to CONTRIBUTING.md, so I've updated the links that point to it, to point to the same text now in community/CONTRIBUTING.md.