### PR TITLE
Only lint markdown files in some areas of the linting

### DIFF
--- a/scripts/lint_site.sh
+++ b/scripts/lint_site.sh
@@ -71,27 +71,27 @@ check_content() {
         FAILED=1
     fi
 
-    if grep -nrP -e "\(https://istio.io/(?!v[0-9]\.[0-9]/|archive/)" .; then
+    if grep -nrP --include "*.md" -e "\(https://istio.io/(?!v[0-9]\.[0-9]/|archive/)" .; then
         echo "Ensure markdown content uses relative references to istio.io"
         FAILED=1
     fi
 
-    if grep -nr -e "(https://preliminary.istio.io" .; then
+    if grep -nr --include "*.md" -e "(https://preliminary.istio.io" .; then
         echo "Ensure markdown content doesn't contain references to preliminary.istio.io"
         FAILED=1
     fi
 
-    if grep -nr -e https://github.com/istio/istio/blob/ .; then
+    if grep -nr --include "*.md" -e https://github.com/istio/istio/blob/ .; then
         echo "Ensure markdown content uses {{< github_blob >}}"
         FAILED=1
     fi
 
-    if grep -nr -e https://github.com/istio/istio/tree/ .; then
+    if grep -nr --include "*.md" -e https://github.com/istio/istio/tree/ .; then
         echo "Ensure markdown content uses {{< github_tree >}}"
         FAILED=1
     fi
 
-    if grep -nr --exclude='*.sh' -e https://raw.githubusercontent.com/istio/istio/ .; then
+    if grep -nr --include "*.md" -e https://raw.githubusercontent.com/istio/istio/ .; then
         echo "Ensure markdown content uses {{< github_file >}}"
         FAILED=1
     fi


### PR DESCRIPTION

Some PRs like https://github.com/istio/istio.io/pull/10079 fail lifting when we are prepping for files with certain text. The error messages for these `grep`s has the error text like `Ensure markdown content uses`. I suspect we should only be checking the *.md files and not all files (one check already excludes .sh files).

This PR update the `graphs to only include files like `*.md`.


- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure