### PR TITLE
fix typo in PortNameIsNotUnderNamingConvention page

### DIFF
--- a/content/en/docs/reference/config/analysis/ist0118/index.md
+++ b/content/en/docs/reference/config/analysis/ist0118/index.md
@@ -34,7 +34,7 @@ spec:
     app: httpbin
 {{< /text >}}
 
-In this example, the port `foo-http` does follow the syntax: `name: <protocol>[-<suffix>]`.
+In this example, the port name `foo-http` does not follow the syntax: `name: <protocol>[-<suffix>]`.
 
 ## How to resolve
 


### PR DESCRIPTION
https://preliminary.istio.io/latest/docs/reference/config/analysis/ist0118/

This sentence is missing a "not"

`In this example, the port foo-http does follow the syntax: name: <protocol>[-<suffix>].`


- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure