### PR TITLE
Update istio test ref to possible 1.11.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/evanphx/json-patch => github.com/evanphx/json-patch v0.0.0-20
 require (
 	github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f
 	github.com/pmezard/go-difflib v1.0.0
-	istio.io/istio v0.0.0-20210810222043-ce6205d503e5
+	istio.io/istio v0.0.0-20210831230922-96710172e1e4
 	istio.io/pkg v0.0.0-20210809175755-95ff2e6f6c81
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v0.21.2

--- a/go.sum
+++ b/go.sum
@@ -1554,13 +1554,13 @@ honnef.co/go/tools v0.0.1-2020.1.5 h1:nI5egYTGJakVyOryqLs1cQO5dO0ksin5XXs2pspk75
 honnef.co/go/tools v0.0.1-2020.1.5/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 istio.io/api v0.0.0-20210809175348-eff556fb5d8a h1:sxWs6PoBztWTsfM6zLNkNtN3zkTSmYQ9xfD48hxPErs=
 istio.io/api v0.0.0-20210809175348-eff556fb5d8a/go.mod h1:nsSFw1LIMmGL7r/+6fJI6FxeG/UGlLxRK8bkojIvBVs=
-istio.io/client-go v1.11.0-rc.3 h1:AxE7E/o9knkUbw0DJI+iGbLSS816IVWWrkhAkbxYZS0=
-istio.io/client-go v1.11.0-rc.3/go.mod h1:LY+kPcgIYdp56G40ZeypEXqCWEJ0muT18HzckczqtiY=
+istio.io/client-go v1.11.0 h1:h1oEF1ResTTjqOrLrrB2uP/1/TorwOrZxJdI59XfT7E=
+istio.io/client-go v1.11.0/go.mod h1:LY+kPcgIYdp56G40ZeypEXqCWEJ0muT18HzckczqtiY=
 istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
 istio.io/gogo-genproto v0.0.0-20210809183655-16cc1841f1f7 h1:C5S3c7jxDPWQGy8sDmqAob/kAxCNWmN2Sy2t3DQ+BpI=
 istio.io/gogo-genproto v0.0.0-20210809183655-16cc1841f1f7/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
-istio.io/istio v0.0.0-20210810222043-ce6205d503e5 h1:GqWxj8Q2XJ/3v4ngSD9EgnVp9/ZrcR7Suh3A2tZXpW8=
-istio.io/istio v0.0.0-20210810222043-ce6205d503e5/go.mod h1:b1g+O9s6HfNH+zFd7hhoi0FbfT9fJXclx4Y8rPS4Ev0=
+istio.io/istio v0.0.0-20210831230922-96710172e1e4 h1:wjWVhRR66R6XmC7nnwmqMdyWgQctMUjmk6X/tt9woDU=
+istio.io/istio v0.0.0-20210831230922-96710172e1e4/go.mod h1:pBfCxZ9g36RhJe/VxV2UH0H+RqZH8ZEIrQLBUD3cN7A=
 istio.io/pkg v0.0.0-20210809175755-95ff2e6f6c81 h1:SJqzlIDNff5sa1Hk3SCy+fCKbFS1R+VU90q5HpFc/gk=
 istio.io/pkg v0.0.0-20210809175755-95ff2e6f6c81/go.mod h1:sGg+vU5lN5gpFVWtazMbR8Oc+Cr+3qoh/h3zdHDM84o=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=


### PR DESCRIPTION
Please provide a description for what this PR is for.

Run istio.io tests with 1.11.2 build

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
