### PR TITLE
Update ref docs for 1.11.2

### DIFF
--- a/content/en/docs/reference/commands/istioctl/index.html
+++ b/content/en/docs/reference/commands/istioctl/index.html
@@ -3972,6 +3972,11 @@ Configure requires either the WorkloadGroup artifact path or its location on the
 <td>The name of the kubeconfig context to use  (default ``)</td>
 </tr>
 <tr>
+<td><code>--externalIP &lt;string&gt;</code></td>
+<td></td>
+<td>External IP address of the workload  (default ``)</td>
+</tr>
+<tr>
 <td><code>--file &lt;string&gt;</code></td>
 <td><code>-f</code></td>
 <td>filename of the WorkloadGroup artifact. Leave this field empty if using the API server  (default ``)</td>
@@ -3985,6 +3990,11 @@ Configure requires either the WorkloadGroup artifact path or its location on the
 <td><code>--ingressService &lt;string&gt;</code></td>
 <td></td>
 <td>Name of the Service to be used as the ingress gateway, in the format &lt;service&gt;.&lt;namespace&gt;. If no namespace is provided, the default istio-system namespace will be used.  (default `istio-eastwestgateway`)</td>
+</tr>
+<tr>
+<td><code>--internalIP &lt;string&gt;</code></td>
+<td></td>
+<td>Internal IP address of the workload  (default ``)</td>
 </tr>
 <tr>
 <td><code>--istioNamespace &lt;string&gt;</code></td>
@@ -4025,11 +4035,6 @@ Configure requires either the WorkloadGroup artifact path or its location on the
 <td><code>--vklog &lt;Level&gt;</code></td>
 <td></td>
 <td>number for the log level verbosity. Like -v flag. ex: --vklog=9  (default `0`)</td>
-</tr>
-<tr>
-<td><code>--workloadIP &lt;string&gt;</code></td>
-<td></td>
-<td>IP address of the workload used in the WorkloadEntry  (default ``)</td>
 </tr>
 </tbody>
 </table>

--- a/content/en/docs/reference/commands/pilot-agent/index.html
+++ b/content/en/docs/reference/commands/pilot-agent/index.html
@@ -1053,6 +1053,12 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <td>If this is set to true, one Istiod will control remote clusters including CA.</td>
 </tr>
 <tr>
+<td><code>FILE_DEBOUNCE_DURATION</code></td>
+<td>Time Duration</td>
+<td><code>100ms</code></td>
+<td>The duration for which the file read operation is delayed once file update is detected</td>
+</tr>
+<tr>
 <td><code>FILE_MOUNTED_CERTS</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>


### PR DESCRIPTION
Please provide a description for what this PR is for.

Run the `make update_ref_docs` when 1.11.2 is built.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
