### PR TITLE
Fixed typo in cipher suites

### DIFF
--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -193,7 +193,7 @@ follows:
 Istio configures `TLSv1_2` as the minimum TLS version for both client and server with
 the following cipher suites:
 
-- `CDHE-ECDSA-AES256-GCM-SHA384`
+- `ECDHE-ECDSA-AES256-GCM-SHA384`
 
 - `ECDHE-RSA-AES256-GCM-SHA384`
 

--- a/content/zh/docs/concepts/security/index.md
+++ b/content/zh/docs/concepts/security/index.md
@@ -123,7 +123,7 @@ Istio 通过客户端和服务器端 PEPs 建立服务到服务的通信通道�
 
 Istio 将 `TLSv1_2` 作为最低 TLS 版本为客户端和服务器配置了如下的加密套件:
 
-- `CDHE-ECDSA-AES256-GCM-SHA384`
+- `ECDHE-ECDSA-AES256-GCM-SHA384`
 
 - `ECDHE-RSA-AES256-GCM-SHA384`
 


### PR DESCRIPTION
Fixed a small typo in the cipher suites. It has to be ECDHE-ECDSA-AES256-GCM-SHA384. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure