### PR TITLE
minor improvements in the Reporting Bugs page

### DIFF
--- a/content/en/docs/releases/bugs/index.md
+++ b/content/en/docs/releases/bugs/index.md
@@ -80,25 +80,25 @@ containing:
 * Current and previous logs from all Istio components and sidecars.
 Here some examples on how to obtain those, please adapt for your environment:
 
-  - Istiod logs:
+  * Istiod logs:
 
         {{< text bash >}}
         $ kubectl logs -n istio-system -l app=istiod
         {{< /text >}}
 
-  - Ingress Gateway logs:
+  * Ingress Gateway logs:
 
         {{< text bash >}}
         $ kubectl logs -l istio=ingressgateway -n istio-system
         {{< /text >}}
 
-  - Egress Gateway logs:
+  * Egress Gateway logs:
 
         {{< text bash >}}
         $ kubectl logs -l istio=egressgateway -n istio-system
         {{< /text >}}
 
-  - Sidecar logs:
+  * Sidecar logs:
 
         {{< text bash >}}
         $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l service.istio.io/canonical-revision -c istio-proxy -n $ns ; done

--- a/content/en/docs/releases/bugs/index.md
+++ b/content/en/docs/releases/bugs/index.md
@@ -42,6 +42,10 @@ Then attach the produced `bug-report.tgz` with your reported problem.
 The `istioctl bug-report` command is only available with `istioctl` version `1.8.0` and higher but it can be used to also collect the information from an older Istio version installed in your cluster.
 {{< /tip >}}
 
+{{< tip >}}
+If you are running bug-report on a large cluster, it might fail to complete. Please use the `--include ns1,ns2` option to target the collection of proxy configs and logs only for the relevant namespaces. For more bug-report options, please visit [the istioctl bug-report reference](/reference/commands/istioctl/#istioctl-bug-report)
+{{< /tip >}}
+
 If you are unable to use the `bug-report` command, please attach your own archive
 containing:
 
@@ -65,16 +69,40 @@ containing:
 
 * Current and previous logs from all Istio components and sidecar
 
-* Istiod logs:
+    * Istiod logs:
 
-    {{< text bash >}}
-    $ kubectl logs -n istio-system -l app=istiod
-    {{< /text >}}
+        {{< text bash >}}
+        $ kubectl logs -n istio-system -l app=istiod
+        {{< /text >}}
+    
+    * Ingress Gateway logs:
+    
+        {{< text bash >}}
+        $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l istio=ingressgateway -n $ns ; done
+        {{< /text >}}
+    
+    * Egress Gateway logs:
+    
+        {{< text bash >}}
+        $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l istio=eressgateway -n $ns ; done
+        {{< /text >}}
+    
+    * Sidecar logs:
+    
+        {{< text bash >}}
+        for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l service.istio.io/canonical-revision=latest -c istio-proxy -n $ns ; done
+        {{< /text >}}
 
 * All Istio configuration artifacts:
 
     {{< text bash >}}
     $ kubectl get $(kubectl get crd  --no-headers | awk '{printf "%s,",$1}END{printf "attributemanifests.config.istio.io\n"}') --all-namespaces
+    {{< /text >}}
+
+* Output of istioctl analyze:
+
+    {{< text bash >}}
+    $ istioctl analyze --all-namespaces
     {{< /text >}}
 
 ## Documentation bugs

--- a/content/en/docs/releases/bugs/index.md
+++ b/content/en/docs/releases/bugs/index.md
@@ -84,19 +84,19 @@ containing:
     * Egress Gateway logs:
     
         {{< text bash >}}
-        $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l istio=eressgateway -n $ns ; done
+        $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l istio=egressgateway -n $ns ; done
         {{< /text >}}
     
     * Sidecar logs:
     
         {{< text bash >}}
-        for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l service.istio.io/canonical-revision=latest -c istio-proxy -n $ns ; done
+        $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l service.istio.io/canonical-revision -c istio-proxy -n $ns ; done
         {{< /text >}}
 
 * All Istio configuration artifacts:
 
     {{< text bash >}}
-    $ kubectl get $(kubectl get crd  --no-headers | awk '{printf "%s,",$1}END{printf "attributemanifests.config.istio.io\n"}') --all-namespaces
+    $ kubectl get istio-io --all-namespaces -o yaml
     {{< /text >}}
 
 * Output of istioctl analyze:

--- a/content/en/docs/releases/bugs/index.md
+++ b/content/en/docs/releases/bugs/index.md
@@ -43,7 +43,11 @@ The `istioctl bug-report` command is only available with `istioctl` version `1.8
 {{< /tip >}}
 
 {{< tip >}}
-If you are running `bug-report` on a large cluster, it might fail to complete. Please use the `--include ns1,ns2` option to target the collection of proxy commands and logs only for the relevant namespaces. For more bug-report options, please visit [the istioctl bug-report reference](/docs/reference/commands/istioctl/#istioctl-bug-report)
+If you are running `bug-report` on a large cluster, it might fail to complete.
+Please use the `--include ns1,ns2` option to target the collection of proxy
+commands and logs only for the relevant namespaces. For more bug-report options,
+please visit [the istioctl bug-report
+reference](/docs/reference/commands/istioctl/#istioctl-bug-report).
 {{< /tip >}}
 
 If you are unable to use the `bug-report` command, please attach your own archive
@@ -73,33 +77,32 @@ containing:
     $ kubectl --namespace istio-system get cm -o yaml
     {{< /text >}}
 
-* Current and previous logs from all Istio components and sidecars:
+* Current and previous logs from all Istio components and sidecars.
+Here some examples on how to obtain those, please adapt for your environment:
 
-  Here some examples on how to obtain those, please adapt for your environment:
+* Istiod logs:
 
-    * Istiod logs:
+    {{< text bash >}}
+    $ kubectl logs -n istio-system -l app=istiod
+    {{< /text >}}
 
-        {{< text bash >}}
-        $ kubectl logs -n istio-system -l app=istiod
-        {{< /text >}}
+* Ingress Gateway logs:
 
-    * Ingress Gateway logs:
+    {{< text bash >}}
+    $ kubectl logs -l istio=ingressgateway -n istio-system
+    {{< /text >}}
 
-        {{< text bash >}}
-        $ kubectl logs -l istio=ingressgateway -n istio-system
-        {{< /text >}}
+* Egress Gateway logs:
 
-    * Egress Gateway logs:
+    {{< text bash >}}
+    $ kubectl logs -l istio=egressgateway -n istio-system
+    {{< /text >}}
 
-        {{< text bash >}}
-        $ kubectl logs -l istio=egressgateway -n istio-system
-        {{< /text >}}
+* Sidecar logs:
 
-    * Sidecar logs:
-
-        {{< text bash >}}
-        $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l service.istio.io/canonical-revision -c istio-proxy -n $ns ; done
-        {{< /text >}}
+    {{< text bash >}}
+    $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l service.istio.io/canonical-revision -c istio-proxy -n $ns ; done
+    {{< /text >}}
 
 * All Istio configuration artifacts:
 

--- a/content/en/docs/releases/bugs/index.md
+++ b/content/en/docs/releases/bugs/index.md
@@ -77,28 +77,27 @@ containing:
     $ kubectl --namespace istio-system get cm -o yaml
     {{< /text >}}
 
-* Current and previous logs from all Istio components and sidecars.
-Here some examples on how to obtain those, please adapt for your environment:
+* Current and previous logs from all Istio components and sidecars. Here some examples on how to obtain those, please adapt for your environment:
 
-  * Istiod logs:
+    * Istiod logs:
 
         {{< text bash >}}
         $ kubectl logs -n istio-system -l app=istiod
         {{< /text >}}
 
-  * Ingress Gateway logs:
+    * Ingress Gateway logs:
 
         {{< text bash >}}
         $ kubectl logs -l istio=ingressgateway -n istio-system
         {{< /text >}}
 
-  * Egress Gateway logs:
+    * Egress Gateway logs:
 
         {{< text bash >}}
         $ kubectl logs -l istio=egressgateway -n istio-system
         {{< /text >}}
 
-  * Sidecar logs:
+    * Sidecar logs:
 
         {{< text bash >}}
         $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l service.istio.io/canonical-revision -c istio-proxy -n $ns ; done

--- a/content/en/docs/releases/bugs/index.md
+++ b/content/en/docs/releases/bugs/index.md
@@ -43,7 +43,7 @@ The `istioctl bug-report` command is only available with `istioctl` version `1.8
 {{< /tip >}}
 
 {{< tip >}}
-If you are running bug-report on a large cluster, it might fail to complete. Please use the `--include ns1,ns2` option to target the collection of proxy configs and logs only for the relevant namespaces. For more bug-report options, please visit [the istioctl bug-report reference](/reference/commands/istioctl/#istioctl-bug-report)
+If you are running `bug-report` on a large cluster, it might fail to complete. Please use the `--include ns1,ns2` option to target the collection of proxy commands and logs only for the relevant namespaces. For more bug-report options, please visit [the istioctl bug-report reference](/docs/reference/commands/istioctl/#istioctl-bug-report)
 {{< /tip >}}
 
 If you are unable to use the `bug-report` command, please attach your own archive
@@ -74,21 +74,21 @@ containing:
         {{< text bash >}}
         $ kubectl logs -n istio-system -l app=istiod
         {{< /text >}}
-    
+
     * Ingress Gateway logs:
-    
+
         {{< text bash >}}
         $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l istio=ingressgateway -n $ns ; done
         {{< /text >}}
-    
+
     * Egress Gateway logs:
-    
+
         {{< text bash >}}
         $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l istio=egressgateway -n $ns ; done
         {{< /text >}}
-    
+
     * Sidecar logs:
-    
+
         {{< text bash >}}
         $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l service.istio.io/canonical-revision -c istio-proxy -n $ns ; done
         {{< /text >}}

--- a/content/en/docs/releases/bugs/index.md
+++ b/content/en/docs/releases/bugs/index.md
@@ -107,7 +107,6 @@ containing:
     $ kubectl get istio-io --all-namespaces -o yaml
     {{< /text >}}
 
-
 ## Documentation bugs
 
 Search our [documentation issue database](https://github.com/istio/istio.io/issues/) to see if

--- a/content/en/docs/releases/bugs/index.md
+++ b/content/en/docs/releases/bugs/index.md
@@ -80,29 +80,29 @@ containing:
 * Current and previous logs from all Istio components and sidecars.
 Here some examples on how to obtain those, please adapt for your environment:
 
-* Istiod logs:
+  - Istiod logs:
 
-    {{< text bash >}}
-    $ kubectl logs -n istio-system -l app=istiod
-    {{< /text >}}
+        {{< text bash >}}
+        $ kubectl logs -n istio-system -l app=istiod
+        {{< /text >}}
 
-* Ingress Gateway logs:
+  - Ingress Gateway logs:
 
-    {{< text bash >}}
-    $ kubectl logs -l istio=ingressgateway -n istio-system
-    {{< /text >}}
+        {{< text bash >}}
+        $ kubectl logs -l istio=ingressgateway -n istio-system
+        {{< /text >}}
 
-* Egress Gateway logs:
+  - Egress Gateway logs:
 
-    {{< text bash >}}
-    $ kubectl logs -l istio=egressgateway -n istio-system
-    {{< /text >}}
+        {{< text bash >}}
+        $ kubectl logs -l istio=egressgateway -n istio-system
+        {{< /text >}}
 
-* Sidecar logs:
+  - Sidecar logs:
 
-    {{< text bash >}}
-    $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l service.istio.io/canonical-revision -c istio-proxy -n $ns ; done
-    {{< /text >}}
+        {{< text bash >}}
+        $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l service.istio.io/canonical-revision -c istio-proxy -n $ns ; done
+        {{< /text >}}
 
 * All Istio configuration artifacts:
 

--- a/content/en/docs/releases/bugs/index.md
+++ b/content/en/docs/releases/bugs/index.md
@@ -49,6 +49,12 @@ If you are running `bug-report` on a large cluster, it might fail to complete. P
 If you are unable to use the `bug-report` command, please attach your own archive
 containing:
 
+* Output of istioctl analyze:
+
+    {{< text bash >}}
+    $ istioctl analyze --all-namespaces
+    {{< /text >}}
+
 * Pods, services, deployments, and endpoints across all namespaces:
 
     {{< text bash >}}
@@ -67,7 +73,9 @@ containing:
     $ kubectl --namespace istio-system get cm -o yaml
     {{< /text >}}
 
-* Current and previous logs from all Istio components and sidecar
+* Current and previous logs from all Istio components and sidecars:
+
+  Here some examples on how to obtain those, please adapt for your environment:
 
     * Istiod logs:
 
@@ -78,13 +86,13 @@ containing:
     * Ingress Gateway logs:
 
         {{< text bash >}}
-        $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l istio=ingressgateway -n $ns ; done
+        $ kubectl logs -l istio=ingressgateway -n istio-system
         {{< /text >}}
 
     * Egress Gateway logs:
 
         {{< text bash >}}
-        $ for ns in $(kubectl get ns -o jsonpath='{.items[*].metadata.name}') ; do kubectl logs -l istio=egressgateway -n $ns ; done
+        $ kubectl logs -l istio=egressgateway -n istio-system
         {{< /text >}}
 
     * Sidecar logs:
@@ -99,11 +107,6 @@ containing:
     $ kubectl get istio-io --all-namespaces -o yaml
     {{< /text >}}
 
-* Output of istioctl analyze:
-
-    {{< text bash >}}
-    $ istioctl analyze --all-namespaces
-    {{< /text >}}
 
 ## Documentation bugs
 


### PR DESCRIPTION
- Adds recommendation to obtain output of istioctl analyze in the case of manual dump (I think it is great to collect this if bug-report is not possible)
- Adds commands to obtain gateways and sidecar logs
- Adds a note on using `--include` if the bug-report is failing to complete in the case of large clusters linking to reference docs for other options.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
