### PR TITLE
glossary: Update spiffe trust-domain reference link

### DIFF
--- a/content/en/docs/reference/glossary/trust-domain.md
+++ b/content/en/docs/reference/glossary/trust-domain.md
@@ -3,7 +3,7 @@ title: Trust Domain
 test: n/a
 ---
 
-[Trust domain](https://spiffe.io/spiffe/concepts/#trust-domain) corresponds to the trust root of a system and is part of a workload identity.
+[Trust domain](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/#trust-domain) corresponds to the trust root of a system and is part of a workload identity.
 
 Istio uses a trust domain to create all [identities](/docs/reference/glossary/#identity) within a mesh.
 For example in `spiffe://mytrustdomain.com/ns/default/sa/myname` the substring `mytrustdomain.com` specifies that the workload is from a trust domain called `mytrustdomain.com`.

--- a/content/zh/docs/reference/glossary/trust-domain.md
+++ b/content/zh/docs/reference/glossary/trust-domain.md
@@ -3,7 +3,7 @@ title: Trust Domain
 test: n/a
 ---
 
-[信任域](https://spiffe.io/spiffe/concepts/#trust-domain)对应于系统的信任根，并且是工作负载标识的一部分。
+[信任域](https://spiffe.io/docs/latest/spiffe-about/spiffe-concepts/#trust-domain)对应于系统的信任根，并且是工作负载标识的一部分。
 
 Istio 使用信任域在网格中创建所有[身份](/zh/docs/reference/glossary/#identity)。每个网格都有一个专用的信任域。
 


### PR DESCRIPTION
This updates the "trust-domain" glossary entry reference link. The `spiffe` docs site is updated and this fixes the link to directly jump to the trust-domain anchor.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
