### PR TITLE
Allow overriding istio/api Git URL for local checking

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -142,8 +142,21 @@ netlify: netlify_install
 	@scripts/build_site.sh "/latest"
 	@scripts/include_archive_site.sh
 
+# ISTIO_API_GIT_SOURCE allows to override the default Istio API repository, https://github.com/istio/api@$(SOURCE_BRANCH_NAME)
+# with, for example, a mapped local directory: file:///work/istio/api@branch-name when running `update_ref_docs`.
+#
+# The format for ISTIO_API_GIT_SOURCE value is {GIT_URL}@{TARGET_BRANCH_NAME}.
+#
+# Note that when running with BUILD_WITH_CONTAINER=1, we can map the local directory by setting
+# the ADDITIONAL_CONTAINER_OPTIONS environment variable as shown in the below example:
+#
+# $ BUILD_WITH_CONTAINER=1 \
+#   ISTIO_API_GIT_SOURCE="file:///work/istio/api@branchname" \
+#   ADDITIONAL_CONTAINER_OPTIONS="-v /path/to/local/istio/api:/work/istio/api" \
+#   	make update_ref_docs
+export ISTIO_API_GIT_SOURCE ?=
 update_ref_docs:
-	@scripts/grab_reference_docs.sh $(SOURCE_BRANCH_NAME)
+	@scripts/grab_reference_docs.sh $(SOURCE_BRANCH_NAME) $(ISTIO_API_GIT_SOURCE)
 
 update_test_reference:
 	@go get istio.io/istio@$(SOURCE_BRANCH_NAME) && go mod tidy

--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -29,6 +29,10 @@ else
   SOURCE_BRANCH_NAME="master"
 fi
 
+if [[ "$2" != "" ]]; then
+  ISTIO_API_GIT_SOURCE="$2"
+fi
+
 # The repos to mine for docs, just add new entries here to pull in more repos.
 REPOS=(
     https://github.com/istio/istio.git@"${SOURCE_BRANCH_NAME}"
@@ -99,6 +103,10 @@ handle_feature_status_scraping() {
 
 handle_doc_scraping() {
     for repo in "${REPOS[@]}"; do
+        if [[ "$repo" == https://github.com/istio/api.git* ]]; then
+            repo="${ISTIO_API_GIT_SOURCE:-$repo}"
+        fi
+
         REPO_URL=$(echo "$repo" | cut -d @ -f 1)
         REPO_BRANCH=$(echo "$repo" | cut -d @ -f 2)
         DEST_DIR=${REPO_URL//\//_}


### PR DESCRIPTION
This allows overriding the default `istio/api` Git repo URL (https://github.com/istio/api.git@branchname) with something else, for example, a local directory, hence we can check how the pages generated from `*.proto` is rendered in a real layout.

For example, if I have a cloned `istio/api` repo in my local (say: `/home/dio/istio/api`) and then I have some changes in `fix-anchors` branch, I can then go ahead running the following command:

```
$ BUILD_WITH_CONTAINER=1 \
  ISTIO_API_GIT_SOURCE="file:///work/istio/api@fix-anchors" \
  ADDITIONAL_CONTAINER_OPTIONS="-v /home/dio/istio/api:/work/istio/api" \
   	make update_ref_docs
```

And do `make serve` in my local to see the introduced changes.

Before this, there is no easy way to see (and fix) without pushing the changes to remote git repo, something like the following:

![image](https://user-images.githubusercontent.com/73152/133973485-68241061-02c1-4d72-8fe7-11ce7e1463ef.png)

where we need to came-casing that field, and further make it an anchor to target the right element.

Signed-off-by: Dhi Aurrahman <dio@rockybars.com>

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
