### PR TITLE
Update index.html

### DIFF
--- a/content/en/docs/reference/config/networking/destination-rule/index.html
+++ b/content/en/docs/reference/config/networking/destination-rule/index.html
@@ -1500,7 +1500,7 @@ Yes
 <td><code>maxConnections</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of HTTP1 /TCP connections to a destination host. Default 2^32-1.</p>
+<p>Maximum number of HTTP1 /TCP connections to a destination host. Default (2^32 / 2) - 1.</p>
 
 </td>
 <td>
@@ -1551,7 +1551,7 @@ No
 <td><code>http1MaxPendingRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of pending HTTP requests to a destination. Default 2^32-1.</p>
+<p>Maximum number of pending HTTP requests to a destination. Default (2^32 / 2) - 1.</p>
 
 </td>
 <td>
@@ -1562,7 +1562,7 @@ No
 <td><code>http2MaxRequests</code></td>
 <td><code>int32</code></td>
 <td>
-<p>Maximum number of requests to a backend. Default 2^32-1.</p>
+<p>Maximum number of requests to a backend. Default (2^32 / 2) - 1.</p>
 
 </td>
 <td>
@@ -1587,7 +1587,7 @@ No
 <td><code>int32</code></td>
 <td>
 <p>Maximum number of retries that can be outstanding to all hosts in a
-cluster at a given time. Defaults to 2^32-1.</p>
+cluster at a given time. Defaults to (2^32 / 2) - 1.</p>
 
 </td>
 <td>


### PR DESCRIPTION
The Go int32 max value is (2^32 / 2) - 1 not 2^32-1. 
Putting 2^32-1 in the destination rule configuration leads to an error:
````
DestinationRule: admission webhook "validation.istio.io" denied the request: error decoding configuration: json: cannot unmarshal number 4294967295 into Go value of type int32 
````

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [X] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
