### PR TITLE
Include sidecar.env for VM configuration

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -285,6 +285,7 @@ If third party tokens are not enabled, you should add the option `--set values.g
 
 Next, use the `istioctl x workload entry` command to generate:
 
+* `sidecar.env`: Contains metadata specific to each VM like istiod address to fetch CA.
 * `cluster.env`: Contains metadata that identifies what namespace, service account, network CIDR and (optionally) what inbound ports to capture.
 * `istio-token`: A Kubernetes token used to get certs from the CA.
 * `mesh.yaml`: Provides `ProxyConfig` to configure `discoveryAddress`, health-checking probes, and some authentication options.
@@ -367,10 +368,10 @@ Run the following commands on the virtual machine you want to add to the Istio m
 
     {{< /tabset >}}
 
-1. Install `cluster.env` within the directory `/var/lib/istio/envoy/`:
+1. Install `cluster.env` and `sidecar.env` within the directory `/var/lib/istio/envoy/`:
 
     {{< text bash >}}
-    $ sudo cp "${HOME}"/cluster.env /var/lib/istio/envoy/cluster.env
+    $ sudo cp "${HOME}"/*.env /var/lib/istio/envoy/
     {{< /text >}}
 
 1. Install the [Mesh Config](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig) to `/etc/istio/config/mesh`:

--- a/content/en/docs/setup/install/virtual-machine/snips.sh
+++ b/content/en/docs/setup/install/virtual-machine/snips.sh
@@ -179,7 +179,7 @@ sudo cp "${HOME}"/istio-token /var/run/secrets/tokens/istio-token
 }
 
 snip_configure_the_virtual_machine_5() {
-sudo cp "${HOME}"/cluster.env /var/lib/istio/envoy/cluster.env
+sudo cp "${HOME}"/*.env /var/lib/istio/envoy/
 }
 
 snip_configure_the_virtual_machine_6() {


### PR DESCRIPTION
Please provide a description for what this PR is for.

BUG: https://github.com/istio/istio/issues/34058
PR: https://github.com/istio/istio/pull/35048 
If the revision is set, we try to use the same discovery address that we setup in /etc/hosts. It involves using *sidecar.env* to pass a revisioned istiod address.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [X] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
