### PR TITLE
Remove iptables workaround for the GKE Docker networking failure

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -18,9 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Workaround https://github.com/kubernetes/test-infra/issues/23741. Should be removed once its fixed upstream
- iptables -t mangle -A POSTROUTING -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
-
 export ISTIO_REMOTE=${ISTIO_REMOTE:-origin}
 export ISTIO_BRANCH=${ISTIO_BRANCH:-master}
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

GKE status shows the Docker environment should working again.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
