### PR TITLE
Fix subzone link not found

### DIFF
--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/_index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/_index.md
@@ -32,7 +32,7 @@ triplet defines a locality:
 - **Sub-zone**: Allows administrators to further subdivide zones for more
   fine-grained control, such as "same rack". The sub-zone concept doesn't exist
   in Kubernetes. As a result, Istio introduced the custom node label
-  [`topology.istio.io/subzone`](https://github.com/istio/api/blob/master/label/label.go#L42)
+  [`topology.istio.io/subzone`](https://github.com/istio/api/blob/master/label/labels.yaml#L76)
   to define a sub-zone.
 
 {{< tip >}}


### PR DESCRIPTION
In link https://istio.io/latest/docs/tasks/traffic-management/locality-load-balancing/, the `topology.istio.io/subzone` link does not exist.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
