### PR TITLE
use consecutive5xxErrors instead of consecutive

### DIFF
--- a/content/zh/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/zh/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -45,7 +45,7 @@ test: yes
             http1MaxPendingRequests: 1
             maxRequestsPerConnection: 1
         outlierDetection:
-          consecutiveErrors: 1
+          consecutive5xxErrors: 1
           interval: 1s
           baseEjectionTime: 3m
           maxEjectionPercent: 100


### PR DESCRIPTION
outlier detection consecutive errors is deprecated, use consecutiveGatewayErrors or consecutive5xxErrors instead

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
