### PR TITLE
Fix Document meshConfiguration example

### DIFF
--- a/content/en/docs/tasks/observability/distributed-tracing/configurability/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/configurability/telemetry-api/index.md
@@ -95,7 +95,8 @@ data:
         stackdriver:
           maxTagLength: 256
       defaultProviders: # If a default provider is not specified, Telemetry resources must fully-specify a provider
-          tracing: "cloudtrace"
+          tracing: 
+          -  "cloudtrace"
 {{< /text >}}
 
 ### Configuring mesh-wide tracing behavior

--- a/content/en/docs/tasks/observability/distributed-tracing/configurability/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/configurability/telemetry-api/index.md
@@ -95,7 +95,7 @@ data:
         stackdriver:
           maxTagLength: 256
       defaultProviders: # If a default provider is not specified, Telemetry resources must fully-specify a provider
-          tracing: 
+          tracing:
           -  "cloudtrace"
 {{< /text >}}
 


### PR DESCRIPTION
https://preliminary.istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-DefaultProviders say `meshConfig.defaultProviders.tracing` type string[] but document use string


- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
