### PR TITLE
Drop operator page to bottom of list

### DIFF
--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -1,12 +1,13 @@
 ---
 title: Istio Operator Install
 description: Instructions to install Istio in a Kubernetes cluster using the Istio operator.
-weight: 20
+weight: 99
 keywords: [kubernetes, operator]
 aliases:
     - /docs/setup/install/standalone-operator
 owner: istio/wg-environments-maintainers
 test: no
+status: Beta
 ---
 
 {{< warning >}}


### PR DESCRIPTION
First line is "don't use this", so we should make it not the second option on the page.