### PR TITLE
[release-1.10] make update_ref_docs to get 1.10.6 updates

### DIFF
--- a/content/en/docs/reference/commands/istioctl/index.html
+++ b/content/en/docs/reference/commands/istioctl/index.html
@@ -6015,6 +6015,12 @@ These environment variables affect the behavior of the <code>istioctl</code> com
 <td>The interval for istiod to fetch the jwks_uri for the jwks public key.</td>
 </tr>
 <tr>
+<td><code>PILOT_MAX_REQUESTS_PER_SECOND</code></td>
+<td>Floating-Point</td>
+<td><code>0</code></td>
+<td>Limits the number of incoming XDS requests per second. On larger machines this can be increased to handle more proxies concurrently.</td>
+</tr>
+<tr>
 <td><code>PILOT_PUSH_THROTTLE</code></td>
 <td>Integer</td>
 <td><code>100</code></td>

--- a/content/en/docs/reference/commands/operator/index.html
+++ b/content/en/docs/reference/commands/operator/index.html
@@ -470,6 +470,12 @@ These environment variables affect the behavior of the <code>operator</code> com
 <td>The interval for istiod to fetch the jwks_uri for the jwks public key.</td>
 </tr>
 <tr>
+<td><code>PILOT_MAX_REQUESTS_PER_SECOND</code></td>
+<td>Floating-Point</td>
+<td><code>0</code></td>
+<td>Limits the number of incoming XDS requests per second. On larger machines this can be increased to handle more proxies concurrently.</td>
+</tr>
+<tr>
 <td><code>PILOT_PUSH_THROTTLE</code></td>
 <td>Integer</td>
 <td><code>100</code></td>

--- a/content/en/docs/reference/commands/pilot-agent/index.html
+++ b/content/en/docs/reference/commands/pilot-agent/index.html
@@ -672,6 +672,12 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <td>If this is set to true, one Istiod will control remote clusters including CA.</td>
 </tr>
 <tr>
+<td><code>FILE_DEBOUNCE_DURATION</code></td>
+<td>Time Duration</td>
+<td><code>100ms</code></td>
+<td>The duration for which the file read operation is delayed once file update is detected</td>
+</tr>
+<tr>
 <td><code>FILE_MOUNTED_CERTS</code></td>
 <td>Boolean</td>
 <td><code>false</code></td>
@@ -778,6 +784,12 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <td>Boolean</td>
 <td><code>false</code></td>
 <td>If set to true, enable the capture of outgoing DNS packets on port 53, redirecting to istio-agent on :15053</td>
+</tr>
+<tr>
+<td><code>ISTIO_META_DNS_CONNTRACK_ZONE</code></td>
+<td>Boolean</td>
+<td><code>false</code></td>
+<td>If set to true, enable the use of conntrack zone for iptables for DNS redirection</td>
 </tr>
 <tr>
 <td><code>ISTIO_MULTIROOT_MESH</code></td>
@@ -1042,6 +1054,12 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <td>Time Duration</td>
 <td><code>20m0s</code></td>
 <td>The interval for istiod to fetch the jwks_uri for the jwks public key.</td>
+</tr>
+<tr>
+<td><code>PILOT_MAX_REQUESTS_PER_SECOND</code></td>
+<td>Floating-Point</td>
+<td><code>0</code></td>
+<td>Limits the number of incoming XDS requests per second. On larger machines this can be increased to handle more proxies concurrently.</td>
 </tr>
 <tr>
 <td><code>PILOT_PUSH_THROTTLE</code></td>

--- a/content/en/docs/reference/commands/pilot-discovery/index.html
+++ b/content/en/docs/reference/commands/pilot-discovery/index.html
@@ -886,6 +886,12 @@ These environment variables affect the behavior of the <code>pilot-discovery</co
 <td>The interval for istiod to fetch the jwks_uri for the jwks public key.</td>
 </tr>
 <tr>
+<td><code>PILOT_MAX_REQUESTS_PER_SECOND</code></td>
+<td>Floating-Point</td>
+<td><code>0</code></td>
+<td>Limits the number of incoming XDS requests per second. On larger machines this can be increased to handle more proxies concurrently.</td>
+</tr>
+<tr>
 <td><code>PILOT_PUSH_THROTTLE</code></td>
 <td>Integer</td>
 <td><code>100</code></td>

--- a/data/analysis.yaml
+++ b/data/analysis.yaml
@@ -453,3 +453,28 @@ messages:
     level: Warning
     description: "Application pods should not run as user ID (UID) 1337"
     template: "User ID (UID) 1337 is reserved for the sidecar proxy."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0144/"
+
+  - name: "ImageAutoWithoutInjectionWarning"
+    code: IST0146
+    level: Warning
+    description: "Deployments with `image: auto` should be targeted for injection."
+    template: "%s %s contains `image: auto` but does not match any Istio injection webhook selectors."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0146/"
+    args:
+      - name: resourceType
+        type: string
+      - name: resourceName
+        type: string
+
+  - name: "ImageAutoWithoutInjectionError"
+    code: IST0147
+    level: Error
+    description: "Pods with `image: auto` should be targeted for injection."
+    template: "%s %s contains `image: auto` but does not match any Istio injection webhook selectors."
+    url: "https://istio.io/latest/docs/reference/config/analysis/ist0147/"
+    args:
+      - name: resourceType
+        type: string
+      - name: resourceName
+        type: string


### PR DESCRIPTION
Please provide a description for what this PR is for.

In case we pull a new archive of 1.10

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
