### PR TITLE
Fix VERIFY_CERT_AT_CLIENT typo in 1.12 release notes

### DIFF
--- a/content/en/news/releases/1.12.x/announcing-1.12/change-notes/index.md
+++ b/content/en/news/releases/1.12.x/announcing-1.12/change-notes/index.md
@@ -62,7 +62,7 @@ aliases:
 - **Added** support to istiod to notice `cacerts` file changes via the `AUTO_RELOAD_PLUGIN_CERTS` environment variable.
   ([Issue #31522](https://github.com/istio/istio/issues/31522))
 
-- **Added** `VERTIFY_CERT_AT_CLIENT` environment variable to istiod. Setting `VERTIFY_CERT_AT_CLIENT` to `true` will verify server certificates using the OS CA certificates when not using a `DestinationRule` `caCertificates` field.
+- **Added** `VERIFY_CERT_AT_CLIENT` environment variable to istiod. Setting `VERIFY_CERT_AT_CLIENT` to `true` will verify server certificates using the OS CA certificates when not using a `DestinationRule` `caCertificates` field.
   ([Issue #33472](https://github.com/istio/istio/issues/33472))
 
 - **Added** Auto mTLS support for workload level peer authentication. You no longer need to configure destination rule when servers are configured with workload level peer authentication policy. This can be disabled by setting `ENABLE_AUTO_MTLS_CHECK_POLICIES` to `false`.


### PR DESCRIPTION
A small typo fix in the release notes hosted on https://istio.io/latest/news/releases/1.12.x/announcing-1.12/change-notes/

The contribution guidelines don't mention sign-off of commits, unlike most of the other kubernetes repos. If this is required, I can force push again. Just did the fix directly on github and it didn't get added there.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
