### PR TITLE
[CNI] Document 1337 UID workaround for init container.

### DIFF
--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -218,7 +218,7 @@ If [DNS proxying](/docs/ops/configuration/traffic-management/dns-proxy/) is enab
 and init container sends traffic with host name and needs DNS resolution, only the first workaround listed above will work.
 
 {{< warning >}}
-Please use the above traffic capture exclusion annotatioins with caution, since the IP/port exclusion annotations not only apply to init container traffic,
+Please use the above traffic capture exclusion annotations with caution, since the IP/port exclusion annotations not only apply to init container traffic,
 but also application container traffic. i.e. application traffic sent to the configured IP/port will bypass the Istio sidecar.
 {{< /warning >}}
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -214,8 +214,9 @@ Avoid this traffic loss with one of the following settings:
 # Set the `traffic.sidecar.istio.io/excludeOutboundPorts` annotation to disable redirecting traffic to the
   specific outbound ports the init containers use.
 
-If [DNS proxying](/docs/ops/configuration/traffic-management/dns-proxy/) is enabled,
-and init container sends traffic with host name and needs DNS resolution, only the first workaround listed above will work.
+{{< tip >}}
+You must use the `runAsUser 1337` workaround if [DNS proxying](/docs/ops/configuration/traffic-management/dns-proxy/) is enabled, and an init container sends traffic to a host name which requires DNS resolution.
+{{< /tip >}}
 
 {{< warning >}}
 Please use the above traffic capture exclusion annotations with caution, since the IP/port exclusion annotations not only apply to init container traffic,

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -207,13 +207,18 @@ starts an injected pod with the following steps:
 Init containers execute before the sidecar proxy starts, which can result in traffic loss during their execution.
 Avoid this traffic loss with one or both of the following settings:
 
+* Set the user of init container to `1337` using `runAsUser`. This will make traffic from init container bypass Istio iptables capture.
+  Application container traffic will still be captured as usual.
 * Set the `traffic.sidecar.istio.io/excludeOutboundIPRanges` annotation to disable redirecting traffic to any
   CIDRs the init containers communicate with.
 * Set the `traffic.sidecar.istio.io/excludeOutboundPorts` annotation to disable redirecting traffic to the
   specific outbound ports the init containers use.
 
+If [DNS proxying](/docs/ops/configuration/traffic-management/dns-proxy/) is enabled,
+and init container sends traffic with host name and needs DNS resolution, only the first workaround listed above will work.
+
 {{< warning >}}
-Please use the above settings with caution, since the IP/port exclusion annotations not only apply to init container traffic,
+Please use the above traffic capture exclusion annotatioins with caution, since the IP/port exclusion annotations not only apply to init container traffic,
 but also application container traffic. i.e. application traffic sent to the configured IP/port will bypass the Istio sidecar.
 {{< /warning >}}
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -207,11 +207,11 @@ starts an injected pod with the following steps:
 Init containers execute before the sidecar proxy starts, which can result in traffic loss during their execution.
 Avoid this traffic loss with one or both of the following settings:
 
-* Set the user of init container to `1337` using `runAsUser`. This will make traffic from init container bypass Istio iptables capture.
+# Set the uid of the init container to `1337` using `runAsUser`. This will make traffic from the init container bypass Istio's `iptables` capture.
   Application container traffic will still be captured as usual.
-* Set the `traffic.sidecar.istio.io/excludeOutboundIPRanges` annotation to disable redirecting traffic to any
+# Set the `traffic.sidecar.istio.io/excludeOutboundIPRanges` annotation to disable redirecting traffic to any
   CIDRs the init containers communicate with.
-* Set the `traffic.sidecar.istio.io/excludeOutboundPorts` annotation to disable redirecting traffic to the
+# Set the `traffic.sidecar.istio.io/excludeOutboundPorts` annotation to disable redirecting traffic to the
   specific outbound ports the init containers use.
 
 If [DNS proxying](/docs/ops/configuration/traffic-management/dns-proxy/) is enabled,

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -207,12 +207,12 @@ starts an injected pod with the following steps:
 Init containers execute before the sidecar proxy starts, which can result in traffic loss during their execution.
 Avoid this traffic loss with one of the following settings:
 
-# Set the uid of the init container to `1337` using `runAsUser`. This will make traffic from the init container bypass Istio's `iptables` capture.
-  Application container traffic will still be captured as usual.
-# Set the `traffic.sidecar.istio.io/excludeOutboundIPRanges` annotation to disable redirecting traffic to any
-  CIDRs the init containers communicate with.
-# Set the `traffic.sidecar.istio.io/excludeOutboundPorts` annotation to disable redirecting traffic to the
-  specific outbound ports the init containers use.
+1. Set the `uid` of the init container to `1337` using `runAsUser`. This will make traffic from the init container bypass Istio's `iptables` capture.
+   Application container traffic will still be captured as usual.
+1. Set the `traffic.sidecar.istio.io/excludeOutboundIPRanges` annotation to disable redirecting traffic to any
+   CIDRs the init containers communicate with.
+1. Set the `traffic.sidecar.istio.io/excludeOutboundPorts` annotation to disable redirecting traffic to the
+   specific outbound ports the init containers use.
 
 {{< tip >}}
 You must use the `runAsUser 1337` workaround if [DNS proxying](/docs/ops/configuration/traffic-management/dns-proxy/) is enabled, and an init container sends traffic to a host name which requires DNS resolution.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -209,7 +209,7 @@ Avoid this traffic loss with one of the following settings:
 
 1. Set the `uid` of the init container to `1337` using `runAsUser`.
   `1337` is the [`uid` used by the sidecar proxy](/docs/ops/deployment/requirements/#pod-requirements).
-   Traffic sent by this `uid` will not be captured by the Istio's `iptables` rule.
+   Traffic sent by this `uid` is not captured by the Istio's `iptables` rule.
    Application container traffic will still be captured as usual.
 1. Set the `traffic.sidecar.istio.io/excludeOutboundIPRanges` annotation to disable redirecting traffic to any
    CIDRs the init containers communicate with.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -219,7 +219,7 @@ You must use the `runAsUser 1337` workaround if [DNS proxying](/docs/ops/configu
 {{< /tip >}}
 
 {{< warning >}}
-Please use the above traffic capture exclusion annotations with caution, since the IP/port exclusion annotations not only apply to init container traffic,
+Please use traffic capture exclusions with caution, since the IP/port exclusion annotations not only apply to init container traffic,
 but also application container traffic. i.e. application traffic sent to the configured IP/port will bypass the Istio sidecar.
 {{< /warning >}}
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -207,7 +207,9 @@ starts an injected pod with the following steps:
 Init containers execute before the sidecar proxy starts, which can result in traffic loss during their execution.
 Avoid this traffic loss with one of the following settings:
 
-1. Set the `uid` of the init container to `1337` using `runAsUser`. This will make traffic from the init container bypass Istio's `iptables` capture.
+1. Set the `uid` of the init container to `1337` using `runAsUser`.
+  `1337` is the [`uid` used by the sidecar proxy](/docs/ops/deployment/requirements/#pod-requirements).
+   Traffic sent by this `uid` will not be captured by the Istio's `iptables` rule.
    Application container traffic will still be captured as usual.
 1. Set the `traffic.sidecar.istio.io/excludeOutboundIPRanges` annotation to disable redirecting traffic to any
    CIDRs the init containers communicate with.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -205,7 +205,7 @@ starts an injected pod with the following steps:
 1. The Istio sidecar proxy starts in the pod along with the pod's other containers.
 
 Init containers execute before the sidecar proxy starts, which can result in traffic loss during their execution.
-Avoid this traffic loss with one or both of the following settings:
+Avoid this traffic loss with one of the following settings:
 
 # Set the uid of the init container to `1337` using `runAsUser`. This will make traffic from the init container bypass Istio's `iptables` capture.
   Application container traffic will still be captured as usual.


### PR DESCRIPTION
fix https://github.com/istio/istio/issues/36453.

Document a workaround for init container with CNI traffic redirection by setting uid of init container to 1337. This is the only working solution with DNS proxy enabled.

cc @nrjpoddar @howardjohn @rvennam 