### PR TITLE
Delete kubernetes-1.22-with-older-releases.md

### DIFF
--- a/content/en/events/banners/kubernetes-1.22-with-older-releases.md
+++ b/content/en/events/banners/kubernetes-1.22-with-older-releases.md
@@ -1,9 +1,0 @@
----
-title: Kubernetes 1.22 Release statement
-period_start: 2021-08-04
-period_duration: 180
-max_impressions: 8
-timeout: 120
-link: /docs/releases/supported-releases#support-status-of-istio-releases
----
-Kubernetes 1.22 will only work with Istio 1.10 and above. Click here for the supported version table.


### PR DESCRIPTION
As Istio 1.10 is out of support, and Kubernetes 1.23 is now current, I suggest it's safe to remove this banner (currently shown to all site visitors).

- [X] Docs
