### PR TITLE
Adding page for istio image signing and validation

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -768,6 +768,7 @@ sidebar_none
 sidecar
 sidecar.env
 SignalFX
+sigstore
 sinkInfo
 SkyWalking
 SLOs

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,4 @@
 /pkg/test/       @istio/wg-docs-maintainers-infra @istio/wg-test-and-release-maintainers
 /static/         @istio/wg-docs-maintainers-english
 /tests/          @istio/wg-docs-maintainers-infra @istio/wg-test-and-release-maintainers
+/static/misc/istio-key.pub @istio/wg-test-and-release-maintainers

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -2,9 +2,8 @@
 title: Image Signing And Validation
 description: Describes how to use image signatures to verify the provenance of Istio images.
 weight: 35
-aliases:
-    - /docs/ops/best-practices/image-signing-validation/
-keywords: [install]
+aliases: []
+keywords: [install,signing]
 owner: istio/wg-environments-maintainers
 test: n/a
 ---
@@ -48,7 +47,7 @@ To validate a docker image, do the following:
 $ ./cosign-binary verify --key {{< static "/misc/istio-key.pub" >}} {{< istio_docker_image "pilot" >}}
 {{< /text >}}
 
-This process will work for any released image or release candidate built with Istio build infrastructure.
+This process will work for any released image or release candidate built with the Istio build infrastructure.
 
 An example with output:
 

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -14,7 +14,7 @@ validate the provenance of Istio image artifacts.
 
 Cosign is a tool developed as part of the
 [sigstore](https://www.sigstore.dev/https://www.sigstore.dev/) project which
-simplifies signing and validation of signed Open Container Initiative artifacts,
+simplifies signing and validation of signed Open Container Initiative (OCI) artifacts,
 such as docker images.
 
 In Istio, we sign all officially published docker images as part of our release

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -1,5 +1,5 @@
 ---
-title: Image Signing And Validation
+title: Image Signing and Validation
 description: Describes how to use image signatures to verify the provenance of Istio images.
 weight: 35
 aliases: []

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -30,7 +30,7 @@ Before you begin, please do the following:
 1. Download the latest
    [Cosign](https://github.com/sigstore/cosign/releases/latest) build for your
    architecture, as well as its signature.
-1. Validate the cosign binary signature:
+1. Validate the `cosign` binary signature:
 
    {{< text bash >}}
 $ openssl dgst -sha256 \

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -18,7 +18,7 @@ simplifies signing and validation of signed Open Container Initiative (OCI) arti
 such as docker images.
 
 In Istio, we sign all officially published docker images as part of our release
-process using our own private key. End users can then verify these images using
+process using our own private key starting with Istio 1.12. End users can then verify these images using
 the process described below.
 
 This process is suitable for either manual execution or integration with build

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -8,7 +8,7 @@ owner: istio/wg-environments-maintainers
 test: n/a
 ---
 
-This page describes how to use [Cosign](https://github.com/sigstore/cosign) to
+This page describes how to use [cosign](https://github.com/sigstore/cosign) to
 validate the provenance of Istio image artifacts.
 
 Cosign is a tool developed as part of the

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -11,7 +11,7 @@ test: n/a
 This page describes how to use [cosign](https://github.com/sigstore/cosign) to
 validate the provenance of Istio image artifacts.
 
-cosign is a tool developed as part of the
+Cosign is a tool developed as part of the
 [sigstore](https://www.sigstore.dev) project which
 simplifies signing and validation of signed Open Container Initiative (OCI) artifacts,
 such as docker images.

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -11,7 +11,7 @@ test: n/a
 This page describes how to use [cosign](https://github.com/sigstore/cosign) to
 validate the provenance of Istio image artifacts.
 
-Cosign is a tool developed as part of the
+cosign is a tool developed as part of the
 [sigstore](https://www.sigstore.dev) project which
 simplifies signing and validation of signed Open Container Initiative (OCI) artifacts,
 such as docker images.

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -39,7 +39,7 @@ $ openssl dgst -sha256 \
     /path/to/cosign-binary
     {{< /text >}}
 
-1. Run `chmod +x` to make the Cosign binary executable
+1. Make the binary executable (`chmod +x`) and move to a location on the `PATH`
 
 ## Validating Image
 

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -16,8 +16,8 @@ Cosign is a tool developed as part of the
 simplifies signing and validation of signed Open Container Initiative (OCI) artifacts,
 such as container images.
 
-In Istio, we sign all officially published docker images as part of our release
-process using our own private key starting with Istio 1.12. End users can then verify these images using
+Starting with Istio 1.12, we sign all officially published container images as part of our release
+process. End users can then verify these images using
 the process described below.
 
 This process is suitable for either manual execution or integration with build

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -44,7 +44,7 @@ $ openssl dgst -sha256 \
 To validate a docker image, do the following:
 
 {{< text bash >}}
-$ ./cosign-binary verify --key {{< static "/misc/istio-key.pub" >}} {{< istio_docker_image "pilot" >}}
+$ ./cosign-binary verify --key "https://istio.io/misc/istio-key.pub" {{< istio_docker_image "pilot" >}}
 {{< /text >}}
 
 This process will work for any released image or release candidate built with the Istio build infrastructure.
@@ -52,7 +52,7 @@ This process will work for any released image or release candidate built with th
 An example with output:
 
 {{< text bash >}}
-$ cosign verify --key {{< static "/misc/istio-key.pub" >}} gcr.io/istio-release/pilot:1.12.0
+$ cosign verify --key "https://istio.io/misc/istio-key.pub" gcr.io/istio-release/pilot:1.12.0
 
 
 Verification for gcr.io/istio-release/pilot:1.12.0 --

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -12,9 +12,9 @@ This page describes how to use [cosign](https://github.com/sigstore/cosign) to
 validate the provenance of Istio image artifacts.
 
 Cosign is a tool developed as part of the
-[sigstore](https://www.sigstore.dev) project which
+[sigstore](https://www.sigstore.dev) project, which
 simplifies signing and validation of signed Open Container Initiative (OCI) artifacts,
-such as docker images.
+such as container images.
 
 In Istio, we sign all officially published docker images as part of our release
 process using our own private key starting with Istio 1.12. End users can then verify these images using

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -1,0 +1,67 @@
+---
+title: Image Signing And Validation
+description: Describes how to use image signatures to verify the provenance of Istio images.
+weight: 35
+aliases:
+    - /docs/ops/best-practices/image-signing-validation/
+keywords: [install]
+owner: istio/wg-environments-maintainers
+test: n/a
+---
+
+This page describes how to use [Cosign](https://github.com/sigstore/cosign) to
+validate the provenance of Istio image artifacts.
+
+Cosign is a tool developed as part of the
+[sigstore](https://www.sigstore.dev/https://www.sigstore.dev/) project which
+simplifies signing and validation of signed Open Container Initiative artifacts,
+such as docker images.
+
+In Istio, we sign all officially published docker images as part of our release
+process using our own private key. End users can then verify these images using
+the process described below.
+
+This process is suitable for either manual execution or integration with build
+or deployment pipelines for automated verification of artifacts.
+
+## Prerequisites
+
+Before you begin, please do the following:
+
+1. Download the latest
+   [Cosign](https://github.com/sigstore/cosign/releases/latest) build for your
+   architecture, as well as its signature.
+1. Validate the cosign binary signature: 
+   {{< text bash >}}
+$ openssl dgst -sha256 \
+	-verify <(curl -ssL https://raw.githubusercontent.com/sigstore/cosign/main/release/release-cosign.pup) \
+	-signature /path/to/cosign.sig \
+	/path/to/cosign-binary
+    {{< /text >}}
+1. Run `chmod +x` to make the Cosign binary executable
+
+## Validating Image
+
+To validate a docker image, do the following:
+
+{{< text bash >}}
+$ ./cosign-binary verify --key {{< static "/misc/istio-key.pub" >}} {{< istio_docker_image "pilot" >}}
+{{< /text >}}
+
+This process will work for any released image or release candidate built with Istio build infrastructure.
+
+An example with output:
+
+{{< text bash >}}
+$ cosign verify --key {{< static "/misc/istio-key.pub" >}} gcr.io/istio-release/pilot:1.12.0
+
+
+Verification for gcr.io/istio-release/pilot:1.12.0 --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - The signatures were verified against the specified public key
+  - Any certificates were verified against the Fulcio roots.
+
+[{"critical":{"identity":{"docker-reference":"gcr.io/istio-release/pilot"},"image":{"docker-manifest-digest":"sha256:c37fd83f6435ca0966d653dc6ac42c9fe5ac11d0d5d719dfe97de84acbf7a32d"},"type":"cosign container image signature"},"optional":null}]
+{{< /text >}}
+

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -12,7 +12,7 @@ This page describes how to use [Cosign](https://github.com/sigstore/cosign) to
 validate the provenance of Istio image artifacts.
 
 Cosign is a tool developed as part of the
-[sigstore](https://www.sigstore.dev/https://www.sigstore.dev/) project which
+[sigstore](https://www.sigstore.dev) project which
 simplifies signing and validation of signed Open Container Initiative (OCI) artifacts,
 such as docker images.
 
@@ -30,13 +30,15 @@ Before you begin, please do the following:
 1. Download the latest
    [Cosign](https://github.com/sigstore/cosign/releases/latest) build for your
    architecture, as well as its signature.
-1. Validate the cosign binary signature: 
+1. Validate the cosign binary signature:
+
    {{< text bash >}}
 $ openssl dgst -sha256 \
-	-verify <(curl -ssL https://raw.githubusercontent.com/sigstore/cosign/main/release/release-cosign.pup) \
-	-signature /path/to/cosign.sig \
-	/path/to/cosign-binary
+    -verify <(curl -ssL https://raw.githubusercontent.com/sigstore/cosign/main/release/release-cosign.pup) \
+    -signature /path/to/cosign.sig \
+    /path/to/cosign-binary
     {{< /text >}}
+
 1. Run `chmod +x` to make the Cosign binary executable
 
 ## Validating Image

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -43,7 +43,7 @@ $ openssl dgst -sha256 \
 
 ## Validating Image
 
-To validate a docker image, do the following:
+To validate a container image, do the following:
 
 {{< text bash >}}
 $ ./cosign-binary verify --key "https://istio.io/misc/istio-key.pub" {{< istio_docker_image "pilot" >}}

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -35,7 +35,7 @@ Before you begin, please do the following:
    {{< text bash >}}
 $ openssl dgst -sha256 \
     -verify <(curl -ssL https://raw.githubusercontent.com/sigstore/cosign/main/release/release-cosign.pub) \
-    -signature /path/to/cosign.sig \
+    -signature <(cat /path/to/cosign.sig | base64 -d) \
     /path/to/cosign-binary
     {{< /text >}}
 

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -34,7 +34,7 @@ Before you begin, please do the following:
 
    {{< text bash >}}
 $ openssl dgst -sha256 \
-    -verify <(curl -ssL https://raw.githubusercontent.com/sigstore/cosign/main/release/release-cosign.pup) \
+    -verify <(curl -ssL https://raw.githubusercontent.com/sigstore/cosign/main/release/release-cosign.pub) \
     -signature /path/to/cosign.sig \
     /path/to/cosign-binary
     {{< /text >}}

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -8,7 +8,7 @@ owner: istio/wg-environments-maintainers
 test: n/a
 ---
 
-This page describes how to use [cosign](https://github.com/sigstore/cosign) to
+This page describes how to use [Cosign](https://github.com/sigstore/cosign) to
 validate the provenance of Istio image artifacts.
 
 Cosign is a tool developed as part of the

--- a/layouts/shortcodes/istio_docker_image.html
+++ b/layouts/shortcodes/istio_docker_image.html
@@ -1,0 +1,1 @@
+{{- if .Site.Data.args.preliminary -}}gcr.io/istio-release/{{(.Get 0)}}:{{ .Site.Data.args.version }}.0-rc.1{{- else -}}gcr.io/istio-release/{{(.Get 0)}}:{{ .Site.Data.args.version }}.0{{- end -}}

--- a/layouts/shortcodes/static.html
+++ b/layouts/shortcodes/static.html
@@ -1,1 +1,0 @@
-{{- printf "%s/%s" ( strings.TrimRight "/" $.Page.Site.BaseURL) ( strings.TrimLeft "/" (.Get 0)) -}}

--- a/layouts/shortcodes/static.html
+++ b/layouts/shortcodes/static.html
@@ -1,0 +1,1 @@
+{{- printf "%s/%s" ( strings.TrimRight "/" $.Page.Site.BaseURL) ( strings.TrimLeft "/" (.Get 0)) -}}

--- a/static/misc/istio-key.pub
+++ b/static/misc/istio-key.pub
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEej5bv2n2vOecKineYGWwq1WaQa7C
+7HTEVN+BkNI4D1+66ufzn1eGTrbaC9dceJqCAkhp37vMxhWOrGufpBUokg==
+-----END PUBLIC KEY-----


### PR DESCRIPTION
Adds documentation for image signing and validation.

I'd appreciate discussion of where this should go. The logical place for it is in best-practices/security/index.md, but that is getting a bit long in the tooth. I created it as a separate page for now, but it may be better to split up the security page into a collection of pages.

We may also want a blurb somewhere in the installation docs referencing this, but I'm not sure where would be best.

Holding merge with do-not-merge label until we have settled on something.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
