### PR TITLE
Add docs about configuring faults and retry/timeout on the same VirtualService

### DIFF
--- a/content/en/docs/concepts/traffic-management/index.md
+++ b/content/en/docs/concepts/traffic-management/index.md
@@ -742,6 +742,12 @@ error conditions. Using fault injection can be particularly useful to ensure
 that your failure recovery policies aren’t incompatible or too restrictive,
 potentially resulting in critical services being unavailable.
 
+{{< warning >}}
+Currently, the fault injection configuration can not be combined with retry or timeout configuration
+on the same virtual service, see
+[Traffic Management Problems](/docs/ops/common-problems/network-issues/#virtual-service-with-fault-injection-and-retry-timeout-policies-not-working-as-expected).
+{{< /warning >}}
+
 Unlike other mechanisms for introducing errors such as delaying packets or
 killing pods at the network layer, Istio’ lets you inject faults at the
 application layer. This lets you inject more relevant failures, such as HTTP


### PR DESCRIPTION
This PR adds documentation about a common issue when testing resilience mechanisms like retries and timeouts using the Istio fault injection: The resilience mechanisms don't work when faults and retrys/timeouts are configured on the same `VirtualService`. See https://github.com/istio/istio/issues/13705 for more details.

I'm currently ironing out the details for signing the CLA as a codecentric employee, I expect that to be done sometime next week but I wanted to open this PR to collect some feedback.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
