### PR TITLE
Fix image used by sleep sample (doesn't use istio/istio sleep)

### DIFF
--- a/content/zh/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/zh/docs/tasks/traffic-management/mirroring/index.md
@@ -121,8 +121,8 @@ test: yes
         spec:
           containers:
           - name: sleep
-            image: tutum/curl
-            command: ["/bin/sleep","infinity"]
+            image: curlimages/curl
+            command: ["/bin/sleep","3650d"]
             imagePullPolicy: IfNotPresent
     EOF
     {{< /text >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fix image used by sleep sample (doesn't use istio/istio sleep) in zh docs
@See #10787

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
