### PR TITLE
Fixes #10813

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-custom/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-custom/index.md
@@ -125,7 +125,7 @@ allows requests with the header `x-ext-authz: allow`.
           envoyExtAuthzHttp:
             service: "ext-authz.foo.svc.cluster.local"
             port: "8000"
-            includeHeadersInCheck: ["x-ext-authz"]
+            includeRequestHeadersInCheck: ["x-ext-authz"]
     {{< /text >}}
 
     Alternatively, you can modify the extension provider to control the behavior of the `ext_authz` filter for things like
@@ -141,7 +141,7 @@ allows requests with the header `x-ext-authz: allow`.
           envoyExtAuthzHttp:
             service: "oauth2-proxy.foo.svc.cluster.local"
             port: "4180" # The default port used by oauth2-proxy.
-            includeHeadersInCheck: ["authorization", "cookie"] # headers sent to the oauth2-proxy in the check request.
+            includeRequestHeadersInCheck: ["authorization", "cookie"] # headers sent to the oauth2-proxy in the check request.
             headersToUpstreamOnAllow: ["authorization", "path", "x-auth-request-user", "x-auth-request-email", "x-auth-request-access-token"] # headers sent to backend application when request is allowed.
             headersToDownstreamOnDeny: ["content-type", "set-cookie"] # headers sent back to the client when request is denied.
     {{< /text >}}

--- a/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
@@ -87,7 +87,7 @@ data:
       envoyExtAuthzHttp:
         service: "ext-authz.foo.svc.cluster.local"
         port: "8000"
-        includeHeadersInCheck: ["x-ext-authz"]
+        includeRequestHeadersInCheck: ["x-ext-authz"]
 ENDSNIP
 
 ! read -r -d '' snip_define_the_external_authorizer_3 <<\ENDSNIP
@@ -98,7 +98,7 @@ data:
       envoyExtAuthzHttp:
         service: "oauth2-proxy.foo.svc.cluster.local"
         port: "4180" # The default port used by oauth2-proxy.
-        includeHeadersInCheck: ["authorization", "cookie"] # headers sent to the oauth2-proxy in the check request.
+        includeRequestHeadersInCheck: ["authorization", "cookie"] # headers sent to the oauth2-proxy in the check request.
         headersToUpstreamOnAllow: ["authorization", "path", "x-auth-request-user", "x-auth-request-email", "x-auth-request-access-token"] # headers sent to backend application when request is allowed.
         headersToDownstreamOnDeny: ["content-type", "set-cookie"] # headers sent back to the client when request is denied.
 ENDSNIP


### PR DESCRIPTION
Fixes #10813

Update the documentation of External Authorization. Removed reference to deprecated keyword

- [ ] Configuration Infrastructure
- [ X ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ X ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
