### PR TITLE
Documentation about holdApplicationUntilProxyStarts

### DIFF
--- a/content/en/docs/ops/common-problems/injection/index.md
+++ b/content/en/docs/ops/common-problems/injection/index.md
@@ -239,3 +239,9 @@ node autoscaler is unable to evict nodes with the injected pods. This is
 a [known issue](https://github.com/kubernetes/autoscaler/issues/3947). The workaround is
 to add a pod annotation `"cluster-autoscaler.kubernetes.io/safe-to-evict":
 "true"` to the injected pods.
+
+## Pod/Containers starts with network issues if istio-proxy not ready
+
+Many applications execute commands or checks which require network connectivity during their startup. This causes restarts or hangs of the applications if the istio-proxy sidecar container is not ready. In this cases you can use the feature `holdApplicationUntilProxyStarts`, which causes the sidecar injector to inject the sidecar at the start of the pod’s container list and configures it to block the start of all other containers until the proxy is ready.
+
+Can be addedd as a global config option `"values.global.proxy.holdApplicationUntilProxyStarts: true"` or as a pod annotation `proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'`.

--- a/content/en/docs/ops/common-problems/injection/index.md
+++ b/content/en/docs/ops/common-problems/injection/index.md
@@ -244,4 +244,4 @@ to add a pod annotation `"cluster-autoscaler.kubernetes.io/safe-to-evict":
 
 Many applications execute commands or checks which require network connectivity during their startup. This causes restarts or hangs of the applications if the istio-proxy sidecar container is not ready. In this cases you can use the feature `holdApplicationUntilProxyStarts`, which causes the sidecar injector to inject the sidecar at the start of the pod’s container list and configures it to block the start of all other containers until the proxy is ready.
 
-Can be addedd as a global config option `"values.global.proxy.holdApplicationUntilProxyStarts: true"` or as a pod annotation `proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'`.
+Can be added as a global config option `values.global.proxy.holdApplicationUntilProxyStarts: true` or as a pod annotation `proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'`.

--- a/content/en/docs/ops/common-problems/injection/index.md
+++ b/content/en/docs/ops/common-problems/injection/index.md
@@ -240,8 +240,20 @@ a [known issue](https://github.com/kubernetes/autoscaler/issues/3947). The worka
 to add a pod annotation `"cluster-autoscaler.kubernetes.io/safe-to-evict":
 "true"` to the injected pods.
 
-## Pod/Containers starts with network issues if istio-proxy not ready
+## Pod or containers start with network issues if istio-proxy is not ready
 
-Many applications execute commands or checks which require network connectivity during their startup. This causes restarts or hangs of the applications if the istio-proxy sidecar container is not ready. In this cases you can use the feature `holdApplicationUntilProxyStarts`, which causes the sidecar injector to inject the sidecar at the start of the pod’s container list and configures it to block the start of all other containers until the proxy is ready.
+Many applications execute commands or checks during startup, which require network connectivity. This can cause application containers to hang or restart if the `istio-proxy` sidecar container is not ready. 
 
-Can be added as a global config option `values.global.proxy.holdApplicationUntilProxyStarts: true` or as a pod annotation `proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'`.
+To avoid this, set `holdApplicationUntilProxyStarts` to `true`. This causes the sidecar injector to inject the sidecar at the start of the pod’s container list, and configures it to block the start of all other containers until the proxy is ready.
+
+This can be added as a global config option:
+
+{{< text yaml >}}
+values.global.proxy.holdApplicationUntilProxyStarts: true
+{{< /text >}}
+
+or as a pod annotation:
+
+{{< text yaml >}}
+proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+{{< /text >}}

--- a/content/en/docs/ops/common-problems/injection/index.md
+++ b/content/en/docs/ops/common-problems/injection/index.md
@@ -242,7 +242,7 @@ to add a pod annotation `"cluster-autoscaler.kubernetes.io/safe-to-evict":
 
 ## Pod or containers start with network issues if istio-proxy is not ready
 
-Many applications execute commands or checks during startup, which require network connectivity. This can cause application containers to hang or restart if the `istio-proxy` sidecar container is not ready. 
+Many applications execute commands or checks during startup, which require network connectivity. This can cause application containers to hang or restart if the `istio-proxy` sidecar container is not ready.
 
 To avoid this, set `holdApplicationUntilProxyStarts` to `true`. This causes the sidecar injector to inject the sidecar at the start of the pod’s container list, and configures it to block the start of all other containers until the proxy is ready.
 


### PR DESCRIPTION
This is a very extended topic about networking issues with pods with the istio-proxy sidecar container and is not spread or well documented.
Many people using solutions as "curl -fsI http://localhost:15021/healthz/ready", or post start hooks, even changing logics in scripts etc.
Adding this in this related documentation can help people find this feature easily.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
