### PR TITLE
Fix incorrect weighting

### DIFF
--- a/content/en/news/releases/1.12.x/_index.md
+++ b/content/en/news/releases/1.12.x/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 1.12.x Releases
 description: Announcements for the 1.12 release and its associated patch releases.
-weight: 18
+weight: 17
 list_by_publishdate: true
 layout: release-grid
 decoration: dot


### PR DESCRIPTION
Sort order for releases is wrong as this wasn't decremented on original copy from the 1.11 example.