### PR TITLE
Add a warning for the shared signing key

### DIFF
--- a/content/en/docs/ops/integrations/kiali/index.md
+++ b/content/en/docs/ops/integrations/kiali/index.md
@@ -30,7 +30,6 @@ installation, be sure to change the `signing_key` in Kiali's ConfigMap when usin
 authentication strategy other than `anonymous`.
 {{< /idea >}}
 
-
 ### Option 2: Customizable install
 
 The Kiali project offers its own [quick start guide](https://kiali.io/docs/installation/quick-start) and [customizable installation methods](https://kiali.io/docs/installation/installation-guide). We recommend production users follow those instructions to ensure they stay up to date with the latest versions and best practices.


### PR DESCRIPTION
Please provide a description for what this PR is for.

Add a warning for the shared signing key in Kiali's sample addon. Just to make sure that people changes it if they are exposing the demo installation.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
