### PR TITLE
Fix RSS layouts for minor release announcements

### DIFF
--- a/layouts/blog/rss.xml
+++ b/layouts/blog/rss.xml
@@ -3,7 +3,7 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Istio Blog</title>
-    <description>Connect, secure, control, and observe services.</description>
+    <description>Blog posts from the Istio service mesh.</description>
     {{ if not .Date.IsZero }}
         <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{ end }}

--- a/layouts/news/rss.xml
+++ b/layouts/news/rss.xml
@@ -3,7 +3,7 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Istio News</title>
-    <description>Connect, secure, control, and observe services.</description>
+    <description>News feed for the Istio service mesh.</description>
     {{ if not .Date.IsZero }}
         <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{ end }}
@@ -17,19 +17,21 @@
     {{ $pages := (where .Site.Pages "Section" "news").ByPublishDate.Reverse }}
 
     {{ range $post := $pages }}
-      {{ if and (not $post.Draft) $post.IsPage }}
-        <item>
-          <title>{{ $post.Title }}</title>
-          <description>{{ $post.Content | html }}</description>
-          <pubDate>{{ $post.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-          <link>{{ $post.Permalink }}</link>
-          <author>{{ $post.Params.attribution }}</author>
-          <guid isPermaLink="true">{{ $post.Permalink }}</guid>
+      {{ with $post.PublishDate }}
+        {{ if not $post.Draft }}
+          <item>
+            <title>{{ $post.Title }}</title>
+            <description>{{ $post.Content | html }}</description>
+            <pubDate>{{ $post.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+            <link>{{ $post.Permalink }}</link>
+            <author>{{ $post.Params.attribution }}</author>
+            <guid isPermaLink="true">{{ $post.Permalink }}</guid>
 
-          {{ range $kw := $post.Keywords }}
-              <category>{{ $kw }}</category>
-          {{ end }}
-        </item>
+            {{ range $kw := $post.Keywords }}
+                <category>{{ $kw }}</category>
+            {{ end }}
+          </item>
+        {{ end }}
       {{ end }}
     {{ end }}
   </channel>

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -3,7 +3,7 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Istio Blog and News</title>
-    <description>Connect, secure, control, and observe services.</description>
+    <description>Combined blog and news feed for the Istio service mesh.</description>
     {{ if not .Date.IsZero }}
         <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
     {{ end }}
@@ -17,19 +17,21 @@
     {{ $pages := (where .Site.Pages "Section" "news").ByPublishDate.Reverse }}
 
     {{ range $post := $pages }}
-      {{ if and (not $post.Draft) $post.IsPage }}
-        <item>
-          <title>{{ $post.Title }}</title>
-          <description>{{ $post.Content | html }}</description>
-          <pubDate>{{ $post.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-          <link>{{ $post.Permalink }}</link>
-          <author>{{ $post.Params.attribution }}</author>
-          <guid isPermaLink="true">{{ $post.Permalink }}</guid>
+      {{ with $post.PublishDate }}
+        {{ if not $post.Draft }}
+          <item>
+            <title>{{ $post.Title }}</title>
+            <description>{{ $post.Content | html }}</description>
+            <pubDate>{{ $post.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+            <link>{{ $post.Permalink }}</link>
+            <author>{{ $post.Params.attribution }}</author>
+            <guid isPermaLink="true">{{ $post.Permalink }}</guid>
 
-          {{ range $kw := $post.Keywords }}
-              <category>{{ $kw }}</category>
-          {{ end }}
-        </item>
+            {{ range $kw := $post.Keywords }}
+                <category>{{ $kw }}</category>
+            {{ end }}
+          </item>
+        {{ end }}
       {{ end }}
     {{ end }}
 


### PR DESCRIPTION
Istio 1.13 isn't in the published News or News and Blog RSS feeds, because it's a Node (with release notes and upgrade notes as children), not a leaf Page.

This change removes the "is a Page" check, and instead adds a "has a publishDate" check, so the `1.xx.0` releases are now included.

* `https://istio.io/latest/news/`: has "Announcing Istio 1.13"
* `https://istio.io/latest/news/feed.xml`: does not 
* `https://istio.io/latest/feed.xml`: also does not

I also updated the descriptions of the feeds.