### PR TITLE
Experiment with setting Netlify URL in the RSS

### DIFF
--- a/layouts/blog/rss.xml
+++ b/layouts/blog/rss.xml
@@ -1,4 +1,4 @@
-{{ $home := .Site.BaseURL }}
+{{ $home := .Site.BaseURL | printf "%s%s" (os.Getenv "DEPLOY_PRIME_URL") }}
 
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>

--- a/layouts/blog/rss.xml
+++ b/layouts/blog/rss.xml
@@ -9,6 +9,7 @@
     {{ end }}
     <link>{{ $home }}</link>
     <image>
+      <title>Istio Blog</title>
       <url>{{ $home }}/favicons/android-192x192.png</url>
       <link>{{ $home }}</link>
     </image>
@@ -20,14 +21,12 @@
       {{ if and (not $post.Draft) $post.IsPage }}
         <item>
           <title>{{ $post.Title }}</title>
-          <description>{{ $post.Content | html }}</description>
+          <description>{{ `<![CDATA[` | safeHTML }}{{ $post.Content | safeHTML }}{{ `]]>` | safeHTML }}</description>
           <pubDate>{{ $post.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-          <link>{{ $post.Permalink }}</link>
-          <author>{{ $post.Params.attribution }}</author>
-          <guid isPermaLink="true">{{ $post.Permalink }}</guid>
-
+          <link>{{ $home }}{{ $post.RelPermalink }}</link>
+          <guid isPermaLink="true">{{ $home }}{{ $post.RelPermalink }}</guid>
           {{ range $kw := $post.Keywords }}
-              <category>{{ $kw }}</category>
+          <category>{{ $kw }}</category>
           {{ end }}
         </item>
       {{ end }}

--- a/layouts/news/rss.xml
+++ b/layouts/news/rss.xml
@@ -9,6 +9,7 @@
     {{ end }}
     <link>{{ $home }}</link>
     <image>
+      <title>Istio News</title>
       <url>{{ $home }}/favicons/android-192x192.png</url>
       <link>{{ $home }}</link>
     </image>
@@ -21,14 +22,12 @@
         {{ if not $post.Draft }}
           <item>
             <title>{{ $post.Title }}</title>
-            <description>{{ $post.Content | html }}</description>
+            <description>{{ `<![CDATA[` | safeHTML }}{{ $post.Content | safeHTML }}{{ `]]>` | safeHTML }}</description>
             <pubDate>{{ $post.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-            <link>{{ $post.Permalink }}</link>
-            <author>{{ $post.Params.attribution }}</author>
-            <guid isPermaLink="true">{{ $post.Permalink }}</guid>
-
+            <link>{{ $home }}{{ $post.RelPermalink }}</link>
+            <guid isPermaLink="true">{{ $home }}{{ $post.RelPermalink }}</guid>
             {{ range $kw := $post.Keywords }}
-                <category>{{ $kw }}</category>
+            <category>{{ $kw }}</category>
             {{ end }}
           </item>
         {{ end }}

--- a/layouts/news/rss.xml
+++ b/layouts/news/rss.xml
@@ -1,4 +1,4 @@
-{{ $home := .Site.BaseURL }}
+{{ $home := .Site.BaseURL | printf "%s%s" (os.Getenv "DEPLOY_PRIME_URL") }}
 
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -9,6 +9,7 @@
     {{ end }}
     <link>{{ $home }}</link>
     <image>
+      <title>Istio Blog and News</title>
       <url>{{ $home }}/favicons/android-192x192.png</url>
       <link>{{ $home }}</link>
     </image>
@@ -21,14 +22,12 @@
         {{ if not $post.Draft }}
           <item>
             <title>{{ $post.Title }}</title>
-            <description>{{ $post.Content | html }}</description>
+            <description>{{ `<![CDATA[` | safeHTML }}{{ $post.Content | safeHTML }}{{ `]]>` | safeHTML }}</description>
             <pubDate>{{ $post.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-            <link>{{ $post.Permalink }}</link>
-            <author>{{ $post.Params.attribution }}</author>
-            <guid isPermaLink="true">{{ $post.Permalink }}</guid>
-
+            <link>{{ $home }}{{ $post.RelPermalink }}</link>
+            <guid isPermaLink="true">{{ $home }}{{ $post.RelPermalink }}</guid>
             {{ range $kw := $post.Keywords }}
-                <category>{{ $kw }}</category>
+              <category>{{ $kw }}</category>
             {{ end }}
           </item>
         {{ end }}
@@ -41,14 +40,12 @@
       {{ if and (not $post.Draft) $post.IsPage }}
         <item>
           <title>{{ $post.Title }}</title>
-          <description>{{ $post.Content | html }}</description>
+          <description>{{ `<![CDATA[` | safeHTML }}{{ $post.Content | safeHTML }}{{ `]]>` | safeHTML }}</description>
           <pubDate>{{ $post.PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-          <link>{{ $post.Permalink }}</link>
-          <author>{{ $post.Params.attribution }}</author>
-          <guid isPermaLink="true">{{ $post.Permalink }}</guid>
-
+          <link>{{ $home }}{{ $post.RelPermalink }}</link>
+          <guid isPermaLink="true">{{ $home }}{{ $post.RelPermalink }}</guid>
           {{ range $kw := $post.Keywords }}
-            <category>{{ $kw }}</category>
+          <category>{{ $kw }}</category>
           {{ end }}
         </item>
       {{ end }}

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,4 +1,4 @@
-{{ $home := .Site.BaseURL }}
+{{ $home := .Site.BaseURL | printf "%s%s" (os.Getenv "DEPLOY_PRIME_URL") }}
 
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>


### PR DESCRIPTION
Fixes #8357, eventually.

When you run `make serve` locally, it sets a base URL of `http://localhost:1313/latest/`, but `make netlify` just uses `/latest`. 

This PR fetches the Netlify URL from `DEPLOY_PRIME_URL` and tacks it on the front of the static entries in the RSS feed/s.