### PR TITLE
Update 1.12.3 release date to put 1.13.0 items together in news

### DIFF
--- a/content/en/news/releases/1.12.x/announcing-1.12.3/index.md
+++ b/content/en/news/releases/1.12.x/announcing-1.12.3/index.md
@@ -3,7 +3,7 @@ title: Announcing Istio 1.12.3
 linktitle: 1.12.3
 subtitle: Patch Release
 description: Istio 1.12.3 patch release.
-publishdate: 2022-02-11
+publishdate: 2022-02-10
 release: 1.12.3
 aliases:
     - /news/announcing-1.12.3


### PR DESCRIPTION
The 1.12.3 announcement is within the 1.13.0 news items. Since we don't have weighting, move the 1.12.3 date up.