### PR TITLE
add GRPC-WEB to docs about gateway protocols

### DIFF
--- a/content/en/docs/reference/config/networking/gateway/index.html
+++ b/content/en/docs/reference/config/networking/gateway/index.html
@@ -673,7 +673,7 @@ Yes
 <td><code>string</code></td>
 <td>
 <p>The protocol exposed on the port.
-MUST BE one of HTTP|HTTPS|GRPC|HTTP2|MONGO|TCP|TLS.
+MUST BE one of HTTP|HTTPS|GRPC|GRPC-WEB|HTTP2|MONGO|TCP|TLS.
 TLS implies the connection will be routed based on the SNI header to
 the destination without terminating the TLS connection.</p>
 


### PR DESCRIPTION
Please provide a description for what this PR is for.
`GRPC-WEB` is a valid port protocol, but not listed correctly in the docs.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
