### PR TITLE
Removed the helm istio-operator install

### DIFF
--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -68,27 +68,6 @@ $ istioctl operator init --watchedNamespaces=istio-namespace1,istio-namespace2
 
 See the [`istioctl operator init` command reference](/docs/reference/commands/istioctl/#istioctl-operator-init) for details.
 
-{{< tip >}}
-You can alternatively deploy the operator using Helm:
-
-1. Create a namespace `istio-operator`.
-
-    {{< text bash >}}
-    $ kubectl create namespace istio-operator
-    {{< /text >}}
-
-1. Install operator using Helm.
-
-    {{< text bash >}}
-    $ helm install istio-operator manifests/charts/istio-operator \
-        --set watchedNamespaces="istio-namespace1\,istio-namespace2" \
-        -n istio-operator
-    {{< /text >}}
-
-Note that you need to [download the Istio release](/docs/setup/getting-started/#download)
-to run the above command.
-{{< /tip >}}
-
 {{< warning >}}
 Prior to Istio 1.10.0, the namespace `istio-system` needed to be created before installing the operator. As of Istio 1.10.0, the `istioctl operator init` will create the `istio-system` namespace.
 


### PR DESCRIPTION
Since the istio-operator helm charts have been
removed, this is no longer possible to do. Remove
the instructions. Please also see this issue

https://github.com/istio/istio/issues/36157

Signed-off-by: Tong Li <litong01@us.ibm.com>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
