### PR TITLE
fix page display

### DIFF
--- a/content/en/docs/tasks/observability/logs/access-log/index.md
+++ b/content/en/docs/tasks/observability/logs/access-log/index.md
@@ -85,6 +85,7 @@ Istio will use the following default access log format if `accessLogFormat` is n
 
 The following table shows an example using the default access log format for a request sent from `sleep` to `httpbin`:
 
+{{<fixed-table "fixed-table">}}
 | Log operator | access log in sleep | access log in httpbin |
 |--------------|---------------------|-----------------------|
 | `[%START_TIME%]` | `[2020-11-25T21:26:18.409Z]` | `[2020-11-25T21:26:18.409Z]`
@@ -109,6 +110,7 @@ The following table shows an example using the default access log format for a r
 | `%DOWNSTREAM_REMOTE_ADDRESS%` | `10.44.1.23:46520` | `10.44.1.23:37652`
 | `%REQUESTED_SERVER_NAME%` | `-` | `outbound_.8000_._.httpbin.foo.svc.cluster.local`
 | `%ROUTE_NAME%` | `default` | `default`
+{{</fixed-table>}}
 
 ## Test the access log
 

--- a/content/en/docs/tasks/observability/logs/otel-provider/index.md
+++ b/content/en/docs/tasks/observability/logs/otel-provider/index.md
@@ -120,6 +120,7 @@ Istio will use the following default access log format if `accessLogFormat` is n
 
 The following table shows an example using the default access log format for a request sent from `sleep` to `httpbin`:
 
+{{<fixed-table "command-flags">}}
 | Log operator | access log in sleep | access log in httpbin |
 |--------------|---------------------|-----------------------|
 | `[%START_TIME%]` | `[2020-11-25T21:26:18.409Z]` | `[2020-11-25T21:26:18.409Z]`
@@ -144,6 +145,7 @@ The following table shows an example using the default access log format for a r
 | `%DOWNSTREAM_REMOTE_ADDRESS%` | `10.44.1.23:46520` | `10.44.1.23:37652`
 | `%REQUESTED_SERVER_NAME%` | `-` | `outbound_.8000_._.httpbin.foo.svc.cluster.local`
 | `%ROUTE_NAME%` | `default` | `default`
+{{</fixed-table>}}
 
 ## Test the access log
 

--- a/content/en/docs/tasks/observability/logs/otel-provider/index.md
+++ b/content/en/docs/tasks/observability/logs/otel-provider/index.md
@@ -120,7 +120,7 @@ Istio will use the following default access log format if `accessLogFormat` is n
 
 The following table shows an example using the default access log format for a request sent from `sleep` to `httpbin`:
 
-{{<fixed-table "command-flags">}}
+{{<fixed-table "fixed-table">}}
 | Log operator | access log in sleep | access log in httpbin |
 |--------------|---------------------|-----------------------|
 | `[%START_TIME%]` | `[2020-11-25T21:26:18.409Z]` | `[2020-11-25T21:26:18.409Z]`

--- a/layouts/shortcodes/fixed-table.html
+++ b/layouts/shortcodes/fixed-table.html
@@ -1,0 +1,6 @@
+{{ $htmlTable := .Inner | markdownify }}
+{{ $class := .Get 0 | default "" }}
+{{ $old := "<table>" }}
+{{ $new := printf "<table class=\"%s\">" $class }}
+{{ $htmlTable := replace $htmlTable $old $new }}
+{{ $htmlTable | safeHTML }}

--- a/src/sass/_all.scss
+++ b/src/sass/_all.scss
@@ -29,6 +29,7 @@
 @import "misc/feature-block";
 @import "misc/feedback";
 @import "misc/figure";
+@import "misc/fixed-table";
 @import "misc/floaters";
 @import "misc/footer";
 @import "misc/get-involved";

--- a/src/sass/misc/_fixed-table.scss
+++ b/src/sass/misc/_fixed-table.scss
@@ -1,0 +1,11 @@
+.fixed-table {
+    table-layout: fixed;
+    
+    td {
+        word-break: break-word;
+    }
+
+    td code {
+        word-break: break-word;
+    }
+}

--- a/src/sass/misc/_fixed-table.scss
+++ b/src/sass/misc/_fixed-table.scss
@@ -1,6 +1,6 @@
 .fixed-table {
     table-layout: fixed;
-    
+
     td {
         word-break: break-word;
     }


### PR DESCRIPTION
Please provide a description for what this PR is for.

the root case is table without `table-layout: fixed;`

fix table display

before:
![image](https://user-images.githubusercontent.com/4354057/158551649-b965d878-b51e-48da-8e8c-aa0e5edabc9a.png)


after:

![image](https://user-images.githubusercontent.com/4354057/158552653-4c17e753-9c63-475c-8611-9481297428bb.png)

@ericvn PTAL.