### PR TITLE
ProxyConfig CRD to enable DNS Proxy by namespace

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -16,7 +16,7 @@ This functionality is also available for services running outside of Kubernetes.
 
 ## Getting started
 
-This feature is not currently enabled by default. To enable it, install Istio with the following settings:
+This feature is not currently enabled by default. To enable it mesh-wide, install Istio with the following settings:
 
 {{< text bash >}}
 $ cat <<EOF | istioctl install -y -f -
@@ -31,6 +31,20 @@ spec:
         # Enable automatic address allocation, optional
         ISTIO_META_DNS_AUTO_ALLOCATE: "true"
 EOF
+{{< /text >}}
+
+To enable on a specific namespace, add a [`ProxyConfig` resource](/docs/reference/config/networking/proxy-config/):
+
+{{< text yaml >}}
+apiVersion: networking.istio.io/v1beta1
+kind: ProxyConfig
+metadata:
+  name: proxy-dns
+  namespace: my-app-namespace
+spec:
+  environmentVariables:
+    ISTIO_META_DNS_CAPTURE: "true"
+    ISTIO_META_DNS_AUTO_ALLOCATE: "true"
 {{< /text >}}
 
 This can also be enabled on a per-pod basis with the [`proxy.istio.io/config` annotation](/docs/reference/config/annotations/).


### PR DESCRIPTION
With the new ProxyConfig CRD introduced in 1.13, it is now very simple to enable DNS Proxying on a per-namespace basis.
This adds instructions to the docs with an example

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
