### PR TITLE
Fix workload aggregating rules for TCP byte metrics

### DIFF
--- a/content/en/docs/ops/best-practices/observability/index.md
+++ b/content/en/docs/ops/best-practices/observability/index.md
@@ -81,6 +81,14 @@ groups:
     expr: |
       sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_response_bytes_bucket)
 
+  - record: "workload:istio_tcp_sent_bytes_total"
+    expr: |
+      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total)
+
+  - record: "workload:istio_tcp_received_bytes_total"
+    expr: |
+      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total)
+
   - record: "workload:istio_tcp_connections_opened_total"
     expr: |
       sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_connections_opened_total)
@@ -88,30 +96,6 @@ groups:
   - record: "workload:istio_tcp_connections_closed_total"
     expr: |
       sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_connections_closed_total)
-
-  - record: "workload:istio_tcp_sent_bytes_total_count"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_count)
-
-  - record: "workload:istio_tcp_sent_bytes_total_sum"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_sum)
-
-  - record: "workload:istio_tcp_sent_bytes_total_bucket"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_bucket)
-
-  - record: "workload:istio_tcp_received_bytes_total_count"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_count)
-
-  - record: "workload:istio_tcp_received_bytes_total_sum"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_sum)
-
-  - record: "workload:istio_tcp_received_bytes_total_bucket"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_bucket)
 {{< /text >}}
 
 {{< /tab >}}
@@ -154,24 +138,14 @@ spec:
     - record: "workload:istio_response_bytes_bucket"
       expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_response_bytes_bucket)"
 
+    - record: "workload:istio_tcp_sent_bytes_total"
+      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total)"
+    - record: "workload:istio_tcp_received_bytes_total"
+      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total)"
     - record: "workload:istio_tcp_connections_opened_total"
       expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_connections_opened_total)"
     - record: "workload:istio_tcp_connections_closed_total"
       expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_connections_closed_total)"
-
-    - record: "workload:istio_tcp_sent_bytes_total_count"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_count)"
-    - record: "workload:istio_tcp_sent_bytes_total_sum"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_sum)"
-    - record: "workload:istio_tcp_sent_bytes_total_bucket"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_bucket)"
-
-    - record: "workload:istio_tcp_received_bytes_total_count"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_count)"
-    - record: "workload:istio_tcp_received_bytes_total_sum"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_sum)"
-    - record: "workload:istio_tcp_received_bytes_total_bucket"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_bucket)"
 {{< /text >}}
 
 {{< /tab >}}

--- a/content/zh/docs/ops/best-practices/observability/index.md
+++ b/content/zh/docs/ops/best-practices/observability/index.md
@@ -73,6 +73,14 @@ groups:
     expr: |
       sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_response_bytes_bucket)
 
+  - record: "workload:istio_tcp_sent_bytes_total"
+    expr: |
+      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total)
+
+  - record: "workload:istio_tcp_received_bytes_total"
+    expr: |
+      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total)
+
   - record: "workload:istio_tcp_connections_opened_total"
     expr: |
       sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_connections_opened_total)
@@ -80,30 +88,6 @@ groups:
   - record: "workload:istio_tcp_connections_closed_total"
     expr: |
       sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_connections_closed_total)
-
-  - record: "workload:istio_tcp_sent_bytes_total_count"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_count)
-
-  - record: "workload:istio_tcp_sent_bytes_total_sum"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_sum)
-
-  - record: "workload:istio_tcp_sent_bytes_total_bucket"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_bucket)
-
-  - record: "workload:istio_tcp_received_bytes_total_count"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_count)
-
-  - record: "workload:istio_tcp_received_bytes_total_sum"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_sum)
-
-  - record: "workload:istio_tcp_received_bytes_total_bucket"
-    expr: |
-      sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_bucket)
 {{< /text >}}
 
 {{< /tab >}}
@@ -146,24 +130,14 @@ spec:
     - record: "workload:istio_response_bytes_bucket"
       expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_response_bytes_bucket)"
 
+    - record: "workload:istio_tcp_sent_bytes_total"
+      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total)"
+    - record: "workload:istio_tcp_received_bytes_total"
+      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total)"
     - record: "workload:istio_tcp_connections_opened_total"
       expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_connections_opened_total)"
     - record: "workload:istio_tcp_connections_closed_total"
       expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_connections_closed_total)"
-
-    - record: "workload:istio_tcp_sent_bytes_total_count"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_count)"
-    - record: "workload:istio_tcp_sent_bytes_total_sum"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_sum)"
-    - record: "workload:istio_tcp_sent_bytes_total_bucket"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_sent_bytes_total_bucket)"
-
-    - record: "workload:istio_tcp_received_bytes_total_count"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_count)"
-    - record: "workload:istio_tcp_received_bytes_total_sum"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_sum)"
-    - record: "workload:istio_tcp_received_bytes_total_bucket"
-      expr: "sum without(instance, kubernetes_namespace, kubernetes_pod_name) (istio_tcp_received_bytes_total_bucket)"
 {{< /text >}}
 
 {{< /tab >}}


### PR DESCRIPTION
Fixes some broken suggested recording rules that treated
`istio_tcp_sent_bytes_total` and `istio_tcp_sent_received_total` as if
they were distribution type metrics rather than counters.

I have also reordered the metrics to more closely align with the order
on the "Istio Standard Metrics" page.

Fixes #10311

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
