### PR TITLE
Pin basic auth extension image at 1.12.0.

### DIFF
--- a/content/en/docs/ops/configuration/extensibility/wasm-module-distribution/index.md
+++ b/content/en/docs/ops/configuration/extensibility/wasm-module-distribution/index.md
@@ -32,7 +32,7 @@ spec:
   selector:
     matchLabels:
       istio: ingressgateway
-  url: oci://ghcr.io/istio-ecosystem/wasm-extensions/basic_auth:{{< istio_version >}}.0
+  url: oci://ghcr.io/istio-ecosystem/wasm-extensions/basic_auth:1.12.0
   phase: AUTHN
   pluginConfig:
     basic_auth_rules:


### PR DESCRIPTION
There is no breaking change at Wasm ABI since Istio 1.8, so no need to release wasm extensions continuously with Istio release. This change pin the version of basic auth module at 1.12.0.