### PR TITLE
Remove heading anchors before spell-checking

### DIFF
--- a/scripts/lint_site.sh
+++ b/scripts/lint_site.sh
@@ -59,6 +59,9 @@ check_content() {
     # elide link="*"
     find "${TMP}" -type f -name \*.md -exec sed -E -i "s/link=\".*\"/LINK/g" {} ";"
 
+    # remove any heading anchors
+    find "${TMP}" -type f -name \*.md -exec sed -E -i "s/(^#.*\S) *\{#.*\} */\1/g" {} ";"
+
     # switch to the temp dir
     pushd "${TMP}" >/dev/null
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fixes https://github.com/istio/istio.io/issues/11156

Update the lint_site script to also remove heading anchors from the temporary files before spell checking.