### PR TITLE
[release-1.12] Fix helm install test - Use correct images and version

### DIFF
--- a/content/en/docs/setup/install/helm/test.sh
+++ b/content/en/docs/setup/install/helm/test.sh
@@ -27,7 +27,11 @@ function rewrite-repo() {
   cmd="$(echo "${cmd}" | sed 's|istio/base|manifests/charts/base|')"
   cmd="$(echo "${cmd}" | sed 's|istio/istiod|manifests/charts/istio-control/istio-discovery|')"
   cmd="$(echo "${cmd}" | sed 's|istio/gateway|manifests/charts/gateway|')"
-  eval "${cmd} --set global.tag=${ISTIO_IMAGE_VERSION=SHOULD_BE_SET}.${ISTIO_LONG_SHA=latest}" --version=1.12.6
+  if [[ "$cmd" == *"gateway"* ]]; then
+    eval "${cmd}"
+  else
+    eval "${cmd} --set global.tag=${ISTIO_IMAGE_VERSION=SHOULD_BE_SET}.${ISTIO_LONG_SHA=latest}"
+  fi
 }
 
 # @setup profile=none

--- a/content/en/docs/setup/install/helm/test.sh
+++ b/content/en/docs/setup/install/helm/test.sh
@@ -27,7 +27,7 @@ function rewrite-repo() {
   cmd="$(echo "${cmd}" | sed 's|istio/base|manifests/charts/base|')"
   cmd="$(echo "${cmd}" | sed 's|istio/istiod|manifests/charts/istio-control/istio-discovery|')"
   cmd="$(echo "${cmd}" | sed 's|istio/gateway|manifests/charts/gateway|')"
-  eval "${cmd}"
+  eval "${cmd} --set global.tag=${ISTIO_IMAGE_VERSION=SHOULD_BE_SET}.${ISTIO_LONG_SHA=latest}" --version=1.12.6
 }
 
 # @setup profile=none

--- a/data/args.yml
+++ b/data/args.yml
@@ -2,7 +2,7 @@
 version: "1.12"
 
 # The full Istio version identifier the docs describe
-full_version: "1.12.3"
+full_version: "1.12.6"
 
 # The previous Istio version identifier the docs describe, used for upgrade documentation
 previous_version: "1.11"


### PR DESCRIPTION
Please provide a description for what this PR is for.

Failure of helm install tests: https://github.com/istio/istio.io/pull/11171

We have had this issue on other releases. The tests try to use the GitHub charts which contain the `tag` of `latest` so we try to install using the local charts but the last built images off the main branch. This is incorrect.

Update to use the images associated with the current istio commit we reference for the tests.

For 1.12, there is an additional requirement since a PR wasn't cherry-picked back, to not specify the tag for the gateway install. It should be injected from istiod which had the tag specified.