### PR TITLE
Including workload rsa key size env to the table

### DIFF
--- a/content/en/docs/reference/commands/pilot-agent/index.html
+++ b/content/en/docs/reference/commands/pilot-agent/index.html
@@ -1946,6 +1946,12 @@ Only applies when traffic from all groups (i.e. &#34;*&#34;) is being redirected
 <td>allow agent pull wasm plugin from insecure registries, for example: &#39;localhost:5000,docker-registry:5000&#39;</td>
 </tr>
 <tr>
+<td><code>WORKLOAD_RSA_KEY_SIZE</code></td>
+<td>Integer</td>
+<td><code>2048</code></td>
+<td>Specify the RSA key size to use for workload certificates.</td>
+</tr>
+<tr>
 <td><code>XDS_AUTH</code></td>
 <td>Boolean</td>
 <td><code>true</code></td>


### PR DESCRIPTION
Related to the PR [#37192](https://github.com/istio/istio/pull/37192)
Updating the docs to include this environment variable under pilot-agent.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure