### PR TITLE
fix incorrect name of validation webhook

### DIFF
--- a/content/en/docs/ops/common-problems/validation/index.md
+++ b/content/en/docs/ops/common-problems/validation/index.md
@@ -23,13 +23,13 @@ necessary.
 
 ## Invalid configuration is accepted
 
-Verify the `istiod-istio-system` `validationwebhookconfiguration` exists and
+Verify the `istiod-default-validator` `validationwebhookconfiguration` exists and
 is correct. The `apiVersion`, `apiGroup`, and `resource` of the
 invalid configuration should be listed in one of the two `webhooks`
 entries.
 
 {{< text bash yaml >}}
-$ kubectl get validatingwebhookconfiguration istiod-istio-system -o yaml
+$ kubectl get validatingwebhookconfiguration istiod-default-validator -o yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -39,7 +39,7 @@ metadata:
     app: istiod
     istio: istiod
     release: istio
-  name: istiod-istio-system
+  name: istiod-default-validator
   ownerReferences:
   - apiVersion: rbac.authorization.k8s.io/v1
     blockOwnerDeletion: true


### PR DESCRIPTION
https://github.com/istio/istio/blob/1.13.3/manifests/charts/default/templates/validatingwebhook.yaml

https://istio.slack.com/archives/CFTRP8NTW/p1651700051392079?thread_ts=1651634052.502209&cid=CFTRP8NTW

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
