### PR TITLE
Fix istio oldies 1.0 fortio and diagram

### DIFF
--- a/archive/v1.0/docs/concepts/performance-and-scalability/index.html
+++ b/archive/v1.0/docs/concepts/performance-and-scalability/index.html
@@ -1,30 +1,1013 @@
-<!doctype html><html lang=en itemscope itemtype=https://schema.org/WebPage><head><meta charset=utf-8><meta http-equiv=x-ua-compatible content="IE=edge"><meta name=viewport content="width=device-width,initial-scale=1,shrink-to-fit=no"><meta name=theme-color content="#466BB0"><meta name=title content="Performance and Scalability"><meta name=description content="Introduces Performance and Scalability methodology, results and best practices for Istio components."><meta name=keywords content="microservices,services,mesh,performance,scalability,scale,benchmarks"><meta property="og:title" content="Performance and Scalability"><meta property="og:type" content="website"><meta property="og:description" content="Introduces Performance and Scalability methodology, results and best practices for Istio components."><meta property="og:url" content="/v1.0/docs/concepts/performance-and-scalability/"><meta property="og:image" content="/v1.0/img/istio-logo-blue-background.svg"><meta property="og:image:alt" content="Istio Logo"><meta property="og:image:width" content="112"><meta property="og:image:height" content="150"><meta property="og:site_name" content="Istio"><meta name=twitter:card content="summary"><meta name=twitter:site content="@IstioMesh"><title>Istioldie 1.0 / Performance and Scalability</title><script async src="https://www.googletagmanager.com/gtag/js?id=UA-98480406-2"></script><script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}
-gtag('js',new Date());gtag('config','UA-98480406-2');</script><script>var branchName="release-1.0";var docTitle="Performance and Scalability";</script><link rel=alternate type=application/rss+xml title="Istio Blog" href=/v1.0/feed.xml><link rel="shortcut icon" href=/v1.0/favicons/favicon.ico><link rel=apple-touch-icon href=/v1.0/favicons/apple-touch-icon-180x180.png sizes=180x180><link rel=icon type=image/png href=/v1.0/favicons/favicon-16x16.png sizes=16x16><link rel=icon type=image/png href=/v1.0/favicons/favicon-32x32.png sizes=32x32><link rel=icon type=image/png href=/v1.0/favicons/android-36x36.png sizes=36x36><link rel=icon type=image/png href=/v1.0/favicons/android-48x48.png sizes=48x48><link rel=icon type=image/png href=/v1.0/favicons/android-72x72.png sizes=72x72><link rel=icon type=image/png href=/v1.0/favicons/android-96x196.png sizes=96x196><link rel=icon type=image/png href=/v1.0/favicons/android-144x144.png sizes=144x144><link rel=icon type=image/png href=/v1.0/favicons/android-192x192.png sizes=192x192><link rel=manifest href=/v1.0/manifest.json><meta name=apple-mobile-web-app-title content="Istio"><meta name=application-name content="Istio"><link rel=stylesheet href="https://fonts.googleapis.com/css?family=Chivo:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic"><link rel=stylesheet href="https://fonts.googleapis.com/css?family=Work Sans:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic"><link rel=stylesheet href=https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css integrity=sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm crossorigin=anonymous><link rel=stylesheet href=https://use.fontawesome.com/releases/v5.0.6/css/all.css><link rel=stylesheet href=/v1.0/css/light_theme_archive.css title=light><link rel="alternate stylesheet" href=/v1.0/css/dark_theme_archive.css title=dark><script src=/v1.0/js/styleSwitcher.min.js></script></head><body class=language-unknown><header><nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark justify-content-between"><a class=navbar-brand href=/v1.0/><span class=logo><svg viewBox="0 0 300 300"><circle cx="150" cy="150" r="150" stroke-width="2" /><polygon points="65,240 225,240 125,270"/><polygon points="65,230 125,220 125,110"/><polygon points="135,220 225,230 135,30"/></svg></span><span class=brand-name>Istioldie 1.0</span></a>
-<button class=navbar-toggler type=button data-toggle=collapse data-target=#navbarCollapse aria-controls=navbarCollapse aria-expanded=false aria-label="Toggle navigation">
-<span class=navbar-toggler-icon></span></button><div class="collapse navbar-collapse justify-content-end" id=navbarCollapse><ul id=navbar-links class="navbar-nav active"><li class=nav-item><a class="nav-link active" title="Learn how to deploy, use, and operate Istio." href=/v1.0/docs/>Docs</a></li><li class=nav-item><a class=nav-link title="Posts about using Istio." href=/v1.0/blog/2019/announcing-1.0.6/>Blog</a></li><li class=nav-item><a class=nav-link title="A bunch of resources to help you deploy, configure and use Istio." href=/v1.0/help/>Help</a></li><li class=nav-item><a class=nav-link title="Get a bit more in-depth info about the Istio project." href=/v1.0/about/>About</a></li><li class="nav-item dropdown" id=gearDropdown style=white-space:nowrap><a title="Options and Settings" href class=nav-link data-toggle=dropdown aria-label=Tools aria-haspopup=true aria-expanded=false><i style=width:1em class="fa fa-lg fa-cog"></i></a><div class="dropdown-menu dropdown-menu-right" aria-labelledby=gearDropdown><a class=dropdown-item id=light-theme-item href onclick="setActiveStyleSheet('light');return false;">Light Theme</a>
-<a class=dropdown-item id=dark-theme-item href onclick="setActiveStyleSheet('dark');return false;">Dark Theme</a><div class=dropdown-divider></div><h6 class=dropdown-header>Other versions of this site</h6><a href=https://istio.io class=dropdown-item>Current Release</a>
-<a href=https://preliminary.istio.io class=dropdown-item>Next Release</a>
-<a href=https://archive.istio.io class=dropdown-item>Older Releases</a></div></li><li class=nav-item><a id=search_show class=nav-link href title="Search istio.io" aria-label=Search><i style=width:1em class="fa fa-lg fa-search"></i></a></li></ul><form name=cse id=search_form class="form-inline mr-sm-2" role=search><input type=hidden name=cx value=013699703217164175118:iwwf17ikgf4>
-<input type=hidden name=ie value=utf-8>
-<input type=hidden name=hl value=en>
-<input type=hidden id=search_page_url value=/v1.0/search.html>
-<input id=search_textbox class=form-control name=q type=text aria-label="Search this site">
-<button id=search_close type=reset aria-label="Cancel Search"><i class="far fa-lg fa-times-circle"></i></button></form></div></nav></header><div class=container-fluid><div class="row row-offcanvas"><div class="col-0 col-md-3 col-xl-2 sidebar-offcanvas"><nav class="sidebar d-print-none"><div class=spacer></div><div class=directory role=tablist><div class=card><div class=card-header role=tab id=header10><a data-toggle=collapse href=#collapse10 title="Learn about the different parts of the Istio system and the abstractions it uses." role=button aria-controls=collapse10><div><img src=/v1.0/img/concepts.svg alt=Icon class=page_icon>
-Concepts</div></a></div><div id=collapse10 class="collapse show" data-parent=#sidebar role=tabpanel aria-labelledby=header10><div class=card-body><ul class=tree><li><a title="Introduces Istio, the problems it solves, its high-level architecture and design goals." href=/v1.0/docs/concepts/what-is-istio/>What is Istio?</a></li><li><a title="Describes the various Istio features focused on traffic routing and control." href=/v1.0/docs/concepts/traffic-management/>Traffic Management</a></li><li><a title="Describes Istio's authorization and authentication functionality." href=/v1.0/docs/concepts/security/>Security</a></li><li><a title="Describes the policy enforcement and telemetry mechanisms." href=/v1.0/docs/concepts/policies-and-telemetry/>Policies and Telemetry</a></li><li><span class=current title="Introduces Performance and Scalability methodology, results and best practices for Istio components.">Performance and Scalability</span></li></ul></div></div></div><div class=card><div class=card-header role=tab id=header20><a data-toggle=collapse href=#collapse20 title="How to deploy Istio in various environments (e.g., Kubernetes, Consul)." role=button aria-controls=collapse20><div><img src=/v1.0/img/setup.svg alt=Icon class=page_icon>
-Setup</div></a></div><div id=collapse20 class=collapse data-parent=#sidebar role=tabpanel aria-labelledby=header20><div class=card-body><ul class=tree><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Instructions for installing the Istio control plane on Kubernetes and adding virtual machines into the mesh." href=/v1.0/docs/setup/kubernetes/>Kubernetes</a></label><ul class="tree collapse"><li><a title="Instructions to download the Istio release." href=/v1.0/docs/setup/kubernetes/download-release/>Downloading the Release</a></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="How to prepare various Kubernetes platforms before installing Istio." href=/v1.0/docs/setup/kubernetes/platform-setup/>Platform Setup</a></label><ul class="tree collapse"><li><a title="Instructions to setup an Alibaba Cloud Kubernetes cluster for Istio." href=/v1.0/docs/setup/kubernetes/platform-setup/alicloud/>Alibaba Cloud</a></li><li><a title="Instructions to setup an AWS cluster with Kops cluster for Istio." href=/v1.0/docs/setup/kubernetes/platform-setup/aws/>Amazon Web Services</a></li><li><a title="Instructions to setup an Azure cluster for Istio." href=/v1.0/docs/setup/kubernetes/platform-setup/azure/>Azure</a></li><li><a title="Instructions to setup a Google Kubernetes Engine cluster for Istio." href=/v1.0/docs/setup/kubernetes/platform-setup/gke/>Google Kubernetes Engine</a></li><li><a title="Instructions to setup an IBM Cloud cluster for Istio." href=/v1.0/docs/setup/kubernetes/platform-setup/ibm/>IBM Cloud</a></li><li><a title="Instructions to setup Minikube for use with Istio." href=/v1.0/docs/setup/kubernetes/platform-setup/minikube/>Minikube</a></li><li><a title="Instructions to setup an OpenShift cluster for Istio." href=/v1.0/docs/setup/kubernetes/platform-setup/openshift/>OpenShift</a></li><li><a title="Instructions to setup an OKE cluster for Istio." href=/v1.0/docs/setup/kubernetes/platform-setup/oci/>Oracle Cloud Infrastructure</a></li></ul></li><li><a title="Instructions to setup the Istio service mesh in a Kubernetes cluster." href=/v1.0/docs/setup/kubernetes/quick-start/>Quick Start with Kubernetes</a></li><li><a title="How to quickly setup Istio using Alibaba Cloud Kubernetes Container Service." href=/v1.0/docs/setup/kubernetes/quick-start-alicloud-ack/>Quick Start with Alibaba Cloud Kubernetes Container Service</a></li><li><a title="How to quickly setup Istio using IBM Cloud Public or IBM Cloud Private." href=/v1.0/docs/setup/kubernetes/quick-start-ibm/>Quick Start with IBM Cloud</a></li><li><a title="Install Istio with the included Helm chart." href=/v1.0/docs/setup/kubernetes/helm-install/>Installation with Helm</a></li><li><a title="Instructions for installing the Istio sidecar in application pods automatically using the sidecar injector webhook or manually using istioctl CLI." href=/v1.0/docs/setup/kubernetes/sidecar-injection/>Installing the sidecar</a></li><li><a title="Install minimal Istio using Helm." href=/v1.0/docs/setup/kubernetes/minimal-install/>Minimal Istio Installation</a></li><li><a title="Install Istio with the included Ansible playbook." href=/v1.0/docs/setup/kubernetes/ansible-install/>Installation with Ansible</a></li><li><a title="Instructions for integrating VMs and bare metal hosts into an Istio mesh deployed on Kubernetes." href=/v1.0/docs/setup/kubernetes/mesh-expansion/>Mesh Expansion</a></li><li><a title="Install Istio with multicluster support." href=/v1.0/docs/setup/kubernetes/multicluster-install/>Istio Multicluster</a></li><li><a title="How to quickly setup Istio using Google Kubernetes Engine (GKE)." href=/v1.0/docs/setup/kubernetes/quick-start-gke/>Quick Start with Google Kubernetes Engine</a></li><li><a title="Demonstrates how to upgrade the Istio control plane and data plane independently." href=/v1.0/docs/setup/kubernetes/upgrading-istio/>Upgrading Istio</a></li><li><a title="Describes the requirements for Kubernetes pods and services to run Istio." href=/v1.0/docs/setup/kubernetes/spec-requirements/>Requirements for Pods and Services</a></li></ul></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Instructions for installing the Istio control plane in a Consul based environment, with or without Nomad." href=/v1.0/docs/setup/consul/>Nomad & Consul</a></label><ul class="tree collapse"><li><a title="Quick Start instructions to setup the Istio service mesh with Docker Compose." href=/v1.0/docs/setup/consul/quick-start/>Quick Start on Docker</a></li><li><a title="Instructions for installing the Istio control plane in a Consul-based environment, with or without Nomad." href=/v1.0/docs/setup/consul/install/>Installation</a></li></ul></li></ul></div></div></div><div class=card><div class=card-header role=tab id=header33><a data-toggle=collapse href=#collapse33 title="How to do single specific targeted activities with the Istio system." role=button aria-controls=collapse33><div><img src=/v1.0/img/tasks.svg alt=Icon class=page_icon>
-Tasks</div></a></div><div id=collapse33 class=collapse data-parent=#sidebar role=tabpanel aria-labelledby=header33><div class=card-body><ul class=tree><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Tasks that demonstrate Istio's traffic routing features." href=/v1.0/docs/tasks/traffic-management/>Traffic Management</a></label><ul class="tree collapse"><li><a title="This task shows you how to configure dynamic request routing to multiple versions of a microservice." href=/v1.0/docs/tasks/traffic-management/request-routing/>Configuring Request Routing</a></li><li><a title="This task shows you how to inject faults to test the resiliency of your application." href=/v1.0/docs/tasks/traffic-management/fault-injection/>Fault Injection</a></li><li><a title="Shows you how to migrate traffic from an old to new version of a service." href=/v1.0/docs/tasks/traffic-management/traffic-shifting/>Traffic Shifting</a></li><li><a title="This task shows you how to setup request timeouts in Envoy using Istio." href=/v1.0/docs/tasks/traffic-management/request-timeouts/>Setting Request Timeouts</a></li><li><a title="Describes how to configure Istio to expose a service outside of the service mesh." href=/v1.0/docs/tasks/traffic-management/ingress/>Control Ingress Traffic</a></li><li><a title="Describes how to configure Istio to expose a service outside of the service mesh, over TLS, mutual TLS or JWT authentication." href=/v1.0/docs/tasks/traffic-management/secure-ingress/>Securing Gateways with HTTPS</a></li><li><a title="Describes how to configure Istio to route traffic from services in the mesh to external services." href=/v1.0/docs/tasks/traffic-management/egress/>Control Egress Traffic</a></li><li><a title="This task shows you how to configure circuit breaking for connections, requests, and outlier detection." href=/v1.0/docs/tasks/traffic-management/circuit-breaking/>Circuit Breaking</a></li><li><a title="This task demonstrates the traffic mirroring/shadowing capabilities of Istio." href=/v1.0/docs/tasks/traffic-management/mirroring/>Mirroring</a></li><li><a title="Shows how to do health checking for Istio services." href=/v1.0/docs/tasks/traffic-management/app-health-check/>Health Checking of Istio Services</a></li></ul></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Demonstrates how to secure the mesh." href=/v1.0/docs/tasks/security/>Security</a></label><ul class="tree collapse"><li><a title="Shows you how to use Istio authentication policy to setup mutual TLS and basic end-user authentication." href=/v1.0/docs/tasks/security/authn-policy/>Authentication Policy</a></li><li><a title="Shows you how to verify and test Istio's automatic mutual TLS authentication." href=/v1.0/docs/tasks/security/mutual-tls/>Mutual TLS Deep-Dive</a></li><li><a title="Shows how to set up role-based access control for services in the mesh." href=/v1.0/docs/tasks/security/role-based-access-control/>Authorization</a></li><li><a title="Shows how operators can configure Citadel with existing root certificate, signing certificate and key." href=/v1.0/docs/tasks/security/plugin-ca-cert/>Plugging in external CA key and certificate</a></li><li><a title="Shows how to enable Citadel health checking with Kubernetes." href=/v1.0/docs/tasks/security/health-check/>Citadel health checking</a></li><li><a title="Shows you how to incrementally migrate your Istio services to mutual TLS." href=/v1.0/docs/tasks/security/mtls-migration/>Mutual TLS Migration</a></li><li><a title="Shows how to enable mutual TLS on HTTPS services." href=/v1.0/docs/tasks/security/https-overlay/>Mutual TLS over HTTPS</a></li></ul></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Demonstrates policy enforcement features." href=/v1.0/docs/tasks/policy-enforcement/>Policies</a></label><ul class="tree collapse"><li><a title="This task shows you how to use Istio to dynamically limit the traffic to a service." href=/v1.0/docs/tasks/policy-enforcement/rate-limiting/>Enabling Rate Limits</a></li><li><a title="Shows how to control access to a service using simple denials or white/black listing." href=/v1.0/docs/tasks/policy-enforcement/denial-and-list/>Denials and White/Black Listing</a></li></ul></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Demonstrates how to collect telemetry information from the mesh." href=/v1.0/docs/tasks/telemetry/>Telemetry</a></label><ul class="tree collapse"><li><a title="How to configure the proxies to send tracing requests to Zipkin or Jaeger." href=/v1.0/docs/tasks/telemetry/distributed-tracing/>Distributed Tracing</a></li><li><a title="This task shows you how to configure Istio to collect metrics and logs." href=/v1.0/docs/tasks/telemetry/metrics-logs/>Collecting Metrics and Logs</a></li><li><a title="This task shows you how to configure Istio to collect metrics for TCP services." href=/v1.0/docs/tasks/telemetry/tcp-metrics/>Collecting Metrics for TCP services</a></li><li><a title="This task shows you how to query for Istio Metrics using Prometheus." href=/v1.0/docs/tasks/telemetry/querying-metrics/>Querying Metrics from Prometheus</a></li><li><a title="This task shows you how to setup and use the Istio Dashboard to monitor mesh traffic." href=/v1.0/docs/tasks/telemetry/using-istio-dashboard/>Visualizing Metrics with Grafana</a></li><li><a title="This task shows you how to visualize your services within an Istio mesh." href=/v1.0/docs/tasks/telemetry/kiali/>Visualizing Your Mesh</a></li><li><a title="This task shows you how to generate a graph of services within an Istio mesh." href=/v1.0/docs/tasks/telemetry/servicegraph/>Generating a Service Graph</a></li><li><a title="This task shows you how to configure Istio to log to a Fluentd daemon." href=/v1.0/docs/tasks/telemetry/fluentd/>Logging with Fluentd</a></li></ul></li></ul></div></div></div><div class=card><div class=card-header role=tab id=header46><a data-toggle=collapse href=#collapse46 title="A variety of fully working example uses for Istio that you can experiment with." role=button aria-controls=collapse46><div><img src=/v1.0/img/examples.svg alt=Icon class=page_icon>
-Examples</div></a></div><div id=collapse46 class=collapse data-parent=#sidebar role=tabpanel aria-labelledby=header46><div class=card-body><ul class=tree><li><a title="Deploys a sample application composed of four separate microservices used to demonstrate various Istio features." href=/v1.0/docs/examples/bookinfo/>Bookinfo Application</a></li><li><a title="Demonstrates how to use various traffic management capabilities of an Istio service mesh." href=/v1.0/docs/examples/intelligent-routing/>Intelligent Routing</a></li><li><a title="Demonstrates how to obtain uniform metrics, logs, traces across different services using Istio Mixer and Istio sidecar." href=/v1.0/docs/examples/telemetry/>In-Depth Telemetry</a></li><li><a title="Explains how to manually integrate Google Cloud Endpoints services with Istio." href=/v1.0/docs/examples/endpoints/>Install Istio for Google Cloud Endpoints Services</a></li><li><a title="Illustrates how to use Istio to control a Kubernetes cluster and raw VMs as a single mesh." href=/v1.0/docs/examples/integrating-vms/>Integrating Virtual Machines</a></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="A variety of fully working examples for egress traffic control in Istio that you can experiment with." href=/v1.0/docs/examples/advanced-egress/>Advanced egress traffic control</a></label><ul class="tree collapse"><li><a title="Describes how to configure Istio to perform TLS origination for traffic to external services." href=/v1.0/docs/examples/advanced-egress/egress-tls-origination/>TLS Origination for Egress Traffic</a></li><li><a title="Describes how to configure Istio to direct traffic to external services through a dedicated gateway." href=/v1.0/docs/examples/advanced-egress/egress-gateway/>Configure an Egress Gateway</a></li></ul></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="A variety of fully working multicluster examples for Istio that you can experiment with." href=/v1.0/docs/examples/multicluster/>Enabling multiclusters</a></label><ul class="tree collapse"><li><a title="Example multicluster GKE install of Istio." href=/v1.0/docs/examples/multicluster/gke/>Google Kubernetes Engine</a></li><li><a title="Example multicluster IBM Cloud Private install of Istio." href=/v1.0/docs/examples/multicluster/icp/>IBM Cloud Private</a></li><li><a title="Example multicluster between IBM Cloud Kubernetes Service & IBM Cloud Private." href=/v1.0/docs/examples/multicluster/iks-icp/>IBM Cloud Kubernetes Service & IBM Cloud Private</a></li></ul></li></ul></div></div></div><div class=card><div class=card-header role=tab id=header78><a data-toggle=collapse href=#collapse78 title="Detailed authoritative reference material such as command-line options, configuration options, and API calling parameters." role=button aria-controls=collapse78><div><img src=/v1.0/img/reference.svg alt=Icon class=page_icon>
-Reference</div></a></div><div id=collapse78 class=collapse data-parent=#sidebar role=tabpanel aria-labelledby=header78><div class=card-body><ul class=tree><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Detailed information on configuration options." href=/v1.0/docs/reference/config/>Configuration</a></label><ul class="tree collapse"><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Describes how to configure Istio's authorization features." href=/v1.0/docs/reference/config/authorization/>Authorization</a></label><ul class="tree collapse"><li><a title="Describes the supported constraints and properties." href=/v1.0/docs/reference/config/authorization/constraints-and-properties/>Constraints and Properties</a></li><li><a title="Configuration for Role Based Access Control." href=/v1.0/docs/reference/config/authorization/istio.rbac.v1alpha1/>RBAC</a></li></ul></li><li><a title="Describes the options available when installing Istio using the included Helm chart." href=/v1.0/docs/reference/config/installation-options/>Installation Options</a></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Describes how to configure Istio's policy and telemetry features." href=/v1.0/docs/reference/config/policy-and-telemetry/>Policies and Telemetry</a></label><ul class="tree collapse"><li><a title="Describes the base attribute vocabulary used for policy and control." href=/v1.0/docs/reference/config/policy-and-telemetry/attribute-vocabulary/>Attribute Vocabulary</a></li><li><a title="Mixer configuration expression language reference." href=/v1.0/docs/reference/config/policy-and-telemetry/expression-language/>Expression Language</a></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Mixer adapters allow Istio to interface to a variety of infrastructure backends for such things as metrics and logs." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/>Adapters</a></label><ul class="tree collapse"><li><a title="Adapter for Apigee's distributed policy checks and analytics." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/apigee/>Apigee</a></li><li><a title="Adapter for circonus.com's monitoring solution." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/circonus/>Circonus</a></li><li><a title="Adapter for cloudwatch metrics." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/cloudwatch/>CloudWatch</a></li><li><a title="Adapter to deliver metrics to a dogstatsd agent for delivery to DataDog." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/datadog/>Datadog</a></li><li><a title="Adapter that always returns a precondition denial." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/denier/>Denier</a></li><li><a title="Adapter that delivers logs to a fluentd daemon." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/fluentd/>Fluentd</a></li><li><a title="Adapter that extracts information from a Kubernetes environment." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/kubernetesenv/>Kubernetes Env</a></li><li><a title="Adapter that performs whitelist or blacklist checks." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/list/>List</a></li><li><a title="Adapter for a simple in-memory quota management system." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/memquota/>Memory quota</a></li><li><a title="Adapter that implements an Open Policy Agent engine." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/opa/>OPA</a></li><li><a title="Adapter that exposes Istio metrics for ingestion by a Prometheus harvester." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/prometheus/>Prometheus</a></li><li><a title="Adapter that exposes Istio's Role-Based Access Control model." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/rbac/>RBAC</a></li><li><a title="Adapter for a Redis-based quota management system." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/redisquota/>Redis Quota</a></li><li><a title="Adapter that delivers logs and metrics to Google Service Control." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/servicecontrol/>Service Control</a></li><li><a title="Adapter that sends Istio metrics to SignalFx." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/signalfx/>SignalFx</a></li><li><a title="Adapter to deliver logs and metrics to Papertrail and AppOptics backends." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/solarwinds/>SolarWinds</a></li><li><a title="Adapter to deliver logs, metrics, and traces to Stackdriver." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/stackdriver/>Stackdriver</a></li><li><a title="Adapter to deliver metrics to a StatsD backend." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/statsd/>StatsD</a></li><li><a title="Adapter for outputting logs and metrics locally." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/stdio/>Stdio</a></li><li><a title="Adapter to deliver metrics to Wavefront by VMware." href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/wavefront/>Wavefront by VMware</a></li></ul></li><li><a title="Default Metrics exported from Istio through Mixer." href=/v1.0/docs/reference/config/policy-and-telemetry/metrics/>Default Metrics</a></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Mixer templates are used to send data to individual adapters." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/>Templates</a></label><ul class="tree collapse"><li><a title="The Analytics template is used to dispatch runtime telemetry to Apigee." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/analytics/>Analytics</a></li><li><a title="A template that represents a single API key." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/apikey/>API Key</a></li><li><a title="A template used to represent an access control query." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/authorization/>Authorization</a></li><li><a title="A template that carries no data, useful for testing." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/checknothing/>Check Nothing</a></li><li><a title="A template that is used to control the production of Kubernetes-specific attributes." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/kubernetes/>Kubernetes</a></li><li><a title="A template designed to let you perform list checking operations." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/listentry/>List Entry</a></li><li><a title="A template that represents a single runtime log entry." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/logentry/>Log Entry</a></li><li><a title="A template that represents a single runtime metric." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/metric/>Metric</a></li><li><a title="A template that represents a quota allocation request." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/quota/>Quota</a></li><li><a title="A template that carries no data, useful for testing." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/reportnothing/>Report Nothing</a></li><li><a title="A template used by the Google Service Control adapter." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/servicecontrolreport/>Service Control Report</a></li><li><a title="A template that represents\ an individual span within a distributed trace." href=/v1.0/docs/reference/config/policy-and-telemetry/templates/tracespan/>Trace Span</a></li></ul></li><li><a title="Describes the rules used to configure Mixer's policy and telemetry features." href=/v1.0/docs/reference/config/policy-and-telemetry/istio.policy.v1beta1/>Rules</a></li></ul></li><li><a title="Authentication policy for Istio services." href=/v1.0/docs/reference/config/istio.authentication.v1alpha1/>Authentication Policy</a></li><li><a title="Configuration affecting traffic routing." href=/v1.0/docs/reference/config/istio.networking.v1alpha3/>Traffic Routing</a></li></ul></li><li class=sublist><label class=tree-toggle><i class="fa fa-lg fa-caret-right"></i><a title="Describes usage and options of the Istio commands and utilities." href=/v1.0/docs/reference/commands/>Commands</a></label><ul class="tree collapse"><li><a title="Galley provides configuration management services for Istio." href=/v1.0/docs/reference/commands/galley/>galley</a></li><li><a title="Istio Certificate Authority (CA)." href=/v1.0/docs/reference/commands/istio_ca/>istio_ca</a></li><li><a title="Istio control interface." href=/v1.0/docs/reference/commands/istioctl/>istioctl</a></li><li><a title="Utility to trigger direct calls to Mixer's API." href=/v1.0/docs/reference/commands/mixc/>mixc</a></li><li><a title="Mixer is Istio's abstraction on top of infrastructure backends." href=/v1.0/docs/reference/commands/mixs/>mixs</a></li><li><a title="Istio security per-node agent." href=/v1.0/docs/reference/commands/node_agent/>node_agent</a></li><li><a title="Istio Pilot agent." href=/v1.0/docs/reference/commands/pilot-agent/>pilot-agent</a></li><li><a title="Istio Pilot." href=/v1.0/docs/reference/commands/pilot-discovery/>pilot-discovery</a></li><li><a title="Kubernetes webhook for automatic Istio sidecar injection." href=/v1.0/docs/reference/commands/sidecar-injector/>sidecar-injector</a></li></ul></li></ul></div></div></div></div></nav></div><div class="col-12 col-md-9 col-xl-8"><p class=d-md-none><label class=sidebar-toggler data-toggle=offcanvas><i class="fa fa-sign-out-alt"></i></label></p><main aria-labelledby=title><div class=pagenav><p><a href=/v1.0/docs/concepts/ title="Learn about the different parts of the Istio system and the abstractions it uses."><i style=transform:scaleX(-1) class="fa fa-level-up-alt"></i>&nbsp;Concepts</a></p></div><h1 id=title>Performance and Scalability</h1><nav class="toc-inlined d-xl-none d-print-none"><hr><div class=directory role=directory><nav id=InlinedTableOfContents><ul><li><a href=#micro-benchmarks>Micro benchmarks</a></li><li><a href=#testing-scenarios>Testing scenarios</a></li><li><a href=#synthetic-end-to-end-benchmarks>Synthetic end to end benchmarks</a></li><li><a href=#realistic-application-benchmark>Realistic application benchmark</a></li><li><a href=#automation>Automation</a></li><li><a href=#scalability-and-sizing-guide>Scalability and sizing guide</a></li><li><a href=#see-also>See also</a></li></ul></nav></div><hr></nav><p>We follow a four-pronged approach to Istio performance characterization, tracking and improvements:</p><ul><li><p>Code level micro-benchmarks</p></li><li><p>Synthetic end-to-end benchmarks across various scenarios</p></li><li><p>Realistic complex app end-to-end benchmarks across various settings</p></li><li><p>Automation to ensure performance doesn't regress</p></li></ul><h2 id=micro-benchmarks>Micro benchmarks</h2><p>We use Go’s native tools to write targeted micro-benchmarks in performance sensitive areas. Our main goal with this approach is to provide easy-to-use micro-benchmarks that developers can use to perform quick before/after performance comparisons for their changes.</p><p>See the <a href=https://raw.githubusercontent.com/istio/istio/release-1.0/mixer/test/perf/singlecheck_test.go>sample micro-benchmark</a> for Mixer that measures the performance of attribute processing code.</p><p>Developers can also utilize a golden-files approach to capture the state of their benchmark results in the source tree for keeping track and referencing purposes. GitHub has this <a href=https://raw.githubusercontent.com/istio/istio/release-1.0/mixer/test/perf/bench.baseline>baseline file</a>.</p><p>Due to the nature of this testing type, there is a high-variance in latency numbers across machines. It is recommended that micro-benchmark numbers captured in this way are compared only against the previous runs on the same machine.</p><p>The <a href=https://raw.githubusercontent.com/istio/istio/release-1.0/bin/perfcheck.sh><code>perfcheck.sh</code> script</a> can be used to quickly run benchmarks in a sub-folder and compare its results against the co-located baseline files.</p><h2 id=testing-scenarios>Testing scenarios</h2><figure style=width:80%><div class=wrapper-with-intrinsic-ratio style=padding-bottom:75%><a class=not-for-endnotes href="https://raw.githubusercontent.com/istio/istio/master/tools/perf_setup.svg?sanitize=true"><img class=element-to-stretch src="https://raw.githubusercontent.com/istio/istio/master/tools/perf_setup.svg?sanitize=true" alt="Performance scenarios diagram" title="Performance scenarios diagram"></a></div><figcaption>Performance scenarios diagram</figcaption></figure><p>The synthetic benchmark scenarios and the source code of the tests are described
-on <a href=https://github.com/istio/istio/blob/release-1.0/tools#istio-load-testing-user-guide>GitHub</a></p><h2 id=synthetic-end-to-end-benchmarks>Synthetic end to end benchmarks</h2><p>We use <a href=https://fortio.org/>Fortio</a> as Istio's synthetic end to end load testing tool. Fortio runs at a specified query per second (qps) and records an histogram of execution time and calculates percentiles (e.g. p99 i.e. the response time such as 99% of the requests take less than that number (in seconds, SI unit)). It can run for a set duration, for a fixed number of calls, or until interrupted (at a constant target QPS, or max speed/load per connection/thread).</p><p>Fortio is a fast, small, reusable, embeddable go library as well as a command line tool and server process, the server includes a simple web UI and graphical representation of the results (both a single latency graph and a multiple results comparative min, max, average and percentiles graphs).</p><p>Fortio is also 100% open-source and with no external dependencies beside go and gRPC so you can reproduce all our results easily and add your own variants or scenarios you are interested in exploring.</p><p>Here is an example of scenario (one out of the 8 scenarios we run for every build) result graphing the latency distribution for istio-0.7.1 at 400 Query-Per-Second (qps) between 2 services inside the mesh (with mutual TLS, Mixer policy checks and telemetry collection):</p><p>Comparing 0.6.0 and 0.7.1 histograms/response time distribution for the same scenario, clearly showing 0.7 improvements:</p><p>And tracking the progress across all the tested releases for that scenario:</p><p>You can learn more about <a href=https://github.com/fortio/fortio/blob/master/README.md#fortio>Fortio</a> on GitHub and see results on <a href=https://fortio.istio.io>https://fortio.istio.io</a>.</p><h2 id=realistic-application-benchmark>Realistic application benchmark</h2><p>Acmeair (a.k.a, BluePerf) is a customer-like microservices application implemented in Java. This application runs on WebSphere Liberty and simulates the operations of a fictitious airline.</p><p>Acmeair is composed by the following microservices:</p><ul><li><p><strong>Flight Service</strong> retrieves flight route data. It is called by the Booking service to check miles for the rewards operations (Acmeair customer fidelity program).</p></li><li><p><strong>Customer Service</strong> stores, updates, and retrieves customer data. It is invoked by the Auth service for login and by the Booking service for the rewards operations.</p></li><li><p><strong>Booking Service</strong> stores, updates, and retrieves booking data.</p></li><li><p><strong>Auth Service</strong> generates JWT if the user/password is valid.</p></li><li><p><strong>Main Service</strong> primarily consists of the presentation layer (web pages) that interact with the other services. This allows the user to interact directly with the application via browser, but it is not exercised during the load test.</p></li></ul><p>The diagram below represents the different pods/containers of the application in the Kubernetes/Istio environment:</p><figure style=width:100%><div class=wrapper-with-intrinsic-ratio style=padding-bottom:80%><a class=not-for-endnotes href=https://ibmcloud-perf.istio.io/regpatrol/istio_regpatrol_readme_files/image004.png><img class=element-to-stretch src=https://ibmcloud-perf.istio.io/regpatrol/istio_regpatrol_readme_files/image004.png alt="Acmeair microservices overview"></a></div><figcaption></figcaption></figure><p>The following table shows the transactions that are driven by the script during the regression test and the approximate distribution of the requests:</p><figure style=width:100%><div class=wrapper-with-intrinsic-ratio style=padding-bottom:20%><a class=not-for-endnotes href=https://ibmcloud-perf.istio.io/regpatrol/istio_regpatrol_readme_files/image006.png><img class=element-to-stretch src=https://ibmcloud-perf.istio.io/regpatrol/istio_regpatrol_readme_files/image006.png alt="Acmeair request types and distribution"></a></div><figcaption></figcaption></figure><p>The Acmeair benchmark application can be found here: <a href=https://github.com/blueperf>IBM's BluePerf</a>.</p><h2 id=automation>Automation</h2><p>Both the synthetic benchmarks (fortio based) and the realistic application (BluePerf)
-are part of the nightly release pipeline and you can see the results on:</p><ul><li><a href=https://fortio-daily.istio.io/>https://fortio-daily.istio.io/</a></li><li><a href=https://ibmcloud-perf.istio.io/regpatrol/>https://ibmcloud-perf.istio.io/regpatrol/</a></li></ul><p>This enables us to catch regression early and track improvements over time.</p><h2 id=scalability-and-sizing-guide>Scalability and sizing guide</h2><ul><li><p>Setup multiple replicas of the control plane components.</p></li><li><p>Setup <a href=https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/>Horizontal Pod Autoscaling</a></p></li><li><p>Split mixer check and report pods.</p></li><li><p>High availability (HA).</p></li><li><p>See also <a href=https://github.com/istio/istio/wiki/Istio-Performance-oriented-setup-FAQ>Istio's Performance oriented FAQ</a></p></li><li><p>And the <a href=https://github.com/istio/community/blob/master/WORKING-GROUPS.md#performance-and-scalability>Performance and Scalability Working Group</a> work.</p></li></ul><p>Current recommendations (when using all Istio features):</p><ul><li><p>1 vCPU per peak thousand requests per second for the sidecar(s) with access logging (which is on by default) and 0.5 without, <code>fluentd</code> on the node is a big contributor to that cost as it captures and uploads logs.</p></li><li><p>Assuming typical cache hit ratio (>80%) for mixer checks: 0.5 vCPU per peak thousand requests per second for the mixer pods.</p></li><li><p>Latency cost/overhead is approximately <a href="https://fortio.istio.io/browse?url=qps_400-s1_to_s2-0.7.1-2018-04-05-22-06.json">10 millisecond</a> for service-to-service (2 proxies involved, mixer telemetry and checks) as of 0.7.1, we expect to bring this down to a low single digit ms.</p></li><li><p>Mutual TLS costs are negligible on AES-NI capable hardware in terms of both CPU and latency.</p></li></ul><p>We plan on providing more granular guidance for customers adopting Istio &ldquo;A la carte&rdquo;.</p><p>We have an ongoing goal to reduce both the CPU overhead and latency of adding Istio to your application. Please note however that if you application is
-handling its own telemetry, policy, security, network routing, a/b testing, etc&mldr; all that code and cost can be removed and that should offset most if
-not all of the Istio overhead.</p><h2 id=see-also>See also</h2><div class=see-also><div class=container-fluid><div class=row><div class="col-xs-12 col-sm-6 col-xl-4"><p class=link><a href=/v1.0/blog/2019/appswitch/>Sidestepping Dependency Ordering with AppSwitch</a></p><p class=desc>Addressing application startup ordering and startup latency using AppSwitch.</p></div><div class="col-xs-12 col-sm-6 col-xl-4"><p class=link><a href=/v1.0/blog/2018/delayering-istio/delayering-istio/>Delayering Istio with AppSwitch</a></p><p class=desc>Automatic application onboarding and latency optimizations using AppSwitch.</p></div></div></div></div></main><div class="container-fluid d-print-none"><br><div class=row><div class="col-6 pagenav"><p><a title="Describes the policy enforcement and telemetry mechanisms." href=/v1.0/docs/concepts/policies-and-telemetry/><i class="fa fa-long-arrow-alt-left"></i>Policies and Telemetry</a></p></div><div class="col-6 pagenav" style=text-align:right></div></div></div><div class="d-none d-print-block" aria-hidden=true><h2>Links</h2><ol id=endnotes></ol></div></div><div class="col-12 col-md-2 d-none d-xl-block d-print-none"><nav class=toc><div class=spacer></div><div id=toc class=directory role=directory><nav id=TableOfContents><ul><li><a href=#micro-benchmarks>Micro benchmarks</a></li><li><a href=#testing-scenarios>Testing scenarios</a></li><li><a href=#synthetic-end-to-end-benchmarks>Synthetic end to end benchmarks</a></li><li><a href=#realistic-application-benchmark>Realistic application benchmark</a></li><li><a href=#automation>Automation</a></li><li><a href=#scalability-and-sizing-guide>Scalability and sizing guide</a></li><li><a href=#see-also>See also</a></li></ul></nav></div></nav></div></div></div><footer class="d-print-none container-fluid"><div class=row><div class="col-5 col-lg-4" role=navigation><div class=container-fluid><div class=row><div class=icon><span>discuss</span>
-<a title="Join the Istio discussion board to participate in discussions and get help troubleshooting problems" href=https://discuss.istio.io aria-label="Istio discussion board"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M225.9 32C103.3 32 0 130.5.0 252.1.0 256 .1 480 .1 480l225.8-.2c122.7.0 222.1-102.3 222.1-223.9S348.6 32 225.9 32zM224 384c-19.4.0-37.9-4.3-54.4-12.1L88.5 392l22.9-75c-9.8-18.1-15.4-38.9-15.4-61 0-70.7 57.3-128 128-128s128 57.3 128 128-57.3 128-128 128z" /></svg></a></div><div class=icon><span>slack</span>
-<a title="Interactively discuss issues with the Istio community on Slack" href=https://istio.slack.com aria-label=slack><svg viewBox="0 0 31.444 31.443"><path d="M31.202 16.369c-.62-1.388-2.249-2.011-3.637-1.391l-1.325.594-3.396-7.591 1.325-.592c1.388-.622 2.01-2.25 1.389-3.637-.62-1.389-2.248-2.012-3.637-1.39l-1.324.593-.593-1.326c-.621-1.388-2.249-2.009-3.637-1.388-1.388.62-2.009 2.247-1.389 3.637l.593 1.325L7.98 8.598 7.388 7.273c-.621-1.39-2.249-2.009-3.637-1.39C2.363 6.504 1.742 8.132 2.362 9.52l.592 1.324L1.63 11.438c-1.388.621-2.01 2.247-1.389 3.636.62 1.388 2.249 2.01 3.637 1.39l1.325-.594 3.394 7.592-1.325.592c-1.388.621-2.009 2.25-1.389 3.637.621 1.389 2.249 2.011 3.637 1.391l1.324-.593.593 1.325c.621 1.389 2.249 2.01 3.637 1.389 1.387-.62 2.009-2.248 1.388-3.636l-.591-1.326 7.591-3.394.592 1.321c.621 1.391 2.248 2.013 3.637 1.392 1.388-.619 2.01-2.248 1.389-3.637l-.592-1.324 1.323-.594C31.201 19.384 31.823 17.757 31.202 16.369zM13.623 21.215l-3.395-7.593 7.591-3.394 3.395 7.591L13.623 21.215z"/></svg></a></div><div class=icon><span>twitter</span>
-<a title="Follow us on Twitter to get the latest news" href=https://twitter.com/IstioMesh aria-label=Twitter><svg viewBox="0 0 310 310"><path d="M302.973 57.388c-4.87 2.16-9.877 3.983-14.993 5.463 6.057-6.85 10.675-14.91 13.494-23.73.632-1.977-.023-4.141-1.648-5.434-1.623-1.294-3.878-1.449-5.665-.39-10.865 6.444-22.587 11.075-34.878 13.783-12.381-12.098-29.197-18.983-46.581-18.983-36.695.0-66.549 29.853-66.549 66.547.0 2.89.183 5.764.545 8.598C101.163 99.244 58.83 76.863 29.76 41.204c-1.036-1.271-2.632-1.956-4.266-1.825-1.635.128-3.104 1.05-3.93 2.467-5.896 10.117-9.013 21.688-9.013 33.461.0 16.035 5.725 31.249 15.838 43.137-3.075-1.065-6.059-2.396-8.907-3.977-1.529-.851-3.395-.838-4.914.033-1.52.871-2.473 2.473-2.513 4.224-.007.295-.007.59-.007.889.0 23.935 12.882 45.484 32.577 57.229-1.692-.169-3.383-.414-5.063-.735-1.732-.331-3.513.276-4.681 1.597-1.17 1.32-1.557 3.16-1.018 4.84 7.29 22.76 26.059 39.501 48.749 44.605-18.819 11.787-40.34 17.961-62.932 17.961-4.714.0-9.455-.277-14.095-.826-2.305-.274-4.509 1.087-5.294 3.279-.785 2.193.047 4.638 2.008 5.895 29.023 18.609 62.582 28.445 97.047 28.445 67.754.0 110.139-31.95 133.764-58.753 29.46-33.421 46.356-77.658 46.356-121.367.0-1.826-.028-3.67-.084-5.508 11.623-8.757 21.63-19.355 29.773-31.536 1.237-1.85 1.103-4.295-.33-5.998C307.394 57.037 305.009 56.486 302.973 57.388z"/></svg></a></div><div class=icon><span>stack overflow</span>
-<a title="Stack Overflow is where you can ask questions and find curated answers on deploying, configuring, and using Istio" href=https://stackoverflow.com/questions/tagged/istio aria-label="Stack Overflow"><svg viewBox="0 0 120 120"><polygon points="84.4,93.8 84.4,70.6 92.1,70.6 92.1,101.5 22.6,101.5 22.6,70.6 30.3,70.6 30.3,93.8"/><path d="M38.8 68.4l37.8 7.9 1.6-7.6-37.8-7.9L38.8 68.4zM43.8 50.4l35 16.3 3.2-7-35-16.4L43.8 50.4zM53.5 33.2l29.7 24.7 4.9-5.9L58.4 27.3 53.5 33.2zM72.7 14.9l-6.2 4.6 23 31 6.2-4.6-23-31zM38 86h38.6v-7.7H38V86z"/></svg></a></div></div><div class="tag row d-none d-lg-flex">for everyone</div></div></div><div class="col-7 col-lg-4"><p class="text-center copyright" role=contentinfo>Istio
-Archive
-1.0<br>&copy; 2019 Istio Authors, <a href=https://policies.google.com/privacy>Privacy Policy</a><br>Archived on March 19, 2019</p></div><div class="col-6 col-lg-4 d-none d-lg-flex" role=navigation><div class=container-fluid><div class="row justify-content-end"><div class=icon><span>github</span>
-<a title="GitHub is where development takes place on Istio code" href=https://github.com/istio/community aria-label=GitHub><svg viewBox="0 0 478.165 478.165"><path d="M349.22 55.768c6.136 14.046 10.241 37.556 4.224 54.69 24.426 20.999 33.073 71.904 21.079 113.704 35.006 2.73 76.666-1.235 103.642 9.484-25.183-3.248-59.651-9.563-91.987-7.431-6.136.458-15.361-.239-14.903 8.408 37.735 3.008 75.092 6.117 105.894 15.779-30.702-4.981-67.74-12.552-105.894-13.668-15.54 30.921-47.239 46.262-90.991 49.49 4.682 10.261 13.847 14.066 15.879 30.702 3.267 24.406-4.881 60.328 3.208 76.686 4.064 7.89 10.579 8.009 14.863 14.604-10.699 12.871-37.257-1.395-40.186-14.604-5.14-22.852 7.89-58.256-6.415-73.737.996 24.865-5.718 59.85.996 82.145 2.789 8.806 10.659 12.113 8.647 20.063-49.809 5.08-28.989-64.373-37.177-105.356-7.471.697-4.204 11.197-4.224 15.76-.199 40.106 8.189 94.836-34.846 89.556-1.315-8.348 5.838-11.217 8.467-19.007 7.91-22.434-1.454-56.045 2.112-83.161-16.417 12.512 1.793 55.666-8.428 77.961-5.838 12.671-24.785 18.27-39.19 12.651 1.873-9.464 11.695-7.989 15.879-16.875 5.818-12.452.02-30.244 2.092-48.494-30.423 6.097-53.993-.877-65.608-20.023-5.12-8.507-6.356-18.708-12.632-26.219-6.117-7.551-16.098-8.507-19.087-18.808 37.755-9.185 39.17 38.771 73.06 39.807 10.44.418 15.799-2.909 25.402-5.16 2.749-12.113 8.428-21.039 16.875-27.494-42.078-5.658-76.865-18.788-93.023-50.466-38.293 1.893-73.339 7.013-105.894 14.843 29.547-10.679 65.807-14.604 104.778-15.819-2.351-13.807-22.434-10.022-34.866-9.543C47.677 227.17 18.449 230.138.0 233.645c26.817-9.543 64.233-8.348 100.454-8.428-11.038-34.767-7.232-90.014 17.015-110.615-6.854-17.254-4.722-45.346 4.184-58.834 27.036 1.175 43.374 12.891 60.388 24.247 21.019-6.017 43.035-9.045 71.904-7.451 12.133.677 24.705 6.097 33.731 5.32 8.906-.877 18.728-10.898 27.534-14.843C326.507 58.099 336.17 56.206 349.22 55.768z"/></svg></a></div><div class=icon><span>drive</span>
-<a title="Access our team drive if you'd like to take a look at the Istio technical design documents" href=https://groups.google.com/forum/#!forum/istio-team-drive-access aria-label="team drive"><svg viewBox="0 0 207.027 207.027"><path d="M69.866 15.557.0 138.919l28.732 52.552 143.288-.029 35.008-59.588L136.39 15.735 69.866 15.557zM17.166 139.046 74.268 38.205 91.21 67.783 33.24 168.447 17.166 139.046zM99.841 82.851l23.805 41.558-47.732-.006L99.841 82.851zM163.434 176.443l-117.332.024 21.53-37.065 64.606.008.067.119 52.865-.085L163.434 176.443zM140.932 124.411 90.157 35.767l-2.966-5.178 40.751.121 57.003 93.706L140.932 124.411z"/></svg></a></div><div class=icon><span>working groups</span>
-<a title="If you'd like to contribute to the Istio project, consider participating in our working groups" href=https://github.com/istio/community/blob/master/WORKING-GROUPS.md aria-label="working groups"><svg viewBox="0 -45 439.833 439.833"><polygon points="246.048,195.833 299.966,235.085 319.497,227.296 276.278,195.833"/><polygon points="193.786,195.833 163.556,195.833 120.33,227.3 139.862,235.089"/><path d="M219.927 11.558c-23.854.0-37.057 12.362-36.814 36.182.348 32.623 14.211 52.414 36.814 52.068.0.0 36.802 1.492 36.802-52.068C256.729 23.918 244.294 11.558 219.927 11.558z"/><path d="M285.017 124.567l-36.77-14.659-8.608-7.256c-2.274-1.922-5.636-1.78-7.741.317l-11.973 11.904-12.008-11.907c-2.109-2.094-5.465-2.229-7.736-.313l-8.611 7.256-36.77 14.661c-11.842 4.715-11.83 46.647-12.848 50.497h155.93C296.866 171.228 296.862 129.28 285.017 124.567z"/><path d="M77.976 228.568s36.801 1.492 36.801-52.068c0-23.82-12.434-36.182-36.801-36.182-23.854.0-37.057 12.362-36.814 36.182C41.509 209.124 55.372 228.915 77.976 228.568z"/><path d="M143.065 253.329l-36.77-14.658-8.609-7.256c-2.275-1.923-5.635-1.781-7.742.315l-11.971 11.904-12.008-11.908c-2.109-2.094-5.465-2.229-7.736-.312l-8.611 7.256-36.77 14.66C1.006 258.045 1.018 299.977.0 303.827h155.93C154.915 299.988 154.911 258.042 143.065 253.329z"/><path d="M361.878 228.568s36.801 1.492 36.801-52.068c0-23.82-12.434-36.182-36.801-36.182-23.854.0-37.057 12.362-36.812 36.182C325.411 209.124 339.274 228.915 361.878 228.568z"/><path d="M426.968 253.329l-36.77-14.658-8.609-7.256c-2.273-1.923-5.635-1.781-7.742.315l-11.971 11.904-12.008-11.908c-2.109-2.094-5.465-2.229-7.736-.312l-8.61 7.256-36.771 14.66c-11.842 4.715-11.83 46.646-12.848 50.497h155.93C438.817 299.988 438.812 258.042 426.968 253.329z"/></svg></a></div></div><div class="tag row justify-content-end text-right">for developers</div></div></div></div></footer><div class="d-xl-none d-print-none"><button id=scroll-to-top aria-hidden=true onclick=scrollToTop() title="Back to top"><i class="fa fa-lg fa-arrow-up"></i></button></div><script src=https://code.jquery.com/jquery-3.2.1.slim.min.js integrity=sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN crossorigin=anonymous></script><script src=https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js integrity=sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl crossorigin=anonymous></script><script src=https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js></script><script src="https://www.google.com/cse/brand?form=search_form"></script><script src=/v1.0/js/all.min.js data-manual></script></body></html>
+<!doctype html>
+<html lang=en itemscope itemtype=https://schema.org/WebPage>
+
+<head>
+    <meta charset=utf-8>
+    <meta http-equiv=x-ua-compatible content="IE=edge">
+    <meta name=viewport content="width=device-width,initial-scale=1,shrink-to-fit=no">
+    <meta name=theme-color content="#466BB0">
+    <meta name=title content="Performance and Scalability">
+    <meta name=description
+        content="Introduces Performance and Scalability methodology, results and best practices for Istio components.">
+    <meta name=keywords content="microservices,services,mesh,performance,scalability,scale,benchmarks">
+    <meta property="og:title" content="Performance and Scalability">
+    <meta property="og:type" content="website">
+    <meta property="og:description"
+        content="Introduces Performance and Scalability methodology, results and best practices for Istio components.">
+    <meta property="og:url" content="/v1.0/docs/concepts/performance-and-scalability/">
+    <meta property="og:image" content="/v1.0/img/istio-logo-blue-background.svg">
+    <meta property="og:image:alt" content="Istio Logo">
+    <meta property="og:image:width" content="112">
+    <meta property="og:image:height" content="150">
+    <meta property="og:site_name" content="Istio">
+    <meta name=twitter:card content="summary">
+    <meta name=twitter:site content="@IstioMesh">
+    <title>Istioldie 1.0 / Performance and Scalability</title>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-98480406-2"></script>
+    <script>window.dataLayer = window.dataLayer || []; function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date()); gtag('config', 'UA-98480406-2');</script>
+    <script>var branchName = "release-1.0"; var docTitle = "Performance and Scalability";</script>
+    <link rel=alternate type=application/rss+xml title="Istio Blog" href=/v1.0/feed.xml>
+    <link rel="shortcut icon" href=/v1.0/favicons/favicon.ico>
+    <link rel=apple-touch-icon href=/v1.0/favicons/apple-touch-icon-180x180.png sizes=180x180>
+    <link rel=icon type=image/png href=/v1.0/favicons/favicon-16x16.png sizes=16x16>
+    <link rel=icon type=image/png href=/v1.0/favicons/favicon-32x32.png sizes=32x32>
+    <link rel=icon type=image/png href=/v1.0/favicons/android-36x36.png sizes=36x36>
+    <link rel=icon type=image/png href=/v1.0/favicons/android-48x48.png sizes=48x48>
+    <link rel=icon type=image/png href=/v1.0/favicons/android-72x72.png sizes=72x72>
+    <link rel=icon type=image/png href=/v1.0/favicons/android-96x196.png sizes=96x196>
+    <link rel=icon type=image/png href=/v1.0/favicons/android-144x144.png sizes=144x144>
+    <link rel=icon type=image/png href=/v1.0/favicons/android-192x192.png sizes=192x192>
+    <link rel=manifest href=/v1.0/manifest.json>
+    <meta name=apple-mobile-web-app-title content="Istio">
+    <meta name=application-name content="Istio">
+    <link rel=stylesheet
+        href="https://fonts.googleapis.com/css?family=Chivo:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic">
+    <link rel=stylesheet
+        href="https://fonts.googleapis.com/css?family=Work Sans:400,100,100italic,300,300italic,400italic,500,500italic,700,700italic,900,900italic">
+    <link rel=stylesheet href=https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css
+        integrity=sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm crossorigin=anonymous>
+    <link rel=stylesheet href=https://use.fontawesome.com/releases/v5.0.6/css/all.css>
+    <link rel=stylesheet href=/v1.0/css/light_theme_archive.css title=light>
+    <link rel="alternate stylesheet" href=/v1.0/css/dark_theme_archive.css title=dark>
+    <script src=/v1.0/js/styleSwitcher.min.js></script>
+</head>
+
+<body class=language-unknown>
+    <header>
+        <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark justify-content-between"><a class=navbar-brand
+                href=/v1.0 /><span class=logo><svg viewBox="0 0 300 300">
+                    <circle cx="150" cy="150" r="150" stroke-width="2" />
+                    <polygon points="65,240 225,240 125,270" />
+                    <polygon points="65,230 125,220 125,110" />
+                    <polygon points="135,220 225,230 135,30" />
+                </svg></span><span class=brand-name>Istioldie 1.0</span></a>
+            <button class=navbar-toggler type=button data-toggle=collapse data-target=#navbarCollapse
+                aria-controls=navbarCollapse aria-expanded=false aria-label="Toggle navigation">
+                <span class=navbar-toggler-icon></span></button>
+            <div class="collapse navbar-collapse justify-content-end" id=navbarCollapse>
+                <ul id=navbar-links class="navbar-nav active">
+                    <li class=nav-item><a class="nav-link active" title="Learn how to deploy, use, and operate Istio."
+                            href=/v1.0/docs />Docs</a></li>
+                    <li class=nav-item><a class=nav-link title="Posts about using Istio."
+                            href=/v1.0/blog/2019/announcing-1.0.6 />Blog</a></li>
+                    <li class=nav-item><a class=nav-link
+                            title="A bunch of resources to help you deploy, configure and use Istio."
+                            href=/v1.0/help />Help</a></li>
+                    <li class=nav-item><a class=nav-link title="Get a bit more in-depth info about the Istio project."
+                            href=/v1.0/about />About</a></li>
+                    <li class="nav-item dropdown" id=gearDropdown style=white-space:nowrap><a
+                            title="Options and Settings" href class=nav-link data-toggle=dropdown aria-label=Tools
+                            aria-haspopup=true aria-expanded=false><i style=width:1em class="fa fa-lg fa-cog"></i></a>
+                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby=gearDropdown><a
+                                class=dropdown-item id=light-theme-item href
+                                onclick="setActiveStyleSheet('light');return false;">Light Theme</a>
+                            <a class=dropdown-item id=dark-theme-item href
+                                onclick="setActiveStyleSheet('dark');return false;">Dark Theme</a>
+                            <div class=dropdown-divider></div>
+                            <h6 class=dropdown-header>Other versions of this site</h6><a href=https://istio.io
+                                class=dropdown-item>Current Release</a>
+                            <a href=https://preliminary.istio.io class=dropdown-item>Next Release</a>
+                            <a href=https://archive.istio.io class=dropdown-item>Older Releases</a>
+                        </div>
+                    </li>
+                    <li class=nav-item><a id=search_show class=nav-link href title="Search istio.io"
+                            aria-label=Search><i style=width:1em class="fa fa-lg fa-search"></i></a></li>
+                </ul>
+                <form name=cse id=search_form class="form-inline mr-sm-2" role=search><input type=hidden name=cx
+                        value=013699703217164175118:iwwf17ikgf4>
+                    <input type=hidden name=ie value=utf-8>
+                    <input type=hidden name=hl value=en>
+                    <input type=hidden id=search_page_url value=/v1.0/search.html>
+                    <input id=search_textbox class=form-control name=q type=text aria-label="Search this site">
+                    <button id=search_close type=reset aria-label="Cancel Search"><i
+                            class="far fa-lg fa-times-circle"></i></button>
+                </form>
+            </div>
+        </nav>
+    </header>
+    <div class=container-fluid>
+        <div class="row row-offcanvas">
+            <div class="col-0 col-md-3 col-xl-2 sidebar-offcanvas">
+                <nav class="sidebar d-print-none">
+                    <div class=spacer></div>
+                    <div class=directory role=tablist>
+                        <div class=card>
+                            <div class=card-header role=tab id=header10><a data-toggle=collapse href=#collapse10
+                                    title="Learn about the different parts of the Istio system and the abstractions it uses."
+                                    role=button aria-controls=collapse10>
+                                    <div><img src=/v1.0/img/concepts.svg alt=Icon class=page_icon>
+                                        Concepts</div>
+                                </a></div>
+                            <div id=collapse10 class="collapse show" data-parent=#sidebar role=tabpanel
+                                aria-labelledby=header10>
+                                <div class=card-body>
+                                    <ul class=tree>
+                                        <li><a title="Introduces Istio, the problems it solves, its high-level architecture and design goals."
+                                                href=/v1.0/docs/concepts/what-is-istio />What is Istio?</a></li>
+                                        <li><a title="Describes the various Istio features focused on traffic routing and control."
+                                                href=/v1.0/docs/concepts/traffic-management />Traffic Management</a>
+                                        </li>
+                                        <li><a title="Describes Istio's authorization and authentication functionality."
+                                                href=/v1.0/docs/concepts/security />Security</a></li>
+                                        <li><a title="Describes the policy enforcement and telemetry mechanisms."
+                                                href=/v1.0/docs/concepts/policies-and-telemetry />Policies and
+                                            Telemetry</a></li>
+                                        <li><span class=current
+                                                title="Introduces Performance and Scalability methodology, results and best practices for Istio components.">Performance
+                                                and Scalability</span></li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <div class=card>
+                            <div class=card-header role=tab id=header20><a data-toggle=collapse href=#collapse20
+                                    title="How to deploy Istio in various environments (e.g., Kubernetes, Consul)."
+                                    role=button aria-controls=collapse20>
+                                    <div><img src=/v1.0/img/setup.svg alt=Icon class=page_icon>
+                                        Setup</div>
+                                </a></div>
+                            <div id=collapse20 class=collapse data-parent=#sidebar role=tabpanel
+                                aria-labelledby=header20>
+                                <div class=card-body>
+                                    <ul class=tree>
+                                        <li class=sublist><label class=tree-toggle><i
+                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                    title="Instructions for installing the Istio control plane on Kubernetes and adding virtual machines into the mesh."
+                                                    href=/v1.0/docs/setup/kubernetes />Kubernetes</a></label>
+                                            <ul class="tree collapse">
+                                                <li><a title="Instructions to download the Istio release."
+                                                        href=/v1.0/docs/setup/kubernetes/download-release />Downloading
+                                                    the Release</a></li>
+                                                <li class=sublist><label class=tree-toggle><i
+                                                            class="fa fa-lg fa-caret-right"></i><a
+                                                            title="How to prepare various Kubernetes platforms before installing Istio."
+                                                            href=/v1.0/docs/setup/kubernetes/platform-setup />Platform
+                                                        Setup</a></label>
+                                                    <ul class="tree collapse">
+                                                        <li><a title="Instructions to setup an Alibaba Cloud Kubernetes cluster for Istio."
+                                                                href=/v1.0/docs/setup/kubernetes/platform-setup/alicloud />Alibaba
+                                                            Cloud</a></li>
+                                                        <li><a title="Instructions to setup an AWS cluster with Kops cluster for Istio."
+                                                                href=/v1.0/docs/setup/kubernetes/platform-setup/aws />Amazon
+                                                            Web Services</a></li>
+                                                        <li><a title="Instructions to setup an Azure cluster for Istio."
+                                                                href=/v1.0/docs/setup/kubernetes/platform-setup/azure />Azure</a>
+                                                        </li>
+                                                        <li><a title="Instructions to setup a Google Kubernetes Engine cluster for Istio."
+                                                                href=/v1.0/docs/setup/kubernetes/platform-setup/gke />Google
+                                                            Kubernetes Engine</a></li>
+                                                        <li><a title="Instructions to setup an IBM Cloud cluster for Istio."
+                                                                href=/v1.0/docs/setup/kubernetes/platform-setup/ibm />IBM
+                                                            Cloud</a></li>
+                                                        <li><a title="Instructions to setup Minikube for use with Istio."
+                                                                href=/v1.0/docs/setup/kubernetes/platform-setup/minikube />Minikube</a>
+                                                        </li>
+                                                        <li><a title="Instructions to setup an OpenShift cluster for Istio."
+                                                                href=/v1.0/docs/setup/kubernetes/platform-setup/openshift />OpenShift</a>
+                                                        </li>
+                                                        <li><a title="Instructions to setup an OKE cluster for Istio."
+                                                                href=/v1.0/docs/setup/kubernetes/platform-setup/oci />Oracle
+                                                            Cloud Infrastructure</a></li>
+                                                    </ul>
+                                                </li>
+                                                <li><a title="Instructions to setup the Istio service mesh in a Kubernetes cluster."
+                                                        href=/v1.0/docs/setup/kubernetes/quick-start />Quick Start with
+                                                    Kubernetes</a></li>
+                                                <li><a title="How to quickly setup Istio using Alibaba Cloud Kubernetes Container Service."
+                                                        href=/v1.0/docs/setup/kubernetes/quick-start-alicloud-ack />Quick
+                                                    Start with Alibaba Cloud Kubernetes Container Service</a></li>
+                                                <li><a title="How to quickly setup Istio using IBM Cloud Public or IBM Cloud Private."
+                                                        href=/v1.0/docs/setup/kubernetes/quick-start-ibm />Quick Start
+                                                    with IBM Cloud</a></li>
+                                                <li><a title="Install Istio with the included Helm chart."
+                                                        href=/v1.0/docs/setup/kubernetes/helm-install />Installation
+                                                    with Helm</a></li>
+                                                <li><a title="Instructions for installing the Istio sidecar in application pods automatically using the sidecar injector webhook or manually using istioctl CLI."
+                                                        href=/v1.0/docs/setup/kubernetes/sidecar-injection />Installing
+                                                    the sidecar</a></li>
+                                                <li><a title="Install minimal Istio using Helm."
+                                                        href=/v1.0/docs/setup/kubernetes/minimal-install />Minimal Istio
+                                                    Installation</a></li>
+                                                <li><a title="Install Istio with the included Ansible playbook."
+                                                        href=/v1.0/docs/setup/kubernetes/ansible-install />Installation
+                                                    with Ansible</a></li>
+                                                <li><a title="Instructions for integrating VMs and bare metal hosts into an Istio mesh deployed on Kubernetes."
+                                                        href=/v1.0/docs/setup/kubernetes/mesh-expansion />Mesh
+                                                    Expansion</a></li>
+                                                <li><a title="Install Istio with multicluster support."
+                                                        href=/v1.0/docs/setup/kubernetes/multicluster-install />Istio
+                                                    Multicluster</a></li>
+                                                <li><a title="How to quickly setup Istio using Google Kubernetes Engine (GKE)."
+                                                        href=/v1.0/docs/setup/kubernetes/quick-start-gke />Quick Start
+                                                    with Google Kubernetes Engine</a></li>
+                                                <li><a title="Demonstrates how to upgrade the Istio control plane and data plane independently."
+                                                        href=/v1.0/docs/setup/kubernetes/upgrading-istio />Upgrading
+                                                    Istio</a></li>
+                                                <li><a title="Describes the requirements for Kubernetes pods and services to run Istio."
+                                                        href=/v1.0/docs/setup/kubernetes/spec-requirements />Requirements
+                                                    for Pods and Services</a></li>
+                                            </ul>
+                                        </li>
+                                        <li class=sublist><label class=tree-toggle><i
+                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                    title="Instructions for installing the Istio control plane in a Consul based environment, with or without Nomad."
+                                                    href=/v1.0/docs/setup/consul />Nomad & Consul</a></label>
+                                            <ul class="tree collapse">
+                                                <li><a title="Quick Start instructions to setup the Istio service mesh with Docker Compose."
+                                                        href=/v1.0/docs/setup/consul/quick-start />Quick Start on
+                                                    Docker</a></li>
+                                                <li><a title="Instructions for installing the Istio control plane in a Consul-based environment, with or without Nomad."
+                                                        href=/v1.0/docs/setup/consul/install />Installation</a></li>
+                                            </ul>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <div class=card>
+                            <div class=card-header role=tab id=header33><a data-toggle=collapse href=#collapse33
+                                    title="How to do single specific targeted activities with the Istio system."
+                                    role=button aria-controls=collapse33>
+                                    <div><img src=/v1.0/img/tasks.svg alt=Icon class=page_icon>
+                                        Tasks</div>
+                                </a></div>
+                            <div id=collapse33 class=collapse data-parent=#sidebar role=tabpanel
+                                aria-labelledby=header33>
+                                <div class=card-body>
+                                    <ul class=tree>
+                                        <li class=sublist><label class=tree-toggle><i
+                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                    title="Tasks that demonstrate Istio's traffic routing features."
+                                                    href=/v1.0/docs/tasks/traffic-management />Traffic
+                                                Management</a></label>
+                                            <ul class="tree collapse">
+                                                <li><a title="This task shows you how to configure dynamic request routing to multiple versions of a microservice."
+                                                        href=/v1.0/docs/tasks/traffic-management/request-routing />Configuring
+                                                    Request Routing</a></li>
+                                                <li><a title="This task shows you how to inject faults to test the resiliency of your application."
+                                                        href=/v1.0/docs/tasks/traffic-management/fault-injection />Fault
+                                                    Injection</a></li>
+                                                <li><a title="Shows you how to migrate traffic from an old to new version of a service."
+                                                        href=/v1.0/docs/tasks/traffic-management/traffic-shifting />Traffic
+                                                    Shifting</a></li>
+                                                <li><a title="This task shows you how to setup request timeouts in Envoy using Istio."
+                                                        href=/v1.0/docs/tasks/traffic-management/request-timeouts />Setting
+                                                    Request Timeouts</a></li>
+                                                <li><a title="Describes how to configure Istio to expose a service outside of the service mesh."
+                                                        href=/v1.0/docs/tasks/traffic-management/ingress />Control
+                                                    Ingress Traffic</a></li>
+                                                <li><a title="Describes how to configure Istio to expose a service outside of the service mesh, over TLS, mutual TLS or JWT authentication."
+                                                        href=/v1.0/docs/tasks/traffic-management/secure-ingress />Securing
+                                                    Gateways with HTTPS</a></li>
+                                                <li><a title="Describes how to configure Istio to route traffic from services in the mesh to external services."
+                                                        href=/v1.0/docs/tasks/traffic-management/egress />Control Egress
+                                                    Traffic</a></li>
+                                                <li><a title="This task shows you how to configure circuit breaking for connections, requests, and outlier detection."
+                                                        href=/v1.0/docs/tasks/traffic-management/circuit-breaking />Circuit
+                                                    Breaking</a></li>
+                                                <li><a title="This task demonstrates the traffic mirroring/shadowing capabilities of Istio."
+                                                        href=/v1.0/docs/tasks/traffic-management/mirroring />Mirroring</a>
+                                                </li>
+                                                <li><a title="Shows how to do health checking for Istio services."
+                                                        href=/v1.0/docs/tasks/traffic-management/app-health-check />Health
+                                                    Checking of Istio Services</a></li>
+                                            </ul>
+                                        </li>
+                                        <li class=sublist><label class=tree-toggle><i
+                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                    title="Demonstrates how to secure the mesh."
+                                                    href=/v1.0/docs/tasks/security />Security</a></label>
+                                            <ul class="tree collapse">
+                                                <li><a title="Shows you how to use Istio authentication policy to setup mutual TLS and basic end-user authentication."
+                                                        href=/v1.0/docs/tasks/security/authn-policy />Authentication
+                                                    Policy</a></li>
+                                                <li><a title="Shows you how to verify and test Istio's automatic mutual TLS authentication."
+                                                        href=/v1.0/docs/tasks/security/mutual-tls />Mutual TLS
+                                                    Deep-Dive</a></li>
+                                                <li><a title="Shows how to set up role-based access control for services in the mesh."
+                                                        href=/v1.0/docs/tasks/security/role-based-access-control />Authorization</a>
+                                                </li>
+                                                <li><a title="Shows how operators can configure Citadel with existing root certificate, signing certificate and key."
+                                                        href=/v1.0/docs/tasks/security/plugin-ca-cert />Plugging in
+                                                    external CA key and certificate</a></li>
+                                                <li><a title="Shows how to enable Citadel health checking with Kubernetes."
+                                                        href=/v1.0/docs/tasks/security/health-check />Citadel health
+                                                    checking</a></li>
+                                                <li><a title="Shows you how to incrementally migrate your Istio services to mutual TLS."
+                                                        href=/v1.0/docs/tasks/security/mtls-migration />Mutual TLS
+                                                    Migration</a></li>
+                                                <li><a title="Shows how to enable mutual TLS on HTTPS services."
+                                                        href=/v1.0/docs/tasks/security/https-overlay />Mutual TLS over
+                                                    HTTPS</a></li>
+                                            </ul>
+                                        </li>
+                                        <li class=sublist><label class=tree-toggle><i
+                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                    title="Demonstrates policy enforcement features."
+                                                    href=/v1.0/docs/tasks/policy-enforcement />Policies</a></label>
+                                            <ul class="tree collapse">
+                                                <li><a title="This task shows you how to use Istio to dynamically limit the traffic to a service."
+                                                        href=/v1.0/docs/tasks/policy-enforcement/rate-limiting />Enabling
+                                                    Rate Limits</a></li>
+                                                <li><a title="Shows how to control access to a service using simple denials or white/black listing."
+                                                        href=/v1.0/docs/tasks/policy-enforcement/denial-and-list />Denials
+                                                    and White/Black Listing</a></li>
+                                            </ul>
+                                        </li>
+                                        <li class=sublist><label class=tree-toggle><i
+                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                    title="Demonstrates how to collect telemetry information from the mesh."
+                                                    href=/v1.0/docs/tasks/telemetry />Telemetry</a></label>
+                                            <ul class="tree collapse">
+                                                <li><a title="How to configure the proxies to send tracing requests to Zipkin or Jaeger."
+                                                        href=/v1.0/docs/tasks/telemetry/distributed-tracing />Distributed
+                                                    Tracing</a></li>
+                                                <li><a title="This task shows you how to configure Istio to collect metrics and logs."
+                                                        href=/v1.0/docs/tasks/telemetry/metrics-logs />Collecting
+                                                    Metrics and Logs</a></li>
+                                                <li><a title="This task shows you how to configure Istio to collect metrics for TCP services."
+                                                        href=/v1.0/docs/tasks/telemetry/tcp-metrics />Collecting Metrics
+                                                    for TCP services</a></li>
+                                                <li><a title="This task shows you how to query for Istio Metrics using Prometheus."
+                                                        href=/v1.0/docs/tasks/telemetry/querying-metrics />Querying
+                                                    Metrics from Prometheus</a></li>
+                                                <li><a title="This task shows you how to setup and use the Istio Dashboard to monitor mesh traffic."
+                                                        href=/v1.0/docs/tasks/telemetry/using-istio-dashboard />Visualizing
+                                                    Metrics with Grafana</a></li>
+                                                <li><a title="This task shows you how to visualize your services within an Istio mesh."
+                                                        href=/v1.0/docs/tasks/telemetry/kiali />Visualizing Your
+                                                    Mesh</a></li>
+                                                <li><a title="This task shows you how to generate a graph of services within an Istio mesh."
+                                                        href=/v1.0/docs/tasks/telemetry/servicegraph />Generating a
+                                                    Service Graph</a></li>
+                                                <li><a title="This task shows you how to configure Istio to log to a Fluentd daemon."
+                                                        href=/v1.0/docs/tasks/telemetry/fluentd />Logging with
+                                                    Fluentd</a></li>
+                                            </ul>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <div class=card>
+                            <div class=card-header role=tab id=header46><a data-toggle=collapse href=#collapse46
+                                    title="A variety of fully working example uses for Istio that you can experiment with."
+                                    role=button aria-controls=collapse46>
+                                    <div><img src=/v1.0/img/examples.svg alt=Icon class=page_icon>
+                                        Examples</div>
+                                </a></div>
+                            <div id=collapse46 class=collapse data-parent=#sidebar role=tabpanel
+                                aria-labelledby=header46>
+                                <div class=card-body>
+                                    <ul class=tree>
+                                        <li><a title="Deploys a sample application composed of four separate microservices used to demonstrate various Istio features."
+                                                href=/v1.0/docs/examples/bookinfo />Bookinfo Application</a></li>
+                                        <li><a title="Demonstrates how to use various traffic management capabilities of an Istio service mesh."
+                                                href=/v1.0/docs/examples/intelligent-routing />Intelligent Routing</a>
+                                        </li>
+                                        <li><a title="Demonstrates how to obtain uniform metrics, logs, traces across different services using Istio Mixer and Istio sidecar."
+                                                href=/v1.0/docs/examples/telemetry />In-Depth Telemetry</a></li>
+                                        <li><a title="Explains how to manually integrate Google Cloud Endpoints services with Istio."
+                                                href=/v1.0/docs/examples/endpoints />Install Istio for Google Cloud
+                                            Endpoints Services</a></li>
+                                        <li><a title="Illustrates how to use Istio to control a Kubernetes cluster and raw VMs as a single mesh."
+                                                href=/v1.0/docs/examples/integrating-vms />Integrating Virtual
+                                            Machines</a></li>
+                                        <li class=sublist><label class=tree-toggle><i
+                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                    title="A variety of fully working examples for egress traffic control in Istio that you can experiment with."
+                                                    href=/v1.0/docs/examples/advanced-egress />Advanced egress traffic
+                                                control</a></label>
+                                            <ul class="tree collapse">
+                                                <li><a title="Describes how to configure Istio to perform TLS origination for traffic to external services."
+                                                        href=/v1.0/docs/examples/advanced-egress/egress-tls-origination />TLS
+                                                    Origination for Egress Traffic</a></li>
+                                                <li><a title="Describes how to configure Istio to direct traffic to external services through a dedicated gateway."
+                                                        href=/v1.0/docs/examples/advanced-egress/egress-gateway />Configure
+                                                    an Egress Gateway</a></li>
+                                            </ul>
+                                        </li>
+                                        <li class=sublist><label class=tree-toggle><i
+                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                    title="A variety of fully working multicluster examples for Istio that you can experiment with."
+                                                    href=/v1.0/docs/examples/multicluster />Enabling
+                                                multiclusters</a></label>
+                                            <ul class="tree collapse">
+                                                <li><a title="Example multicluster GKE install of Istio."
+                                                        href=/v1.0/docs/examples/multicluster/gke />Google Kubernetes
+                                                    Engine</a></li>
+                                                <li><a title="Example multicluster IBM Cloud Private install of Istio."
+                                                        href=/v1.0/docs/examples/multicluster/icp />IBM Cloud
+                                                    Private</a></li>
+                                                <li><a title="Example multicluster between IBM Cloud Kubernetes Service & IBM Cloud Private."
+                                                        href=/v1.0/docs/examples/multicluster/iks-icp />IBM Cloud
+                                                    Kubernetes Service & IBM Cloud Private</a></li>
+                                            </ul>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                        <div class=card>
+                            <div class=card-header role=tab id=header78><a data-toggle=collapse href=#collapse78
+                                    title="Detailed authoritative reference material such as command-line options, configuration options, and API calling parameters."
+                                    role=button aria-controls=collapse78>
+                                    <div><img src=/v1.0/img/reference.svg alt=Icon class=page_icon>
+                                        Reference</div>
+                                </a></div>
+                            <div id=collapse78 class=collapse data-parent=#sidebar role=tabpanel
+                                aria-labelledby=header78>
+                                <div class=card-body>
+                                    <ul class=tree>
+                                        <li class=sublist><label class=tree-toggle><i
+                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                    title="Detailed information on configuration options."
+                                                    href=/v1.0/docs/reference/config />Configuration</a></label>
+                                            <ul class="tree collapse">
+                                                <li class=sublist><label class=tree-toggle><i
+                                                            class="fa fa-lg fa-caret-right"></i><a
+                                                            title="Describes how to configure Istio's authorization features."
+                                                            href=/v1.0/docs/reference/config/authorization />Authorization</a></label>
+                                                    <ul class="tree collapse">
+                                                        <li><a title="Describes the supported constraints and properties."
+                                                                href=/v1.0/docs/reference/config/authorization/constraints-and-properties />Constraints
+                                                            and Properties</a></li>
+                                                        <li><a title="Configuration for Role Based Access Control."
+                                                                href=/v1.0/docs/reference/config/authorization/istio.rbac.v1alpha1 />RBAC</a>
+                                                        </li>
+                                                    </ul>
+                                                </li>
+                                                <li><a title="Describes the options available when installing Istio using the included Helm chart."
+                                                        href=/v1.0/docs/reference/config/installation-options />Installation
+                                                    Options</a></li>
+                                                <li class=sublist><label class=tree-toggle><i
+                                                            class="fa fa-lg fa-caret-right"></i><a
+                                                            title="Describes how to configure Istio's policy and telemetry features."
+                                                            href=/v1.0/docs/reference/config/policy-and-telemetry />Policies
+                                                        and Telemetry</a></label>
+                                                    <ul class="tree collapse">
+                                                        <li><a title="Describes the base attribute vocabulary used for policy and control."
+                                                                href=/v1.0/docs/reference/config/policy-and-telemetry/attribute-vocabulary />Attribute
+                                                            Vocabulary</a></li>
+                                                        <li><a title="Mixer configuration expression language reference."
+                                                                href=/v1.0/docs/reference/config/policy-and-telemetry/expression-language />Expression
+                                                            Language</a></li>
+                                                        <li class=sublist><label class=tree-toggle><i
+                                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                                    title="Mixer adapters allow Istio to interface to a variety of infrastructure backends for such things as metrics and logs."
+                                                                    href=/v1.0/docs/reference/config/policy-and-telemetry/adapters />Adapters</a></label>
+                                                            <ul class="tree collapse">
+                                                                <li><a title="Adapter for Apigee's distributed policy checks and analytics."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/apigee />Apigee</a>
+                                                                </li>
+                                                                <li><a title="Adapter for circonus.com's monitoring solution."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/circonus />Circonus</a>
+                                                                </li>
+                                                                <li><a title="Adapter for cloudwatch metrics."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/cloudwatch />CloudWatch</a>
+                                                                </li>
+                                                                <li><a title="Adapter to deliver metrics to a dogstatsd agent for delivery to DataDog."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/datadog />Datadog</a>
+                                                                </li>
+                                                                <li><a title="Adapter that always returns a precondition denial."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/denier />Denier</a>
+                                                                </li>
+                                                                <li><a title="Adapter that delivers logs to a fluentd daemon."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/fluentd />Fluentd</a>
+                                                                </li>
+                                                                <li><a title="Adapter that extracts information from a Kubernetes environment."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/kubernetesenv />Kubernetes
+                                                                    Env</a></li>
+                                                                <li><a title="Adapter that performs whitelist or blacklist checks."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/list />List</a>
+                                                                </li>
+                                                                <li><a title="Adapter for a simple in-memory quota management system."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/memquota />Memory
+                                                                    quota</a></li>
+                                                                <li><a title="Adapter that implements an Open Policy Agent engine."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/opa />OPA</a>
+                                                                </li>
+                                                                <li><a title="Adapter that exposes Istio metrics for ingestion by a Prometheus harvester."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/prometheus />Prometheus</a>
+                                                                </li>
+                                                                <li><a title="Adapter that exposes Istio's Role-Based Access Control model."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/rbac />RBAC</a>
+                                                                </li>
+                                                                <li><a title="Adapter for a Redis-based quota management system."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/redisquota />Redis
+                                                                    Quota</a></li>
+                                                                <li><a title="Adapter that delivers logs and metrics to Google Service Control."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/servicecontrol />Service
+                                                                    Control</a></li>
+                                                                <li><a title="Adapter that sends Istio metrics to SignalFx."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/signalfx />SignalFx</a>
+                                                                </li>
+                                                                <li><a title="Adapter to deliver logs and metrics to Papertrail and AppOptics backends."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/solarwinds />SolarWinds</a>
+                                                                </li>
+                                                                <li><a title="Adapter to deliver logs, metrics, and traces to Stackdriver."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/stackdriver />Stackdriver</a>
+                                                                </li>
+                                                                <li><a title="Adapter to deliver metrics to a StatsD backend."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/statsd />StatsD</a>
+                                                                </li>
+                                                                <li><a title="Adapter for outputting logs and metrics locally."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/stdio />Stdio</a>
+                                                                </li>
+                                                                <li><a title="Adapter to deliver metrics to Wavefront by VMware."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/adapters/wavefront />Wavefront
+                                                                    by VMware</a></li>
+                                                            </ul>
+                                                        </li>
+                                                        <li><a title="Default Metrics exported from Istio through Mixer."
+                                                                href=/v1.0/docs/reference/config/policy-and-telemetry/metrics />Default
+                                                            Metrics</a></li>
+                                                        <li class=sublist><label class=tree-toggle><i
+                                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                                    title="Mixer templates are used to send data to individual adapters."
+                                                                    href=/v1.0/docs/reference/config/policy-and-telemetry/templates />Templates</a></label>
+                                                            <ul class="tree collapse">
+                                                                <li><a title="The Analytics template is used to dispatch runtime telemetry to Apigee."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/analytics />Analytics</a>
+                                                                </li>
+                                                                <li><a title="A template that represents a single API key."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/apikey />API
+                                                                    Key</a></li>
+                                                                <li><a title="A template used to represent an access control query."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/authorization />Authorization</a>
+                                                                </li>
+                                                                <li><a title="A template that carries no data, useful for testing."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/checknothing />Check
+                                                                    Nothing</a></li>
+                                                                <li><a title="A template that is used to control the production of Kubernetes-specific attributes."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/kubernetes />Kubernetes</a>
+                                                                </li>
+                                                                <li><a title="A template designed to let you perform list checking operations."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/listentry />List
+                                                                    Entry</a></li>
+                                                                <li><a title="A template that represents a single runtime log entry."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/logentry />Log
+                                                                    Entry</a></li>
+                                                                <li><a title="A template that represents a single runtime metric."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/metric />Metric</a>
+                                                                </li>
+                                                                <li><a title="A template that represents a quota allocation request."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/quota />Quota</a>
+                                                                </li>
+                                                                <li><a title="A template that carries no data, useful for testing."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/reportnothing />Report
+                                                                    Nothing</a></li>
+                                                                <li><a title="A template used by the Google Service Control adapter."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/servicecontrolreport />Service
+                                                                    Control Report</a></li>
+                                                                <li><a title="A template that represents\ an individual span within a distributed trace."
+                                                                        href=/v1.0/docs/reference/config/policy-and-telemetry/templates/tracespan />Trace
+                                                                    Span</a></li>
+                                                            </ul>
+                                                        </li>
+                                                        <li><a title="Describes the rules used to configure Mixer's policy and telemetry features."
+                                                                href=/v1.0/docs/reference/config/policy-and-telemetry/istio.policy.v1beta1 />Rules</a>
+                                                        </li>
+                                                    </ul>
+                                                </li>
+                                                <li><a title="Authentication policy for Istio services."
+                                                        href=/v1.0/docs/reference/config/istio.authentication.v1alpha1 />Authentication
+                                                    Policy</a></li>
+                                                <li><a title="Configuration affecting traffic routing."
+                                                        href=/v1.0/docs/reference/config/istio.networking.v1alpha3 />Traffic
+                                                    Routing</a></li>
+                                            </ul>
+                                        </li>
+                                        <li class=sublist><label class=tree-toggle><i
+                                                    class="fa fa-lg fa-caret-right"></i><a
+                                                    title="Describes usage and options of the Istio commands and utilities."
+                                                    href=/v1.0/docs/reference/commands />Commands</a></label>
+                                            <ul class="tree collapse">
+                                                <li><a title="Galley provides configuration management services for Istio."
+                                                        href=/v1.0/docs/reference/commands/galley />galley</a></li>
+                                                <li><a title="Istio Certificate Authority (CA)."
+                                                        href=/v1.0/docs/reference/commands/istio_ca />istio_ca</a></li>
+                                                <li><a title="Istio control interface."
+                                                        href=/v1.0/docs/reference/commands/istioctl />istioctl</a></li>
+                                                <li><a title="Utility to trigger direct calls to Mixer's API."
+                                                        href=/v1.0/docs/reference/commands/mixc />mixc</a></li>
+                                                <li><a title="Mixer is Istio's abstraction on top of infrastructure backends."
+                                                        href=/v1.0/docs/reference/commands/mixs />mixs</a></li>
+                                                <li><a title="Istio security per-node agent."
+                                                        href=/v1.0/docs/reference/commands/node_agent />node_agent</a>
+                                                </li>
+                                                <li><a title="Istio Pilot agent."
+                                                        href=/v1.0/docs/reference/commands/pilot-agent />pilot-agent</a>
+                                                </li>
+                                                <li><a title="Istio Pilot."
+                                                        href=/v1.0/docs/reference/commands/pilot-discovery />pilot-discovery</a>
+                                                </li>
+                                                <li><a title="Kubernetes webhook for automatic Istio sidecar injection."
+                                                        href=/v1.0/docs/reference/commands/sidecar-injector />sidecar-injector</a>
+                                                </li>
+                                            </ul>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </nav>
+            </div>
+            <div class="col-12 col-md-9 col-xl-8">
+                <p class=d-md-none><label class=sidebar-toggler data-toggle=offcanvas><i
+                            class="fa fa-sign-out-alt"></i></label></p>
+                <main aria-labelledby=title>
+                    <div class=pagenav>
+                        <p><a href=/v1.0/docs/concepts/
+                                title="Learn about the different parts of the Istio system and the abstractions it uses."><i
+                                    style=transform:scaleX(-1) class="fa fa-level-up-alt"></i>&nbsp;Concepts</a></p>
+                    </div>
+                    <h1 id=title>Performance and Scalability</h1>
+                    <nav class="toc-inlined d-xl-none d-print-none">
+                        <hr>
+                        <div class=directory role=directory>
+                            <nav id=InlinedTableOfContents>
+                                <ul>
+                                    <li><a href=#micro-benchmarks>Micro benchmarks</a></li>
+                                    <li><a href=#testing-scenarios>Testing scenarios</a></li>
+                                    <li><a href=#synthetic-end-to-end-benchmarks>Synthetic end to end benchmarks</a>
+                                    </li>
+                                    <li><a href=#realistic-application-benchmark>Realistic application benchmark</a>
+                                    </li>
+                                    <li><a href=#automation>Automation</a></li>
+                                    <li><a href=#scalability-and-sizing-guide>Scalability and sizing guide</a></li>
+                                    <li><a href=#see-also>See also</a></li>
+                                </ul>
+                            </nav>
+                        </div>
+                        <hr>
+                    </nav>
+                    <p>We follow a four-pronged approach to Istio performance characterization, tracking and
+                        improvements:</p>
+                    <ul>
+                        <li>
+                            <p>Code level micro-benchmarks</p>
+                        </li>
+                        <li>
+                            <p>Synthetic end-to-end benchmarks across various scenarios</p>
+                        </li>
+                        <li>
+                            <p>Realistic complex app end-to-end benchmarks across various settings</p>
+                        </li>
+                        <li>
+                            <p>Automation to ensure performance doesn't regress</p>
+                        </li>
+                    </ul>
+                    <h2 id=micro-benchmarks>Micro benchmarks</h2>
+                    <p>We use Go’s native tools to write targeted micro-benchmarks in performance sensitive areas. Our
+                        main goal with this approach is to provide easy-to-use micro-benchmarks that developers can use
+                        to perform quick before/after performance comparisons for their changes.</p>
+                    <p>See the <a
+                            href=https://raw.githubusercontent.com/istio/istio/release-1.0/mixer/test/perf/singlecheck_test.go>sample
+                            micro-benchmark</a> for Mixer that measures the performance of attribute processing code.
+                    </p>
+                    <p>Developers can also utilize a golden-files approach to capture the state of their benchmark
+                        results in the source tree for keeping track and referencing purposes. GitHub has this <a
+                            href=https://raw.githubusercontent.com/istio/istio/release-1.0/mixer/test/perf/bench.baseline>baseline
+                            file</a>.</p>
+                    <p>Due to the nature of this testing type, there is a high-variance in latency numbers across
+                        machines. It is recommended that micro-benchmark numbers captured in this way are compared only
+                        against the previous runs on the same machine.</p>
+                    <p>The <a
+                            href=https://raw.githubusercontent.com/istio/istio/release-1.0/bin/perfcheck.sh><code>perfcheck.sh</code>
+                            script</a> can be used to quickly run benchmarks in a sub-folder and compare its results
+                        against the co-located baseline files.</p>
+                    <h2 id=testing-scenarios>Testing scenarios</h2>
+                    <figure style=width:80%>
+                        <div class=wrapper-with-intrinsic-ratio style=padding-bottom:75%><a class=not-for-endnotes
+                                href="https://raw.githubusercontent.com/istio/istio/master/tools/perf_setup.svg?sanitize=true"><img
+                                    class=element-to-stretch
+                                    src="https://raw.githubusercontent.com/istio/istio/master/tools/perf_setup.svg?sanitize=true"
+                                    alt="Performance scenarios diagram" title="Performance scenarios diagram"></a></div>
+                        <figcaption>Performance scenarios diagram</figcaption>
+                    </figure>
+                    <p>The synthetic benchmark scenarios and the source code of the tests are described
+                        on <a
+                            href=https://github.com/istio/istio/blob/release-1.0/tools#istio-load-testing-user-guide>GitHub</a>
+                    </p>
+                    <h2 id=synthetic-end-to-end-benchmarks>Synthetic end to end benchmarks</h2>
+                    <p>We use <a href=https://fortio.org />Fortio</a> as Istio's synthetic end to end load testing tool.
+                        Fortio runs at a specified query per second (qps) and records an histogram of execution time and
+                        calculates percentiles (e.g. p99 i.e. the response time such as 99% of the requests take less
+                        than that number (in seconds, SI unit)). It can run for a set duration, for a fixed number of
+                        calls, or until interrupted (at a constant target QPS, or max speed/load per connection/thread).
+                    </p>
+                    <p>Fortio is a fast, small, reusable, embeddable go library as well as a command line tool and
+                        server process, the server includes a simple web UI and graphical representation of the results
+                        (both a single latency graph and a multiple results comparative min, max, average and
+                        percentiles graphs).</p>
+                    <p>Fortio is also 100% open-source and with no external dependencies beside go and gRPC so you can
+                        reproduce all our results easily and add your own variants or scenarios you are interested in
+                        exploring.</p>
+                    <p>Here is an example of scenario (one out of the 8 scenarios we run for every build) result
+                        graphing the latency distribution for istio-0.7.1 at 400 Query-Per-Second (qps) between 2
+                        services inside the mesh (with mutual TLS, Mixer policy checks and telemetry collection):</p>
+                    <p>Comparing 0.6.0 and 0.7.1 histograms/response time distribution for the same scenario, clearly
+                        showing 0.7 improvements:</p>
+                    <p>And tracking the progress across all the tested releases for that scenario:</p>
+                    <p>You can learn more about <a
+                            href=https://github.com/fortio/fortio/blob/master/README.md#fortio>Fortio</a> on GitHub and
+                        see results on <a href=https://fortio.istio.io>https://fortio.istio.io</a>.</p>
+                    <h2 id=realistic-application-benchmark>Realistic application benchmark</h2>
+                    <p>Acmeair (a.k.a, BluePerf) is a customer-like microservices application implemented in Java. This
+                        application runs on WebSphere Liberty and simulates the operations of a fictitious airline.</p>
+                    <p>Acmeair is composed by the following microservices:</p>
+                    <ul>
+                        <li>
+                            <p><strong>Flight Service</strong> retrieves flight route data. It is called by the Booking
+                                service to check miles for the rewards operations (Acmeair customer fidelity program).
+                            </p>
+                        </li>
+                        <li>
+                            <p><strong>Customer Service</strong> stores, updates, and retrieves customer data. It is
+                                invoked by the Auth service for login and by the Booking service for the rewards
+                                operations.</p>
+                        </li>
+                        <li>
+                            <p><strong>Booking Service</strong> stores, updates, and retrieves booking data.</p>
+                        </li>
+                        <li>
+                            <p><strong>Auth Service</strong> generates JWT if the user/password is valid.</p>
+                        </li>
+                        <li>
+                            <p><strong>Main Service</strong> primarily consists of the presentation layer (web pages)
+                                that interact with the other services. This allows the user to interact directly with
+                                the application via browser, but it is not exercised during the load test.</p>
+                        </li>
+                    </ul>
+                    <p>The diagram below represents the different pods/containers of the application in the
+                        Kubernetes/Istio environment:</p>
+                    <figure style=width:100%>
+                        <div class=wrapper-with-intrinsic-ratio style=padding-bottom:80%><a class=not-for-endnotes
+                                href=https://ibmcloud-perf.istio.io/regpatrol/istio_regpatrol_readme_files/image004.png><img
+                                    class=element-to-stretch
+                                    src=https://ibmcloud-perf.istio.io/regpatrol/istio_regpatrol_readme_files/image004.png
+                                    alt="Acmeair microservices overview"></a></div>
+                        <figcaption></figcaption>
+                    </figure>
+                    <p>The following table shows the transactions that are driven by the script during the regression
+                        test and the approximate distribution of the requests:</p>
+                    <figure style=width:100%>
+                        <div class=wrapper-with-intrinsic-ratio style=padding-bottom:20%><a class=not-for-endnotes
+                                href=https://ibmcloud-perf.istio.io/regpatrol/istio_regpatrol_readme_files/image006.png><img
+                                    class=element-to-stretch
+                                    src=https://ibmcloud-perf.istio.io/regpatrol/istio_regpatrol_readme_files/image006.png
+                                    alt="Acmeair request types and distribution"></a></div>
+                        <figcaption></figcaption>
+                    </figure>
+                    <p>The Acmeair benchmark application can be found here: <a href=https://github.com/blueperf>IBM's
+                            BluePerf</a>.</p>
+                    <h2 id=automation>Automation</h2>
+                    <p>Both the synthetic benchmarks (fortio based) and the realistic application (BluePerf)
+                        are part of the nightly release pipeline and you can see the results on:</p>
+                    <ul>
+                        <li><a href=https://fortio-daily.istio.io />https://fortio-daily.istio.io/</a></li>
+                        <li><a
+                                href=https://ibmcloud-perf.istio.io/regpatrol />https://ibmcloud-perf.istio.io/regpatrol/</a>
+                        </li>
+                    </ul>
+                    <p>This enables us to catch regression early and track improvements over time.</p>
+                    <h2 id=scalability-and-sizing-guide>Scalability and sizing guide</h2>
+                    <ul>
+                        <li>
+                            <p>Setup multiple replicas of the control plane components.</p>
+                        </li>
+                        <li>
+                            <p>Setup <a
+                                    href=https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale />Horizontal
+                                Pod Autoscaling</a></p>
+                        </li>
+                        <li>
+                            <p>Split mixer check and report pods.</p>
+                        </li>
+                        <li>
+                            <p>High availability (HA).</p>
+                        </li>
+                        <li>
+                            <p>See also <a
+                                    href=https://github.com/istio/istio/wiki/Istio-Performance-oriented-setup-FAQ>Istio's
+                                    Performance oriented FAQ</a></p>
+                        </li>
+                        <li>
+                            <p>And the <a
+                                    href=https://github.com/istio/community/blob/master/WORKING-GROUPS.md#performance-and-scalability>Performance
+                                    and Scalability Working Group</a> work.</p>
+                        </li>
+                    </ul>
+                    <p>Current recommendations (when using all Istio features):</p>
+                    <ul>
+                        <li>
+                            <p>1 vCPU per peak thousand requests per second for the sidecar(s) with access logging
+                                (which is on by default) and 0.5 without, <code>fluentd</code> on the node is a big
+                                contributor to that cost as it captures and uploads logs.</p>
+                        </li>
+                        <li>
+                            <p>Assuming typical cache hit ratio (>80%) for mixer checks: 0.5 vCPU per peak thousand
+                                requests per second for the mixer pods.</p>
+                        </li>
+                        <li>
+                            <p>Latency cost/overhead is approximately <a
+                                    href="https://fortio.istio.io/browse?url=qps_400-s1_to_s2-0.7.1-2018-04-05-22-06.json">10
+                                    millisecond</a> for service-to-service (2 proxies involved, mixer telemetry and
+                                checks) as of 0.7.1, we expect to bring this down to a low single digit ms.</p>
+                        </li>
+                        <li>
+                            <p>Mutual TLS costs are negligible on AES-NI capable hardware in terms of both CPU and
+                                latency.</p>
+                        </li>
+                    </ul>
+                    <p>We plan on providing more granular guidance for customers adopting Istio &ldquo;A la
+                        carte&rdquo;.</p>
+                    <p>We have an ongoing goal to reduce both the CPU overhead and latency of adding Istio to your
+                        application. Please note however that if you application is
+                        handling its own telemetry, policy, security, network routing, a/b testing, etc&mldr; all that
+                        code and cost can be removed and that should offset most if
+                        not all of the Istio overhead.</p>
+                    <h2 id=see-also>See also</h2>
+                    <div class=see-also>
+                        <div class=container-fluid>
+                            <div class=row>
+                                <div class="col-xs-12 col-sm-6 col-xl-4">
+                                    <p class=link><a href=/v1.0/blog/2019/appswitch />Sidestepping Dependency Ordering
+                                        with AppSwitch</a></p>
+                                    <p class=desc>Addressing application startup ordering and startup latency using
+                                        AppSwitch.</p>
+                                </div>
+                                <div class="col-xs-12 col-sm-6 col-xl-4">
+                                    <p class=link><a href=/v1.0/blog/2018/delayering-istio/delayering-istio />Delayering
+                                        Istio with AppSwitch</a></p>
+                                    <p class=desc>Automatic application onboarding and latency optimizations using
+                                        AppSwitch.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </main>
+                <div class="container-fluid d-print-none"><br>
+                    <div class=row>
+                        <div class="col-6 pagenav">
+                            <p><a title="Describes the policy enforcement and telemetry mechanisms."
+                                    href=/v1.0/docs/concepts/policies-and-telemetry /><i
+                                    class="fa fa-long-arrow-alt-left"></i>Policies and Telemetry</a></p>
+                        </div>
+                        <div class="col-6 pagenav" style=text-align:right></div>
+                    </div>
+                </div>
+                <div class="d-none d-print-block" aria-hidden=true>
+                    <h2>Links</h2>
+                    <ol id=endnotes></ol>
+                </div>
+            </div>
+            <div class="col-12 col-md-2 d-none d-xl-block d-print-none">
+                <nav class=toc>
+                    <div class=spacer></div>
+                    <div id=toc class=directory role=directory>
+                        <nav id=TableOfContents>
+                            <ul>
+                                <li><a href=#micro-benchmarks>Micro benchmarks</a></li>
+                                <li><a href=#testing-scenarios>Testing scenarios</a></li>
+                                <li><a href=#synthetic-end-to-end-benchmarks>Synthetic end to end benchmarks</a></li>
+                                <li><a href=#realistic-application-benchmark>Realistic application benchmark</a></li>
+                                <li><a href=#automation>Automation</a></li>
+                                <li><a href=#scalability-and-sizing-guide>Scalability and sizing guide</a></li>
+                                <li><a href=#see-also>See also</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </nav>
+            </div>
+        </div>
+    </div>
+    <footer class="d-print-none container-fluid">
+        <div class=row>
+            <div class="col-5 col-lg-4" role=navigation>
+                <div class=container-fluid>
+                    <div class=row>
+                        <div class=icon><span>discuss</span>
+                            <a title="Join the Istio discussion board to participate in discussions and get help troubleshooting problems"
+                                href=https://discuss.istio.io aria-label="Istio discussion board"><svg
+                                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+                                    <path
+                                        d="M225.9 32C103.3 32 0 130.5.0 252.1.0 256 .1 480 .1 480l225.8-.2c122.7.0 222.1-102.3 222.1-223.9S348.6 32 225.9 32zM224 384c-19.4.0-37.9-4.3-54.4-12.1L88.5 392l22.9-75c-9.8-18.1-15.4-38.9-15.4-61 0-70.7 57.3-128 128-128s128 57.3 128 128-57.3 128-128 128z" />
+                                </svg></a>
+                        </div>
+                        <div class=icon><span>slack</span>
+                            <a title="Interactively discuss issues with the Istio community on Slack"
+                                href=https://istio.slack.com aria-label=slack><svg viewBox="0 0 31.444 31.443">
+                                    <path
+                                        d="M31.202 16.369c-.62-1.388-2.249-2.011-3.637-1.391l-1.325.594-3.396-7.591 1.325-.592c1.388-.622 2.01-2.25 1.389-3.637-.62-1.389-2.248-2.012-3.637-1.39l-1.324.593-.593-1.326c-.621-1.388-2.249-2.009-3.637-1.388-1.388.62-2.009 2.247-1.389 3.637l.593 1.325L7.98 8.598 7.388 7.273c-.621-1.39-2.249-2.009-3.637-1.39C2.363 6.504 1.742 8.132 2.362 9.52l.592 1.324L1.63 11.438c-1.388.621-2.01 2.247-1.389 3.636.62 1.388 2.249 2.01 3.637 1.39l1.325-.594 3.394 7.592-1.325.592c-1.388.621-2.009 2.25-1.389 3.637.621 1.389 2.249 2.011 3.637 1.391l1.324-.593.593 1.325c.621 1.389 2.249 2.01 3.637 1.389 1.387-.62 2.009-2.248 1.388-3.636l-.591-1.326 7.591-3.394.592 1.321c.621 1.391 2.248 2.013 3.637 1.392 1.388-.619 2.01-2.248 1.389-3.637l-.592-1.324 1.323-.594C31.201 19.384 31.823 17.757 31.202 16.369zM13.623 21.215l-3.395-7.593 7.591-3.394 3.395 7.591L13.623 21.215z" />
+                                </svg></a>
+                        </div>
+                        <div class=icon><span>twitter</span>
+                            <a title="Follow us on Twitter to get the latest news" href=https://twitter.com/IstioMesh
+                                aria-label=Twitter><svg viewBox="0 0 310 310">
+                                    <path
+                                        d="M302.973 57.388c-4.87 2.16-9.877 3.983-14.993 5.463 6.057-6.85 10.675-14.91 13.494-23.73.632-1.977-.023-4.141-1.648-5.434-1.623-1.294-3.878-1.449-5.665-.39-10.865 6.444-22.587 11.075-34.878 13.783-12.381-12.098-29.197-18.983-46.581-18.983-36.695.0-66.549 29.853-66.549 66.547.0 2.89.183 5.764.545 8.598C101.163 99.244 58.83 76.863 29.76 41.204c-1.036-1.271-2.632-1.956-4.266-1.825-1.635.128-3.104 1.05-3.93 2.467-5.896 10.117-9.013 21.688-9.013 33.461.0 16.035 5.725 31.249 15.838 43.137-3.075-1.065-6.059-2.396-8.907-3.977-1.529-.851-3.395-.838-4.914.033-1.52.871-2.473 2.473-2.513 4.224-.007.295-.007.59-.007.889.0 23.935 12.882 45.484 32.577 57.229-1.692-.169-3.383-.414-5.063-.735-1.732-.331-3.513.276-4.681 1.597-1.17 1.32-1.557 3.16-1.018 4.84 7.29 22.76 26.059 39.501 48.749 44.605-18.819 11.787-40.34 17.961-62.932 17.961-4.714.0-9.455-.277-14.095-.826-2.305-.274-4.509 1.087-5.294 3.279-.785 2.193.047 4.638 2.008 5.895 29.023 18.609 62.582 28.445 97.047 28.445 67.754.0 110.139-31.95 133.764-58.753 29.46-33.421 46.356-77.658 46.356-121.367.0-1.826-.028-3.67-.084-5.508 11.623-8.757 21.63-19.355 29.773-31.536 1.237-1.85 1.103-4.295-.33-5.998C307.394 57.037 305.009 56.486 302.973 57.388z" />
+                                </svg></a>
+                        </div>
+                        <div class=icon><span>stack overflow</span>
+                            <a title="Stack Overflow is where you can ask questions and find curated answers on deploying, configuring, and using Istio"
+                                href=https://stackoverflow.com/questions/tagged/istio aria-label="Stack Overflow"><svg
+                                    viewBox="0 0 120 120">
+                                    <polygon
+                                        points="84.4,93.8 84.4,70.6 92.1,70.6 92.1,101.5 22.6,101.5 22.6,70.6 30.3,70.6 30.3,93.8" />
+                                    <path
+                                        d="M38.8 68.4l37.8 7.9 1.6-7.6-37.8-7.9L38.8 68.4zM43.8 50.4l35 16.3 3.2-7-35-16.4L43.8 50.4zM53.5 33.2l29.7 24.7 4.9-5.9L58.4 27.3 53.5 33.2zM72.7 14.9l-6.2 4.6 23 31 6.2-4.6-23-31zM38 86h38.6v-7.7H38V86z" />
+                                </svg></a>
+                        </div>
+                    </div>
+                    <div class="tag row d-none d-lg-flex">for everyone</div>
+                </div>
+            </div>
+            <div class="col-7 col-lg-4">
+                <p class="text-center copyright" role=contentinfo>Istio
+                    Archive
+                    1.0<br>&copy; 2019 Istio Authors, <a href=https://policies.google.com/privacy>Privacy
+                        Policy</a><br>Archived on March 19, 2019</p>
+            </div>
+            <div class="col-6 col-lg-4 d-none d-lg-flex" role=navigation>
+                <div class=container-fluid>
+                    <div class="row justify-content-end">
+                        <div class=icon><span>github</span>
+                            <a title="GitHub is where development takes place on Istio code"
+                                href=https://github.com/istio/community aria-label=GitHub><svg
+                                    viewBox="0 0 478.165 478.165">
+                                    <path
+                                        d="M349.22 55.768c6.136 14.046 10.241 37.556 4.224 54.69 24.426 20.999 33.073 71.904 21.079 113.704 35.006 2.73 76.666-1.235 103.642 9.484-25.183-3.248-59.651-9.563-91.987-7.431-6.136.458-15.361-.239-14.903 8.408 37.735 3.008 75.092 6.117 105.894 15.779-30.702-4.981-67.74-12.552-105.894-13.668-15.54 30.921-47.239 46.262-90.991 49.49 4.682 10.261 13.847 14.066 15.879 30.702 3.267 24.406-4.881 60.328 3.208 76.686 4.064 7.89 10.579 8.009 14.863 14.604-10.699 12.871-37.257-1.395-40.186-14.604-5.14-22.852 7.89-58.256-6.415-73.737.996 24.865-5.718 59.85.996 82.145 2.789 8.806 10.659 12.113 8.647 20.063-49.809 5.08-28.989-64.373-37.177-105.356-7.471.697-4.204 11.197-4.224 15.76-.199 40.106 8.189 94.836-34.846 89.556-1.315-8.348 5.838-11.217 8.467-19.007 7.91-22.434-1.454-56.045 2.112-83.161-16.417 12.512 1.793 55.666-8.428 77.961-5.838 12.671-24.785 18.27-39.19 12.651 1.873-9.464 11.695-7.989 15.879-16.875 5.818-12.452.02-30.244 2.092-48.494-30.423 6.097-53.993-.877-65.608-20.023-5.12-8.507-6.356-18.708-12.632-26.219-6.117-7.551-16.098-8.507-19.087-18.808 37.755-9.185 39.17 38.771 73.06 39.807 10.44.418 15.799-2.909 25.402-5.16 2.749-12.113 8.428-21.039 16.875-27.494-42.078-5.658-76.865-18.788-93.023-50.466-38.293 1.893-73.339 7.013-105.894 14.843 29.547-10.679 65.807-14.604 104.778-15.819-2.351-13.807-22.434-10.022-34.866-9.543C47.677 227.17 18.449 230.138.0 233.645c26.817-9.543 64.233-8.348 100.454-8.428-11.038-34.767-7.232-90.014 17.015-110.615-6.854-17.254-4.722-45.346 4.184-58.834 27.036 1.175 43.374 12.891 60.388 24.247 21.019-6.017 43.035-9.045 71.904-7.451 12.133.677 24.705 6.097 33.731 5.32 8.906-.877 18.728-10.898 27.534-14.843C326.507 58.099 336.17 56.206 349.22 55.768z" />
+                                </svg></a>
+                        </div>
+                        <div class=icon><span>drive</span>
+                            <a title="Access our team drive if you'd like to take a look at the Istio technical design documents"
+                                href=https://groups.google.com/forum/#!forum/istio-team-drive-access
+                                aria-label="team drive"><svg viewBox="0 0 207.027 207.027">
+                                    <path
+                                        d="M69.866 15.557.0 138.919l28.732 52.552 143.288-.029 35.008-59.588L136.39 15.735 69.866 15.557zM17.166 139.046 74.268 38.205 91.21 67.783 33.24 168.447 17.166 139.046zM99.841 82.851l23.805 41.558-47.732-.006L99.841 82.851zM163.434 176.443l-117.332.024 21.53-37.065 64.606.008.067.119 52.865-.085L163.434 176.443zM140.932 124.411 90.157 35.767l-2.966-5.178 40.751.121 57.003 93.706L140.932 124.411z" />
+                                </svg></a>
+                        </div>
+                        <div class=icon><span>working groups</span>
+                            <a title="If you'd like to contribute to the Istio project, consider participating in our working groups"
+                                href=https://github.com/istio/community/blob/master/WORKING-GROUPS.md
+                                aria-label="working groups"><svg viewBox="0 -45 439.833 439.833">
+                                    <polygon points="246.048,195.833 299.966,235.085 319.497,227.296 276.278,195.833" />
+                                    <polygon points="193.786,195.833 163.556,195.833 120.33,227.3 139.862,235.089" />
+                                    <path
+                                        d="M219.927 11.558c-23.854.0-37.057 12.362-36.814 36.182.348 32.623 14.211 52.414 36.814 52.068.0.0 36.802 1.492 36.802-52.068C256.729 23.918 244.294 11.558 219.927 11.558z" />
+                                    <path
+                                        d="M285.017 124.567l-36.77-14.659-8.608-7.256c-2.274-1.922-5.636-1.78-7.741.317l-11.973 11.904-12.008-11.907c-2.109-2.094-5.465-2.229-7.736-.313l-8.611 7.256-36.77 14.661c-11.842 4.715-11.83 46.647-12.848 50.497h155.93C296.866 171.228 296.862 129.28 285.017 124.567z" />
+                                    <path
+                                        d="M77.976 228.568s36.801 1.492 36.801-52.068c0-23.82-12.434-36.182-36.801-36.182-23.854.0-37.057 12.362-36.814 36.182C41.509 209.124 55.372 228.915 77.976 228.568z" />
+                                    <path
+                                        d="M143.065 253.329l-36.77-14.658-8.609-7.256c-2.275-1.923-5.635-1.781-7.742.315l-11.971 11.904-12.008-11.908c-2.109-2.094-5.465-2.229-7.736-.312l-8.611 7.256-36.77 14.66C1.006 258.045 1.018 299.977.0 303.827h155.93C154.915 299.988 154.911 258.042 143.065 253.329z" />
+                                    <path
+                                        d="M361.878 228.568s36.801 1.492 36.801-52.068c0-23.82-12.434-36.182-36.801-36.182-23.854.0-37.057 12.362-36.812 36.182C325.411 209.124 339.274 228.915 361.878 228.568z" />
+                                    <path
+                                        d="M426.968 253.329l-36.77-14.658-8.609-7.256c-2.273-1.923-5.635-1.781-7.742.315l-11.971 11.904-12.008-11.908c-2.109-2.094-5.465-2.229-7.736-.312l-8.61 7.256-36.771 14.66c-11.842 4.715-11.83 46.646-12.848 50.497h155.93C438.817 299.988 438.812 258.042 426.968 253.329z" />
+                                </svg></a>
+                        </div>
+                    </div>
+                    <div class="tag row justify-content-end text-right">for developers</div>
+                </div>
+            </div>
+        </div>
+    </footer>
+    <div class="d-xl-none d-print-none"><button id=scroll-to-top aria-hidden=true onclick=scrollToTop()
+            title="Back to top"><i class="fa fa-lg fa-arrow-up"></i></button></div>
+    <script src=https://code.jquery.com/jquery-3.2.1.slim.min.js
+        integrity=sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN
+        crossorigin=anonymous></script>
+    <script src=https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js
+        integrity=sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl
+        crossorigin=anonymous></script>
+    <script src=https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js></script>
+    <script src="https://www.google.com/cse/brand?form=search_form"></script>
+    <script src=/v1.0/js/all.min.js data-manual></script>
+</body>
+
+</html>

--- a/archive/v1.0/docs/concepts/performance-and-scalability/index.html
+++ b/archive/v1.0/docs/concepts/performance-and-scalability/index.html
@@ -702,9 +702,9 @@
                     <h2 id=testing-scenarios>Testing scenarios</h2>
                     <figure style=width:80%>
                         <div class=wrapper-with-intrinsic-ratio style=padding-bottom:75%><a class=not-for-endnotes
-                                href="https://raw.githubusercontent.com/istio/istio/master/tools/perf_setup.svg?sanitize=true"><img
+                                href="https://raw.githubusercontent.com/istio/istio/release-1.0/tools/perf_setup.svg?sanitize=true"><img
                                     class=element-to-stretch
-                                    src="https://raw.githubusercontent.com/istio/istio/master/tools/perf_setup.svg?sanitize=true"
+                                    src="https://raw.githubusercontent.com/istio/istio/release-1.0/tools/perf_setup.svg?sanitize=true"
                                     alt="Performance scenarios diagram" title="Performance scenarios diagram"></a></div>
                         <figcaption>Performance scenarios diagram</figcaption>
                     </figure>
@@ -729,9 +729,12 @@
                     <p>Here is an example of scenario (one out of the 8 scenarios we run for every build) result
                         graphing the latency distribution for istio-0.7.1 at 400 Query-Per-Second (qps) between 2
                         services inside the mesh (with mutual TLS, Mixer policy checks and telemetry collection):</p>
+<iframe src="https://fortio.istio.io/browse?url=qps_400-s1_to_s2-0.7.1-2018-04-05-22-06.json&xMax=105&yLog=true" width="100%" height="1024" scrolling="no" frameborder="0"></iframe>
                     <p>Comparing 0.6.0 and 0.7.1 histograms/response time distribution for the same scenario, clearly
                         showing 0.7 improvements:</p>
+<iframe src="https://fortio.istio.io/?xMin=2&xMax=110&xLog=true&sel=qps_400-s1_to_s2-0.7.1-2018-04-05-22-06&sel=qps_400-s1_to_s2-0.6.0-2018-04-05-22-33" width="100%" height="1024" scrolling="no" frameborder="0"></iframe>
                     <p>And tracking the progress across all the tested releases for that scenario:</p>
+<iframe src="https://fortio.istio.io/?s=qps_400-s1_to_s2" width="100%" height="1024" scrolling="no" frameborder="0"></iframe>
                     <p>You can learn more about <a
                             href=https://github.com/fortio/fortio/blob/master/README.md#fortio>Fortio</a> on GitHub and
                         see results on <a href=https://fortio.istio.io>https://fortio.istio.io</a>.</p>


### PR DESCRIPTION
Fixes #11311

Please provide a description for what this PR is for.

Add the iframe present in the source in the branch back into the html
Also fixes the diagram broken link

The first commit is whitespace to make the second commit readable (it does make the page a bit heavier)
so to review: https://github.com/istio/istio.io/pull/11312/commits/66b985998c85bed93d9be6da63246649c8ce9782

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [x] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
