### PR TITLE
Update broken Envoy links (envoyproxy.github.io)

### DIFF
--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -173,7 +173,7 @@ affect your security posture before it is enforced.
 
 Istio tunnels service-to-service communication through the client- and
 server-side PEPs, which are implemented as [Envoy
-proxies](https://envoyproxy.github.io/envoy/). When a workload sends a request
+proxies](https://www.envoyproxy.io/). When a workload sends a request
 to another workload using mutual TLS authentication, the request is handled as
 follows:
 

--- a/content/en/docs/ops/deployment/architecture/index.md
+++ b/content/en/docs/ops/deployment/architecture/index.md
@@ -34,7 +34,7 @@ The following sections provide a brief overview of each of Istio's core componen
 ### Envoy
 
 Istio uses an extended version of the
-[Envoy](https://envoyproxy.github.io/envoy/) proxy. Envoy is a high-performance
+[Envoy](https://www.envoyproxy.io/) proxy. Envoy is a high-performance
 proxy developed in C++ to mediate all inbound and outbound traffic for all
 services in the service mesh.
 Envoy proxies are the only Istio components that interact with data plane

--- a/content/en/docs/reference/glossary/envoy.md
+++ b/content/en/docs/reference/glossary/envoy.md
@@ -4,4 +4,4 @@ test: n/a
 ---
 
 The high-performance proxy that Istio uses to mediate inbound and outbound traffic for all [services](/docs/reference/glossary/#service) in the
-[service mesh](/docs/reference/glossary/#service-mesh). [Learn more about Envoy](https://envoyproxy.github.io/envoy/).
+[service mesh](/docs/reference/glossary/#service-mesh). [Learn more about Envoy](https://www.envoyproxy.io/).

--- a/content/zh/docs/concepts/security/index.md
+++ b/content/zh/docs/concepts/security/index.md
@@ -114,7 +114,7 @@ Istio 提供两种类型的认证：
 
 ### 双向 TLS 认证{#mutual-TLS-authentication}
 
-Istio 通过客户端和服务器端 PEPs 建立服务到服务的通信通道，PEPs 被实现为[Envoy 代理](https://envoyproxy.github.io/envoy/)。当一个工作负载使用双向 TLS 认证向另一个工作负载发送请求时，该请求的处理方式如下：
+Istio 通过客户端和服务器端 PEPs 建立服务到服务的通信通道，PEPs 被实现为[Envoy 代理](https://www.envoyproxy.io/)。当一个工作负载使用双向 TLS 认证向另一个工作负载发送请求时，该请求的处理方式如下：
 
 1. Istio 将出站流量从客户端重新路由到客户端的本地 sidecar Envoy。
 1. 客户端 Envoy 与服务器端 Envoy 开始双向 TLS 握手。在握手期间，客户端 Envoy 还做了[安全命名](/zh/docs/concepts/security/#secure-naming)检查，以验证服务器证书中显示的服务帐户是否被授权运行目标服务。

--- a/content/zh/docs/ops/deployment/architecture/index.md
+++ b/content/zh/docs/ops/deployment/architecture/index.md
@@ -29,7 +29,7 @@ Istio 服务网格从逻辑上分为**数据平面**和**控制平面**。
 
 ### Envoy{#envoy}
 
-Istio 使用 [Envoy](https://envoyproxy.github.io/envoy/) 代理的扩展版本。Envoy 是用 C++ 开发的高性能代理，用于协调服务网格中所有服务的入站和出站流量。Envoy 代理是唯一与数据平面流量交互的 Istio 组件。
+Istio 使用 [Envoy](https://www.envoyproxy.io/) 代理的扩展版本。Envoy 是用 C++ 开发的高性能代理，用于协调服务网格中所有服务的入站和出站流量。Envoy 代理是唯一与数据平面流量交互的 Istio 组件。
 
 Envoy 代理被部署为服务的 Sidecar，在逻辑上为服务增加了 Envoy 的许多内置特性，例如：
 

--- a/content/zh/docs/reference/glossary/envoy.md
+++ b/content/zh/docs/reference/glossary/envoy.md
@@ -4,4 +4,4 @@ test: n/a
 ---
 
 Envoy 是在 Istio 里使用的高性能代理，用于为所有[服务网格](/zh/docs/reference/glossary/#service-mesh)里的[服务](/zh/docs/reference/glossary/#service)调度进出的流量。
-[了解更多关于 Envoy](https://envoyproxy.github.io/envoy/)。
+[了解更多关于 Envoy](https://www.envoyproxy.io/)。


### PR DESCRIPTION
This change updates broken Envoy links in documentation.

Change: envoyproxy.github.io/envoy/ -> www.envoyproxy.io/
Updates pages under: content/*/docs/
Ignores pages under:
* content/*/blog/
* archive/


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [X] Docs
