### PR TITLE
Update minikube instructions related to ingress host and port

### DIFF
--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -197,43 +197,37 @@ chosen platform:
 
 {{< tab name="Minikube" category-value="external-lb" >}}
 
-Set the ingress ports:
+Run this command in a new terminal window to start a Minikube tunnel that
+sends traffic to your Istio Ingress Gateway. This will provide an external
+load balancer, `EXTERNAL-IP`, for `service/istio-ingressgateway`.
 
 {{< text bash >}}
-$ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
-$ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
+$ minikube tunnel
 {{< /text >}}
 
-Ensure a port was successfully assigned to each environment variable:
+Set the ingress host and ports:
+
+{{< text bash >}}
+$ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+$ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
+$ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
+{{< /text >}}
+
+Ensure an IP address and ports were successfully assigned to each environment variable:
+
+{{< text bash >}}
+$ echo "$INGRESS_HOST"
+127.0.0.1
+{{< /text >}}
 
 {{< text bash >}}
 $ echo "$INGRESS_PORT"
-32194
+80
 {{< /text >}}
 
 {{< text bash >}}
 $ echo "$SECURE_INGRESS_PORT"
-31632
-{{< /text >}}
-
-Set the ingress IP:
-
-{{< text bash >}}
-$ export INGRESS_HOST=$(minikube ip)
-{{< /text >}}
-
-Ensure an IP address was successfully assigned to the environment variable:
-
-{{< text bash >}}
-$ echo "$INGRESS_HOST"
-192.168.4.102
-{{< /text >}}
-
-Run this command in a new terminal window to start a Minikube tunnel that
-sends traffic to your Istio Ingress Gateway:
-
-{{< text bash >}}
-$ minikube tunnel
+443
 {{< /text >}}
 
 {{< /tab >}}

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -105,12 +105,6 @@ Setting the ingress IP depends on the cluster provider:
     $ export INGRESS_HOST=public-IP-of-one-of-the-worker-nodes
     {{< /text >}}
 
-1.  _Minikube:_
-
-    {{< text bash >}}
-    $ export INGRESS_HOST=$(minikube ip)
-    {{< /text >}}
-
 1.  _Docker For Desktop:_
 
     {{< text bash >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fixes https://github.com/istio/istio.io/issues/11243

MiniKube has changed how it provides ingress to the cluster. Using `minikube tunnel` one gets an external load balancer assigned to the ingress gateway. Update the instructions to follow the external load balancer related setting of ingress host and port.