### PR TITLE
Egress TLS Origination - fix typos

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -192,7 +192,7 @@ example would not be sufficient.
 Also note that even with HTTPS originated by the application, an attacker could know that requests to `edition.cnn.com`
 are being sent by inspecting [Server Name Indication (SNI)](https://en.wikipedia.org/wiki/Server_Name_Indication).
 The _SNI_ field is sent unencrypted during the TLS handshake. Using HTTPS prevents the attackers from knowing specific
-topics and articles but does not prevent an attackers from learning that `edition.cnn.com` is accessed.
+topics and articles but does not prevent attackers from learning that `edition.cnn.com` is accessed.
 
 ### Cleanup the TLS origination configuration
 
@@ -266,7 +266,7 @@ Follow [these steps](/docs/tasks/traffic-management/egress/egress-gateway-tls-or
           tls:
             mode: MUTUAL
             credentialName: client-credential # this must match the secret created earlier to hold client certs, and works only when DR has a workloadSelector
-            sni: my-nginx.mesh-external.svc.cluster.local
+            sni: my-nginx.mesh-external.svc.cluster.local # this is optional
     EOF
     {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
@@ -153,7 +153,7 @@ spec:
       tls:
         mode: MUTUAL
         credentialName: client-credential # this must match the secret created earlier to hold client certs, and works only when DR has a workloadSelector
-        sni: my-nginx.mesh-external.svc.cluster.local
+        sni: my-nginx.mesh-external.svc.cluster.local # this is optional
 EOF
 }
 


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

Fixing a small typo that was seen in the document. Also enhancing one of the comments for SNI in DR config

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
