### PR TITLE
Update multicluster test kind image

### DIFF
--- a/archive/v1.10/docs/tasks/traffic-management/locality-load-balancing/common.sh
+++ b/archive/v1.10/docs/tasks/traffic-management/locality-load-balancing/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2154
 
 # Copyright Istio Authors
 #

--- a/archive/v1.10/zh/docs/tasks/traffic-management/locality-load-balancing/common.sh
+++ b/archive/v1.10/zh/docs/tasks/traffic-management/locality-load-balancing/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2154
 
 # Copyright Istio Authors
 #

--- a/archive/v1.11/docs/tasks/traffic-management/locality-load-balancing/common.sh
+++ b/archive/v1.11/docs/tasks/traffic-management/locality-load-balancing/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2154
 
 # Copyright Istio Authors
 #

--- a/archive/v1.11/zh/docs/tasks/traffic-management/locality-load-balancing/common.sh
+++ b/archive/v1.11/zh/docs/tasks/traffic-management/locality-load-balancing/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2154
 
 # Copyright Istio Authors
 #

--- a/archive/v1.12/docs/tasks/traffic-management/locality-load-balancing/common.sh
+++ b/archive/v1.12/docs/tasks/traffic-management/locality-load-balancing/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2154
 
 # Copyright Istio Authors
 #

--- a/archive/v1.12/zh/docs/tasks/traffic-management/locality-load-balancing/common.sh
+++ b/archive/v1.12/zh/docs/tasks/traffic-management/locality-load-balancing/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2154
 
 # Copyright Istio Authors
 #

--- a/archive/v1.9/docs/tasks/traffic-management/locality-load-balancing/common.sh
+++ b/archive/v1.9/docs/tasks/traffic-management/locality-load-balancing/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2154
 
 # Copyright Istio Authors
 #

--- a/common/config/.golangci-format.yml
+++ b/common/config/.golangci-format.yml
@@ -44,6 +44,11 @@ linters-settings:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
     local-prefixes: istio.io/
+  gci:
+     sections:
+       - standard
+       - default
+       - prefix(istio.io/)
 
 issues:
 

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/common.sh
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2154
 
 # Copyright Istio Authors
 #

--- a/content/zh/docs/tasks/traffic-management/locality-load-balancing/common.sh
+++ b/content/zh/docs/tasks/traffic-management/locality-load-balancing/common.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2034
+# shellcheck disable=SC2034,SC2154
 
 # Copyright Istio Authors
 #

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -86,7 +86,7 @@ while (( "$#" )); do
 done
 
 export IP_FAMILY="${IP_FAMILY:-ipv4}"
-export NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.20.5"
+export NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.21.1"
 
 if [[ -z "${SKIP_SETUP:-}" ]]; then
   export ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"


### PR DESCRIPTION
Please provide a description for what this PR is for.

The current kind 1.20.5 image does not work with kind 0.14.0. Update the image to 1.21.1 which does.