### PR TITLE
Add document for kernel module requirements under platform setup

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -330,6 +330,7 @@ docker.io
 dogfood
 double-tls
 Drucker
+Dual-stack
 Dubbo
 Duggirala
 DynamoDB

--- a/.spelling
+++ b/.spelling
@@ -329,8 +329,8 @@ docker-compose's
 docker.io
 dogfood
 double-tls
+dual-stack
 Drucker
-Dual-stack
 Dubbo
 Duggirala
 DynamoDB

--- a/content/en/docs/setup/platform-setup/prerequisites/index.md
+++ b/content/en/docs/setup/platform-setup/prerequisites/index.md
@@ -1,0 +1,53 @@
+---
+title: Platform Prerequisites
+description: Prerequisites for platform setup for istio.
+weight: 1
+skip_seealso: true
+aliases:
+    - /docs/setup/kubernetes/prepare/platform-setup/prerequisites/
+    - /docs/setup/kubernetes/platform-setup/prerequisites/
+keywords: [platform-setup,prerequisites]
+owner: istio/wg-environments-maintainers
+test: no
+---
+
+
+## Kernel Module Requirements on Cluster Nodes
+
+The following kernel modules must be loaded on the cluster node running application pods with a Service Mesh proxy sidecar container.
+The modules are needed specifically by the `istio-init` container which sets up iptables rules in the pod to redirect any incoming or
+outgoing traffic towards the sidecar proxy in the istio-proxy container. While in many platforms, these seem to be automatically
+loaded, it is always good to make sure the prerequisites are met, as there were incidents reported where some of the specific
+modules listed down below were not loaded.
+
+| Module | Remark |
+| --- | --- |
+| `br_netfilter` | selinux in RHEL sometimes prevent the loading of this module. Refer [`selinux issue`](https://www.suse.com/support/kb/doc/?id=000020241) |
+| `ip6table_mangle` | Only needed for IPv6 or Dual-stack clusters |
+| `ip6table_nat` | Only needed for IPv6 or Dual-stack clusters |
+| `ip6table_raw` | Only needed for IPv6 or Dual-stack clusters |
+| `iptable_mangle` |  |
+| `iptable_nat` |  |
+| `iptable_raw` |  |
+| `xt_REDIRECT` |  |
+| `xt_connmark` |  |
+| `xt_conntrack` |  |
+| `xt_mark` |  |
+| `xt_owner` |  |
+| `xt_tcpudp` |  |
+
+The following additional modules are used by the above listed modules and should be also loaded on the cluster node:
+
+| Module | Remark |
+| --- | --- |
+| `bridge` | selinux in RHEL sometimes prevent the loading of this module. Refer [`selinux issue`](https://www.suse.com/support/kb/doc/?id=000020241) |
+| `ip6_tables` | Only needed for IPv6 or Dual-stack clusters |
+| `ip_tables` |  |
+| `nf_conntrack` |  |
+| `nf_conntrack_ipv4` |  |
+| `nf_conntrack_ipv6` | Only needed for IPv6 or Dual-stack clusters |
+| `nf_nat` |  |
+| `nf_nat_ipv4` |  |
+| `nf_nat_ipv6` | Only needed for IPv6 or Dual-stack clusters |
+| `nf_nat_redirect` |  |
+| `x_tables` |  |

--- a/content/en/docs/setup/platform-setup/prerequisites/index.md
+++ b/content/en/docs/setup/platform-setup/prerequisites/index.md
@@ -1,11 +1,8 @@
 ---
 title: Platform Prerequisites
-description: Prerequisites for platform setup for istio.
+description: Prerequisites for platform setup for Istio.
 weight: 1
 skip_seealso: true
-aliases:
-    - /docs/setup/kubernetes/prepare/platform-setup/prerequisites/
-    - /docs/setup/kubernetes/platform-setup/prerequisites/
 keywords: [platform-setup,prerequisites]
 owner: istio/wg-environments-maintainers
 test: no
@@ -14,23 +11,26 @@ test: no
 
 ## Kernel Module Requirements on Cluster Nodes
 
-The following kernel modules must be loaded on the cluster node running application pods with a Service Mesh proxy sidecar container.
-The modules are needed specifically by the `istio-init` container which sets up iptables rules in the pod to redirect any incoming or
-outgoing traffic towards the sidecar proxy in the istio-proxy container. While in many platforms, these seem to be automatically
-loaded, it is always good to make sure the prerequisites are met, as there were incidents reported where some of the specific
-modules listed down below were not available on the host or could not be automatically loaded by the iptables. For example,
-[`selinux issue`](https://www.suse.com/support/kb/doc/?id=000020241) talks about selinux in RHEL sometimes preventing
+The cluster node running application pods with Istio proxy sidecar container, when using iptables interception mode,
+requires certain kernel modules to be loaded. Istio can also work in 'whitebox mode' where iptables interception is not done
+and in such cases this section can be skipped as there is no need of any special kernel module.
+
+The modules are needed specifically by the `istio-init` container or `istio-cni` daemon which sets up iptables rules in the pod to
+redirect any incoming or outgoing traffic towards the sidecar proxy in the istio-proxy container. While in many platforms, these seem
+to be automatically loaded, it is always good to make sure the prerequisites are met, as there were incidents reported where some of
+the specific modules listed down below were not available on the host or could not be automatically loaded by the iptables. For example,
+this [`selinux issue`](https://www.suse.com/support/kb/doc/?id=000020241) talks about selinux in RHEL sometimes preventing
 the automatic loading of some of the below mentioned kernel modules.
 
 | Module | Remark |
 | --- | --- |
 | `br_netfilter` |  |
-| `ip6table_mangle` | Only needed for IPv6 or Dual-stack clusters |
-| `ip6table_nat` | Only needed for IPv6 or Dual-stack clusters |
-| `ip6table_raw` | Only needed for IPv6 or Dual-stack clusters |
+| `ip6table_mangle` | Only needed for IPv6 or dual-stack clusters |
+| `ip6table_nat` | Only needed for IPv6 or dual-stack clusters |
+| `ip6table_raw` | Only needed for IPv6 or dual-stack clusters |
 | `iptable_mangle` |  |
 | `iptable_nat` |  |
-| `iptable_raw` |  |
+| `iptable_raw` | Only needed for `DNS` interception |
 | `xt_REDIRECT` |  |
 | `xt_connmark` | Only needed for `TPROXY` interception mode |
 | `xt_conntrack` |  |
@@ -43,13 +43,13 @@ The following additional modules are used by the above listed modules and should
 | Module | Remark |
 | --- | --- |
 | `bridge` |  |
-| `ip6_tables` | Only needed for IPv6 or Dual-stack clusters |
+| `ip6_tables` | Only needed for IPv6 or dual-stack clusters |
 | `ip_tables` |  |
 | `nf_conntrack` |  |
 | `nf_conntrack_ipv4` |  |
-| `nf_conntrack_ipv6` | Only needed for IPv6 or Dual-stack clusters |
+| `nf_conntrack_ipv6` | Only needed for IPv6 or dual-stack clusters |
 | `nf_nat` |  |
 | `nf_nat_ipv4` |  |
-| `nf_nat_ipv6` | Only needed for IPv6 or Dual-stack clusters |
+| `nf_nat_ipv6` | Only needed for IPv6 or dual-stack clusters |
 | `nf_nat_redirect` |  |
 | `x_tables` |  |

--- a/content/en/docs/setup/platform-setup/prerequisites/index.md
+++ b/content/en/docs/setup/platform-setup/prerequisites/index.md
@@ -12,7 +12,7 @@ test: no
 ## Kernel Module Requirements on Cluster Nodes
 
 The cluster node running application pods with Istio proxy sidecar container, when using iptables interception mode,
-requires certain kernel modules to be loaded. Istio can also work in 'whitebox mode' where iptables interception is not done
+requires certain kernel modules to be loaded. Istio can also work in `whitebox` mode where iptables interception is not done
 and in such cases this section can be skipped as there is no need of any special kernel module.
 
 The modules are needed specifically by the `istio-init` container or `istio-cni` daemon which sets up iptables rules in the pod to

--- a/content/en/docs/setup/platform-setup/prerequisites/index.md
+++ b/content/en/docs/setup/platform-setup/prerequisites/index.md
@@ -18,11 +18,13 @@ The following kernel modules must be loaded on the cluster node running applicat
 The modules are needed specifically by the `istio-init` container which sets up iptables rules in the pod to redirect any incoming or
 outgoing traffic towards the sidecar proxy in the istio-proxy container. While in many platforms, these seem to be automatically
 loaded, it is always good to make sure the prerequisites are met, as there were incidents reported where some of the specific
-modules listed down below were not loaded.
+modules listed down below were not available on the host or could not be automatically loaded by the iptables. For example,
+[`selinux issue`](https://www.suse.com/support/kb/doc/?id=000020241) talks about selinux in RHEL sometimes preventing
+the automatic loading of some of the below mentioned kernel modules.
 
 | Module | Remark |
 | --- | --- |
-| `br_netfilter` | selinux in RHEL sometimes prevent the loading of this module. Refer [`selinux issue`](https://www.suse.com/support/kb/doc/?id=000020241) |
+| `br_netfilter` |  |
 | `ip6table_mangle` | Only needed for IPv6 or Dual-stack clusters |
 | `ip6table_nat` | Only needed for IPv6 or Dual-stack clusters |
 | `ip6table_raw` | Only needed for IPv6 or Dual-stack clusters |
@@ -30,9 +32,9 @@ modules listed down below were not loaded.
 | `iptable_nat` |  |
 | `iptable_raw` |  |
 | `xt_REDIRECT` |  |
-| `xt_connmark` |  |
+| `xt_connmark` | Only needed for `TPROXY` interception mode |
 | `xt_conntrack` |  |
-| `xt_mark` |  |
+| `xt_mark` | Only needed for `TPROXY` interception mode |
 | `xt_owner` |  |
 | `xt_tcpudp` |  |
 
@@ -40,7 +42,7 @@ The following additional modules are used by the above listed modules and should
 
 | Module | Remark |
 | --- | --- |
-| `bridge` | selinux in RHEL sometimes prevent the loading of this module. Refer [`selinux issue`](https://www.suse.com/support/kb/doc/?id=000020241) |
+| `bridge` |  |
 | `ip6_tables` | Only needed for IPv6 or Dual-stack clusters |
 | `ip_tables` |  |
 | `nf_conntrack` |  |


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

Adding a prerequisite page for explicitly listing down the kernel modules that must be loaded on the cluster node running application pods with a Service Mesh proxy sidecar container. These modules are needed specifically by the istio-init container which sets up iptable rules in the pod to redirect any incoming or outgoing traffic towards the sidecar proxy in the istio-proxy container. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
