### PR TITLE
fix:spire-quickstart.yaml path is incorrect in doc "Install SPIRE Option 1: Quick start" #11374

### DIFF
--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -226,7 +226,7 @@ To improve workload attestation security robustness, SPIRE is able to verify aga
 1. Deploy an example workload:
 
     {{< text bash >}}
-    $ istioctl kube-inject --filename @samples/security/spire/sleep-spire.yaml | kubectl apply -f -
+    $ istioctl kube-inject --filename samples/security/spire/sleep-spire.yaml | kubectl apply -f -
     {{< /text >}}
 
     Note that the workload will need the SPIFFE CSI Driver volume to access the SPIRE Agent socket. To accomplish this,

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -226,7 +226,7 @@ To improve workload attestation security robustness, SPIRE is able to verify aga
 1. Deploy an example workload:
 
     {{< text bash >}}
-    $ istioctl kube-inject --filename samples/security/spire/sleep-spire.yaml | kubectl apply -f -
+    $ istioctl kube-inject --filename @samples/security/spire/sleep-spire.yaml@ | kubectl apply -f -
     {{< /text >}}
 
     Note that the workload will need the SPIFFE CSI Driver volume to access the SPIRE Agent socket. To accomplish this,


### PR DESCRIPTION
Please provide a description for what this PR is for.
fix: #11374 
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
