### PR TITLE
Fix ServiceEntry example in concepts/traffic-management

### DIFF
--- a/content/en/docs/concepts/traffic-management/index.md
+++ b/content/en/docs/concepts/traffic-management/index.md
@@ -561,7 +561,7 @@ adjusts the TCP connection timeout for requests to the `ext-svc.example.com`
 external service that we configured using the service entry:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
   name: ext-res-dr

--- a/content/en/docs/concepts/traffic-management/index.md
+++ b/content/en/docs/concepts/traffic-management/index.md
@@ -557,22 +557,20 @@ fully or use a wildcard prefixed domain name.
 You can configure virtual services and destination rules to control traffic to a
 service entry in a more granular way, in the same way you configure traffic for
 any other service in the mesh. For example, the following destination rule
-configures the traffic route to use mutual TLS to secure the connection to the
-`ext-svc.example.com` external service that we configured using the service entry:
+adjusts the TCP connection timeout for requests to the `ext-svc.example.com`
+external service that we configured using the service entry:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   name: ext-res-dr
 spec:
   host: ext-svc.example.com
   trafficPolicy:
-    tls:
-      mode: MUTUAL
-      clientCertificate: /etc/certs/myclientcert.pem
-      privateKey: /etc/certs/client_private_key.pem
-      caCertificates: /etc/certs/rootcacerts.pem
+    connectionPool:
+      tcp:
+        connectTimeout: 1s
 {{< /text >}}
 
 See the


### PR DESCRIPTION
Fixes issue #11396.

This change replaces the incorrect mTLS egress example with a simpler,
valid example that adjusts the TCP connection timeout.

Page: Documentation / Concepts / Traffic Management
Section: Service entry example
URL: https://istio.io/latest/docs/concepts/traffic-management/#service-entry-example

- [x] Docs
