### PR TITLE
Improve clarity of Egress Gateway docs

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -543,7 +543,7 @@ external service.
     sleep istio-proxy
     {{< /text >}}
 
-1.  Create the same destination rule as for the `sleep` pod in the `default` namespace to direct the traffic through the egress gateway:
+1.  Create the same destination rule as for the `sleep` pod above, just now in the `test-egress` namespace, to direct the traffic through the egress gateway:
 
     {{< text bash >}}
     $ kubectl apply -n test-egress -f - <<EOF

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -543,7 +543,7 @@ external service.
     sleep istio-proxy
     {{< /text >}}
 
-1.  Create the same destination rule as for the `sleep` pod above, just now in the `test-egress` namespace, to direct the traffic through the egress gateway:
+1.  Create a similar destination rule as used for the `sleep` pod in the `default` namespace, to direct the `test-egress` namespace traffic through the egress gateway:
 
     {{< text bash >}}
     $ kubectl apply -n test-egress -f - <<EOF


### PR DESCRIPTION
Make the step 13 more clear, since it is creating a DestinationRule in the test-egress namespace and not in the default namespace.

---

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
