### PR TITLE
fix 1.13 proxy-config example

### DIFF
--- a/archive/v1.13/docs/reference/config/networking/proxy-config/index.html
+++ b/archive/v1.13/docs/reference/config/networking/proxy-config/index.html
@@ -42,11 +42,11 @@ metadata:
   namespace: example
 spec:
   selector:
-    labels:
+    matchLabels:
       app: ratings
   concurrency: 0
   image:
-    type: debug
+    imageType: debug
 </code></pre><p>If a <code>ProxyConfig</code> CR is defined that matches a workload it will merge with its <code>proxy.istio.io/config</code> annotation if present,
 with the CR taking precedence over the annotation for overlapping fields. Similarly, if a mesh wide <code>ProxyConfig</code> CR is defined and
 <code>meshConfig.DefaultConfig</code> is set, the two resources will be merged with the CR taking precedence for overlapping fields.</p><h2 id=ProxyConfig>ProxyConfig</h2><section><p><code>ProxyConfig</code> exposes proxy level configuration options.</p><table class=message-fields><thead><tr><th>Field</th><th>Type</th><th>Description</th><th>Required</th></tr></thead><tbody><tr id=ProxyConfig-selector><td><code>selector</code></td><td><code><a href=/v1.13/docs/reference/config/type/workload-selector/#WorkloadSelector>WorkloadSelector</a></code></td><td><p>Optional. Selectors specify the set of pods/VMs on which this <code>ProxyConfig</code> resource should be applied.


### PR DESCRIPTION
The example in [proxy-config](https://istio.io/latest/docs/reference/config/networking/proxy-config/) is invalid. Cause configuration error：


```
error validating data: [ValidationError(ProxyConfig.spec.image): unknown field "type" in io.istio.networking.v1beta1.ProxyConfig.spec.image, ValidationError(ProxyConfig.spec): unknown field "workloadSelector" in io.istio.networking.v1beta1.ProxyConfig.spec]; if you choose to ignore these errors, turn validation off with --validate=false

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
