### PR TITLE
zh:added zh text to docs/setup/upgrade/_index.md

### DIFF
--- a/content/zh/docs/setup/upgrade/_index.md
+++ b/content/zh/docs/setup/upgrade/_index.md
@@ -1,11 +1,11 @@
 ---
 title: 升级 Istio
-linktitle: Upgrade
+linktitle: 升级
 description: 跨多个控制平面升级、降级和管理 Istio。
 weight: 25
 test: n/a
 ---
 
 {{< warning >}}
-尚未正式测试和推行一步升级多个版本（如1.6.x 到 1.8.x）。
+尚未正式测试和推行一步升级多个版本（如 1.6.x 到 1.8.x）。
 {{< /warning >}}


### PR DESCRIPTION
https://istio.io/latest/zh/docs/setup/upgrade/

Added the Chinese text to title. If not, it looks alone:
![image](https://user-images.githubusercontent.com/79828097/175751441-870eeede-a13e-4048-9642-94f60263c557.png)

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
