### PR TITLE
[release-1.12] Update reference docs for upcoming 1.12 build

### DIFF
--- a/content/en/docs/reference/commands/install-cni/index.html
+++ b/content/en/docs/reference/commands/install-cni/index.html
@@ -28,6 +28,10 @@ remove_toc_prefix: 'install-cni '
 <td>Name of the CNI configuration file  (default ``)</td>
 </tr>
 <tr>
+<td><code>--cni-enable-install</code></td>
+<td>Whether to install CNI configuration and binary files </td>
+</tr>
+<tr>
 <td><code>--cni-enable-reinstall</code></td>
 <td>Whether to reinstall CNI configuration and binary files </td>
 </tr>
@@ -627,6 +631,12 @@ These environment variables affect the behavior of the <code>install-cni</code> 
 <td>String</td>
 <td><code></code></td>
 <td>Name of the CNI configuration file</td>
+</tr>
+<tr>
+<td><code>CNI_ENABLE_INSTALL</code></td>
+<td>Boolean</td>
+<td><code>true</code></td>
+<td>Whether to install CNI configuration and binary files</td>
 </tr>
 <tr>
 <td><code>CNI_ENABLE_REINSTALL</code></td>

--- a/content/en/docs/reference/commands/istioctl/index.html
+++ b/content/en/docs/reference/commands/istioctl/index.html
@@ -7199,6 +7199,12 @@ These environment variables affect the behavior of the <code>istioctl</code> com
 <td>If enabled, pilot will allow any upstream cluster to be used with AUTO_PASSTHROUGH. This option is intended for backwards compatibility only and is not secure with untrusted downstreams; it will be removed in the future.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_LEGACY_ISTIO_MUTUAL_CREDENTIAL_NAME</code></td>
+<td>Boolean</td>
+<td><code>true</code></td>
+<td>If enabled, Gateway&#39;s with ISTIO_MUTUAL mode and credentialName configured will use simple TLS. This is to retain legacy behavior only and not recommended for use beyond migration.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_METADATA_EXCHANGE</code></td>
 <td>Boolean</td>
 <td><code>true</code></td>

--- a/content/en/docs/reference/commands/operator/index.html
+++ b/content/en/docs/reference/commands/operator/index.html
@@ -571,6 +571,12 @@ These environment variables affect the behavior of the <code>operator</code> com
 <td>If enabled, pilot will allow any upstream cluster to be used with AUTO_PASSTHROUGH. This option is intended for backwards compatibility only and is not secure with untrusted downstreams; it will be removed in the future.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_LEGACY_ISTIO_MUTUAL_CREDENTIAL_NAME</code></td>
+<td>Boolean</td>
+<td><code>true</code></td>
+<td>If enabled, Gateway&#39;s with ISTIO_MUTUAL mode and credentialName configured will use simple TLS. This is to retain legacy behavior only and not recommended for use beyond migration.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_METADATA_EXCHANGE</code></td>
 <td>Boolean</td>
 <td><code>true</code></td>

--- a/content/en/docs/reference/commands/pilot-agent/index.html
+++ b/content/en/docs/reference/commands/pilot-agent/index.html
@@ -1461,6 +1461,12 @@ These environment variables affect the behavior of the <code>pilot-agent</code> 
 <td>If enabled, pilot will allow any upstream cluster to be used with AUTO_PASSTHROUGH. This option is intended for backwards compatibility only and is not secure with untrusted downstreams; it will be removed in the future.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_LEGACY_ISTIO_MUTUAL_CREDENTIAL_NAME</code></td>
+<td>Boolean</td>
+<td><code>true</code></td>
+<td>If enabled, Gateway&#39;s with ISTIO_MUTUAL mode and credentialName configured will use simple TLS. This is to retain legacy behavior only and not recommended for use beyond migration.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_METADATA_EXCHANGE</code></td>
 <td>Boolean</td>
 <td><code>true</code></td>

--- a/content/en/docs/reference/commands/pilot-discovery/index.html
+++ b/content/en/docs/reference/commands/pilot-discovery/index.html
@@ -822,6 +822,12 @@ These environment variables affect the behavior of the <code>pilot-discovery</co
 <td>If enabled, pilot will allow any upstream cluster to be used with AUTO_PASSTHROUGH. This option is intended for backwards compatibility only and is not secure with untrusted downstreams; it will be removed in the future.</td>
 </tr>
 <tr>
+<td><code>PILOT_ENABLE_LEGACY_ISTIO_MUTUAL_CREDENTIAL_NAME</code></td>
+<td>Boolean</td>
+<td><code>true</code></td>
+<td>If enabled, Gateway&#39;s with ISTIO_MUTUAL mode and credentialName configured will use simple TLS. This is to retain legacy behavior only and not recommended for use beyond migration.</td>
+</tr>
+<tr>
 <td><code>PILOT_ENABLE_METADATA_EXCHANGE</code></td>
 <td>Boolean</td>
 <td><code>true</code></td>

--- a/content/en/docs/reference/config/networking/virtual-service/index.html
+++ b/content/en/docs/reference/config/networking/virtual-service/index.html
@@ -2325,9 +2325,9 @@ No
 <td>
 <p>Specifies the conditions under which retry takes place.
 One or more policies can be specified using a ‘,’ delimited list.
-If retry<em>on specifies a valid HTTP status, it will be added to retriable</em>status<em>codes retry policy.
-See the [retry policies](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http</em>filters/router<em>filter#x-envoy-retry-on)
-and [gRPC retry policies](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http</em>filters/router_filter#x-envoy-retry-grpc-on) for more details.</p>
+If <code>retry_on</code> specifies a valid HTTP status, it will be added to retriable<em>status</em>codes retry policy.
+See the <a href="https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-on">retry policies</a>
+and <a href="https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#x-envoy-retry-grpc-on">gRPC retry policies</a> for more details.</p>
 
 </td>
 <td>


### PR DESCRIPTION
Please provide a description for what this PR is for.

Prep run at updating the ref docs for last 1.12 build. Not sure we need ref doc updates prior to 1.14 as we won't really be rebuilding the archive to include it. Should the automation update it in multiple places?