### PR TITLE
Update the url of aeraki

### DIFF
--- a/data/companies.yml
+++ b/data/companies.yml
@@ -86,7 +86,7 @@ providers:
 integrations:
   - name: "Aeraki"
     logo: "/logos/aeraki.png"
-    url: "https://github.com/aeraki-framework/"
+    url: "https://github.com/aeraki-mesh/"
     description: "Aeraki extends Istio to manage traffic for any layer-7 protocols."
     details:
       - "Aeraki [Air-rah-ki] is the Greek word for ‘breeze’. While Istio connects microservices in a service mesh, Aeraki provides a framework to allow Istio to support more layer-7 protocols other than HTTP and gRPC. We hope this breeze can help Istio sail a little further."


### PR DESCRIPTION
Please provide a description for what this PR is for.

The integration aeraki URL is outdated, update to https://github.com/aeraki-mesh

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
