### PR TITLE
SHA-1 signatures will not work with Golang 1.18 (#11539)

### DIFF
--- a/content/en/docs/tasks/security/cert-management/plugin-ca-cert/index.md
+++ b/content/en/docs/tasks/security/cert-management/plugin-ca-cert/index.md
@@ -38,6 +38,10 @@ It is a good practice to manage the root CA on an offline machine with strong
 security protection.
 {{< /warning >}}
 
+{{< warning >}}
+Support for SHA-1 signatures is [disabled by default in Go 1.18](https://github.com/golang/go/issues/41682). If you are generating the certificate on macOS make sure you are using OpenSSL [as described in GitHub issue 38049](https://github.com/istio/istio/issues/38049).
+{{< /warning >}}
+
 1.  In the top-level directory of the Istio installation package, create a directory to hold certificates and keys:
 
     {{< text bash >}}


### PR DESCRIPTION
* SHA-1 signatures will not work with Golang 1.18

Support for SHA-1 signatures is disabled by default in Go 1.18 or newer. When generating the certificates please use OpenSSL on MacOS to make sure the certificates will work with istio.

* Lint fixes

* Lint fix

Co-authored-by: craigbox <craigbox@google.com>

Cherry-pick of #11539