### PR TITLE
add product security team to approvals

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,9 +1,10 @@
-*                @istio/wg-docs-maintainers-infra
-/.spelling       @istio/wg-docs-maintainers-english
-/content/en/     @istio/wg-docs-maintainers-english
-/content/zh/     @istio/wg-docs-maintainers-chinese
-/i18n/en.toml    @istio/wg-docs-maintainers-english
-/i18n/zh.toml    @istio/wg-docs-maintainers-chinese
-/pkg/test/       @istio/wg-docs-maintainers-infra @istio/wg-test-and-release-maintainers
-/static/         @istio/wg-docs-maintainers-english
-/tests/          @istio/wg-docs-maintainers-infra @istio/wg-test-and-release-maintainers
+*                           @istio/wg-docs-maintainers-infra
+/.spelling                  @istio/wg-docs-maintainers-english
+/content/en/                @istio/wg-docs-maintainers-english
+/content/en/news/security/  @istio/wg-docs-maintainers-english @istio/wg-product-security-maintainers
+/content/zh/                @istio/wg-docs-maintainers-chinese
+/i18n/en.toml               @istio/wg-docs-maintainers-english
+/i18n/zh.toml               @istio/wg-docs-maintainers-chinese
+/pkg/test/                  @istio/wg-docs-maintainers-infra @istio/wg-test-and-release-maintainers
+/static/                    @istio/wg-docs-maintainers-english
+/tests/                     @istio/wg-docs-maintainers-infra @istio/wg-test-and-release-maintainers


### PR DESCRIPTION
Please provide a description for what this PR is for.

per TOC discussion on July 11, ensure product security members have approval permissions to security releases directory

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
