### PR TITLE
add start-otel-collector-service.md

### DIFF
--- a/content/zh/boilerplates/start-otel-collector-service.md
+++ b/content/zh/boilerplates/start-otel-collector-service.md
@@ -1,0 +1,7 @@
+---
+---
+*   启动 [otel-collector]({{< github_tree >}}/samples/open-telemetry) 示例
+
+    {{< text bash >}}
+    $ kubectl apply -f @samples/open-telemetry/otel.yaml@
+    {{< /text >}}


### PR DESCRIPTION
When I tried to convert [**content/zh/docs/tasks/observability/logs/otel-provider/index.md** to Chinese](https://github.com/istio/istio.io/pull/11564), THE Istio check kept returning the following error as there was no file in the Chinese directory: so I thought I should put the document in the Chinese directory first to solve the problem：
![image](https://user-images.githubusercontent.com/29862632/178756846-3e14264f-baa1-4102-9663-c524eb955694.png)


- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
