### PR TITLE
Add minikube in the instructions per Kubernetes environment

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -111,6 +111,18 @@ Setting the ingress IP depends on the cluster provider:
     $ export INGRESS_HOST=127.0.0.1
     {{< /text >}}
 
+1.  _minikube:_
+
+    {{< text bash >}}
+    minikube tunnel
+    {{< /text >}}
+    
+    and then open a new tab with
+    
+    {{< text bash >}}
+    $ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    {{< /text >}}
+
 1.  _Other environments:_
 
     {{< text bash >}}


### PR DESCRIPTION
I was coming from https://istio.io/latest/docs/examples/bookinfo/ "Follow these instructions to set the INGRESS_HOST and INGRESS_PORT ..." and did not realize I would have to setup the minikube tunnel as explained in the [Getting Started Guide](https://istio.io/latest/docs/setup/getting-started/#determining-the-ingress-ip-and-ports)

For this reason I suggest to add it here as well.

---
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [X] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
