### PR TITLE
Update create generic secret for mutual TLS

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -344,8 +344,8 @@ its clients, and we must use the name `cacert` to hold the CA certificate.
 
 {{< text bash >}}
 $ kubectl -n istio-system delete secret httpbin-credential
-$ kubectl create -n istio-system secret generic httpbin-credential --from-file=tls.key=httpbin.example.com.key \
---from-file=tls.crt=httpbin.example.com.crt --from-file=ca.crt=example.com.crt
+$ kubectl create -n istio-system secret generic httpbin-credential --from-file=key=httpbin.example.com.key \
+--from-file=cert=httpbin.example.com.crt --from-file=cacert=example.com.crt
 {{< /text >}}
 
 1. Change the gateway's definition to set the TLS mode to `MUTUAL`.


### PR DESCRIPTION
issue: https://github.com/istio/istio.io/issues/10736

Please provide a description for what this PR is for.

correct the `kubectl create secret` command in the [configure a mutual TLS ingress gateway](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/#configure-a-mutual-tls-ingress-gateway) as reported in the issue https://github.com/istio/istio.io/issues/10736.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
