### PR TITLE
Fix verify_like matching token prefix not ending in -

### DIFF
--- a/content/en/docs/setup/install/external-controlplane/test.sh
+++ b/content/en/docs/setup/install/external-controlplane/test.sh
@@ -51,7 +51,7 @@ snip_set_up_the_remote_config_cluster_2
 echo y | snip_set_up_the_remote_config_cluster_3
 #set -e
 
-_verify_contains snip_set_up_the_remote_config_cluster_4 "istio-sidecar-injector-external-istiod"
+_verify_like snip_set_up_the_remote_config_cluster_4 "$snip_set_up_the_remote_config_cluster_4_out"
 
 _verify_like snip_set_up_the_remote_config_cluster_5 "$snip_set_up_the_remote_config_cluster_5_out"
 

--- a/tests/util/verify.sh
+++ b/tests/util/verify.sh
@@ -209,15 +209,14 @@ __cmp_like() {
 
                 local comm=""
                 for ((k=0; k < ${#otok}; k++)) do
-                    if [ "${otok:$k:1}" = "${etok:$k:1}" ]; then
-                        comm="${comm}${otok:$k:1}"
-                    else
-                        if [[ "$comm" =~ ^([a-zA-Z0-9_]+-)+ ]]; then
-                            break
-                        fi
-                        return 1
+                    if [ "${otok:$k:1}" != "${etok:$k:1}" ]; then
+                        break
                     fi
+                    comm="${comm}${otok:$k:1}"
                 done
+                if ! [[ "$comm" =~ ^([a-zA-Z0-9_]+-)+ ]]; then
+                    return 1
+                fi
             done
         done
     fi


### PR DESCRIPTION
Please provide a description for what this PR is for.

The test framework `verify_like` function prefix match was incorrectly returning true when the output token did not end with a `-` char. For example, output token "abc" matched expected token "abc-def".

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
