### PR TITLE
[zh]Update docs/concepts/observability

### DIFF
--- a/content/zh/docs/concepts/observability/index.md
+++ b/content/zh/docs/concepts/observability/index.md
@@ -97,12 +97,7 @@ istio_requests_total{
 
 每一个 Istio 的组件（Pilot、Galley、Mixer）都提供了对自身监控指标的集合。这些指标容许监控 Istio 自己的行为（这与网格内的服务有所不同）。
 
-有关这些被维护指标的更多信息，请查看每个组件的参考文档：
-
-- [Pilot](/zh/docs/reference/commands/pilot-discovery/#metrics)
-- [Galley](/zh/docs/reference/commands/galley/#metrics)
-- [Mixer](/zh/docs/reference/commands/mixs/#metrics)
-- [Citadel](/zh/docs/reference/commands/istio_ca/#metrics)
+有关这些被维护指标的更多信息，请查看[参考文档](/zh/docs/reference/commands/pilot-discovery/#metrics)：
 
 ## 分布式追踪 {#distributed-traces}
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

The docs of /zh/docs/concepts/observability has been outofsync, please see where the English documentation is updated:
<img width="1224" alt="image" src="https://user-images.githubusercontent.com/76980726/188265118-d0a3057c-00c6-4fa4-a843-56ed8225853a.png">


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
