### PR TITLE
egress tls origination with credential name - clarify required RBAC

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -238,7 +238,7 @@ Follow [these steps](/docs/tasks/traffic-management/egress/egress-gateway-tls-or
 1. Create required `RBAC` to make sure the secret created in the above step is accessible to the client pod, which is `sleep` in this case.
 
     {{< text bash >}}
-    $ kubectl create role client-credential-role --resource=secret --verb=get,list,watch
+    $ kubectl create role client-credential-role --resource=secret --verb=list
     $ kubectl create rolebinding client-credential-role-binding --role=client-credential-role --serviceaccount=default:sleep
     {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
@@ -129,7 +129,7 @@ kubectl create secret generic client-credential --from-file=tls.key=client.examp
 }
 
 snip_configure_the_client_sleep_pod_2() {
-kubectl create role client-credential-role --resource=secret --verb=get,list,watch
+kubectl create role client-credential-role --resource=secret --verb=list
 kubectl create rolebinding client-credential-role-binding --role=client-credential-role --serviceaccount=default:sleep
 }
 


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

When credential name is used at sidecar for egress tls origination, explicit RBAC is needed to allow access to the credential.
The doc currently talks about the need for having get and watch permissions, however in practice only list permission is needed.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
