### PR TITLE
[zh] update docs/concepts/wasm

### DIFF
--- a/content/zh/docs/concepts/wasm/index.md
+++ b/content/zh/docs/concepts/wasm/index.md
@@ -7,7 +7,7 @@ owner: istio/wg-policies-and-telemetry-maintainers
 test: n/a
 ---
 
-WebAssembly 是一种沙盒技术，可以用于扩展 Istio 代理（Envoy）的能力。Proxy-Wasm 沙盒 API 取代了 Mixer 作为 Istio 主要的扩展机制。在 Istio 1.6 中将会为 Proxy-Wasm 插件提供一种统一的配置 API。
+WebAssembly 是一种沙盒技术，可以用于扩展 Istio 代理（Envoy）的能力。Proxy-Wasm 沙盒 API 取代了 Mixer 作为 Istio 主要的扩展机制。
 
 WebAssembly 沙盒的目标：
 


### PR DESCRIPTION
Signed-off-by: xin.li <xin.li@daocloud.io>

Please provide a description for what this PR is for.

The docs of content/zh/docs/concepts/wasm/index.md has been outofsync, please see where the English documentation is updated :
<img width="868" alt="image" src="https://user-images.githubusercontent.com/76980726/188650452-7b5cf969-5aee-47b3-87b7-3167cee561aa.png">


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
