### PR TITLE
missing cleanup command

### DIFF
--- a/content/en/docs/tasks/security/authentication/mtls-migration/index.md
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/index.md
@@ -155,6 +155,7 @@ $ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$
 1. Remove the mesh-wide authentication policy.
 
 {{< text bash >}}
+$ kubectl delete peerauthentication -n foo default
 $ kubectl delete peerauthentication -n istio-system default
 {{< /text >}}
 

--- a/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
@@ -115,6 +115,7 @@ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$(k
 }
 
 snip_clean_up_the_example_1() {
+kubectl delete peerauthentication -n foo default
 kubectl delete peerauthentication -n istio-system default
 }
 


### PR DESCRIPTION
the current instructions are missing clean up command for  `peerauthentication` in `foo` namespace

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
