### PR TITLE
fix egress-tls-origination test

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/tls_test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/tls_test.sh
@@ -34,14 +34,13 @@ snip_before_you_begin_3
 snip_apply_simple
 
 _wait_for_istio serviceentry default edition-cnn-com
-_wait_for_istio virtualservice default edition-cnn-com
 
 _verify_elided snip_curl_simple "$snip_curl_simple_out"
 
 # Apply TLS origination config, check http and https content is correct
 snip_apply_origination
 
-_wait_for_istio virtualservice default edition-cnn-com
+_wait_for_istio serviceentry default edition-cnn-com
 _wait_for_istio destinationrule default edition-cnn-com
 
 _verify_elided snip_curl_origination_http "$snip_curl_origination_http_out"


### PR DESCRIPTION
The test waits for vs resource, that is not even created. Wait on SE and DR is only needed.

Signed-off-by: Faseela K <faseela.k@est.tech>

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
