### PR TITLE
clarify unmentioned constraint port.name equalness (cherry-pick #11680)

### DIFF
--- a/content/en/docs/reference/glossary/namespace-sameness.md
+++ b/content/en/docs/reference/glossary/namespace-sameness.md
@@ -7,3 +7,5 @@ Within a multicluster mesh, [namespace sameness](https://github.com/kubernetes/c
 applies and all namespaces with a given name are considered to be the same namespace. If multiple clusters contain a
 `Service` with the same namespaced name, they will be recognized as a single combined service. By default, traffic is
 load-balanced across all clusters in the mesh for a given service.
+
+For one or many ports within the combined service, same port value should also have same port name.


### PR DESCRIPTION
Please provide a description for what this PR is for.

*cherry-pick* #11680 

In our multi cluster mesh, we found that, even we meet the `namespace-sameness`, cross cluster calls to remote cluster through eastwest gateway never happen in some cases. (calls always invoke to primary cluster)
After some digging, we found that the `same` kubernetes `Service` had different `port.name`, and the code that aggregating eds reads the port.name to match endpoint with service.
And if we correct the `Service.spec.ports[_].name` to be same as what in primary cluster (literally equal, both name no specified consider equal "" == "" ), cross cluster calls act as expect.
So as `namespace-sameness`, the addition constraint should be documented.

https://github.com/istio/istio/blob/93e4ec424b52da807228bd7784c59d646ec73733/pilot/pkg/xds/endpoint_builder.go#L240-L242

```golang
for _, ep := range endpoints {
			// TODO(nmittler): Consider merging discoverability policy with cluster-local
			if !ep.IsDiscoverableFromProxy(b.proxy) {
				continue
			}
			if svcPort.Name != ep.ServicePortName {
				continue
			}
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [x] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure