### PR TITLE
fix layout of /authentication/mtls-migration/index.md

### DIFF
--- a/content/en/docs/tasks/security/authentication/mtls-migration/index.md
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/index.md
@@ -154,14 +154,14 @@ $ for from in "foo" "bar" "legacy"; do for to in "foo" "bar"; do kubectl exec "$
 
 1. Remove the mesh-wide authentication policy.
 
-{{< text bash >}}
-$ kubectl delete peerauthentication -n foo default
-$ kubectl delete peerauthentication -n istio-system default
-{{< /text >}}
+    {{< text bash >}}
+    $ kubectl delete peerauthentication -n foo default
+    $ kubectl delete peerauthentication -n istio-system default
+    {{< /text >}}
 
 1. Remove the test namespaces.
 
-{{< text bash >}}
-$ kubectl delete ns foo bar legacy
-Namespaces foo bar legacy deleted.
-{{< /text >}}
+    {{< text bash >}}
+    $ kubectl delete ns foo bar legacy
+    Namespaces foo bar legacy deleted.
+    {{< /text >}}


### PR DESCRIPTION
Fix layout on [Mutual TLS Migration](https://istio.io/latest/docs/tasks/security/authentication/mtls-migration/#clean-up-the-example):

![image](https://user-images.githubusercontent.com/79828097/189643862-26ee1fce-d8da-45c3-9fda-d7627f20c275.png)


- [x] Docs

