### PR TITLE
Fix outdated URL fragment

### DIFF
--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -244,7 +244,7 @@ istio-ingressgateway   LoadBalancer   172.21.109.129   130.211.10.121  80:31380/
 
 If the `EXTERNAL-IP` value is set, your environment has an external load balancer that you can use for the ingress gateway.
 If the `EXTERNAL-IP` value is `<none>` (or perpetually `<pending>`), your environment does not provide an external load balancer for the ingress gateway.
-In this case, you can access the gateway using the service's [node port](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+In this case, you can access the gateway using the service's [node port](https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport).
 
 Choose the instructions corresponding to your environment:
 


### PR DESCRIPTION
Fix broken link on documentation. This section ID on Kubernetes docs was renamed from `#nodeport` to `#type-nodeport`.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
