### PR TITLE
zh:sync /setup/upgrade/in-place/

### DIFF
--- a/content/zh/docs/setup/upgrade/in-place/index.md
+++ b/content/zh/docs/setup/upgrade/in-place/index.md
@@ -1,6 +1,6 @@
 ---
-title: 热升级
-description: 热升级和回退。
+title: 原地升级
+description: 原地升级和回退。
 weight: 20
 keywords: [kubernetes,upgrading,in-place]
 owner: istio/wg-environments-maintainers
@@ -10,7 +10,7 @@ test: no
 通过 `istioctl upgrade` 命令对 Istio 进行升级。在开始升级之前，该命令会自动检查 Istio 的安装是否满足升级需求。同时，如果该命令检测到 Istio 与当前版本的配置文件默认值存在变动时，会警告用户。
 
 {{< tip >}}
-[金丝雀升级](/zh/docs/setup/upgrade/canary/)比热升级更安全，是推荐的升级方法。
+[金丝雀升级](/zh/docs/setup/upgrade/canary/)比原地升级更安全，是推荐的升级方法。
 {{< /tip >}}
 
 Istio 的升级指令同样可以执行回退操作。
@@ -18,7 +18,7 @@ Istio 的升级指令同样可以执行回退操作。
 阅读 [`istioctl` 升级参考](/zh/docs/reference/commands/istioctl/#istioctl-upgrade)来了解 `istoictl upgrade` 指令提供的全部参数。
 
 {{< warning >}}
-`istioctl upgrade` 用于热升级，并且与使用 `--revision` 参数进行的安装不兼容。此类安装的升级将失败，并显示错误。
+`istioctl upgrade` 用于原地升级，并且与使用 `--revision` 参数进行的安装不兼容。此类安装的升级将失败，并显示错误。
 {{< /warning >}}
 
 ## 升级的前置条件{#upgrade-prerequisites}

--- a/content/zh/docs/setup/upgrade/in-place/index.md
+++ b/content/zh/docs/setup/upgrade/in-place/index.md
@@ -9,7 +9,11 @@ test: no
 
 通过 `istioctl upgrade` 命令对 Istio 进行升级。在开始升级之前，该命令会自动检查 Istio 的安装是否满足升级需求。同时，如果该命令检测到 Istio 与当前版本的配置文件默认值存在变动时，会警告用户。
 
-Istio 的升级指令同样可以执行将回退操作。
+{{< tip >}}
+[金丝雀升级](/zh/docs/setup/upgrade/canary/)比热升级更安全，是推荐的升级方法。
+{{< /tip >}}
+
+Istio 的升级指令同样可以执行回退操作。
 
 阅读 [`istioctl` 升级参考](/zh/docs/reference/commands/istioctl/#istioctl-upgrade)来了解 `istoictl upgrade` 指令提供的全部参数。
 
@@ -28,7 +32,7 @@ Istio 的升级指令同样可以执行将回退操作。
 ## 升级步骤{#upgrade-steps}
 
 {{< warning >}}
-在升级过程中，服务可能会发生流量中断。为了最大程度的减少中断，请确保每个组件（Citadel 除外）至少有两个副本正在运行。另外，请确保 [`PodDisruptionBudgets`](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) 配置的最低可用行为1。
+在升级过程中，服务可能会发生流量中断。为了最大程度的减少中断，请确保 `istiod` 至少有两个副本正在运行。另外，请确保 [`PodDisruptionBudgets`](https://kubernetes.io/zh-cn/docs/tasks/run-application/configure-pdb/) 配置的最低可用性为 1。
 {{< /warning >}}
 
 本节所使用的所有命令应该使用新版本的 `istioctl` 运行，可执行文件可以在下载包的 `bin/` 目录下找到。
@@ -41,7 +45,15 @@ Istio 的升级指令同样可以执行将回退操作。
     $ kubectl config view
     {{< /text >}}
 
-1. 通过该执行进行升级：
+1. 确保此升级与您的环境兼容。
+
+    {{< text bash >}}
+    $ istioctl x precheck
+    ✔ No issues found when checking the cluster. Istio is safe to install or upgrade!
+    To get started, check out https://istio.io/latest/docs/setup/getting-started/
+    {{< /text >}}
+
+1. 通过执行以下指令开始升级：
 
     {{< text bash >}}
     $ istioctl upgrade
@@ -79,4 +91,4 @@ Istio 的升级指令同样可以执行将回退操作。
 
 您可以使用 `istioctl upgrade` 来回退 Istio 到低版本。回退步骤与上一步中所述的升级过程相同，不过需要使用较低版本（例如 1.6.5) 的 `istioctl` 二进制文件。完成后，Istio 将会更新到低版本。
 
-另外，`istioctl install` 可用于安装旧版 `istio` 的控制平面，但是不建议将使用，因为这个过程不会执行任何检查。例如，用于配置集群的配置文件的某些默认值可能会发生变动，但是不会发出任何警告。
+另外，`istioctl install` 可用于安装旧版 `istio` 的控制平面，但是不建议这样使用，因为这个过程不会执行任何检查。例如，用于配置集群的配置文件的某些默认值可能会发生变动，但是不会发出任何警告。


### PR DESCRIPTION
- Sync with the en upstream
- Fix typos and other minor errors
```
content/zh/docs/setup/upgrade/in-place/index.md
```
- [x] Docs

