### PR TITLE
zh:remove redundant glossary

### DIFF
--- a/content/zh/docs/reference/glossary/mixer-handler.md
+++ b/content/zh/docs/reference/glossary/mixer-handler.md
@@ -1,4 +1,0 @@
----
-title: Mixer Handler
----
-Handler 相当于配置完备的 Mixer 适配器。一个适配器二进制文件可以被不同配置使用，这些配置也可以称为 handler。在 Mixer 运行时，Mixer 将 [instances](/zh/docs/reference/glossary/#mixer-instance) 路由到一个或多个 handlers。

--- a/content/zh/docs/reference/glossary/mixer-instance.md
+++ b/content/zh/docs/reference/glossary/mixer-instance.md
@@ -1,5 +1,0 @@
----
-title: Mixer Instance
----
-
-Mixer Instance 表示通过检查一组请求[属性](/zh/docs/reference/glossary/#attribute) ，并结合使用者提供的配置而生成的数据块。Mixer Instance 在随请求到达各种基础后端设施的途中，会被传递给各个[处理程序](/zh/docs/reference/glossary/#mixer-handler)。


### PR DESCRIPTION
Mixer-related glossary is outdated, so perform a removal action to sync with the en upstream:

```
content/zh/docs/reference/glossary/mixer-handler.md
content/zh/docs/reference/glossary/mixer-instance.md
```

- [x] Docs