### PR TITLE
Fix ingress control doc related to other providers and numbering

### DIFF
--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -282,7 +282,7 @@ $ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingress
 _GKE:_
 
 {{< text bash >}}
-$ export INGRESS_HOST=workerNodeAddress
+$ export INGRESS_HOST=worker-node-address
 {{< /text >}}
 
 You need to create firewall rules to allow the TCP traffic to the `ingressgateway` service's ports.

--- a/content/en/docs/setup/getting-started/snips.sh
+++ b/content/en/docs/setup/getting-started/snips.sh
@@ -185,7 +185,7 @@ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressga
 }
 
 snip_determining_the_ingress_ip_and_ports_10() {
-export INGRESS_HOST=workerNodeAddress
+export INGRESS_HOST=worker-node-address
 }
 
 snip_determining_the_ingress_ip_and_ports_11() {

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -57,7 +57,7 @@ Choose the instructions corresponding to your environment:
 
 {{< tab name="external load balancer" category-value="external-lb" >}}
 
-Follow these instructions if you have determined that your environment has an external load balancer.
+**Follow these instructions if you have determined that your environment has an external load balancer.**
 
 Set the ingress IP and ports:
 
@@ -65,7 +65,6 @@ Set the ingress IP and ports:
 $ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 $ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
 $ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
-$ export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].port}')
 {{< /text >}}
 
 {{< warning >}}
@@ -84,51 +83,47 @@ $ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway
 
 {{< tab name="node port" category-value="node-port" >}}
 
-Follow these instructions if you have determined that your environment does not have an external load balancer,
-so you need to use a node port instead.
+**Follow these instructions if your environment does not have an external load balancer and choose a node port instead.**
 
 Set the ingress ports:
 
 {{< text bash >}}
 $ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
 $ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
-$ export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].nodePort}')
 {{< /text >}}
 
-Setting the ingress IP depends on the cluster provider:
+_GKE:_
 
-1.  _GKE:_
+{{< text bash >}}
+$ export INGRESS_HOST=workerNodeAddress
+{{< /text >}}
 
-    {{< text bash >}}
-    $ export INGRESS_HOST=worker-node-address
-    {{< /text >}}
+You need to create firewall rules to allow the TCP traffic to the `ingressgateway` service's ports.
+Run the following commands to allow the traffic for the HTTP port, the secure port (HTTPS) or both:
 
-    You need to create firewall rules to allow the TCP traffic to the _ingressgateway_ service's ports.
-    Run the following commands to allow the traffic for the HTTP port, the secure port (HTTPS) or both:
+{{< text bash >}}
+$ gcloud compute firewall-rules create allow-gateway-http --allow "tcp:$INGRESS_PORT"
+$ gcloud compute firewall-rules create allow-gateway-https --allow "tcp:$SECURE_INGRESS_PORT"
+{{< /text >}}
 
-    {{< text bash >}}
-    $ gcloud compute firewall-rules create allow-gateway-http --allow "tcp:$INGRESS_PORT"
-    $ gcloud compute firewall-rules create allow-gateway-https --allow "tcp:$SECURE_INGRESS_PORT"
-    {{< /text >}}
+_IBM Cloud Kubernetes Service:_
 
-1.  _IBM Cloud Kubernetes Service:_
+{{< text bash >}}
+$ ibmcloud ks workers --cluster cluster-name-or-id
+$ export INGRESS_HOST=public-IP-of-one-of-the-worker-nodes
+{{< /text >}}
 
-    {{< text bash >}}
-    $ ibmcloud ks workers --cluster cluster-name-or-id
-    $ export INGRESS_HOST=public-IP-of-one-of-the-worker-nodes
-    {{< /text >}}
+_Docker For Desktop:_
 
-1.  _Docker For Desktop:_
+{{< text bash >}}
+$ export INGRESS_HOST=127.0.0.1
+{{< /text >}}
 
-    {{< text bash >}}
-    $ export INGRESS_HOST=127.0.0.1
-    {{< /text >}}
+_Other environments:_
 
-1.  _Other environments:_
-
-    {{< text bash >}}
-    $ export INGRESS_HOST=$(kubectl get po -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].status.hostIP}')
-    {{< /text >}}
+{{< text bash >}}
+$ export INGRESS_HOST=$(kubectl get po -l istio=ingressgateway -n istio-system -o jsonpath='{.items[0].status.hostIP}')
+{{< /text >}}
 
 {{< /tab >}}
 

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -65,6 +65,7 @@ Set the ingress IP and ports:
 $ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 $ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
 $ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
+$ export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].port}')
 {{< /text >}}
 
 {{< warning >}}
@@ -90,6 +91,7 @@ Set the ingress ports:
 {{< text bash >}}
 $ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
 $ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
+$ export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].nodePort}')
 {{< /text >}}
 
 _GKE:_

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -97,7 +97,7 @@ $ export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgat
 _GKE:_
 
 {{< text bash >}}
-$ export INGRESS_HOST=workerNodeAddress
+$ export INGRESS_HOST=worker-node-address
 {{< /text >}}
 
 You need to create firewall rules to allow the TCP traffic to the `ingressgateway` service's ports.

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -52,7 +52,7 @@ export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgatew
 }
 
 snip_determining_the_ingress_ip_and_ports_6() {
-export INGRESS_HOST=workerNodeAddress
+export INGRESS_HOST=worker-node-address
 }
 
 snip_determining_the_ingress_ip_and_ports_7() {

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -38,6 +38,7 @@ snip_determining_the_ingress_ip_and_ports_3() {
 export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
 export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
+export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].port}')
 }
 
 snip_determining_the_ingress_ip_and_ports_4() {
@@ -47,6 +48,7 @@ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -
 snip_determining_the_ingress_ip_and_ports_5() {
 export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
 export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
+export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].nodePort}')
 }
 
 snip_determining_the_ingress_ip_and_ports_6() {

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -38,7 +38,6 @@ snip_determining_the_ingress_ip_and_ports_3() {
 export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
 export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
-export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].port}')
 }
 
 snip_determining_the_ingress_ip_and_ports_4() {
@@ -48,11 +47,10 @@ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -
 snip_determining_the_ingress_ip_and_ports_5() {
 export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}')
 export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
-export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].nodePort}')
 }
 
 snip_determining_the_ingress_ip_and_ports_6() {
-export INGRESS_HOST=worker-node-address
+export INGRESS_HOST=workerNodeAddress
 }
 
 snip_determining_the_ingress_ip_and_ports_7() {


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fixes https://github.com/istio/istio.io/issues/11962

See issue for more info, but short story is that updating to the new markdown caused the numbering and indention within the ingress control page to be incorrect. This PR takes the similar text from Getting Started, which was actually copied from the ingress-control page originally, and copies it back to remove the numbering and indentation so the issues are resolved. 

Another solution would be to dig into the tabset.html to fix the actually issue.