### PR TITLE
update: Istio 1.13 EOL

### DIFF
--- a/content/en/docs/releases/supported-releases/index.md
+++ b/content/en/docs/releases/supported-releases/index.md
@@ -13,10 +13,10 @@ This page lists the status, timeline and policy for currently supported releases
 releases that are in the active maintenance window and are patched for security and bug fixes. Subsequent patch releases
 on a minor release do not contain backward incompatible changes.
 
-* [Support Policy](#support-policy)
-* [Naming scheme](#naming-scheme)
-* [Support status of Istio releases](#support-status-of-istio-releases)
-* [Releases without known Common Vulnerabilities and Exposures (CVEs)](#releases-without-known-Common-Vulnerabilities-and Exposures)
+- [Support policy](#support-policy)
+- [Naming scheme](#naming-scheme)
+- [Support status of Istio releases](#support-status-of-istio-releases)
+- [Supported releases without known Common Vulnerabilities and Exposures (CVEs)](#supported-releases-without-known-common-vulnerabilities-and-exposures-cves)
 
 ## Support policy
 
@@ -56,7 +56,7 @@ current `<minor>` release. A patch is usually a small change relative to the `<m
 | master          | No, development only |                   |                          |                               |                                    |
 | 1.15            | Yes                  | August 31, 2022   | ~March 2023 (Expected)   | 1.22, 1.23, 1.24, 1.25        | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
 | 1.14            | Yes                  | May 24, 2022      | ~January 2023 (Expected) | 1.21, 1.22, 1.23, 1.24        | 1.16, 1.17, 1.18, 1.19, 1.20       |
-| 1.13            | Yes                  | February 11, 2022 | ~October 2022 (Expected) | 1.20, 1.21, 1.22, 1.23        | 1.16, 1.17, 1.18, 1.19             |
+| 1.13            | Yes                  | February 11, 2022 | Oct 12, 2022             | 1.20, 1.21, 1.22, 1.23        | 1.16, 1.17, 1.18, 1.19             |
 | 1.12            | No                   | November 18, 2021 | Jul 12, 2022             | 1.19, 1.20, 1.21, 1.22        | 1.16, 1.17, 1.18                   |
 | 1.11            | No                   | August 12, 2021   | Mar 25, 2022             | 1.18, 1.19, 1.20, 1.21, 1.22  | 1.16, 1.17                         |
 | 1.10            | No                   | May 18, 2021      | Jan 7, 2022              | 1.18, 1.19, 1.20, 1.21        | 1.16, 1.17, 1.22                   |


### PR DESCRIPTION
Based on the following announcement, I propose to update the EOL of Istio 1.13 on [Support status of Istio releases](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) Docs.
https://istio.io/latest/news/support/announcing-1.13-eol/

Also, https://github.com/istio/istio.io/pull/11860 was reverted and will be fixed.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
