### PR TITLE
'Because of this' semantic discrepancy

### DIFF
--- a/content/en/docs/concepts/traffic-management/index.md
+++ b/content/en/docs/concepts/traffic-management/index.md
@@ -261,7 +261,7 @@ subset named v2. You’ll see how you define a service subset in the section on
 Routing rules are **evaluated in sequential order from top to bottom**, with the
 first rule in the virtual service definition being given highest priority. In
 this case you want anything that doesn't match the first routing rule to go to a
-default destination, specified in the second rule. Because of this, the second
+default destination, specified in the second rule. But, in the second
 rule has no match conditions and just directs traffic to the v3 subset.
 
 {{< text yaml >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.
I think the purpose of the last sentence in this passage is to explain why the route goes to v3 (that is, yaml below), but the penultimate sentence of this passage has clarified that v3 satisfies the routing rules. Therefore, the meaning is repeated, and it is easy to produce ambiguity.
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
