### PR TITLE
'Because of this' semantic discrepancy

### DIFF
--- a/content/en/docs/concepts/traffic-management/index.md
+++ b/content/en/docs/concepts/traffic-management/index.md
@@ -261,7 +261,7 @@ subset named v2. You’ll see how you define a service subset in the section on
 Routing rules are **evaluated in sequential order from top to bottom**, with the
 first rule in the virtual service definition being given highest priority. In
 this case you want anything that doesn't match the first routing rule to go to a
-default destination, specified in the second rule. Because of this, the second
+default destination, specified in the second rule. Here, the second
 rule has no match conditions and just directs traffic to the v3 subset.
 
 {{< text yaml >}}


### PR DESCRIPTION
ooptimization

'Because of this' semantic discrepancy

Please provide a description for what this PR is for.
This is the result of the port [12059](https://github.com/istio/istio.io/pull/12059).
And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
