### PR TITLE
Add missing multiCluster.clusterName attributes

### DIFF
--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -136,6 +136,8 @@ spec:
     istiodRemote:
       injectionPath: /inject/cluster/cluster2/net/network1
     global:
+      multiCluster:
+        clusterName: cluster2
       remotePilotAddress: ${DISCOVERY_ADDRESS}
 EOF
 {{< /text >}}

--- a/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
@@ -80,6 +80,8 @@ spec:
     istiodRemote:
       injectionPath: /inject/cluster/cluster2/net/network1
     global:
+      multiCluster:
+        clusterName: cluster2
       remotePilotAddress: ${DISCOVERY_ADDRESS}
 EOF
 }

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -167,6 +167,8 @@ spec:
     istiodRemote:
       injectionPath: /inject/cluster/cluster2/net/network2
     global:
+      multiCluster:
+        clusterName: cluster2
       remotePilotAddress: ${DISCOVERY_ADDRESS}
 EOF
 {{< /text >}}

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
@@ -94,6 +94,8 @@ spec:
     istiodRemote:
       injectionPath: /inject/cluster/cluster2/net/network2
     global:
+      multiCluster:
+        clusterName: cluster2
       remotePilotAddress: ${DISCOVERY_ADDRESS}
 EOF
 }


### PR DESCRIPTION
### What the PR solves

Without a `multiCluster.clusterName` configured inside the `IstioOperator` object for the remote cluster, `istioctl` creates the `istiod` Service with ClusterIP `None`, which prevents calling Kubernetes webhooks (e.g. sidecar injection).

Ref. https://discuss.istio.io/t/pods-not-created-with-headless-service/13940/3?u=antoineco

### Areas

- [ ] Configuration Infrastructure
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
