### PR TITLE
Remove restart requirement for ext-authz

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-custom/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-custom/index.md
@@ -146,13 +146,6 @@ allows requests with the header `x-ext-authz: allow`.
             headersToDownstreamOnDeny: ["content-type", "set-cookie"] # headers sent back to the client when request is denied.
     {{< /text >}}
 
-1. Restart Istiod to allow the change to take effect with the following command:
-
-    {{< text bash >}}
-    $ kubectl rollout restart deployment/istiod -n istio-system
-    deployment.apps/istiod restarted
-    {{< /text >}}
-
 ## Enable with external authorization
 
 The external authorizer is now ready to be used by the authorization policy.

--- a/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
@@ -103,14 +103,6 @@ data:
         headersToDownstreamOnDeny: ["content-type", "set-cookie"] # headers sent back to the client when request is denied.
 ENDSNIP
 
-snip_define_the_external_authorizer_4() {
-kubectl rollout restart deployment/istiod -n istio-system
-}
-
-! read -r -d '' snip_define_the_external_authorizer_4_out <<\ENDSNIP
-deployment.apps/istiod restarted
-ENDSNIP
-
 snip_enable_with_external_authorization_1() {
 kubectl apply -n foo -f - <<EOF
 apiVersion: security.istio.io/v1beta1


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

Per https://github.com/istio/enhancements/pull/125, removing the restart.
It is tested and works without restart.