### PR TITLE
Egress TLS origination: Modify the role to allow only TLS certificate secret access

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -238,7 +238,7 @@ Follow [these steps](/docs/tasks/traffic-management/egress/egress-gateway-tls-or
 1. Create required `RBAC` to make sure the secret created in the above step is accessible to the client pod, which is `sleep` in this case.
 
     {{< text bash >}}
-    $ kubectl create role client-credential-role --resource=secret --verb=list
+    $ kubectl create role client-credential-role --resource=secret --verb=get --resource-name=client-credential
     $ kubectl create rolebinding client-credential-role-binding --role=client-credential-role --serviceaccount=default:sleep
     {{< /text >}}
 


### PR DESCRIPTION
The role definition in the documentation suggests allowing a pod to read all the secrets in the namespaces and this is violating the least privilege principle.

It is possible to allow access only to the secret containing the TLS certificate and it is confirmed that with this narrow role, the sidecar proxy is still able to access the secret. 

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure