### PR TITLE
Update ingress task to use networking.k8s.io/v1 apiVersion (#12013)

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
@@ -28,7 +28,7 @@ Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       annotations:
@@ -39,10 +39,13 @@ Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
       - host: httpbin.example.com
         http:
           paths:
-          - path: /status/*
+          - path: /status
+            pathType: Prefix
             backend:
-              serviceName: httpbin
-              servicePort: 8000
+              service:
+                name: httpbin
+                port:
+                  number: 8000
     EOF
     {{< /text >}}
 
@@ -86,14 +89,14 @@ In Kubernetes 1.18, a new field, `pathType`, was added. This allows explicitly d
 In Kubernetes 1.18, a new resource, `IngressClass`, was added, replacing the `kubernetes.io/ingress.class` annotation on the `Ingress` resource. If you are using this resource, you will need to set the `controller` field to `istio.io/ingress-controller`. For example:
 
 {{< text yaml >}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   name: istio
 spec:
   controller: istio.io/ingress-controller
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress
@@ -106,8 +109,10 @@ spec:
       - path: /
         pathType: Prefix
         backend:
-          serviceName: httpbin
-          servicePort: 8000
+          service:
+            name: httpbin
+            port:
+              number: 8000
 {{< /text >}}
 
 ## Cleanup

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/snips.sh
@@ -22,7 +22,7 @@
 
 snip_configuring_ingress_using_an_ingress_resource_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -33,10 +33,13 @@ spec:
   - host: httpbin.example.com
     http:
       paths:
-      - path: /status/*
+      - path: /status
+        pathType: Prefix
         backend:
-          serviceName: httpbin
-          servicePort: 8000
+          service:
+            name: httpbin
+            port:
+              number: 8000
 EOF
 }
 
@@ -60,14 +63,14 @@ HTTP/1.1 404 Not Found
 ENDSNIP
 
 ! read -r -d '' snip_specifying_ingressclass_1 <<\ENDSNIP
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   name: istio
 spec:
   controller: istio.io/ingress-controller
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress
@@ -80,8 +83,10 @@ spec:
       - path: /
         pathType: Prefix
         backend:
-          serviceName: httpbin
-          servicePort: 8000
+          service:
+            name: httpbin
+            port:
+              number: 8000
 ENDSNIP
 
 snip_cleanup_1() {


### PR DESCRIPTION
**Description**
This PR updates the documentation page for the Ingress task to use `networking.k8s.io/v1` endpoint instead of the deprecated `networking.k8s.io/v1beta` endpoint (https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-control/).

Other fields are also updated for this new API endpoint (path/pathType, serviceName/servicePort)

Related issue: #12013 


I am working with @johnma14 to update this.
I tested this new specification locally and it seems to exhibit the same behavior as before the change, but please let me know if other fields should also be updated or of other issues. Thanks.

**Areas that this PR affects**
- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
