### PR TITLE
Replace extensions/v1beta1 with networking.k8s.io/v1

### DIFF
--- a/content/en/about/faq/traffic-management/ingress-with-no-route-rules.md
+++ b/content/en/about/faq/traffic-management/ingress-with-no-route-rules.md
@@ -13,21 +13,24 @@ example.com host, with /helloworld as the URL.
 
 {{< text bash >}}
 $ kubectl create -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-name: simple-ingress
-annotations:
-  kubernetes.io/ingress.class: istio
+  name: simple-ingress
+  annotations:
+    kubernetes.io/ingress.class: istio
 spec:
-rules:
-- host: example.com
-  http:
-    paths:
-    - path: /helloworld
-      backend:
-        serviceName: myservice
-        servicePort: grpc
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /helloworld
+        pathType: Prefix
+        backend:
+          service:
+            name: myservice
+            port:
+              number: 8000
 EOF
 {{< /text >}}
 
@@ -36,22 +39,25 @@ expressions in the path and `ingress.kubernetes.io` annotations:
 
 {{< text bash >}}
 $ kubectl create -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-name: this-will-not-work
-annotations:
-  kubernetes.io/ingress.class: istio
-  # Ingress annotations other than ingress class will not be honored
-  ingress.kubernetes.io/rewrite-target: /
+  name: this-will-not-work
+  annotations:
+    kubernetes.io/ingress.class: istio
+    # Ingress annotations other than ingress class will not be honored
+    ingress.kubernetes.io/rewrite-target: /
 spec:
-rules:
-- host: example.com
-  http:
-    paths:
-    - path: /hello(.*?)world/
-      backend:
-        serviceName: myservice
-        servicePort: grpc
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /hello(.*?)world/
+        pathType: Prefix
+        backend:
+          service:
+            name: myservice
+            port:
+              number: 8000
 EOF
 {{< /text >}}


### PR DESCRIPTION
This is the last reference to extensions/v1beta1 API in our docs(this was removed in Kubernetes 1.22 release). Removing old references from our docs. The remaining references are in the blogs referencing previous releases (won't update those).

Partially Fixes: #12216


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
