### PR TITLE
Replace references to removed API's in K8s v1.22

### DIFF
--- a/content/en/docs/examples/microservices-istio/setup-kubernetes-cluster/index.md
+++ b/content/en/docs/examples/microservices-istio/setup-kubernetes-cluster/index.md
@@ -121,7 +121,7 @@ proceed to [setting up your local computer](/docs/examples/microservices-istio/s
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
     kind: Role
-    apiVersion: rbac.authorization.k8s.io/v1beta1
+    apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: istio-system-access
       namespace: istio-system
@@ -157,7 +157,7 @@ proceed to [setting up your local computer](/docs/examples/microservices-istio/s
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
     kind: Role
-    apiVersion: rbac.authorization.k8s.io/v1beta1
+    apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: ${NAMESPACE}-access
       namespace: $NAMESPACE
@@ -168,7 +168,7 @@ proceed to [setting up your local computer](/docs/examples/microservices-istio/s
       verbs: ["*"]
     ---
     kind: RoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1beta1
+    apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: ${NAMESPACE}-access
       namespace: $NAMESPACE
@@ -182,7 +182,7 @@ proceed to [setting up your local computer](/docs/examples/microservices-istio/s
       name: ${NAMESPACE}-access
     ---
     kind: RoleBinding
-    apiVersion: rbac.authorization.k8s.io/v1beta1
+    apiVersion: rbac.authorization.k8s.io/v1
     metadata:
       name: ${NAMESPACE}-istio-system-access
       namespace: istio-system

--- a/content/en/docs/ops/configuration/mesh/webhook/index.md
+++ b/content/en/docs/ops/configuration/mesh/webhook/index.md
@@ -50,7 +50,6 @@ webhooks and dependent features are not functioning properly.
     {{< text bash >}}
     $ kubectl api-versions | grep admissionregistration.k8s.io/v1
     admissionregistration.k8s.io/v1
-    admissionregistration.k8s.io/v1beta1
     {{< /text >}}
 
 1. Verify `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` plugins are

--- a/content/en/test/tb/index.md
+++ b/content/en/test/tb/index.md
@@ -43,7 +43,7 @@ Bash text block with yaml output and download name
 
 {{< text syntax="bash" outputis="yaml" downloadas="foo.yaml" >}}
 $ kubectl -n istio-system get configmap istio-galley-configuration -o jsonpath='{.data}'
-map[validatingwebhookconfiguration.yaml:apiVersion: admissionregistration.k8s.io/v1beta1
+map[validatingwebhookconfiguration.yaml:apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: istio-galley


### PR DESCRIPTION
Fix references to `admissionregistration.k8s.io/v1beta1` and `authorization.k8s.io/v1beta1`

Partially Fixes: #12216

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
