### PR TITLE
Update ingress steps to use v1

### DIFF
--- a/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
+++ b/content/en/docs/examples/microservices-istio/bookinfo-kubernetes/index.md
@@ -123,7 +123,7 @@ service/productpage patched
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: bookinfo
@@ -135,22 +135,33 @@ service/productpage patched
         http:
           paths:
           - path: /productpage
+            pathType: Prefix
             backend:
-              serviceName: productpage
-              servicePort: 9080
+              service:
+                name: productpage
+                port:
+                  number: 9080
           - path: /login
+            pathType: Prefix
             backend:
-              serviceName: productpage
-              servicePort: 9080
+              service:
+                name: productpage
+                port:
+                  number: 9080
           - path: /logout
+            pathType: Prefix
             backend:
-              serviceName: productpage
-              servicePort: 9080
+              service:
+                name: productpage
+                port:
+                  number: 9080
           - path: /static
             pathType: Prefix
             backend:
-              serviceName: productpage
-              servicePort: 9080
+              service:
+                name: productpage
+                port:
+                  number: 9080
     EOF
     {{< /text >}}
 

--- a/content/en/docs/examples/microservices-istio/setup-kubernetes-cluster/index.md
+++ b/content/en/docs/examples/microservices-istio/setup-kubernetes-cluster/index.md
@@ -70,7 +70,7 @@ proceed to [setting up your local computer](/docs/examples/microservices-istio/s
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.k8s.io/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: istio-system
@@ -85,32 +85,40 @@ proceed to [setting up your local computer](/docs/examples/microservices-istio/s
           - path: /
             pathType: Prefix
             backend:
-              serviceName: grafana
-              servicePort: 3000
+              service:
+                name: grafana
+                port:
+                  number: 3000
       - host: my-istio-tracing.io
         http:
           paths:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: tracing
-              servicePort: 9411
+              service:
+                name: tracing
+                port:
+                  number: 9411
       - host: my-istio-logs-database.io
         http:
           paths:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: prometheus
-              servicePort: 9090
+              service:
+                name: prometheus
+                port:
+                  number: 9090
       - host: my-kiali.io
         http:
           paths:
           - path: /
             pathType: Prefix
             backend:
-              serviceName: kiali
-              servicePort: 20001
+              service:
+                name: kiali
+                port:
+                  number: 20001
     EOF
     {{< /text >}}
 


### PR DESCRIPTION
Fixes: #12205

Please provide a description for what this PR is for.
Update to the docs for using `networking.k8s.io/v1`

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
