### PR TITLE
we are using the incorrect namespace and incorrect service name

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -225,7 +225,7 @@ Set the `INGRESS_HOST` and `INGRESS_PORT` environment variables according to the
 If you are unsure, you can determine if your Kubernetes cluster is running in an environment that supports external load balancers using the following command:
 
 {{< text bash >}}
-$ kubectl get svc istio-ingressgateway -n istio-system
+$ kubectl get svc istio-ingressgateway -n istio-ingress
 NAME                   TYPE           CLUSTER-IP       EXTERNAL-IP      PORT(S)   AGE
 istio-ingressgateway   LoadBalancer   172.21.109.129   130.211.10.121   ...       17h
 {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -238,10 +238,10 @@ If your environment does not support external load balancers, you can try
 Otherwise, set the ingress IP and ports using the following commands:
 
 {{< text bash >}}
-$ export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-$ export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
-$ export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
-$ export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].port}')
+$ export INGRESS_HOST=$(kubectl -n istio-ingress get service istio-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+$ export INGRESS_PORT=$(kubectl -n istio-ingress get service istio-ingress -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
+$ export SECURE_INGRESS_PORT=$(kubectl -n istio-ingress get service istio-ingress -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
+$ export TCP_INGRESS_PORT=$(kubectl -n istio-ingress get service istio-ingress -o jsonpath='{.spec.ports[?(@.name=="tcp")].port}')
 {{< /text >}}
 
 {{< warning >}}

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -125,7 +125,7 @@ minikube tunnel
 }
 
 snip_determining_the_ingress_ip_and_ports_2() {
-kubectl get svc istio-ingressgateway -n istio-system
+kubectl get svc istio-ingressgateway -n istio-ingress
 }
 
 ! read -r -d '' snip_determining_the_ingress_ip_and_ports_2_out <<\ENDSNIP
@@ -134,10 +134,10 @@ istio-ingressgateway   LoadBalancer   172.21.109.129   130.211.10.121   ...     
 ENDSNIP
 
 snip_determining_the_ingress_ip_and_ports_3() {
-export INGRESS_HOST=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-export INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
-export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
-export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].port}')
+export INGRESS_HOST=$(kubectl -n istio-ingress get service istio-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+export INGRESS_PORT=$(kubectl -n istio-ingress get service istio-ingress -o jsonpath='{.spec.ports[?(@.name=="http2")].port}')
+export SECURE_INGRESS_PORT=$(kubectl -n istio-ingress get service istio-ingress -o jsonpath='{.spec.ports[?(@.name=="https")].port}')
+export TCP_INGRESS_PORT=$(kubectl -n istio-ingress get service istio-ingress -o jsonpath='{.spec.ports[?(@.name=="tcp")].port}')
 }
 
 snip_determining_the_ingress_ip_and_ports_4() {


### PR DESCRIPTION
According to the docs provided in https://istio.io/latest/docs/examples/bookinfo/ , the ingress-gateway is created under the istio-ingress namespace, not under the istio-system namespace

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
