### PR TITLE
Remove explicit webhookconfig deletion steps

### DIFF
--- a/content/en/docs/setup/install/helm/test.sh
+++ b/content/en/docs/setup/install/helm/test.sh
@@ -20,9 +20,6 @@ set -o pipefail
 
 # @setup profile=none
 
-# Delete a vailidatingwebhookconfiguration that seems to have been left around from a prior test.
-kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io istiod-default-validator  --ignore-not-found
-
 snip_create_istio_system_namespace
 _rewrite_helm_repo snip_install_base
 

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -480,6 +480,7 @@ To uninstall Istio, run the following command:
 {{< text bash >}}
 $ kubectl delete -n istio-system -f @samples/multicluster/expose-istiod.yaml@
 $ istioctl manifest generate | kubectl delete -f -
+$ istioctl uninstall -y --purge
 {{< /text >}}
 
 The control plane namespace (e.g., `istio-system`) is not removed by default.

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -479,7 +479,6 @@ To uninstall Istio, run the following command:
 
 {{< text bash >}}
 $ kubectl delete -n istio-system -f @samples/multicluster/expose-istiod.yaml@
-$ istioctl manifest generate | kubectl delete -f -
 $ istioctl uninstall -y --purge
 {{< /text >}}
 

--- a/content/en/docs/setup/install/virtual-machine/snips.sh
+++ b/content/en/docs/setup/install/virtual-machine/snips.sh
@@ -245,6 +245,7 @@ sudo rpm -e istio-sidecar
 snip_uninstall_4() {
 kubectl delete -n istio-system -f samples/multicluster/expose-istiod.yaml
 istioctl manifest generate | kubectl delete -f -
+istioctl uninstall -y --purge
 }
 
 snip_uninstall_5() {

--- a/content/en/docs/setup/install/virtual-machine/snips.sh
+++ b/content/en/docs/setup/install/virtual-machine/snips.sh
@@ -244,7 +244,6 @@ sudo rpm -e istio-sidecar
 
 snip_uninstall_4() {
 kubectl delete -n istio-system -f samples/multicluster/expose-istiod.yaml
-istioctl manifest generate | kubectl delete -f -
 istioctl uninstall -y --purge
 }
 

--- a/content/en/docs/setup/install/virtual-machine/test.sh
+++ b/content/en/docs/setup/install/virtual-machine/test.sh
@@ -51,6 +51,4 @@ _verify_contains check_call "Hello version:"
 # @cleanup
 docker stop vm
 snip_uninstall_4
-kubectl delete validatingwebhookconfiguration istiod-default-validator #TODO fix snip and then remove
-kubectl delete mutatingwebhookconfiguration istio-revision-tag-default #TODO fix snip and then remove
 kubectl delete namespace istio-system vm-namespace sample


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

istioctl uninstall would remove the webhookconfig as well, so no need for explicit delete steps.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
