### PR TITLE
cleanup failure on doc.test.profile_default_istio.io

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -500,24 +500,26 @@ they have valid values, according to the output of the following commands:
 
 {{< tab name="Istio classic" category-value="istio-classic" >}}
 
-Delete the `Gateway` and `VirtualService` configuration, and shutdown the [httpbin]({{< github_tree >}}/samples/httpbin) service:
+Delete the `Gateway` and `VirtualService` configuration, shutdown the [httpbin]({{< github_tree >}}/samples/httpbin) service and uninstall Istio:
 
 {{< text bash >}}
 $ kubectl delete gateway httpbin-gateway
 $ kubectl delete virtualservice httpbin
 $ kubectl delete --ignore-not-found=true -f @samples/httpbin/httpbin.yaml@
+$ istioctl uninstall -y --purge
 {{< /text >}}
 
 {{< /tab >}}
 
 {{< tab name="Gateway API" category-value="gateway-api" >}}
 
-Delete the `Gateway` and `HTTPRoute` configuration, and shutdown the [httpbin]({{< github_tree >}}/samples/httpbin) service:
+Delete the `Gateway` and `HTTPRoute` configuration, shutdown the [httpbin]({{< github_tree >}}/samples/httpbin) service and uninstall Istio:
 
 {{< text bash >}}
 $ kubectl delete gtw httpbin-gateway
 $ kubectl delete httproute httpbin
 $ kubectl delete --ignore-not-found=true -f @samples/httpbin/httpbin.yaml@
+$ istioctl uninstall -y --purge
 {{< /text >}}
 
 {{< /tab >}}

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -290,10 +290,12 @@ snip_cleanup_1() {
 kubectl delete gateway httpbin-gateway
 kubectl delete virtualservice httpbin
 kubectl delete --ignore-not-found=true -f samples/httpbin/httpbin.yaml
+istioctl uninstall -y --purge
 }
 
 snip_cleanup_2() {
 kubectl delete gtw httpbin-gateway
 kubectl delete httproute httpbin
 kubectl delete --ignore-not-found=true -f samples/httpbin/httpbin.yaml
+istioctl uninstall -y --purge
 }


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

Seeing this after snapshot failure on many PRs on profile default test
eg: https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_istio.io/12289/doc.test.profile_default_istio.io/1595877997422841856/artifacts/tests-setup-profile-default-589/TestDocs/tasks/traffic-management/ingress/ingress-control/gtwapi_test.sh/after_snapshot/_test_context/diff.txt

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
