### PR TITLE
updated 2 docs about fetching chart from URLs

### DIFF
--- a/content/en/docs/setup/additional-setup/customize-installation/index.md
+++ b/content/en/docs/setup/additional-setup/customize-installation/index.md
@@ -231,7 +231,7 @@ profiles:
 
 - compiled in charts. This is the default if no `--manifests` option is set. The compiled in charts are the same as those
 in the `manifests/` directory of the Istio release `.tgz`.
-- charts in the local file system, e.g., `istioctl install --manifests istio-{{< istio_full_version >}}/manifests`
+- charts in the local file system, e.g., `istioctl install --manifests istio-{{< istio_full_version >}}/manifests`.
 
 Local file system charts and profiles can be customized by editing the files in `manifests/`. For extensive changes,
 we recommend making a copy of the `manifests` directory and make changes there. Note, however, that the content layout

--- a/content/en/docs/setup/additional-setup/customize-installation/index.md
+++ b/content/en/docs/setup/additional-setup/customize-installation/index.md
@@ -232,7 +232,6 @@ profiles:
 - compiled in charts. This is the default if no `--manifests` option is set. The compiled in charts are the same as those
 in the `manifests/` directory of the Istio release `.tgz`.
 - charts in the local file system, e.g., `istioctl install --manifests istio-{{< istio_full_version >}}/manifests`
-- charts in GitHub, e.g., `istioctl install --manifests https://github.com/istio/istio/releases/download/{{< istio_full_version >}}/istio-{{< istio_full_version >}}-linux-arm64.tar.gz`
 
 Local file system charts and profiles can be customized by editing the files in `manifests/`. For extensive changes,
 we recommend making a copy of the `manifests` directory and make changes there. Note, however, that the content layout

--- a/content/zh/docs/setup/additional-setup/customize-installation/index.md
+++ b/content/zh/docs/setup/additional-setup/customize-installation/index.md
@@ -224,7 +224,6 @@ spec:
 - 内置的 chart。如果没有设置 `--manifests`，则用 default。
   内置的 chart 和 Istio `.tgz` 发行包内 `manifests/` 目录下的内容相同。
 - 本地文件系统中的 chart，例如，`istioctl install --manifests istio-{{< istio_full_version >}}/manifests`
-- GitHub 上的 chart，例如，`istioctl install --manifests https://github.com/istio/istio/releases/download/{{< istio_full_version >}}/istio-{{< istio_full_version >}}-linux-arm64.tar.gz`
 
 本地文件系统的 chart 和配置档可以通过编辑 `manifests/` 目录下的文件定制。
 要进行广泛的更改，建议拷贝 `manifests` 目录，然后修改副本。

--- a/content/zh/docs/setup/additional-setup/customize-installation/index.md
+++ b/content/zh/docs/setup/additional-setup/customize-installation/index.md
@@ -223,7 +223,7 @@ spec:
 
 - 内置的 chart。如果没有设置 `--manifests`，则用 default。
   内置的 chart 和 Istio `.tgz` 发行包内 `manifests/` 目录下的内容相同。
-- 本地文件系统中的 chart，例如，`istioctl install --manifests istio-{{< istio_full_version >}}/manifests`
+- 本地文件系统中的 chart，例如 `istioctl install --manifests istio-{{< istio_full_version >}}/manifests`。
 
 本地文件系统的 chart 和配置档可以通过编辑 `manifests/` 目录下的文件定制。
 要进行广泛的更改，建议拷贝 `manifests` 目录，然后修改副本。


### PR DESCRIPTION
As noted in #12310 and [#41756](https://github.com/istio/istio/pull/41756), remove the desc about fetching chart from URLs in 2 files:
```
content/en/docs/setup/additional-setup/customize-installation/index.md
content/zh/docs/setup/additional-setup/customize-installation/index.md
```

- [x] Docs

