### PR TITLE
Update update_test_ref to also run gen target

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -161,7 +161,9 @@ export ISTIO_API_GIT_SOURCE ?=
 update_ref_docs:
 	@scripts/grab_reference_docs.sh $(SOURCE_BRANCH_NAME) $(ISTIO_API_GIT_SOURCE)
 
-update_test_reference:
+update_test_reference: get_istio_sha gen
+
+get_istio_sha:
 	@go get istio.io/istio@$(SOURCE_BRANCH_NAME) && go mod tidy
 
 update_all: update_ref_docs update_test_reference

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 require (
 	github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f
 	github.com/pmezard/go-difflib v1.0.0
-	istio.io/istio v0.0.0-20221206063006-05425f2a523c
+	istio.io/istio v0.0.0-20221207020011-9e1104d7a0a5
 	istio.io/pkg v0.0.0-20221115162234-5e468deffb77
 	k8s.io/apimachinery v0.25.3
 	k8s.io/client-go v0.25.3

--- a/go.sum
+++ b/go.sum
@@ -1476,8 +1476,8 @@ istio.io/api v0.0.0-20221205210105-82e7f2d88e02 h1:nH5OQpMOK7N1AJPUp0jVxlydc9bNg
 istio.io/api v0.0.0-20221205210105-82e7f2d88e02/go.mod h1:oV64LW9BQmwkiP2KxXeOrktfTuLlHaV4ee3xPshNZuw=
 istio.io/client-go v1.16.0-rc.0.0.20221109202342-07ece772a919 h1:TnZQP5IcgDLp4OH0Di31/qoDNFqN+EkVPg2iMl4WOnU=
 istio.io/client-go v1.16.0-rc.0.0.20221109202342-07ece772a919/go.mod h1:UV8SFeM2qNime5sobkr2m8oTCPxxVt9xCY4ol50U9YQ=
-istio.io/istio v0.0.0-20221206063006-05425f2a523c h1:XjlaBqd9O+juaAAYWXV27gTGj1ZJomD1e+bg9r9ZDAU=
-istio.io/istio v0.0.0-20221206063006-05425f2a523c/go.mod h1:zOxqpRl6Y0d878ig+TSoCwnKdgMGBvTQqQN7sjBQEWw=
+istio.io/istio v0.0.0-20221207020011-9e1104d7a0a5 h1:y4rxniD5+ydLlCoHVrQKb6c925BNfYqF981kzbHkyZ8=
+istio.io/istio v0.0.0-20221207020011-9e1104d7a0a5/go.mod h1:zOxqpRl6Y0d878ig+TSoCwnKdgMGBvTQqQN7sjBQEWw=
 istio.io/pkg v0.0.0-20221115162234-5e468deffb77 h1:2l0ufc1Lj/pnzxlQMtQx9cjdt4lrvcNMSg5sy/1zjoM=
 istio.io/pkg v0.0.0-20221115162234-5e468deffb77/go.mod h1:1297yENoCcROUAWFZEdwD4VFN8Qa/if1UtzwvVgah7I=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=


### PR DESCRIPTION
Please provide a description for what this PR is for.

The last update_test_ref updated the gateway crd version which should update the docs to use the new version. The `gencheck` test failed so it would be good to do that as part of the automation.

I also ran the change which updates the istio test ref as well, and observed the `make gen` happening.