### PR TITLE
Add warning banner for older blog posts

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -5,6 +5,30 @@
         <p>{{ .Params.description }}</p>
       </div>
       <p class="post-author">{{ (.Params.publishdate).Format "Jan 2, 2006" }} <span> | </span> By {{ replace (replace .Params.attribution "(" "- ") ")" "" }}</p>
+      {{ if .Page.Params.target_release }}
+          {{ $page_parts := split .Page.Params.target_release "." }}
+          {{ $page_version := int (index $page_parts 0) }}
+          {{ $page_revision := int (index $page_parts 1) }}
+          {{ $page_normalized_version := add (add (mul $page_version 1000000) (mul $page_revision 1000)) 0 }}
+
+          {{ $site_parts := split .Site.Data.args.version "." }}
+          {{ $site_version := int (index $site_parts 0) }}
+          {{ $site_revision := int (index $site_parts 1) }}
+          {{ $site_normalized_version := add (add (mul $site_version 1000000) (mul $site_revision 1000)) 0 }}
+
+          {{ if gt $site_normalized_version $page_normalized_version }}
+              <div>
+                  <aside class="callout warning">
+                      <div class="type">
+                          {{- partial "large_icon.html" "callout-warning" -}}
+                      </div>
+                      <div class="content">
+                          {{ printf (i18n "target_release") .Page.Params.target_release }}
+                      </div>
+                  </aside>
+              </div>
+          {{ end }}
+      {{ end }}
       <div>
         {{ .Content }}
       </div>


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

Previously there used to be a warning banner for blog posts to indicate which target_release this was tested against, which seems to have broken ever since new istio.io design was introduced. (https://github.com/istio/istio.io/pull/9324)

For eg: see https://istio.io/v1.9/blog/2019/webhook/  vs https://istio.io/latest/blog/2019/webhook/

@ericvn This is basically because blog posts no longer are using [primary_top.html ](https://github.com/istio/istio.io/blob/master/layouts/partials/primary_top.html#L157). However adding this directly to the blog posts brings in too many other changes to the page layout, including layout changes and bringing back sidebar on the left hand side, which would have been purposefully avoided as per the new design(i am not sure, you may know the history better). Hence I have tried copying only the target_release section for the blog posts.


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
