### PR TITLE
Fix a layout in /distributed-tracing/overview/

### DIFF
--- a/content/en/docs/tasks/observability/distributed-tracing/overview/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/overview/index.md
@@ -32,6 +32,7 @@ For Zipkin, Jaeger, Stackdriver, and OpenCensus Agent the B3 multi-header format
 * `x-b3-parentspanid`
 * `x-b3-sampled`
 * `x-b3-flags`
+
 These are supported by Zipkin, Jaeger, OpenCensus, and many other tools.
 
 For Datadog, the following headers should be forwarded. Forwarding these is handled automatically by Datadog client libraries for many languages and frameworks.


### PR DESCRIPTION
- [x] Docs

Find a blank line is missing in:

```
content/en/docs/tasks/observability/distributed-tracing/overview/index.md
```


<img width="884" alt="image" src="https://user-images.githubusercontent.com/79828097/207832105-262bfb4c-ff06-44b2-aa1d-2257d9e8692e.png">
