### PR TITLE
fix: pods dont have label istio.io/rev

### DIFF
--- a/content/en/docs/setup/upgrade/canary/index.md
+++ b/content/en/docs/setup/upgrade/canary/index.md
@@ -94,29 +94,20 @@ To upgrade the namespace `test-ns`, remove the `istio-injection` label, and add 
 $ kubectl label namespace test-ns istio-injection- istio.io/rev=canary
 {{< /text >}}
 
-After the namespace updates, you need to restart the pods to trigger re-injection. One way to do
-this is using:
+After the namespace updates, you need to restart the pods to trigger re-injection.
+One way to restart all pods in namespace `test-ns` is using:
 
 {{< text bash >}}
 $ kubectl rollout restart deployment -n test-ns
 {{< /text >}}
 
-When the pods are re-injected, they will be configured to point to the `istiod-canary` control plane. You can verify this by looking at the pod labels.
-
-For example, the following command will show all the pods using the `canary` revision:
+When the pods are re-injected, they will be configured to point to the `istiod-canary` control plane. You can verify this by using `istioctl proxy-status`.
 
 {{< text bash >}}
-$ kubectl get pods -n test-ns -l istio.io/rev=canary
+$ istioctl proxy-status | grep "\.test-ns "
 {{< /text >}}
 
-To verify that the new pods in the `test-ns` namespace are using the `istiod-canary` service corresponding to the `canary` revision, select one newly created pod and use the `pod_name` in the following command:
-
-{{< text bash >}}
-$ istioctl proxy-status | grep ${pod_name} | awk '{print $7}'
-istiod-canary-6956db645c-vwhsk
-{{< /text >}}
-
-The output confirms that the pod is using `istiod-canary` revision of the control plane.
+The output will show all pods under the namespace that are using the canary revision.
 
 ## Stable revision labels (experimental)
 

--- a/content/zh/docs/setup/upgrade/canary/index.md
+++ b/content/zh/docs/setup/upgrade/canary/index.md
@@ -91,28 +91,19 @@ istiod-canary-6956db645c-vwhsk
 $ kubectl label namespace test-ns istio-injection- istio.io/rev=canary
 {{< /text >}}
 
-命名空间更新后，您需要重新启动 Pod 才能触发重新注入。一种方法是使用：
+命名空间更新后，您需要重新启动 Pod 才能触发重新注入。一种重启命名空间 `test-ns` 中所有 Pod 的方法是：
 
 {{< text bash >}}
 $ kubectl rollout restart deployment -n test-ns
 {{< /text >}}
 
-当 Pod 被重新注入时，它们将被配置为指向 `istiod-canary` 控制平面。你可以查看 Pod 标签验证这一点。
-
-例如，运行以下命令将显示使用 `canary` 修订版本的所有 Pod：
+当 Pod 被重新注入时，它们将被配置为指向 `istiod-canary` 控制平面。你可以使用 `istioctl proxy-status` 来验证。
 
 {{< text bash >}}
-$ kubectl get pods -n test-ns -l istio.io/rev=canary
+$ istioctl proxy-status | grep "\.test-ns "
 {{< /text >}}
 
-要验证 `test-ns` 命名空间中的新 Pod 正在使用与修订版本 `istiod-canary` 相对应的服务 `canary`， 请选择一个新创建的 Pod，然后在 `pod_name` 中使用以下命令：
-
-{{< text bash >}}
-$ istioctl proxy-status | grep ${pod_name} | awk '{print $8}'
-istiod-canary-6956db645c-vwhsk
-{{< /text >}}
-
-输出确认 Pod 正在使用 `istiod-canary` 控制平面的修订版本。
+输出会展示命名空间下所有正在使用修订版本的 Pod。
 
 ## 卸载旧的控制平面 {#uninstall-old-control-plane}
 


### PR DESCRIPTION

Canary upgrade pod will not have lable `istio.io/rev`.

- [ X] Docs
