### PR TITLE
Clarify that Sidecar is not applicable to gateways

### DIFF
--- a/content/en/docs/reference/config/networking/sidecar/index.html
+++ b/content/en/docs/reference/config/networking/sidecar/index.html
@@ -42,6 +42,11 @@ system is undefined if two or more <code>Sidecar</code> configurations with a
 will be applied by default to all namespaces without a <code>Sidecar</code>
 configuration</em></em>. This global default <code>Sidecar</code> configuration should not have
 any <code>workloadSelector</code>.</p>
+
+{{< warning >}}
+`Sidecar` is not applicable to gateways, even though gateways are istio-proxies.
+{{< /warning >}}
+
 <p>The example below declares a global default <code>Sidecar</code> configuration
 in the root namespace called <code>istio-config</code>, that configures
 sidecars in all namespaces to allow egress traffic only to other


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

To avoid confusion like in this [issue](https://github.com/istio/istio/issues/32041), I think it's worth to clarify in a warning that `Sidecar` is not applicable to gateways. Users may guess that `Sidecar` should work for gateways, because both gateway and sidecar proxies are the same istio-proxy.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
