### PR TITLE
Replace setup with set up if it's a verb

### DIFF
--- a/content/en/about/faq/security/auth-mix-and-match.md
+++ b/content/en/about/faq/security/auth-mix-and-match.md
@@ -4,4 +4,4 @@ weight: 20
 ---
 
 [Authentication policy](/docs/concepts/security/#authentication-policies) can be mesh-wide (which affects all services in the mesh), namespace-wide
-(all services in the same namespace), or service specific. You can have policy or policies to setup mutual TLS for services in a cluster in any way as you want.
+(all services in the same namespace), or service specific. You can have policy or policies to set up mutual TLS for services in a cluster in any way as you want.

--- a/content/en/blog/2018/export-logs-through-stackdriver/index.md
+++ b/content/en/blog/2018/export-logs-through-stackdriver/index.md
@@ -31,7 +31,7 @@ metrics (coming..) among others. Following is a diagram of the pipeline:
 
 Istio supports exporting logs to Stackdriver which can in turn be configured to export
 logs to your favorite sink like BigQuery, Pub/Sub or GCS. Please follow the steps
-below to setup your favorite sink for exporting logs first and then Stackdriver
+below to set up your favorite sink for exporting logs first and then Stackdriver
 in Istio.
 
 ### Setting up various log sinks

--- a/content/en/blog/2018/incremental-traffic-management/index.md
+++ b/content/en/blog/2018/incremental-traffic-management/index.md
@@ -37,7 +37,7 @@ Let’s say you have two services that are part of the Istio mesh, Service A and
 
 {{< image width="60%" link="./fifty-fifty.png" caption="50/50 Traffic Split" >}}
 
-If Services A and B are not part of the Istio mesh, there is no sidecar proxy that knows how to route traffic to different versions of Service B. In that case you need to use another approach to get traffic from Service A to Service B, following the 50/50 rules you’ve setup.
+If Services A and B are not part of the Istio mesh, there is no sidecar proxy that knows how to route traffic to different versions of Service B. In that case you need to use another approach to get traffic from Service A to Service B, following the 50/50 rules you’ve set up.
 
 Fortunately, a standard Istio deployment already includes a [Gateway](/docs/concepts/traffic-management/#gateways) that specifically deals with ingress traffic outside of the Istio mesh. This Gateway is used to allow ingress traffic from outside the cluster via an external load balancer, or to allow ingress traffic from within the Kubernetes cluster but outside the service mesh. It can be configured to proxy incoming ingress traffic to the appropriate Pods, even if they don’t have a sidecar proxy. While this approach allows you to leverage Istio’s traffic management features, it does mean that traffic going through the ingress gateway will incur an extra hop.
 
@@ -45,9 +45,9 @@ Fortunately, a standard Istio deployment already includes a [Gateway](/docs/conc
 
 ## In action: traffic routing with Istio
 
-A simple way to see this type of approach in action is to first setup your Kubernetes environment using the [Platform Setup](/docs/setup/platform-setup/) instructions, and then install the **minimal** Istio profile using [Helm](https://archive.istio.io/1.4/docs/setup/install/helm/), including only the traffic management components (ingress gateway, egress gateway, Pilot). The following example uses [Google Kubernetes Engine](https://cloud.google.com/gke).
+A simple way to see this type of approach in action is to first set up your Kubernetes environment using the [Platform Setup](/docs/setup/platform-setup/) instructions, and then install the **minimal** Istio profile using [Helm](https://archive.istio.io/1.4/docs/setup/install/helm/), including only the traffic management components (ingress gateway, egress gateway, Pilot). The following example uses [Google Kubernetes Engine](https://cloud.google.com/gke).
 
-First, setup and configure [GKE](/docs/setup/platform-setup/gke/):
+First, set up and configure [GKE](/docs/setup/platform-setup/gke/):
 
 {{< text bash >}}
 $ gcloud container clusters create istio-inc --zone us-central1-f

--- a/content/en/blog/2019/evolving-istios-apis/index.md
+++ b/content/en/blog/2019/evolving-istios-apis/index.md
@@ -51,7 +51,7 @@ AutoTrader UK has one of our favorite examples of a custom platform built on Ist
 
 Some areas of improvement that we’re working on for upcoming releases include:
 
-- Installation profiles to setup standard patterns for ingress and egress, with the Istio operator
+- Installation profiles to set up standard patterns for ingress and egress, with the Istio operator
 - Automatic inference of container ports and protocols for telemetry
 - Support for routing all traffic by default to constrain routing incrementally
 - Add a single global flag to enable mutual TLS and encrypt all inter-pod traffic

--- a/content/en/docs/examples/microservices-istio/prereq/index.md
+++ b/content/en/docs/examples/microservices-istio/prereq/index.md
@@ -13,7 +13,7 @@ tutorial's modules and a local computer to run the commands. If you have your
 own cluster, ensure your cluster satisfies the prerequisites.
 
 If you are in a workshop and the instructors provide a cluster, let
-them handle the cluster prerequisites, while you skip ahead to setup your local
+them handle the cluster prerequisites, while you skip ahead to set up your local
 computer.
 
 ## Kubernetes cluster

--- a/content/en/docs/examples/microservices-istio/setup-kubernetes-cluster/index.md
+++ b/content/en/docs/examples/microservices-istio/setup-kubernetes-cluster/index.md
@@ -1,5 +1,5 @@
 ---
-title: Setup a Kubernetes Cluster
+title: Set up a Kubernetes Cluster
 overview: Set up your Kubernetes cluster for the tutorial.
 weight: 2
 owner: istio/wg-docs-maintainers
@@ -272,4 +272,4 @@ proceed to [setting up your local computer](/docs/examples/microservices-istio/s
 
 Congratulations, you configured your cluster for the tutorial!
 
-You are ready to [setup a local computer](/docs/examples/microservices-istio/setup-local-computer).
+You are ready to [set up a local computer](/docs/examples/microservices-istio/setup-local-computer).

--- a/content/en/docs/examples/microservices-istio/setup-local-computer/index.md
+++ b/content/en/docs/examples/microservices-istio/setup-local-computer/index.md
@@ -1,5 +1,5 @@
 ---
-title: Setup a Local Computer
+title: Set up a Local Computer
 overview: Set up your local computer for the tutorial.
 weight: 3
 owner: istio/wg-docs-maintainers

--- a/content/en/docs/ops/configuration/security/harden-docker-images/index.md
+++ b/content/en/docs/ops/configuration/security/harden-docker-images/index.md
@@ -13,7 +13,7 @@ To ease the process of hardening docker images, Istio provides a set of images b
 
 ## Install distroless images
 
-Follow the [Installation Steps](/docs/setup/install/istioctl/) to setup Istio.
+Follow the [Installation Steps](/docs/setup/install/istioctl/) to set up Istio.
 Add the option `--set tag={{< istio_full_version >}}-distroless` to use the *distroless images*.
 
 {{< text bash >}}

--- a/content/en/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/index.md
+++ b/content/en/docs/ops/configuration/telemetry/monitoring-multicluster-prometheus/index.md
@@ -23,7 +23,7 @@ of the clusters within the mesh.
 
 ## Multicluster Istio setup
 
-Follow the [multicluster installation](/docs/setup/install/multicluster/) section to setup your Istio clusters in one of the
+Follow the [multicluster installation](/docs/setup/install/multicluster/) section to set up your Istio clusters in one of the
 supported [multicluster deployment models](/docs/ops/deployment/deployment-models/#multiple-clusters). For the purpose of
 this guide, any of those approaches will work, with the following caveat:
 

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -25,7 +25,7 @@ Follow this guide to deploy Istio and connect a virtual machine to it.
 
 1. Create a virtual machine
 1. Set the environment variables `VM_APP`, `WORK_DIR` , `VM_NAMESPACE`,
-and `SERVICE_ACCOUNT` on your machine that you're using to setup the cluster.
+and `SERVICE_ACCOUNT` on your machine that you're using to set up the cluster.
     (e.g., `WORK_DIR="${HOME}/vmintegration"`):
 
     {{< tabset category-name="network-mode" >}}
@@ -61,7 +61,7 @@ and `SERVICE_ACCOUNT` on your machine that you're using to setup the cluster.
 
     {{< /tabset >}}
 
-1. Create the working directory on your machine that you're using to setup the cluster:
+1. Create the working directory on your machine that you're using to set up the cluster:
 
     {{< text syntax=bash snip_id=setup_wd >}}
     $ mkdir -p "${WORK_DIR}"

--- a/content/en/docs/setup/platform-setup/MicroK8s/index.md
+++ b/content/en/docs/setup/platform-setup/MicroK8s/index.md
@@ -1,6 +1,6 @@
 ---
 title: MicroK8s
-description: Instructions to setup MicroK8s for use with Istio.
+description: Instructions to set up MicroK8s for use with Istio.
 weight: 45
 skip_seealso: true
 aliases:

--- a/content/en/docs/setup/platform-setup/alicloud/index.md
+++ b/content/en/docs/setup/platform-setup/alicloud/index.md
@@ -1,6 +1,6 @@
 ---
 title: Alibaba Cloud
-description: Instructions to setup an Alibaba Cloud Kubernetes cluster for Istio.
+description: Instructions to set up an Alibaba Cloud Kubernetes cluster for Istio.
 weight: 5
 skip_seealso: true
 aliases:

--- a/content/en/docs/setup/platform-setup/azure/index.md
+++ b/content/en/docs/setup/platform-setup/azure/index.md
@@ -1,6 +1,6 @@
 ---
 title: Azure
-description: Instructions to setup an Azure cluster for Istio.
+description: Instructions to set up an Azure cluster for Istio.
 weight: 10
 skip_seealso: true
 aliases:

--- a/content/en/docs/setup/platform-setup/docker/index.md
+++ b/content/en/docs/setup/platform-setup/docker/index.md
@@ -1,6 +1,6 @@
 ---
 title: Docker Desktop
-description: Instructions to setup Docker Desktop for Istio.
+description: Instructions to set up Docker Desktop for Istio.
 weight: 15
 skip_seealso: true
 aliases:

--- a/content/en/docs/setup/platform-setup/gardener/index.md
+++ b/content/en/docs/setup/platform-setup/gardener/index.md
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes Gardener
-description: Instructions to setup a Gardener cluster for Istio.
+description: Instructions to set up a Gardener cluster for Istio.
 weight: 35
 aliases:
     - /docs/setup/kubernetes/platform-setup/gardener/

--- a/content/en/docs/setup/platform-setup/gke/index.md
+++ b/content/en/docs/setup/platform-setup/gke/index.md
@@ -1,6 +1,6 @@
 ---
 title: Google Kubernetes Engine
-description: Instructions to setup a Google Kubernetes Engine cluster for Istio.
+description: Instructions to set up a Google Kubernetes Engine cluster for Istio.
 weight: 20
 skip_seealso: true
 aliases:

--- a/content/en/docs/setup/platform-setup/huaweicloud/index.md
+++ b/content/en/docs/setup/platform-setup/huaweicloud/index.md
@@ -1,6 +1,6 @@
 ---
 title: Huawei Cloud
-description: Instructions to setup an Huawei Cloud kubernetes cluster for Istio.
+description: Instructions to set up an Huawei Cloud kubernetes cluster for Istio.
 weight: 23
 skip_seealso: true
 aliases:

--- a/content/en/docs/setup/platform-setup/ibm/index.md
+++ b/content/en/docs/setup/platform-setup/ibm/index.md
@@ -1,6 +1,6 @@
 ---
 title: IBM Cloud
-description: Instructions to setup an IBM Cloud cluster for Istio.
+description: Instructions to set up an IBM Cloud cluster for Istio.
 weight: 25
 skip_seealso: true
 aliases:

--- a/content/en/docs/setup/platform-setup/kind/index.md
+++ b/content/en/docs/setup/platform-setup/kind/index.md
@@ -1,6 +1,6 @@
 ---
 title: kind
-description: Instructions to setup kind for Istio.
+description: Instructions to set up kind for Istio.
 weight: 30
 skip_seealso: true
 keywords: [platform-setup,kubernetes,kind]
@@ -71,7 +71,7 @@ Follow these instructions to prepare a kind cluster for Istio installation.
 ## Setup Dashboard UI for kind
 
 kind does not have a built in Dashboard UI like minikube. But you can still setup Dashboard, a web based Kubernetes UI, to view your cluster.
-Follow these instructions to setup Dashboard for kind.
+Follow these instructions to set up Dashboard for kind.
 
 1.  To deploy Dashboard, run the following command:
 

--- a/content/en/docs/setup/platform-setup/kops/index.md
+++ b/content/en/docs/setup/platform-setup/kops/index.md
@@ -1,6 +1,6 @@
 ---
 title: Kops
-description: Instructions to setup Kops for use with Istio.
+description: Instructions to set up Kops for use with Istio.
 weight: 33
 skip_seealso: true
 keywords: [platform-setup,kubernetes,kops]

--- a/content/en/docs/setup/platform-setup/kubesphere/index.md
+++ b/content/en/docs/setup/platform-setup/kubesphere/index.md
@@ -1,6 +1,6 @@
 ---
 title: KubeSphere Container Platform
-description: Instructions to setup a KubeSphere Container Platform for Istio.
+description: Instructions to set up a KubeSphere Container Platform for Istio.
 weight: 40
 skip_seealso: true
 keywords: [platform-setup,kubesphere,kubernetes]

--- a/content/en/docs/setup/platform-setup/minikube/index.md
+++ b/content/en/docs/setup/platform-setup/minikube/index.md
@@ -1,6 +1,6 @@
 ---
 title: Minikube
-description: Instructions to setup minikube for Istio.
+description: Instructions to set up minikube for Istio.
 weight: 50
 skip_seealso: true
 aliases:

--- a/content/en/docs/setup/platform-setup/openshift/index.md
+++ b/content/en/docs/setup/platform-setup/openshift/index.md
@@ -1,6 +1,6 @@
 ---
 title: OpenShift
-description: Instructions to setup an OpenShift cluster for Istio.
+description: Instructions to set up an OpenShift cluster for Istio.
 weight: 55
 skip_seealso: true
 aliases:

--- a/content/en/docs/setup/platform-setup/tencent-cloud-mesh/index.md
+++ b/content/en/docs/setup/platform-setup/tencent-cloud-mesh/index.md
@@ -1,6 +1,6 @@
 ---
 title: Tencent Cloud
-description: Instructions to setup Istio quickly in Tencent Cloud.
+description: Instructions to set up Istio quickly in Tencent Cloud.
 weight: 65
 skip_seealso: true
 keywords: [platform-setup,tencent-cloud-mesh,tcm,tencent-cloud,tencentcloud]

--- a/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
+++ b/content/en/docs/tasks/observability/metrics/using-istio-dashboard/index.md
@@ -1,6 +1,6 @@
 ---
 title: Visualizing Metrics with Grafana
-description: This task shows you how to setup and use the Istio Dashboard to monitor mesh traffic.
+description: This task shows you how to set up and use the Istio Dashboard to monitor mesh traffic.
 weight: 40
 keywords: [telemetry,visualization]
 aliases:
@@ -10,7 +10,7 @@ owner: istio/wg-policies-and-telemetry-maintainers
 test: yes
 ---
 
-This task shows you how to setup and use the Istio Dashboard to monitor mesh
+This task shows you how to set up and use the Istio Dashboard to monitor mesh
 traffic. As part of this task, you will use the Grafana Istio addon and
 the web-based interface for viewing service mesh traffic data.
 

--- a/content/en/docs/tasks/security/authentication/authn-policy/index.md
+++ b/content/en/docs/tasks/security/authentication/authn-policy/index.md
@@ -1,6 +1,6 @@
 ---
 title: Authentication Policy
-description: Shows you how to use Istio authentication policy to setup mutual TLS and basic end-user authentication.
+description: Shows you how to use Istio authentication policy to set up mutual TLS and basic end-user authentication.
 weight: 10
 keywords: [security,authentication]
 aliases:

--- a/content/en/docs/tasks/traffic-management/request-timeouts/index.md
+++ b/content/en/docs/tasks/traffic-management/request-timeouts/index.md
@@ -1,6 +1,6 @@
 ---
 title: Request Timeouts
-description: This task shows you how to setup request timeouts in Envoy using Istio.
+description: This task shows you how to set up request timeouts in Envoy using Istio.
 weight: 40
 aliases:
     - /docs/tasks/request-timeouts.html
@@ -9,7 +9,7 @@ owner: istio/wg-networking-maintainers
 test: yes
 ---
 
-This task shows you how to setup request timeouts in Envoy using Istio.
+This task shows you how to set up request timeouts in Envoy using Istio.
 
 ## Before you begin
 

--- a/content/en/news/releases/1.2.x/announcing-1.2/change-notes/index.md
+++ b/content/en/news/releases/1.2.x/announcing-1.2/change-notes/index.md
@@ -76,7 +76,7 @@ Refer to the [installation option change page](/news/releases/1.2.x/announcing-1
 
 ## Miscellaneous
 
-- **Added** [Istio CNI support](/docs/setup/additional-setup/cni/) to setup sidecar network redirection and remove the use of `istio-init` containers requiring `NET_ADMIN` capability.
+- **Added** [Istio CNI support](/docs/setup/additional-setup/cni/) to set up sidecar network redirection and remove the use of `istio-init` containers requiring `NET_ADMIN` capability.
 - **Added** a new experimental ['a-la-carte' Istio installer](https://github.com/istio/installer/wiki) to enable users to install and upgrade Istio with desired isolation and security.
 - **Added** [environment variable and configuration file support](https://docs.google.com/document/d/1M-qqBMNbhbAxl3S_8qQfaeOLAiRqSBpSgfWebFBRuu8/edit) for configuring Galley, in addition to command-line flags.
 - **Added** [ControlZ](/docs/ops/diagnostic-tools/controlz/) support to visualize the state of the MCP Server in Galley.


### PR DESCRIPTION
Grammar tips:

- `setup` is a noun (e.g., “it was a setup!”) or an adjective (e.g., “follow the setup instructions”). 
- `set up` functions as a verb (e.g., “I’m going to set up the computer”).

- [x] Docs
