### PR TITLE
bugfix(proxyConfig): for sidecar and gateway, default concurrency is …

### DIFF
--- a/content/en/docs/reference/config/networking/proxy-config/index.html
+++ b/content/en/docs/reference/config/networking/proxy-config/index.html
@@ -88,8 +88,12 @@ No
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#int32value">Int32Value</a></code></td>
 <td>
 <p>The number of worker threads to run.
-If unset, defaults to 2. If set to 0, this will be configured to use all cores on the machine using
-CPU requests and limits to choose a value, with limits taking precedence over requests.</p>
+
+For sidecar, defaults to 2.
+If set to 0, this will be computed from sidecar's CPU requests and limits,
+with limits taking precedence over requests.
+
+For gateway, defaults to the number of hardware threads on then machine.</p>
 
 </td>
 <td>

--- a/content/zh/docs/reference/config/networking/proxy-config/index.html
+++ b/content/zh/docs/reference/config/networking/proxy-config/index.html
@@ -88,8 +88,12 @@ No
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#int32value">Int32Value</a></code></td>
 <td>
 <p>The number of worker threads to run.
-If unset, defaults to 2. If set to 0, this will be configured to use all cores on the machine using
-CPU requests and limits to choose a value, with limits taking precedence over requests.</p>
+
+For sidecar, defaults to 2.
+If set to 0, this will be computed from sidecar's CPU requests and limits,
+with limits taking precedence over requests.
+
+For gateway, defaults to the number of hardware threads on then machine.</p>
 
 </td>
 <td>


### PR DESCRIPTION
Default concurrency for sidecar and gateway is different.

- [ ] Configuration Infrastructure
- [X ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
