### PR TITLE
update filter that depends on xds v2 api

### DIFF
--- a/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
@@ -70,7 +70,7 @@ spec:
       listener:
         filterChain:
           filter:
-            name: "envoy.http_connection_manager"
+            name: "envoy.filters.network.http_connection_manager"
             subFilter:
               name: "istio.stats"
     patch:
@@ -212,7 +212,7 @@ spec:
       listener:
         filterChain:
           filter:
-            name: "envoy.http_connection_manager"
+            name: "envoy.filters.network.http_connection_manager"
             subFilter:
               name: "istio.stats"
     patch:


### PR DESCRIPTION
Please provide a description for what this PR is for.

Updated deprecated filter `envoy.http_connection_manager`  shown in [classifying metrics example](https://istio.io/latest/docs/tasks/observability/metrics/classify-metrics/#classify-metrics-by-request). 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
