### PR TITLE
Add `targetPort` to a Service for gateway injection

### DIFF
--- a/content/en/docs/setup/additional-setup/gateway/index.md
+++ b/content/en/docs/setup/additional-setup/gateway/index.md
@@ -123,10 +123,12 @@ spec:
   selector:
     istio: ingressgateway
   ports:
-  - port: 80
-    name: http
-  - port: 443
-    name: https
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/content/en/docs/setup/additional-setup/gateway/snips.sh
+++ b/content/en/docs/setup/additional-setup/gateway/snips.sh
@@ -64,10 +64,12 @@ spec:
   selector:
     istio: ingressgateway
   ports:
-  - port: 80
-    name: http
-  - port: 443
-    name: https
+  - name: http
+    port: 80
+    targetPort: 8080
+  - name: https
+    port: 443
+    targetPort: 8443
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Signed-off-by: Jacek Ewertowski <jewertow@redhat.com>

An example of gateway injection is missing the `targetPort` that may be required in some environments. I experienced this problem on OpenShift with MetalLB.

The [documentation](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec) says that this field is ignored when `clusterIP=None`, but the `type: LoadBalancer` does not imply that `clusterIP` will be set to `None`.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
