### PR TITLE
Stable Revisions feature is Alpha

### DIFF
--- a/content/en/docs/setup/upgrade/canary/index.md
+++ b/content/en/docs/setup/upgrade/canary/index.md
@@ -109,7 +109,7 @@ $ istioctl proxy-status | grep "\.test-ns "
 
 The output will show all pods under the namespace that are using the canary revision.
 
-## Stable revision labels (experimental)
+## Stable revision labels (Alpha)
 
 {{< tip >}}
 If you're using Helm, refer to the [Helm upgrade documentation](/docs/setup/upgrade/helm).


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

As per: https://github.com/Nordix/istio_enhancements/blob/master/features.yaml#L385 Revision Tags feature is Alpha. 
I am in the process of promoting this to Beta. So thought of fixing this first before starting with the promotion tasks

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
