### PR TITLE
Update Gateway selector in ingress demo for Helm Installation

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -79,6 +79,30 @@ spec:
 EOF
 {{< /text >}}
 
+{{< tip >}}
+If you installed Istio using Helm, the selector for the `Gateway` is `istio=ingress`:
+
+{{< text bash >}}
+$ kubectl apply -f - <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: httpbin-gateway
+spec:
+  selector:
+    istio: ingress # use Istio gateway installed with Helm CLI
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "httpbin.example.com"
+EOF
+{{< /text >}}
+
+{{< /tip >}}
+
 Configure routes for traffic entering via the `Gateway`:
 
 {{< text bash >}}

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -67,8 +67,10 @@ kind: Gateway
 metadata:
   name: httpbin-gateway
 spec:
+  # The selector matches the ingress gateway pod labels.
+  # If you installed Istio using Helm following the standard documentation, this would be "istio=ingress"
   selector:
-    istio: ingressgateway # use Istio default gateway implementation
+    istio: ingressgateway
   servers:
   - port:
       number: 80
@@ -78,30 +80,6 @@ spec:
     - "httpbin.example.com"
 EOF
 {{< /text >}}
-
-{{< tip >}}
-If you installed Istio using Helm, the selector for the `Gateway` is `istio=ingress`:
-
-{{< text bash >}}
-$ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  name: httpbin-gateway
-spec:
-  selector:
-    istio: ingress # use Istio gateway installed with Helm CLI
-  servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-    - "httpbin.example.com"
-EOF
-{{< /text >}}
-
-{{< /tip >}}
 
 Configure routes for traffic entering via the `Gateway`:
 
@@ -369,8 +347,10 @@ kind: Gateway
 metadata:
   name: httpbin-gateway
 spec:
+  # The selector matches the ingress gateway pod labels.
+  # If you installed Istio using Helm following the standard documentation, this would be "istio=ingress"
   selector:
-    istio: ingressgateway # use Istio default gateway implementation
+    istio: ingressgateway
   servers:
   - port:
       number: 80

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -36,27 +36,10 @@ kind: Gateway
 metadata:
   name: httpbin-gateway
 spec:
+  # The selector matches the ingress gateway pod labels.
+  # If you installed Istio using Helm following the standard documentation, this would be "istio=ingress"
   selector:
-    istio: ingressgateway # use Istio default gateway implementation
-  servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
-    - "httpbin.example.com"
-EOF
-}
-
-snip_configuring_ingress_using_a_gateway_6() {
-kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
-kind: Gateway
-metadata:
-  name: httpbin-gateway
-spec:
-  selector:
-    istio: ingress # use Istio gateway installed with Helm CLI
+    istio: ingressgateway
   servers:
   - port:
       number: 80
@@ -209,8 +192,10 @@ kind: Gateway
 metadata:
   name: httpbin-gateway
 spec:
+  # The selector matches the ingress gateway pod labels.
+  # If you installed Istio using Helm following the standard documentation, this would be "istio=ingress"
   selector:
-    istio: ingressgateway # use Istio default gateway implementation
+    istio: ingressgateway
   servers:
   - port:
       number: 80

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -48,6 +48,25 @@ spec:
 EOF
 }
 
+snip_configuring_ingress_using_a_gateway_6() {
+kubectl apply -f - <<EOF
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: httpbin-gateway
+spec:
+  selector:
+    istio: ingress # use Istio gateway installed with Helm CLI
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "httpbin.example.com"
+EOF
+}
+
 snip_configuring_ingress_using_a_gateway_2() {
 kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1alpha3

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
@@ -53,7 +53,7 @@ else
     _verify_like snip_determining_the_ingress_ip_and_ports_4 "$snip_determining_the_ingress_ip_and_ports_4_out"
 
     # set INGRESS_HOST, INGRESS_PORT, SECURE_INGRESS_PORT, and TCP_INGRESS_PORT environment variables
-    snip_determining_the_ingress_ip_and_ports_6
+    snip_determining_the_ingress_ip_and_ports_5
 fi
 
 # access the httpbin service

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
@@ -53,7 +53,7 @@ else
     _verify_like snip_determining_the_ingress_ip_and_ports_4 "$snip_determining_the_ingress_ip_and_ports_4_out"
 
     # set INGRESS_HOST, INGRESS_PORT, SECURE_INGRESS_PORT, and TCP_INGRESS_PORT environment variables
-    snip_determining_the_ingress_ip_and_ports_5
+    snip_determining_the_ingress_ip_and_ports_6
 fi
 
 # access the httpbin service


### PR DESCRIPTION
Signed-off-by: nshankar <nshankar@microsoft.ghe.com>

Please provide a description for what this PR is for.

When the Istio ingress-gateway is installed via the Gateway Helm chart, following the steps provided in the [Helm Install guide](https://istio.io/latest/docs/setup/install/helm/), the selector for the ingress-gateway is different from what it is when the ingress-gateway is installed via istioctl. This PR updates the ingress guide for the appropriate configuration for Helm installations. 

```
Labels:       app=istio-ingress
              istio=ingress
              istio.io/rev=default
              pod-template-hash=54464bcb87
              service.istio.io/canonical-name=istio-ingress
              service.istio.io/canonical-revision=latest
              sidecar.istio.io/inject=true
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
