### PR TITLE
Update custom CA integration with k8s CSR API doc to remove chiron reference

### DIFF
--- a/content/en/docs/tasks/security/cert-management/custom-ca-k8s/index.md
+++ b/content/en/docs/tasks/security/cert-management/custom-ca-k8s/index.md
@@ -16,8 +16,7 @@ This feature requires Kubernetes version >= 1.18.
 
 This task shows how to provision Workload Certificates
 using a custom certificate authority that integrates with the
-[Kubernetes CSR API](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/). Different workloads can get their certificates signed from different cert-signers. Each cert-signer is effectively a different CA. It is expected that workloads whose certificates are issued from the same cert-signer can talk MTLS to each other while workloads signed by different signers cannot.
-This feature leverages [Chiron](/blog/2019/dns-cert/), a lightweight component linked with Istiod that signs certificates using the Kubernetes CSR API.
+[Kubernetes CSR API](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/). Different workloads can get their certificates signed from different cert-signers. Each cert-signer is effectively a different CA. It is expected that workloads whose certificates are issued from the same cert-signer can establish an mTLS connection while workloads signed by different signers cannot.
 
 For this example, we use [open-source cert-manager](https://cert-manager.io).
 Cert-manager has added [experimental Support for Kubernetes `CertificateSigningRequests`](https://cert-manager.io/docs/usage/kube-csr/) starting with version 1.4.


### PR DESCRIPTION
Please provide a description for what this PR is for.

This PR removes the line indicating that the custom CA integration with k8s CSR API
leverages Chiron. In the [Istio DNS Cert Management doc](https://istio.io/v1.13/docs/tasks/security/cert-management/dns-cert/) for Istio v1.13, Chiron is described
as a tool linked to istiod for signing certificates using the Kubernetes CA API. I
believe that support for Istio using the Kubernetes CA to sign certificates has
been [deprecated](https://docs.google.com/document/d/1kvmZgJ-QZByMlhqZDTdoxwHtJQxsrl5kj2-4HB4ip80/edit?resourcekey=0-OcIivFMxKkGxRB5KRPcGvg#heading=h.ew41k5ph127f). 

This change also rewords a line about mTLS in the custom CA integration with k8s CSR
API doc.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
