### PR TITLE
Is the sleep delete affecting the later start?

### DIFF
--- a/tests/util/samples.sh
+++ b/tests/util/samples.sh
@@ -47,11 +47,6 @@ cleanup_bookinfo_sample() {
 }
 
 startup_sleep_sample() {
-    # TODO: how to make sure previous test cleaned up everything?
-    set +e
-    kubectl delete pods -l app=sleep --force
-    set -e
-
     kubectl apply -f samples/sleep/sleep.yaml -n default
     _wait_for_deployment default sleep
 }


### PR DESCRIPTION
Please provide a description for what this PR is for.

@frankbu @kfaseela 

Since the previous change didn't seem to fix anything, and it seems like the sleep pod might be going away, let's remove this delete before we start the sample. I'm thinking there is a timing thing where the earlier command might be causing the later sleep pods to be terminated.

I think the cleanup should be handled by each test and the cleanup check. Not sure of the best way for we are restarting multiple times within a given test.

I do notice this is the only start that actually has a delete to cleanup prior things...