### PR TITLE
Add PDB and HPA example for gateway-api

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/gateway-api/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/gateway-api/index.md
@@ -226,15 +226,14 @@ Note: only one address may be specified.
 #### Resource Attachment and Scaling
 
 {{< warning >}}
-Resource attachment is current experimental.
+Resource attachment is currently experimental.
 {{< /warning >}}
 
-To customize the Gateway, resources can be *attached* to the `Gateway`.
-Since most APIs do not directly support attaching, they can instead be attached to the generated `Deployment` and `Service`.
+Resources can be *attached* to a `Gateway` to customize it.
+However, most Kubernetes resources do not currently support attaching directly to a `Gateway`, but they can be attached to the corresponding generated `Deployment` and `Service` instead.
+This is easily done because both of these resources are generated with the same name as the `Gateway` and with a label `istio.io/gateway-name: <gateway name>`.
 
-Both of these objects are guaranteed to be named the same as the `Gateway` and have a label `istio.io/gateway-name: GATEWAY_NAME`.
-
-For example, to deploy a `HorizontalPodAutoscaler` and `PodDisruptionBudget`:
+For example, to deploy a `Gateway` with a `HorizontalPodAutoscaler` and `PodDisruptionBudget`:
 
 {{< text yaml >}}
 apiVersion: gateway.networking.k8s.io/v1beta1

--- a/content/en/docs/tasks/traffic-management/ingress/gateway-api/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/gateway-api/snips.sh
@@ -154,6 +154,55 @@ spec:
 ...
 ENDSNIP
 
+! read -r -d '' snip_resource_attachment_and_scaling_1 <<\ENDSNIP
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: default
+    hostname: "*.example.com"
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: gateway
+spec:
+  # Match the generated Deployment by reference
+  # Note: Do not use `kind: Gateway`.
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gateway
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: 50
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: gateway
+spec:
+  minAvailable: 1
+  selector:
+    # Match the generated Deployment by label
+    matchLabels:
+      istio.io/gateway-name: gateway
+ENDSNIP
+
 ! read -r -d '' snip_manual_deployment_1 <<\ENDSNIP
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: Gateway


### PR DESCRIPTION
I've marked this as experimental since hopefully long term the attachment is directly to the Gateway. And we maybe change the deployment name