### PR TITLE
Add more context to the PROXY protocol gateway config section

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -208,7 +208,7 @@ without relying on L7 protocols such as HTTP and the `X-Forwarded-For` and `X-En
 PROXY protocol is only supported for TCP traffic forwarding by Envoy. See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/ip_transparency#proxy-protocol) for more details, along with some important performance caveats.
 
 PROXY protocol should not be used for L7 traffic, or for Istio gateways behind L7 load balancers.
-{{< /idea >}}
+{{< /warning >}}
 
 If your external TCP load balancer is configured to forward TCP traffic and use the PROXY protocol, the Istio Gateway TCP listener must also be configured to accept the PROXY protocol. Enabling this requires adding the [Envoy Proxy Protocol filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/listener_filters/proxy_protocol) using an `EnvoyFilter` applied on the gateway workload. For example:
 

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -232,7 +232,7 @@ spec:
       istio: ingressgateway
 {{< /text >}}
 
-The client IP is retrieved from the PROXY protocol by the gateway and set (or appended) in the `X-Forwarded-For` and `X-Envoy-External-Address` header. Note that the PROXY protocol is mutually exclusive with L7 headers like `X-Forwarded-For` and `X-Envoy-External-Address` - when PROXY protocol is used in conjunction with the `gatewayTopology` configuration, the `numTrustedProxies` and the received `X-Forwarded-For` header takes precedence in determining the trusted client addresses, and PROXY protocol client information will be ignored.
+The client IP is retrieved from the PROXY protocol by the gateway and set (or appended) in the `X-Forwarded-For` and `X-Envoy-External-Address` header. Note that the PROXY protocol is mutually exclusive with L7 headers like `X-Forwarded-For` and `X-Envoy-External-Address`. When PROXY protocol is used in conjunction with the `gatewayTopology` configuration, the `numTrustedProxies` and the received `X-Forwarded-For` header takes precedence in determining the trusted client addresses, and PROXY protocol client information will be ignored.
 
 Note that the above example only configures the Gateway to accept incoming PROXY protocol TCP traffic - See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/ip_transparency#proxy-protocol) for examples of how to configure Envoy itself to communicate with upstream services using PROXY protocol.
 

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -202,7 +202,7 @@ for examples of using this capability.
 
 {{< boilerplate experimental >}}
 The [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) allows for exchanging and preservation of client attributes between TCP proxies,
-without relying on L7 protocols such as HTTP and the `X-Forwarded-For` and `X-Envoy-External-Address` headers, and is intended for scenarios where an external TCP load balancer needs to proxy TCP traffic through an Istio gateway to a backend TCP service and still expose client attributes such as source IP to upstream TCP service endpoints. 
+without relying on L7 protocols such as HTTP and the `X-Forwarded-For` and `X-Envoy-External-Address` headers. It is intended for scenarios where an external TCP load balancer needs to proxy TCP traffic through an Istio gateway to a backend TCP service and still expose client attributes such as source IP to upstream TCP service endpoints.
 
 {{< idea >}}
 PROXY protocol is only supported for TCP traffic forwarding by Envoy. See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/ip_transparency#proxy-protocol) for more details, along with some important performance caveats.

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -200,9 +200,8 @@ for examples of using this capability.
 
 ## PROXY Protocol
 
-{{< boilerplate experimental >}}
 The [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) allows for exchanging and preservation of client attributes between TCP proxies,
-without relying on L7 protocols such as HTTP and the `X-Forwarded-For` and `X-Envoy-External-Address` headers. It is intended for scenarios where an external TCP load balancer needs to proxy TCP traffic through an Istio gateway to a backend TCP service and still expose client attributes such as source IP to upstream TCP service endpoints.
+without relying on L7 protocols such as HTTP and the `X-Forwarded-For` and `X-Envoy-External-Address` headers. It is intended for scenarios where an external TCP load balancer needs to proxy TCP traffic through an Istio gateway to a backend TCP service and still expose client attributes such as source IP to upstream TCP service endpoints. PROXY protocol can be enabled via EnvoyFilter.
 
 {{< warning >}}
 PROXY protocol is only supported for TCP traffic forwarding by Envoy. See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/ip_transparency#proxy-protocol) for more details, along with some important performance caveats.

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -204,7 +204,7 @@ for examples of using this capability.
 The [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) allows for exchanging and preservation of client attributes between TCP proxies,
 without relying on L7 protocols such as HTTP and the `X-Forwarded-For` and `X-Envoy-External-Address` headers. It is intended for scenarios where an external TCP load balancer needs to proxy TCP traffic through an Istio gateway to a backend TCP service and still expose client attributes such as source IP to upstream TCP service endpoints.
 
-{{< idea >}}
+{{< warning >}}
 PROXY protocol is only supported for TCP traffic forwarding by Envoy. See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/ip_transparency#proxy-protocol) for more details, along with some important performance caveats.
 
 PROXY protocol should not be used for L7 traffic, or for Istio gateways behind L7 load balancers.

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -201,7 +201,7 @@ for examples of using this capability.
 ## PROXY Protocol
 
 The [PROXY protocol](https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt) allows for exchanging and preservation of client attributes between TCP proxies,
-without relying on L7 protocols such as HTTP and the `X-Forwarded-For` and `X-Envoy-External-Address` headers. It is intended for scenarios where an external TCP load balancer needs to proxy TCP traffic through an Istio gateway to a backend TCP service and still expose client attributes such as source IP to upstream TCP service endpoints. PROXY protocol can be enabled via EnvoyFilter.
+without relying on L7 protocols such as HTTP and the `X-Forwarded-For` and `X-Envoy-External-Address` headers. It is intended for scenarios where an external TCP load balancer needs to proxy TCP traffic through an Istio gateway to a backend TCP service and still expose client attributes such as source IP to upstream TCP service endpoints. PROXY protocol can be enabled via `EnvoyFilter`.
 
 {{< warning >}}
 PROXY protocol is only supported for TCP traffic forwarding by Envoy. See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/other_features/ip_transparency#proxy-protocol) for more details, along with some important performance caveats.


### PR DESCRIPTION
Add some more detail to the currently (somewhat sparse) PROXY protocol gateway config section.

 - PROXY protocol should only be used for TCP traffic - echo the upstream Envoy docs in strongly encouraging people to not use it with L7 load balancers/traffic.
 
 - Add more context around what it is, where to use it, and more pointers to Envoy docs with specifics.
 
Associated with https://github.com/istio/istio/pull/42962


EDIT: As per discussion in https://github.com/istio/istio/pull/42962#issuecomment-1402236303, removing the `experimental` tag from the doc - we do not support PROXY protocol at all in Istio and it is not in any current feature matrix, but it _may_ be enabled via EnvoyFilter, which is a feature that already has its own status.



- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
