### PR TITLE
WIP - Try moving gateway tests in default to it's own group

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/gtwapi_test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/gtwapi_test.sh
@@ -18,7 +18,7 @@
 source "tests/util/gateway-api.sh"
 install_gateway_api_crds
 
-# @setup profile=default
+# @setup profile=default-gateway
 source "content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh"
 
 # TODO fix cleanup approach and remove this temporary hack

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/gtwapi_test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/gtwapi_test.sh
@@ -18,7 +18,7 @@
 source "tests/util/gateway-api.sh"
 install_gateway_api_crds
 
-# @setup profile=default
+# @setup profile=default-gateway
 source "content/en/docs/tasks/traffic-management/ingress/secure-ingress/test.sh"
 
 # TODO fix cleanup approach and remove this temporary hack

--- a/content/en/docs/tasks/traffic-management/mirroring/gtwapi_test.sh
+++ b/content/en/docs/tasks/traffic-management/mirroring/gtwapi_test.sh
@@ -18,7 +18,7 @@
 source "tests/util/gateway-api.sh"
 install_gateway_api_crds
 
-# @setup profile=default
+# @setup profile=default-gateway
 source "content/en/docs/tasks/traffic-management/mirroring/test.sh"
 
 # @cleanup

--- a/content/en/docs/tasks/traffic-management/request-routing/gtwapi_test.sh
+++ b/content/en/docs/tasks/traffic-management/request-routing/gtwapi_test.sh
@@ -18,7 +18,7 @@
 source "tests/util/gateway-api.sh"
 install_gateway_api_crds
 
-# @setup profile=default
+# @setup profile=default-gateway
 source "content/en/docs/tasks/traffic-management/request-routing/test.sh"
 
 # @cleanup

--- a/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/gtwapi_test.sh
+++ b/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/gtwapi_test.sh
@@ -18,7 +18,7 @@
 source "tests/util/gateway-api.sh"
 install_gateway_api_crds
 
-# @setup profile=default
+# @setup profile=default-gateway
 source "content/en/docs/tasks/traffic-management/tcp-traffic-shifting/test.sh"
 
 # @cleanup

--- a/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/test.sh
+++ b/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/test.sh
@@ -54,6 +54,10 @@ else
     _set_ingress_environment_variables
 fi
 
+# Check the number of ssh keys.
+gcloud compute project-info describe
+kubectl config view
+
 _verify_lines snip_apply_weightbased_tcp_routing_4 "
 + one
 - two

--- a/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/test.sh
+++ b/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/test.sh
@@ -54,10 +54,6 @@ else
     _set_ingress_environment_variables
 fi
 
-# Check the number of ssh keys.
-gcloud compute project-info describe
-kubectl config view
-
 _verify_lines snip_apply_weightbased_tcp_routing_4 "
 + one
 - two

--- a/content/en/docs/tasks/traffic-management/traffic-shifting/gtwapi_test.sh
+++ b/content/en/docs/tasks/traffic-management/traffic-shifting/gtwapi_test.sh
@@ -18,7 +18,7 @@
 source "tests/util/gateway-api.sh"
 install_gateway_api_crds
 
-# @setup profile=default
+# @setup profile=default-gateway
 source "content/en/docs/tasks/traffic-management/traffic-shifting/test.sh"
 
 # @cleanup

--- a/tests/setup/profile_default_gateway/doc_test.go
+++ b/tests/setup/profile_default_gateway/doc_test.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package setupconfig
+
+import (
+	"testing"
+
+	"istio.io/istio.io/pkg/test/istioio"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+func TestMain(m *testing.M) {
+	// nolint: staticcheck
+	framework.
+		NewSuite(m).
+		Setup(istio.Setup(nil, setupConfig)).
+		Run()
+}
+
+func TestDocs(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(istioio.NewTestDocsFunc("profile=default-gateway"))
+}
+
+func setupConfig(ctx resource.Context, cfg *istio.Config) {
+	cfg.ControlPlaneValues = `
+values:
+  pilot:
+    env:
+      PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING: true
+`
+}


### PR DESCRIPTION
Please provide a description for what this PR is for.

Are the test flakes solvable by moving the gateway tests, in the default profile) to their own group.

First need to verify that simply adding to the name removes them from default, or I may need to specify something else like gateway.
