### PR TITLE
Add markdown-only lint option

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -118,6 +118,9 @@ lint-en: clean_public build_nominify lint-copyright-banner lint-python lint-yaml
 lint-fast: clean_public build_nominify lint-copyright-banner lint-python lint-yaml lint-dockerfiles lint-scripts lint-sass lint-typescript lint-go
 	@SKIP_LINK_CHECK=true scripts/lint_site.sh en
 
+lint-md: clean_public build_nominify
+	@SKIP_LINK_CHECK=true scripts/lint_site.sh en
+
 serve: site
 	@hugo serve --baseURL "http://${ISTIO_SERVE_DOMAIN}:1313/latest/" --bind 0.0.0.0 --disableFastRender
 


### PR DESCRIPTION
Add an option to only do markdown linting.  Useful for people writing blog posts.