### PR TITLE
Add minimal profile for docs test setups

### DIFF
--- a/tests/setup/README.md
+++ b/tests/setup/README.md
@@ -1,6 +1,6 @@
 # Setup Configs for istio.io Doc Tests
 
-Each folder under `tests/setup` corresponds to an istio setup configuration. Currently supported setup configurations include: `profile_default` to install the default profile, `profile_demo` to install the demo profile, and `profile_none` to not install istio at all.
+Each folder under `tests/setup` corresponds to an istio setup configuration. Currently supported setup configurations include: `profile_default` to install the default profile, `profile_demo` to install the demo profile, `profile_minimal` to install the minimal profile and `profile_none` to not install istio at all.
 
 ## Adding a Setup Config
 

--- a/tests/setup/profile_minimal/doc_test.go
+++ b/tests/setup/profile_minimal/doc_test.go
@@ -1,0 +1,47 @@
+// Copyright 2023 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package setupconfig
+
+import (
+	"testing"
+
+	"istio.io/istio.io/pkg/test/istioio"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+func TestMain(m *testing.M) {
+	// nolint: staticcheck
+	framework.
+		NewSuite(m).
+		Setup(istio.Setup(nil, setupConfig)).
+		Run()
+}
+
+func TestDocs(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(istioio.NewTestDocsFunc("profile=minimal"))
+}
+
+func setupConfig(ctx resource.Context, cfg *istio.Config) {
+	cfg.ControlPlaneValues = `
+profile: demo
+values:
+  pilot:
+    env:
+      PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING: true
+`
+}

--- a/tests/setup/profile_minimal/doc_test.go
+++ b/tests/setup/profile_minimal/doc_test.go
@@ -38,7 +38,7 @@ func TestDocs(t *testing.T) {
 
 func setupConfig(ctx resource.Context, cfg *istio.Config) {
 	cfg.ControlPlaneValues = `
-profile: demo
+profile: minimal
 values:
   pilot:
     env:


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

Have been using minimal profile in some of the tests, so i think it makes sense to add this, and then migrate those tests to use this new setup.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
