### PR TITLE
Preparing release notes for Istio-release-1.17

### DIFF
--- a/content/en/docs/releases/supported-releases/index.md
+++ b/content/en/docs/releases/supported-releases/index.md
@@ -59,20 +59,21 @@ As of now, data plane to data plane is compatible across all versions; however, 
 
 ## Support status of Istio releases
 
-| Version         | Currently Supported  | Release Date      | End of Life            | Supported Kubernetes Versions | Tested, but not supported          |
-| --------------- | -------------------- | ----------------- | ---------------------- | ----------------------------- | ---------------------------------- |
-| master          | No, development only |                   |                        |                               |                                    |
-| 1.16            | Yes                  | November 15, 2022 | ~June 2023 (Expected)  | 1.22, 1.23, 1.24, 1.25        | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
-| 1.15            | Yes                  | August 31, 2022   | ~March 2023 (Expected) | 1.22, 1.23, 1.24, 1.25        | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21 |
-| 1.14            | No                   | May 24, 2022      | Dec 27, 2022           | 1.21, 1.22, 1.23, 1.24        | 1.16, 1.17, 1.18, 1.19, 1.20       |
-| 1.13            | No                   | February 11, 2022 | Oct 12, 2022           | 1.20, 1.21, 1.22, 1.23        | 1.16, 1.17, 1.18, 1.19             |
-| 1.12            | No                   | November 18, 2021 | Jul 12, 2022           | 1.19, 1.20, 1.21, 1.22        | 1.16, 1.17, 1.18                   |
-| 1.11            | No                   | August 12, 2021   | Mar 25, 2022           | 1.18, 1.19, 1.20, 1.21, 1.22  | 1.16, 1.17                         |
-| 1.10            | No                   | May 18, 2021      | Jan 7, 2022            | 1.18, 1.19, 1.20, 1.21        | 1.16, 1.17, 1.22                   |
-| 1.9             | No                   | February 9, 2021  | Oct 8, 2021            | 1.17, 1.18, 1.19, 1.20        | 1.15, 1.16                         |
-| 1.8             | No                   | November 10, 2020 | May 12, 2021           | 1.16, 1.17, 1.18, 1.19        | 1.15                               |
-| 1.7             | No                   | August 21, 2020   | Feb 25, 2021           | 1.16, 1.17, 1.18              | 1.15                               |
-| 1.6 and earlier | No                   |                   |                        |                               |                                    |
+| Version         | Currently Supported  | Release Date      | End of Life            | Supported Kubernetes Versions | Tested, but not supported                |
+| --------------- | -------------------- | ----------------- | ---------------------- | ----------------------------- | -----------------------------------------|
+| master          | No, development only |                   |                        |                               |                                          |
+| 1.17            | Yes                  | February 14, 2023 | ~Sept 2023 (Expected)  | 1.23, 1.24, 1.25, 1.26        | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21, 1.22 |
+| 1.16            | Yes                  | November 15, 2022 | ~June 2023 (Expected)  | 1.22, 1.23, 1.24, 1.25        | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21       |
+| 1.15            | Yes                  | August 31, 2022   | ~March 2023 (Expected) | 1.22, 1.23, 1.24, 1.25        | 1.16, 1.17, 1.18, 1.19, 1.20, 1.21       |
+| 1.14            | No                   | May 24, 2022      | Dec 27, 2022           | 1.21, 1.22, 1.23, 1.24        | 1.16, 1.17, 1.18, 1.19, 1.20             |
+| 1.13            | No                   | February 11, 2022 | Oct 12, 2022           | 1.20, 1.21, 1.22, 1.23        | 1.16, 1.17, 1.18, 1.19                   |
+| 1.12            | No                   | November 18, 2021 | Jul 12, 2022           | 1.19, 1.20, 1.21, 1.22        | 1.16, 1.17, 1.18                         |
+| 1.11            | No                   | August 12, 2021   | Mar 25, 2022           | 1.18, 1.19, 1.20, 1.21, 1.22  | 1.16, 1.17                               |
+| 1.10            | No                   | May 18, 2021      | Jan 7, 2022            | 1.18, 1.19, 1.20, 1.21        | 1.16, 1.17, 1.22                         |
+| 1.9             | No                   | February 9, 2021  | Oct 8, 2021            | 1.17, 1.18, 1.19, 1.20        | 1.15, 1.16                               |
+| 1.8             | No                   | November 10, 2020 | May 12, 2021           | 1.16, 1.17, 1.18, 1.19        | 1.15                                     |
+| 1.7             | No                   | August 21, 2020   | Feb 25, 2021           | 1.16, 1.17, 1.18              | 1.15                                     |
+| 1.6 and earlier | No                   |                   |                        |                               |                                          |
 
 {{< warning >}}
 [Kubernetes 1.22 removed some deprecated APIs](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/) and as a result versions of Istio prior to 1.10.0 will no longer work. If you are upgrading your Kubernetes version, make sure that your Istio version is still supported.

--- a/content/en/news/releases/1.17.x/_index.md
+++ b/content/en/news/releases/1.17.x/_index.md
@@ -1,0 +1,8 @@
+---
+title: 1.17.x Releases
+description: Announcements for the 1.17 release and its associated patch releases.
+weight: 12
+list_by_publishdate: true
+layout: release-grid
+decoration: dot
+---

--- a/content/en/news/releases/1.17.x/announcing-1.17/_index.md
+++ b/content/en/news/releases/1.17.x/announcing-1.17/_index.md
@@ -1,0 +1,76 @@
+---
+title: Announcing Istio release-1.17
+linktitle: 1.17
+subtitle: Major Update
+description: Istio 1.17 release annoucement.
+publishdate: 2023-02-14
+release: 1.17.0
+aliases:
+    - /news/announcing-1.17
+    - /news/announcing-1.17.0
+---
+
+We are pleased to announce the release of Istio 1.17. This is the first Istio release of 2023. We would like to thank the entire Istio community for helping get the 1.17.0 release published. We would like to thank the Release Managers for this release, `Mariam John` from IBM, `Paul Merrison` from Tetrate and `Kalya Subramanian` from Microsoft. The release managers would specially like to thank the Test & Release WG lead Eric Van Norman (IBM) for his help and guidance throughout the release cycle. We would also like to thank the maintainers of the Istio work groups and the broader Istio community for helping us throughout the release process with timely feedback, reviews, community testing and for all your support to help ensure a timely release.
+
+{{< relnote >}}
+
+{{< tip >}}
+Istio 1.17.0 is officially supported on Kubernetes versions `1.23` to `1.26`.
+{{< /tip >}}
+
+## What's new
+
+Since the 1.16 release we’ve added some important new features and marked some of our existing features as Beta signaling that they’re ready for production use. Here are some highlights:
+
+### Canary upgrade and revision tags were promoted to Beta
+
+Basic support for upgrading the service mesh following a canary pattern using revisions was introduced in the Istio 1.6 release. Using this approach, you can run multiple control planes side-by-side without impacting an existing deployment and slowly migrate workloads from the old control plane to the new. In Istio 1.10, revision tags was introduced as an improvement to canary upgrades to help reduce the number of changes an operator has to make to use revisions, and safely upgrade an Istio control plane. This is a very widely adopted and used feature by our users in production. All integration tests and end-to-end tests covering documentation have been completed for this feature to graduate to Beta.
+
+### Helm installation was promoted to Beta
+
+Helm based installation of Istio, first introduced in Istio 0.4, has graduated to Beta. It is one of the most widely used methods to install Istio in production. All requirements to promote this feature to Beta were completed in this release including updating integration tests to use helm charts for install/upgrade, updating Helm integration tests and documenting advanced Helm chart customization and attributes in `values.yaml`.
+
+### Upgraded support for the Kubernetes Gateway API
+
+Istio's implementation of the [Gateway API](https://gateway-api.sigs.k8s.io/) has been moved to, and is now fully compliant with, the latest version of the API (0.6.1).
+
+### Istio dual stack support
+
+`IPv6` support in dual stack mode was added in Kubernetes in version 1.16 and graduated to stable in the 1.22 release. The basic foundation to enable dual stack support in Istio started in the Istio 1.16 release. In the Istio 1.17 release, the following capabilities were added to enable dual support in Istio:
+
+- Enable users to deploy a service with a single or dual stack IP family on a dual stack cluster. For instance, a user can separately deploy 3 services with IPv4 only, IPv6 only and dual stack IP families on a dual stack Kubernetes cluster, enabling these services to be accessible to each other via sidecar.
+- Added extra source address configuration for gateway's listeners to support dual stack mode, so that IPv4 and IPV6 clients outside of the service mesh can access the gateway. This is applicable only for auto deployed gateways via the gateway controller, and the native gateway of Kubernetes should already support dual stack.
+
+This is an alpha feature and is currently under [active development]( https://github.com/istio/istio/issues/40394).
+
+### Added support for filter patching in Istio
+
+Added support for listener filter patching which enables users to perform `ADD`, `REMOVE`, `REPLACE`, `INSERT_FIRST`, `INSERT_BEFORE`, `INSERT_AFTER` operations for `LISTENER_FILTER` in Istio's `EnvoyFilter` resource.
+
+### Added support for using `QuickAssist Technology` (QAT) `PrivateKeyProvider` in Istio
+
+Added support for using `QuickAssist Technology` (QAT) `PrivateKeyProvider` in SDS and added corresponding configuration for selecting QAT private key provider for gateways and sidecars. This builds on the fact that Envoy added [support for QAT]( https://github.com/envoyproxy/envoy/issues/21531) as another private key provider in addition to [CryptoMB]( https://istio.io/latest/blog/2022/cryptomb-privatekeyprovider/). For more information on QAT, you can refer [here]( https://www.intel.com/content/www/us/en/developer/articles/technical/envoy-tls-acceleration-with-quickassist-technology.html).
+
+### Enhancements to the `RequestAuth` API
+
+Added support to copy JWT claims to HTTP request headers in the `RequestAuth` API.
+
+### Enhancements to the `istioctl` command
+
+Added a number of enhancements to the istioctl command including adding:
+
+- `revision` flag to `istioctl admin log`, to switch controls between Istiod’s
+- `istioctl proxy-config ecds`, to support retrieving typed extension configuration from Envoy for a specified pod
+- `istioctl proxy-config log`, to set proxy log level for all pods in a deployment
+- `--revision` flag to `istioctl analyze`, to specify a specific revision
+
+## Join us at Istio Day, 2023
+
+[Istio Day Europe 2023](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/co-located-events/istio-day/), set for April 18th, is the first Istio conference hosted by CNCF. It will be a Day 0 event co-located with [KubeCon + CloudNativeCon Europe 2023](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe). This is a great opportunity for community members from across the globe to connect with Istio’s ecosystem of developers, partners and vendors. For more information related to the event, visit the [conference website](https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/). We hope you can join us at Istio Day Europe.
+
+## Upgrading to 1.17
+
+We would like to hear from you regarding your experience upgrading to Istio 1.17. Please take a few minutes to respond to a [brief survey](https://forms.gle/99uiMML96AmsXY5d6) and let us know how we are doing and what we can do to improve.
+
+You can also join the conversation at [Discuss Istio](https://discuss.istio.io/), or join our [Slack workspace](https://slack.istio.io/).
+Would you like to contribute directly to Istio? Find and join one of our [Working Groups](https://github.com/istio/community/blob/master/WORKING-GROUPS.md) and help us improve.

--- a/content/en/news/releases/1.17.x/announcing-1.17/change-notes/index.md
+++ b/content/en/news/releases/1.17.x/announcing-1.17/change-notes/index.md
@@ -1,0 +1,147 @@
+---
+title: Istio 1.17.0 Change Notes
+linktitle: 1.17.0
+subtitle: Minor Release
+description: Istio 1.17.0 change notes.
+publishdate: 2023-02-14
+release: 1.17.0
+weight: 10
+---
+
+## Deprecation Notices
+
+These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/docs/releases/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.
+
+- **Deprecated** setting `PILOT_CERT_PROVIDER` to `kubernetes` for Kubernetes versions less than 1.20. [PR #42233](https://github.com/istio/istio/pull/42233)
+
+- **Deprecated** Lightstep provider. Please use OpenTelemetry provider instead. [Issue #40027](https://github.com/istio/istio/issues/40027)
+
+## Traffic Management
+
+- **Improved** `MostSpecificHostMatch` to prevent full scanning hosts when encountering wildcards. [Issue #41453](https://github.com/istio/istio/issues/41453)
+
+- **Improved** Gateway naming conventions to be the concatenation of `Name` and `GatewayClassName`. Deployment also now deploys with its own Service Account, rather than using the `default` token. Naming convention affects name of Deployment, Service and Service Account. [PR #43103](https://github.com/istio/istio/pull/43103)
+
+- **Added** dual stack support for `statefulsets/headless`, service entry and gateway and use `getWildcardsAndLocalHost` for inbound cluster building. [PR #42712](https://github.com/istio/istio/pull/42712)
+
+- **Added** support for `ADD`, `REMOVE`, `REPLACE`, `INSERT_FIRST`, `INSERT_BEFORE`, `INSERT_AFTER` operations for `LISTENER_FILTER` in `EnvoyFilter`. [Issue #41445](https://github.com/istio/istio/issues/41445)
+
+- **Added** validation to `Gateway` and `Sidecar` to prevent partial wildcards as Envoy does not support them in hostnames. [Issue #42094](https://github.com/istio/istio/issues/42094)
+
+- **Added** support for k8s `ServiceInternalTrafficPolicy` (does not take `ProxyTerminatingEndpoints` into account). [Issue #42377](https://github.com/istio/istio/issues/42377)
+
+- **Added** `excludeInterfaces` support to the CNI plugin. [Issue #42381](https://github.com/istio/istio/pull/42381)
+
+- **Added** support for missing resource types to `/config_dump` API. [PR #42658](https://github.com/istio/istio/pull/42658)
+
+- **Fixed** `istio-clean-iptables` to properly cleanup when `InboundInterceptionMode` is TPROXY. [PR #41431](https://github.com/istio/istio/pull/41431)
+
+- **Fixed** `PrivateKeyProvider` may not be changed using proxy-config. [Issue #41760](https://github.com/istio/istio/issues/41760)
+
+- **Fixed** issue where Istio and K8S Gateway API resources are not handled correctly when namespace is selected or deselected by discovery selectors or namespace label (`ENABLE_ENHANCED_RESOURCE_SCOPING=true`). [Issue #42173](https://github.com/istio/istio/issues/42173)
+
+- **Fixed** ServiceEntries using `DNS_ROUND_ROBIN` being able to specify 0 endpoints. [Issue #42184](https://github.com/istio/istio/issues/42184)
+
+- **Fixed** ServiceEntries with a different revision label (than the Istio version installed) were being processed and endpoints for them created. [Issue #42212](https://github.com/istio/istio/issues/42212)
+
+- **Fixed** an issue where the sync timeout setting doesn't work on the remote clusters. [PR #42252](https://github.com/istio/istio/pull/42252)
+
+- **Fixed** Kubernetes service `exportTo` annotation not working on gateways by fixing gateway service dependencies. [Issue #42400](https://github.com/istio/istio/issues/42400)
+
+- **Fixed** locality label missing for a sidecar without service selected. [PR #42412](https://github.com/istio/istio/pull/42412)
+
+- **Fixed** an issue where the network endpoints are incorrectly computed when network gateway changes. [Issue #42818](https://github.com/istio/istio/issues/42818)
+
+- **Fixed** auto-passthrough gateways not getting XDS pushes on service updates if `PILOT_FILTER_GATEWAY_CLUSTER_CONFIG` is enabled. [PR #42721](https://github.com/istio/istio/pull/42721)
+
+- **Fixed** VirtualService delegate behavior not working with `defaultVirtualServiceExportTo: ["."]` setting. [Issue #42602](https://github.com/istio/istio/issues/42602)
+
+- **Fixed** Pilot push XDS panic when `PortLevelSettings[].Port` is nil leading to abnormal exit of Pilot. [Issue #42598](https://github.com/istio/istio/issues/42598)
+
+- **Fixed** a bug that caused the Namespace's network label to have a higher priority than the Pod's network label. [Issue #42675](https://github.com/istio/istio/issues/42675)
+
+- **Fixed** pilot status to not log too many errors when `PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING` is not enabled. [Issue #42612](https://github.com/istio/istio/issues/42612)
+
+## Security
+
+- **Added** validation warning message for L7 Deny rules which will block all TCP traffic under the scope of the policy having that rule. [PR #41802](https://github.com/istio/istio/pull/41802)
+
+- **Added** support for using QAT (`QuickAssist Technology`) `PrivateKeyProvider` in SDS. [PR #42203](https://github.com/istio/istio/pull/42203)
+
+- **Added** configuration for selecting QAT private key provider for gateways and sidecars. [PR #2565](https://github.com/istio/api/pull/2565)
+
+- **Added** support to Copy JWT claims to HTTP request headers. [Issue #39724](https://github.com/istio/istio/issues/39724)
+
+- **Fixed** an issue preventing istio-proxy to access root CA when `automountServiceAccountToken` is `false` and `PILOT_CERT_PROVIDER` is `kubernetes`. [PR #42233](https://github.com/istio/istio/pull/42233)
+
+## Telemetry
+
+- **Updated** the Telemetry API to use a new native extension (stats) for Prometheus stats instead of the Wasm-based extension. This improves CPU overhead and memory usage of the feature. Custom dimensions no longer require regex and bootstrap annotations. If customizations use CEL expressions with Wasm attributes, they are likely to be affected. [PR #41441](https://github.com/istio/istio/pull/41441)
+
+- **Added** an analyzer for Telemetry resource. [Issue #41170](https://github.com/istio/istio/issues/41170) [PR #41785](https://github.com/istio/istio/pull/41785)
+
+- **Added** support for `reporting_interval`. This allows end-users to configure `tcp_reporting_duration` (configuration of the time between calls) via  the Telemetry API for metrics reporting. This currently supports TCP metrics only, but in the future we may use this for long duration HTTP streams. [Issue #41763](https://github.com/istio/istio/issues/41763)
+
+- **Fixed** an issue with bad request `malformed Host header` in the Telemetry API when configuring `Datadog` tracing provider. [Issue #41829](https://github.com/istio/istio/issues/41829)
+
+- **Fixed** OpenTelemetry tracer not working because of missing service name. [Issue #42080](https://github.com/istio/istio/issues/42080)
+
+## Installation
+
+- **Updated** Kiali addon from version `1.55.1` to `1.63.1`. [PR #43052](https://github.com/istio/istio/pull/43052), [PR #42193](https://github.com/istio/istio/pull/42193), [PR #41984](https://github.com/istio/istio/pull/41984)
+
+- **Updated** minimum supported Kubernetes version to `1.23.x`. [PR #43252](https://github.com/istio/istio/pull/43252)
+
+- **Added** `--purge` flag to `istioctl operator remove` which will remove all revisions of Istio operator. [Issue #41547](https://github.com/istio/istio/issues/41547)
+
+- **Added** support for allowing CSR signers via Helm installation. [PR #41923](https://github.com/istio/istio/pull/41923)
+
+- **Added** an input to the Gateway Helm deployment to explicitly set the `imagePullPolicy` of a gateway deployment. [Issue #42852](https://github.com/istio/istio/issues/42852)
+
+- **Fixed** `istioctl install` fails when specifying `--revision default`. [PR #41912](https://github.com/istio/istio/pull/41912)
+
+- **Fixed** inconsistent behavior of `istioctl verify-install` when `--revision` is not specified and when it is specified with `default`. [PR #41912](https://github.com/istio/istio/pull/41912)
+
+- **Fixed** `mutatingwebhook` not being split when setting multiple revision tags. [Issue #42234](https://github.com/istio/istio/issues/42234)
+
+- **Fixed** initialization of secure gRPC server of Pilot when serving certificates are provided in default location. [Issue #42249](https://github.com/istio/istio/issues/42249)
+
+- **Fixed** `appProtocol` field not taking effect in IstioOperator `ServicePort`. [Issue #42759](https://github.com/istio/istio/issues/42759)
+
+- **Fixed** an issue where gateway pods were not respecting the `global.imagePullPolicy` specified in the Helm values. [PR #42026](https://github.com/istio/istio/pull/42026)
+
+- **Removed** warning if `istio-cni` is not the default CNI plugin when CNI is used as a standalone plugin. [PR #41858](https://github.com/istio/istio/pull/41858)
+
+- **Removed** fetching charts from URLs in `istio-operator`. [Issue #41704](https://github.com/istio/istio/issues/41704)
+
+## istioctl
+
+- **Added** `revision` flag to admin log to switch controls between `Istiods`. [PR #41321](https://github.com/istio/istio/pull/41321)
+
+- **Updated** `admin log`'s `-r` flag to be shorthand for `--revision` for consistency with other commands (originally `-r` was shorthand for `--reset`). [PR #41321](https://github.com/istio/istio/pull/41321)
+
+- **Added** `istioctl proxy-config ecds` to support retrieving typed extension configuration from Envoy for a specified pod. [PR #42365](https://github.com/istio/istio/pull/42365)
+
+- **Added** the ability to set proxy log level for all pods in a deployment for `istioctl proxy-config log` command. [Issue #42919](https://github.com/istio/istio/issues/42919)
+
+- **Added** `--revision` to `istioctl analyze` to specify a specific revision. [Issue #38148](https://github.com/istio/istio/issues/38148)
+
+- **Fixed** manifest URL path (for downloading Istio version from a `Github` release) to support multi-arch instead of hard coding it. [PR #41483](https://github.com/istio/istio/pull/41483)
+
+- **Fixed** the default behavior of generating manifests using the helm chart library when using `istioctl` without `--cluster-specific` option to instead use the minimum Kubernetes version defined by `istioctl`. [Issue #42441](https://github.com/istio/istio/issues/42441)
+
+- **Fixed** the issue where `istioctl analyze` was throwing `SIGSEGV` when optional field `filter` was missing under `EnvoyFilter.ListenerMatch.FilterChainMatch` section. [Issue #42831](https://github.com/istio/istio/issues/42831)
+
+- **Fixed** `istioctl proxy-config` failure when a user specifies a custom proxy admin port with `--proxy-admin-port`. [Issue #43063](https://github.com/istio/istio/issues/43063)
+
+- **Fixed** `istioctl version` not compatible with custom versions. [PR #41650](https://github.com/istio/istio/pull/41650)
+
+- **Fixed** `istioctl validate` not detecting service port `appProtocol`. [PR #41517](https://github.com/istio/istio/pull/41517)
+
+- **Fixed** `istioctl proxy-config endpoint -f -` returns `Error: open -: no such file or directory`. [Issue #43045](https://github.com/istio/istio/issues/43045)
+
+## Documentation changes
+
+- **Fixed** incorrect `pilot-discovery` environment variable name from `VERIFY_CERT_AT_CLIENT` to `VERIFY_CERTIFICATE_AT_CLIENT`. [PR #2596](https://github.com/istio/api/pull/2596)
+
+- **Removed** comment about not supporting regex for delegate VirtualService. [Issue #2527](https://github.com/istio/api/issues/2527)

--- a/content/en/news/releases/1.17.x/announcing-1.17/upgrade-notes/index.md
+++ b/content/en/news/releases/1.17.x/announcing-1.17/upgrade-notes/index.md
@@ -1,0 +1,17 @@
+---
+title: Istio 1.17 Upgrade Notes
+description: Important changes to consider when upgrading to Istio 1.17.
+publishdate: 2023-02-14
+weight: 20
+---
+
+When you upgrade from Istio 1.16.x to Istio 1.17, you need to consider the changes on this page.
+These notes detail the changes which purposefully break backwards compatibility with Istio `1.16.x`.
+The notes also mention changes which preserve backwards compatibility while introducing new behavior.
+Changes are only included if the new behavior would be unexpected to a user of Istio `1.16.x`.
+Users upgrading from 1.15.x to Istio 1.17 should also reference the [1.16 change notes](/news/releases/1.16.x/announcing-1.16/change-notes/).
+
+## Gateway naming scheme updated
+
+If you are using the [Kubernetes Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.Gateway)
+to manage your Istio gateways, the names of the `Kubernetes Deployment` and `Service` has been modified. The default `Service Account` used has also switched to use its own token. To continue using the old convention during upgrades, the `gateway.istio.io/name-override` and `gateway.istio.io/service-account` annotations can be used.

--- a/data/args.yml
+++ b/data/args.yml
@@ -29,7 +29,7 @@ source_branch_name: release-1.17
 doc_branch_name: master
 
 # The list of supported versions described by the docs
-supported_kubernetes_versions: ["1.22", "1.23", "1.24", "1.25"]
+supported_kubernetes_versions: ["1.23", "1.24", "1.25", "1.26"]
 
 ####### Static values
 


### PR DESCRIPTION
Draft of release notes for 1.17 release. 

Completed:
[x] Ran the release notes tool to generate the release notes for 1.17 using the command: `./gen-release-notes --notes ../../../istio --oldBranch 1.16.0 --newBranch release-1.17` (against the istio/istio and istio/api repos)
[x] Scanned through the generated change notes and sorted all the release notes under the right heading (WG) and recorded all the PR's as well as issues associated to them, fixed grammatical errors.
[x] Need to sweep through the change notes again and correctly associate the issues->PR's where available and not linked and correspondingly update the release note to link to the issues with PR's. For release notes without issues created, will use the link to corresponding PR's
[x] Need to add a draft of the overview for the 1.17 announcement


- [ ] Configuration Infrastructure
- [X ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
