### PR TITLE
TEST PR : check if minimal profile test is being run in multiple jobs

### DIFF
--- a/tests/setup/profile_minimal/doc_test.go
+++ b/tests/setup/profile_minimal/doc_test.go
@@ -40,6 +40,7 @@ func setupConfig(ctx resource.Context, cfg *istio.Config) {
 	// FIXME: test framework does not honor profile=minimal config at present,
 	// hence we have to explicitly disable the gateways.
 	cfg.ControlPlaneValues = `
+profile: minimal
 values:
   pilot:
     env:


### PR DESCRIPTION
Signed-off-by: Faseela K <faseela.k@est.tech>

https://github.com/istio/istio.io/pull/12576 tried to move ingress-sni-passthrough test to minimal profile, but looks like the test is not being run in the CI in both the default and minimal profile tests. Pushing this PR just to see what is going wrong.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
