### PR TITLE
Change for consistency with title in claim-to-header

### DIFF
--- a/content/en/docs/tasks/security/authentication/claim-to-header/index.md
+++ b/content/en/docs/tasks/security/authentication/claim-to-header/index.md
@@ -1,6 +1,6 @@
 ---
 title: Copy JWT Claims to HTTP Headers
-description: Shows how users can copy their jWT claims to http headers.
+description: Shows how users can copy their JWT claims to HTTP headers.
 weight: 30
 keywords: [security,authentication,JWT,claim]
 aliases:
@@ -10,7 +10,8 @@ owner: istio/wg-security-maintainers
 test: yes
 status: Experimental
 ---
-This task shows you how to copy valid JWT claims to http headers after JWT authentication is successfully completed via Istio request authentication policy.
+
+This task shows you how to copy valid JWT claims to HTTP headers after JWT authentication is successfully completed via an Istio request authentication policy.
 
 {{< warning >}}
 Only claims of type string, boolean, and integer are supported. Array type claims are not supported at this time.
@@ -27,7 +28,7 @@ Before you begin this task, do the following:
 * Install Istio using [Istio installation guide](/docs/setup/install/istioctl/).
 
 * Deploy `httpbin` and `sleep` workloads in namespace `foo` with sidecar injection enabled.
-Deploy the example namespace and workloads using these commands:
+    Deploy the example namespace and workloads using these commands:
 
     {{< text bash >}}
     $ kubectl create ns foo
@@ -43,16 +44,16 @@ Deploy the example namespace and workloads using these commands:
     200
     {{< /text >}}
 
-{{< warning >}}
-If you don’t see the expected output, retry after a few seconds.
-Caching and propagation can cause a delay.
-{{< /warning >}}
+    {{< warning >}}
+    If you don’t see the expected output, retry after a few seconds.
+    Caching and propagation can cause a delay.
+    {{< /warning >}}
 
 ## Allow requests with valid JWT and list-typed claims
 
 1. The following command creates the `jwt-example` request authentication policy
-for the `httpbin` workload in the `foo` namespace. This policy
-accepts a JWT issued by `testing@secure.istio.io` and copies the value of claim `foo` to an http header `X-Jwt-Claim-Foo`:
+    for the `httpbin` workload in the `foo` namespace. This policy
+    accepts a JWT issued by `testing@secure.istio.io` and copies the value of claim `foo` to an HTTP header `X-Jwt-Claim-Foo`:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
@@ -95,7 +96,7 @@ accepts a JWT issued by `testing@secure.istio.io` and copies the value of claim 
     200
     {{< /text >}}
 
-1. Verify that a request contains a valid http header with JWT claim value:
+1. Verify that a request contains a valid HTTP header with JWT claim value:
 
     {{< text bash >}}
     $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -H "Authorization: Bearer $TOKEN" | grep "X-Jwt-Claim-Foo" | sed -e 's/^[ \t]*//'


### PR DESCRIPTION
- Change capitalization to enable terms consistent with that title:
  - JWT
  - HTTP header
- Fix indentations

- [x] Docs

