### PR TITLE
Nit: modify the path of `pilot-k8s.yaml`

### DIFF
--- a/content/en/docs/setup/additional-setup/customize-installation/index.md
+++ b/content/en/docs/setup/additional-setup/customize-installation/index.md
@@ -128,7 +128,7 @@ spec:
 Use `istioctl install` to apply the modified settings to the cluster:
 
 {{< text syntax="bash" repo="operator" >}}
-$ istioctl install -f samples/operator/pilot-k8s.yaml
+$ istioctl install -f operator/samples/pilot-k8s.yaml
 {{< /text >}}
 
 ### Customize Istio settings using the Helm API


### PR DESCRIPTION
`pilot-k8s.yaml` is currently located at https://github.com/istio/istio/blob/master/operator/samples/pilot-k8s.yaml

so let me update the doc.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
