### PR TITLE
gateway api: ignore error on install CRDs

### DIFF
--- a/content/en/blog/2022/getting-started-gtwapi/index.md
+++ b/content/en/blog/2022/getting-started-gtwapi/index.md
@@ -55,7 +55,7 @@ To get started using the Gateway API, you need to first download the CRDs, which
 on most Kubernetes clusters, at least not yet:
 
 {{< text bash >}}
-$ kubectl get crd gateways.gateway.networking.k8s.io || \
+$ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref={{< k8s_gateway_api_version >}}" | kubectl apply -f -; }
 {{< /text >}}
 

--- a/content/en/boilerplates/gateway-api-install-crds.md
+++ b/content/en/boilerplates/gateway-api-install-crds.md
@@ -4,6 +4,6 @@ Note that the Kubernetes Gateway API CRDs do not come installed by default on mo
 installed before using the Gateway API:
 
 {{< text syntax=bash snip_id=install_crds >}}
-$ kubectl get crd gateways.gateway.networking.k8s.io || \
+$ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref={{< k8s_gateway_api_version >}}" | kubectl apply -f -; }
 {{< /text >}}

--- a/content/en/boilerplates/snips/gateway-api-install-crds.sh
+++ b/content/en/boilerplates/snips/gateway-api-install-crds.sh
@@ -21,6 +21,6 @@
 ####################################################################################################
 
 bpsnip_gateway_api_install_crds_install_crds() {
-kubectl get crd gateways.gateway.networking.k8s.io || \
+kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.6.1" | kubectl apply -f -; }
 }

--- a/content/en/docs/setup/additional-setup/getting-started/index.md
+++ b/content/en/docs/setup/additional-setup/getting-started/index.md
@@ -23,7 +23,7 @@ The Kubernetes Gateway API CRDs do not come installed by default on most Kuberne
 installed before using the Gateway API:
 
 {{< text bash >}}
-$ kubectl get crd gateways.gateway.networking.k8s.io || \
+$ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref={{< k8s_gateway_api_version >}}" | kubectl apply -f -; }
 {{< /text >}}
 

--- a/content/en/docs/setup/additional-setup/getting-started/snips.sh
+++ b/content/en/docs/setup/additional-setup/getting-started/snips.sh
@@ -22,7 +22,7 @@
 source "content/en/boilerplates/snips/trace-generation.sh"
 
 snip__1() {
-kubectl get crd gateways.gateway.networking.k8s.io || \
+kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.6.1" | kubectl apply -f -; }
 }
 

--- a/content/en/docs/setup/install/external-controlplane/index.md
+++ b/content/en/docs/setup/install/external-controlplane/index.md
@@ -631,7 +631,7 @@ The Kubernetes Gateway API CRDs do not come installed by default on most Kuberne
 installed before using the Gateway API:
 
 {{< text syntax=bash snip_id=install_crds >}}
-$ kubectl get crd gateways.gateway.networking.k8s.io --context="${CTX_REMOTE_CLUSTER}" || \
+$ kubectl get crd gateways.gateway.networking.k8s.io --context="${CTX_REMOTE_CLUSTER}" &> /dev/null || \
   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref={{< k8s_gateway_api_version >}}" | kubectl apply -f - --context="${CTX_REMOTE_CLUSTER}"; }
 {{< /text >}}
 

--- a/content/en/docs/setup/install/external-controlplane/snips.sh
+++ b/content/en/docs/setup/install/external-controlplane/snips.sh
@@ -407,7 +407,7 @@ istio-ingressgateway-7bcd5c6bbd-kmtl4   1/1     Running   0          8m4s
 ENDSNIP
 
 snip_install_crds() {
-kubectl get crd gateways.gateway.networking.k8s.io --context="${CTX_REMOTE_CLUSTER}" || \
+kubectl get crd gateways.gateway.networking.k8s.io --context="${CTX_REMOTE_CLUSTER}" &> /dev/null || \
   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.6.1" | kubectl apply -f - --context="${CTX_REMOTE_CLUSTER}"; }
 }
 

--- a/content/en/docs/tasks/traffic-management/ingress/gateway-api/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/gateway-api/index.md
@@ -28,7 +28,7 @@ You can even use the Gateway API, right from the start, by following the [future
 1. The Gateway APIs do not come installed by default on most Kubernetes clusters. Install the Gateway API CRDs if they are not present:
 
     {{< text bash >}}
-    $ kubectl get crd gateways.gateway.networking.k8s.io || \
+    $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
       { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref={{< k8s_gateway_api_version >}}" | kubectl apply -f -; }
     {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/ingress/gateway-api/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/gateway-api/snips.sh
@@ -21,7 +21,7 @@
 ####################################################################################################
 
 snip_setup_1() {
-kubectl get crd gateways.gateway.networking.k8s.io || \
+kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.6.1" | kubectl apply -f -; }
 }
 


### PR DESCRIPTION
The *expected* result is an error, so ignore it.,

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
