### PR TITLE
Bump Hugo version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
     publish = "public"
 
 [build.environment]
-    HUGO_VERSION = "0.109.0"
+    HUGO_VERSION = "0.110.0"
     NODE_VERSION = "18.12.1"
     BUILD_WITH_CONTAINER = "0"
     GO_VERSION = "1.19.3"


### PR DESCRIPTION
Use [Hugo 0.110.0](https://github.com/gohugoio/hugo/releases/tag/v0.110.0) to build the site.
Hugo 0.110.0 was the latest available at time I checked.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
