### PR TITLE
Fix cleanup instructions for TLS version config task

### DIFF
--- a/content/en/docs/tasks/security/tls-configuration/workload-min-tls-version/index.md
+++ b/content/en/docs/tasks/security/tls-configuration/workload-min-tls-version/index.md
@@ -86,17 +86,17 @@ Cipher is (NONE)
 
 ## Cleanup
 
-Delete sample applications `sleep` and `httpbin` from `foo` namespace:
+Delete sample applications `sleep` and `httpbin` from the `foo` namespace:
 
 {{< text bash >}}
 $ kubectl delete -f samples/httpbin/httpbin.yaml -n foo
 $ kubectl delete -f samples/sleep/sleep.yaml -n foo
 {{< /text >}}
 
-Uninstall Istio from cluster:
+Uninstall Istio from the cluster:
 
 {{< text bash >}}
-$ istioctl uninstall --revision=default
+$ istioctl uninstall --purge -y
 {{< /text >}}
 
 To remove the `foo` and `istio-system` namespaces:

--- a/content/en/docs/tasks/security/tls-configuration/workload-min-tls-version/index.md
+++ b/content/en/docs/tasks/security/tls-configuration/workload-min-tls-version/index.md
@@ -86,6 +86,19 @@ Cipher is (NONE)
 
 ## Cleanup
 
+Delete sample applications `sleep` and `httpbin` from `foo` namespace:
+
+{{< text bash >}}
+$ kubectl delete -f samples/httpbin/httpbin.yaml -n foo
+$ kubectl delete -f samples/sleep/sleep.yaml -n foo
+{{< /text >}}
+
+Uninstall Istio from cluster:
+
+{{< text bash >}}
+$ istioctl uninstall --revision=default
+{{< /text >}}
+
 To remove the `foo` and `istio-system` namespaces:
 
 {{< text bash >}}

--- a/content/en/docs/tasks/security/tls-configuration/workload-min-tls-version/snips.sh
+++ b/content/en/docs/tasks/security/tls-configuration/workload-min-tls-version/snips.sh
@@ -63,5 +63,14 @@ Cipher is (NONE)
 ENDSNIP
 
 snip_cleanup_1() {
+kubectl delete -f samples/httpbin/httpbin.yaml -n foo
+kubectl delete -f samples/sleep/sleep.yaml -n foo
+}
+
+snip_cleanup_2() {
+istioctl uninstall --purge -y
+}
+
+snip_cleanup_3() {
 kubectl delete ns foo istio-system
 }

--- a/content/en/docs/tasks/security/tls-configuration/workload-min-tls-version/test.sh
+++ b/content/en/docs/tasks/security/tls-configuration/workload-min-tls-version/test.sh
@@ -40,5 +40,6 @@ _verify_contains snip_check_the_tls_configuration_of_istio_workloads_3 "$snip_ch
 _verify_contains snip_check_the_tls_configuration_of_istio_workloads_5 "$snip_check_the_tls_configuration_of_istio_workloads_6"
 
 # @cleanup
-echo y | istioctl uninstall --revision=default
 snip_cleanup_1
+snip_cleanup_2
+snip_cleanup_3


### PR DESCRIPTION
Please provide a description for what this PR is for.

The cleanup instructions for **Istio Workload Minimum TLS Version Configuration** are not complete as they do not currently include the delete of sample applications and the uninstall of Istio.

This PR relates to #12727.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
