### PR TITLE
Add instructions to set global_downstream_max_connections

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1114,3 +1114,4 @@ Ziyang
 Zolotusky
 ztunnel
 ztunnels
+global_downstream_max_connections

--- a/.spelling
+++ b/.spelling
@@ -442,7 +442,6 @@ git
 GitHub
 GitOps
 GKE
-global_downstream_max_connections
 Gloo
 GlueCon
 Gmail

--- a/.spelling
+++ b/.spelling
@@ -442,6 +442,7 @@ git
 GitHub
 GitOps
 GKE
+global_downstream_max_connections
 Gloo
 GlueCon
 Gmail
@@ -1114,4 +1115,3 @@ Ziyang
 Zolotusky
 ztunnel
 ztunnels
-global_downstream_max_connections

--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -675,11 +675,11 @@ While most cloud providers support this feature now, many local development tool
 
 By default, Istio (and Envoy) have no limit on the number of downstream connections. This can be exploited by a malicious actor (see [security bulletin 2020-007](/news/security/istio-security-2020-007/)). To work around you this, you must configure an appropriate connection limit for your environment.
 
-It is currently possible to configure the global_downstream_max_connections value in two ways: via Helm or patching the ingress gateway deployment.
+The `global_downstream_max_connections` value can be set when installing and configuring Istio via Helm or patching the ingress gateway deployment.
 
 ### Configure global_downstream_max_connections value with Helm
 
-When installing and configuring an Istio mesh using Helm it is possible to set the global_downstream_max_connections value as follows:
+When installing and configuring an Istio mesh using Helm it is possible to set the `global_downstream_max_connections` value as follows:
 
 1. Create `istiod-values.yaml` similar to:
 

--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -675,4 +675,68 @@ While most cloud providers support this feature now, many local development tool
 
 By default, Istio (and Envoy) have no limit on the number of downstream connections. This can be exploited by a malicious actor (see [security bulletin 2020-007](/news/security/istio-security-2020-007/)). To work around you this, you must configure an appropriate connection limit for your environment.
 
+It is currently possible to configure the global_downstream_max_connections value in two ways: via Helm or patching the ingress gateway deployment.
+
+### Configure global_downstream_max_connections value with Helm
+
+When installing and configuring an Istio mesh using Helm it is possible to set the global_downstream_max_connections value as follows:
+
+1. Create `istiod-values.yaml` similar to:
+{{< text yaml >}}
+meshConfig:
+  defaultConfig:
+    runtimeValues:
+      "overload.global_downstream_max_connections": "100000"
+{{< /text >}}
+
+2. Install Istio via Helm
+{{< text bash >}}
+$ helm install istio-base istio/base -n istio-system
+$ helm install istiod istio/istiod -n istio-system --values istiod-values.yaml
+{{< /text >}}
+
+3. Download Istio
+{{< text bash >}}
+$ curl -L https://istio.io/downloadIstio | sh -
+$ cd istio-1.17.0
+{{< /text >}}
+
+4. Create namespace, enable istio proxy injection and deploy sample application
+{{< text bash >}}
+$ kubectl create ns foo
+$ kubectl label ns foo istio-injection=enabled
+$ kubectl apply -f samples/httpbin/httpbin.yaml -n foo
+{{< /text >}}
+
+5. Check pod status
+{{< text bash >}}
+$ kubectl get po -n foo
+NAME                       READY   STATUS    RESTARTS   AGE
+httpbin-847f64cc8d-tlsg6   2/2     Running   0          6m7s
+{{< /text >}}
+
+6. Verify `global_downstream_max_connections` is set in `proxy config runtimeValues`
+{{< text bash >}}
+$ kubectl$ logs -n foo httpbin-847f64cc8d-tlsg6 -c istio-proxy
+...
+concurrency: 2
+configPath: ./etc/istio/proxy
+controlPlaneAuthPolicy: MUTUAL_TLS
+discoveryAddress: istiod.istio-system.svc:15012
+drainDuration: 45s
+proxyAdminPort: 15000
+runtimeValues:
+  overload.global_downstream_max_connections: "100000"
+serviceCluster: istio-proxy
+statNameLength: 189
+statusPort: 15020
+terminationDrainDuration: 5s
+tracing:
+  zipkin:
+    address: zipkin.istio-system:9411
+...
+{{< /text >}}
+
+### Configure global_downstream_max_connections value patching the ingress gateway deployment
+
 {{< boilerplate cve-2020-007-configmap >}}

--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -682,6 +682,7 @@ It is currently possible to configure the global_downstream_max_connections valu
 When installing and configuring an Istio mesh using Helm it is possible to set the global_downstream_max_connections value as follows:
 
 1. Create `istiod-values.yaml` similar to:
+
 {{< text yaml >}}
 meshConfig:
   defaultConfig:
@@ -689,33 +690,38 @@ meshConfig:
       "overload.global_downstream_max_connections": "100000"
 {{< /text >}}
 
-2. Install Istio via Helm
+1. Install Istio via Helm
+
 {{< text bash >}}
 $ helm install istio-base istio/base -n istio-system
 $ helm install istiod istio/istiod -n istio-system --values istiod-values.yaml
 {{< /text >}}
 
-3. Download Istio
+1. Download Istio
+
 {{< text bash >}}
 $ curl -L https://istio.io/downloadIstio | sh -
 $ cd istio-1.17.0
 {{< /text >}}
 
-4. Create namespace, enable istio proxy injection and deploy sample application
+1. Create the namespace, enable the Istio proxy injection and deploy the sample application
+
 {{< text bash >}}
 $ kubectl create ns foo
 $ kubectl label ns foo istio-injection=enabled
 $ kubectl apply -f samples/httpbin/httpbin.yaml -n foo
 {{< /text >}}
 
-5. Check pod status
+1. Check pod status
+
 {{< text bash >}}
 $ kubectl get po -n foo
 NAME                       READY   STATUS    RESTARTS   AGE
 httpbin-847f64cc8d-tlsg6   2/2     Running   0          6m7s
 {{< /text >}}
 
-6. Verify `global_downstream_max_connections` is set in `proxy config runtimeValues`
+1. Verify `global_downstream_max_connections` is set in `proxy config runtimeValues`
+
 {{< text bash >}}
 $ kubectl$ logs -n foo httpbin-847f64cc8d-tlsg6 -c istio-proxy
 ...

--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -675,13 +675,9 @@ While most cloud providers support this feature now, many local development tool
 
 By default, Istio (and Envoy) have no limit on the number of downstream connections. This can be exploited by a malicious actor (see [security bulletin 2020-007](/news/security/istio-security-2020-007/)). To work around you this, you must configure an appropriate connection limit for your environment.
 
-The `global_downstream_max_connections` value can be set when installing and configuring Istio via Helm or patching the ingress gateway deployment.
+### Configure `global_downstream_max_connections` value
 
-### Configure `global_downstream_max_connections` value with Helm
-
-When installing and configuring an Istio mesh using Helm it is possible to set the `global_downstream_max_connections` value as follows:
-
-1. Create `istiod-values.yaml` similar to:
+The following configuration can be supplied during installation:
 
 {{< text yaml >}}
 meshConfig:
@@ -689,60 +685,3 @@ meshConfig:
     runtimeValues:
       "overload.global_downstream_max_connections": "100000"
 {{< /text >}}
-
-1. Install Istio via Helm
-
-{{< text bash >}}
-$ helm install istio-base istio/base -n istio-system
-$ helm install istiod istio/istiod -n istio-system --values istiod-values.yaml
-{{< /text >}}
-
-1. Download Istio
-
-{{< text bash >}}
-$ curl -L https://istio.io/downloadIstio | sh -
-$ cd istio-1.17.0
-{{< /text >}}
-
-1. Create the namespace, enable the Istio proxy injection and deploy the sample application
-
-{{< text bash >}}
-$ kubectl create ns foo
-$ kubectl label ns foo istio-injection=enabled
-$ kubectl apply -f samples/httpbin/httpbin.yaml -n foo
-{{< /text >}}
-
-1. Check pod status
-
-{{< text bash >}}
-$ kubectl get po -n foo
-NAME                       READY   STATUS    RESTARTS   AGE
-httpbin-847f64cc8d-tlsg6   2/2     Running   0          6m7s
-{{< /text >}}
-
-1. Verify `global_downstream_max_connections` is set in `proxy config runtimeValues`
-
-{{< text bash >}}
-$ kubectl$ logs -n foo httpbin-847f64cc8d-tlsg6 -c istio-proxy
-...
-concurrency: 2
-configPath: ./etc/istio/proxy
-controlPlaneAuthPolicy: MUTUAL_TLS
-discoveryAddress: istiod.istio-system.svc:15012
-drainDuration: 45s
-proxyAdminPort: 15000
-runtimeValues:
-  overload.global_downstream_max_connections: "100000"
-serviceCluster: istio-proxy
-statNameLength: 189
-statusPort: 15020
-terminationDrainDuration: 5s
-tracing:
-  zipkin:
-    address: zipkin.istio-system:9411
-...
-{{< /text >}}
-
-### Configure `global_downstream_max_connections` value patching the ingress gateway deployment
-
-{{< boilerplate cve-2020-007-configmap >}}

--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -677,7 +677,7 @@ By default, Istio (and Envoy) have no limit on the number of downstream connecti
 
 The `global_downstream_max_connections` value can be set when installing and configuring Istio via Helm or patching the ingress gateway deployment.
 
-### Configure global_downstream_max_connections value with Helm
+### Configure `global_downstream_max_connections` value with Helm
 
 When installing and configuring an Istio mesh using Helm it is possible to set the `global_downstream_max_connections` value as follows:
 
@@ -743,6 +743,6 @@ tracing:
 ...
 {{< /text >}}
 
-### Configure global_downstream_max_connections value patching the ingress gateway deployment
+### Configure `global_downstream_max_connections` value patching the ingress gateway deployment
 
 {{< boilerplate cve-2020-007-configmap >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.

* Add instructions to set `global_downstream_max_connections`  in meshConfig runtimeValues
* Fix issue https://github.com/istio/istio/issues/37443


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
