### PR TITLE
Include cleanup section for istioctl analyse

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -156,6 +156,18 @@ To ignore multiple codes for a resource, separate each code with a comma:
 $ kubectl annotate deployment my-deployment galley.istio.io/analyze-suppress=IST0107,IST0002
 {{< /text >}}
 
+### Cleanup
+You could also cleanup the deployments by running:
+
+{{< text syntax=bash snip_id=analyse_cleanup >}}
+$ kubectl label namespace default istio-injection-
+$ kubectl delete ns frod
+$ kubectl delete deployment my-deployment
+$ kubectl delete vs ratings
+$ istioctl uninstall --purge -y
+$ kubectl delete ns istio-system
+{{< /text >}}
+
 ## Helping us improve this tool
 
 We're continuing to add more analysis capability and we'd love your help in identifying more use cases.

--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/snips.sh
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/snips.sh
@@ -114,3 +114,12 @@ kubectl annotate deployment my-deployment galley.istio.io/analyze-suppress=IST01
 snip_annotate_for_deployment_suppression_107() {
 kubectl annotate deployment my-deployment galley.istio.io/analyze-suppress=IST0107,IST0002
 }
+
+snip_analyse_cleanup() {
+kubectl label namespace default istio-injection-
+kubectl delete ns frod
+kubectl delete deployment my-deployment
+kubectl delete vs ratings
+istioctl uninstall --purge -y
+kubectl delete ns istio-system
+}


### PR DESCRIPTION
Please provide a description for what this PR is for.
Subject: https://github.com/istio/istio.io/issues/12759 - Add cleanup instructions to istioctl analyze pag
Description:
This PR brings cleanup document section for ```istioctl analyse``` command

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
