### PR TITLE
remove explicit istio-injection labeling on ns for ingress-gateway

### DIFF
--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -125,7 +125,6 @@ You can display the default values of configuration parameters using the `helm s
 
     {{< text syntax=bash snip_id=install_ingressgateway >}}
     $ kubectl create namespace istio-ingress
-    $ kubectl label namespace istio-ingress istio-injection=enabled
     $ helm install istio-ingress istio/gateway -n istio-ingress --wait
     {{< /text >}}
 

--- a/content/en/docs/setup/install/helm/snips.sh
+++ b/content/en/docs/setup/install/helm/snips.sh
@@ -98,7 +98,6 @@ ENDSNIP
 
 snip_install_ingressgateway() {
 kubectl create namespace istio-ingress
-kubectl label namespace istio-ingress istio-injection=enabled
 helm install istio-ingress istio/gateway -n istio-ingress --wait
 }
 

--- a/content/en/docs/setup/upgrade/canary/canary_upgrade_test.sh
+++ b/content/en/docs/setup/upgrade/canary/canary_upgrade_test.sh
@@ -30,6 +30,7 @@ kubectl -n test-ns apply -f samples/sleep/sleep.yaml
 _wait_for_deployment test-ns sleep
 
 # precheck before upgrade
+# shellcheck disable=SC2154
 _verify_lines snip_before_you_upgrade_1 "$snip_before_you_upgrade_1_out"
 
 # install canary revision

--- a/content/en/docs/setup/upgrade/canary/canary_upgrade_test.sh
+++ b/content/en/docs/setup/upgrade/canary/canary_upgrade_test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2154
 # Copyright Istio Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +31,6 @@ kubectl -n test-ns apply -f samples/sleep/sleep.yaml
 _wait_for_deployment test-ns sleep
 
 # precheck before upgrade
-# shellcheck disable=SC2154
 _verify_lines snip_before_you_upgrade_1 "$snip_before_you_upgrade_1_out"
 
 # install canary revision

--- a/content/zh/docs/setup/install/helm/index.md
+++ b/content/zh/docs/setup/install/helm/index.md
@@ -128,7 +128,6 @@ $ helm install <release> <chart> --namespace <namespace> --create-namespace [--s
 
     {{< text syntax=bash snip_id=install_ingressgateway >}}
     $ kubectl create namespace istio-ingress
-    $ kubectl label namespace istio-ingress istio-injection=enabled
     $ helm install istio-ingress istio/gateway -n istio-ingress --wait
     {{< /text >}}
 


### PR DESCRIPTION
The gateway deployment already has the annotation "sidecar.istio.io/inject=true"

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
