### PR TITLE
[zh] sync news/releases/1.15.x

### DIFF
--- a/content/zh/news/releases/1.15.x/announcing-1.15.2/index.md
+++ b/content/zh/news/releases/1.15.x/announcing-1.15.2/index.md
@@ -7,19 +7,21 @@ publishdate: 2022-10-11
 release: 1.15.2
 ---
 
-该版本包括（2022-10-04 发布的）Go 1.19.2 中对 `archive/tar`、`net/http/httputil` 和 `regexp` 包的安全修复。
-这个版本包含了改进稳健性的漏洞修复。
+该版本包含了对 [CVE-2022-39278](/zh/news/security/istio-security-2022-007/#cve-2022-39278)
+的修复以及改进稳健性的漏洞修复。
 本发布说明描述了 Istio 1.15.1 和 Istio 1.15.2 之间的不同之处。
 
+仅供参考，该版本包括（2022-10-04 发布的）Go 1.19.2 中对 `archive/tar`、`net/http/httputil`
+和 `regexp` 包的安全修复。
 {{< relnote >}}}
 
 ## 变更{#changes}
 
--  **修复** 修复了在 1.14.0 中 Passthrough 集群的默认 `idleTimeout` 更改为 `0s` 会禁用超时的问题。
+- **修复** 修复了在 1.14.0 中 Passthrough 集群的默认 `idleTimeout` 更改为 `0s` 会禁用超时的问题。
   将其恢复为之前的行为，即 Envoy 的默认值 1 小时。
   ([Issue #41114](https://github.com/istio/istio/issues/41114))
 
--  **修复** 修复了移除 `v1alpha2` 版本时 Gateway API 集成不失败的问题。
+- **修复** 修复了移除 `v1alpha2` 版本时 Gateway API 集成不失败的问题。
 
--  **修复** 修复了处理已弃用的自动扩缩设置时的问题。
+- **修复** 修复了处理已弃用的自动扩缩设置时的问题。
   ([Issue #41011](https://github.com/istio/istio/issues/41011))

--- a/content/zh/news/releases/1.15.x/announcing-1.15.4/index.md
+++ b/content/zh/news/releases/1.15.x/announcing-1.15.4/index.md
@@ -1,0 +1,34 @@
+---
+title: 发布 Istio 1.15.4
+linktitle: 1.15.4
+subtitle: 补丁发布
+description: Istio 1.15.4 补丁发布。
+publishdate: 2022-12-12
+release: 1.15.4
+---
+
+此版本包含了一些改进稳健性的漏洞修复。本发布说明描述了 Istio 1.15.3 和 Istio 1.15.4 之间的不同之处。
+
+此版本包含 Go 1.19.4（发布于 2022 年 12 月 6 日）中针对 `os` 和 `net/http` 包的安全修复。
+
+{{< relnote >}}
+
+## 变更{#changes}
+
+- **改进** 当 Wasm 模块下载失败且 `fail_open` 值为 true 时，一个允许所有流量的
+  RBAC 过滤器会被传递给 Envoy，而不是原来的 Wasm 过滤器。
+  之前，在这种情况下，给定的 Wasm 过滤器本身被传递给 Envoy，但它可能会导致错误，
+  因为 Wasm 配置的某些字段在 Istio 中是可选的，但在 Envoy 中不是。
+
+- **修复** 修复了当使用 Istio Operator 资源删除一个自定义网关时，其他网关会被重新启动的问题。
+  ([Issue #40577](https://github.com/istio/istio/issues/40577))
+
+- **修复** 修复了当 `cni.resourceQuotas` 被启用时，Istio Operator 无法正确创建 CNI 的问题。
+  ([Issue #41159](https://github.com/istio/istio/issues/41159))
+
+- **修复** 修复了 `istiod` 以 `PILOT_ENABLE_STATUS=true` 启动时，缺乏清理分发报告 ConfigMap 的权限的问题。
+
+- **修复** 修复了 `pilotExists` 总是返回 `false`的问题。
+  ([Issue #41631](https://github.com/istio/istio/issues/41631))
+
+- **修复** 修复了 Gateway Pod 不遵守 Helm 值中指定的 `global.imagePullPolicy`。

--- a/content/zh/news/releases/1.15.x/announcing-1.15.5/index.md
+++ b/content/zh/news/releases/1.15.x/announcing-1.15.5/index.md
@@ -1,0 +1,28 @@
+---
+title: 发布 Istio 1.15.5
+linktitle: 1.15.5
+subtitle: 补丁发布
+description: Istio 1.15.5 补丁发布。
+publishdate: 2023-01-30
+release: 1.15.5
+aliases:
+    - /zh/news/announcing-1.15.5
+---
+
+此版本包含了一些改进稳健性的漏洞修复。本发布说明描述了 Istio 1.15.4 和 Istio 1.15.5 之间的不同之处。
+
+{{< relnote >}}
+
+## 变更{#changes}
+
+- **新增** 在 `istioctl analyze` 命令中加入 `--revision` 参数，使其可以指定一个版本。
+  ([Issue #38148](https://github.com/istio/istio/issues/38148))
+
+- **新增** 缓解由 Go http2 库中的问题引起的请求偷渡漏洞。
+  ([Issue #56352](https://github.com/golang/go/issues/56352))
+
+- **修复** 修复了当 DestinationRule `PortLevelSettings[].Port` 为 nil 时，导致 istiod 异常退出的问题。
+  ([Issue #42598](https://github.com/istio/istio/issues/42598))
+
+- **修复** 修复了一个导致命名空间级网络标签（`topology.istio.io/network`）优先于 Pod 标签的问题。
+  ([Issue #42675](https://github.com/istio/istio/issues/42675))

--- a/content/zh/news/releases/1.15.x/announcing-1.15.6/index.md
+++ b/content/zh/news/releases/1.15.x/announcing-1.15.6/index.md
@@ -1,0 +1,21 @@
+---
+title: 发布 Istio 1.15.6
+linktitle: 1.15.6
+subtitle: 补丁发布
+description: Istio 1.15.6 补丁发布。
+publishdate: 2023-02-21T07:00:00-06:00
+release: 1.15.6
+aliases:
+  - /zh/news/announcing-1.15.6
+---
+
+本发布说明描述了 Istio 1.15.5 和 Istio 1.15.6 之间的不同之处。
+
+此版本包括 Go 1.19.6（2023 年 2 月 14 日发布）中
+`path/filepath`、`net/http`、`mime/multipart` 和 `crypto/tls` 软件包的安全修复。
+
+{{< relnote >}}
+
+## 变更{#changes}
+
+- 这个版本的唯一变化是 Go 的安全更新。

--- a/content/zh/news/releases/1.15.x/announcing-1.15/change-notes/index.md
+++ b/content/zh/news/releases/1.15.x/announcing-1.15/change-notes/index.md
@@ -22,7 +22,7 @@ weight: 10
   ([Issue #27990](https://github.com/istio/istio/issues/27990))
 
 - **新增** 新增对配置网格内部地址的支持。这可以通过设置
-`ENABLE_HCM_INTERNAL_NETWORKS` 为 true 来启用。
+  `ENABLE_HCM_INTERNAL_NETWORKS` 为 true 来启用。
 
 - **新增** 为 sidecar 新增了 `traffic.sidecar.istio.io/excludeInterfaces` 注解。
   ([Issue #39404](https://github.com/istio/istio/pull/39404))
@@ -74,7 +74,7 @@ weight: 10
 
 - **修复** 修复了一个 Bug，即 JWKS 动态生成的 `n` 没有经过 base64 编码，导致 envoy 无法正确解析它。
 
-## 观测{#telemetry} 
+## 观测{#telemetry}
 
 - **修复** 修复了 sidecar 客户端和 `ISTIO_MUTUAL`，网关的 TCP 服务器之间的 TCP 元数据交换。
 
@@ -134,8 +134,6 @@ weight: 10
 - **修复** 修复了当 `ServiceEntry` 地址为空但网状配置 `ISTIO_META_DNS_AUTO_ALLOCATE` 被启用时 `istioctl analyze` 返回一个意外的 IST0134 消息。
 
 - **修复** 修复了一个导致 `istioctl x injector list` 提供不正确的 Pod 信息的问题。
-
-- **修复** 修复了当对特定命名空间使用 `exportTo` 时，`istioctl analyze` 会出现 `ConflictingMeshGatewayVirtualServiceHosts（IST0109）` 信息。
 
 - **修复** 修复了当对特定命名空间使用 `exportTo` 时，`istioctl analyze` 会出现 `ConflictingMeshGatewayVirtualServiceHosts（IST0109）` 信息。
   ([Issue #39634](https://github.com/istio/istio/issues/39634))


### PR DESCRIPTION
This PR syncs page under `news/releases/1.15.x` with upstream.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
