### PR TITLE
Added headersToDownstreamOnAllow example in ext authz task page

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-custom/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-custom/index.md
@@ -143,7 +143,7 @@ allows requests with the header `x-ext-authz: allow`.
             port: "4180" # The default port used by oauth2-proxy.
             includeRequestHeadersInCheck: ["authorization", "cookie"] # headers sent to the oauth2-proxy in the check request.
             headersToUpstreamOnAllow: ["authorization", "path", "x-auth-request-user", "x-auth-request-email", "x-auth-request-access-token"] # headers sent to backend application when request is allowed.
-            headersToDownstreamOnAllow:["content-type", "set-cookie"] # headers sent back to the client when request is allowed.
+            headersToDownstreamOnAllow: ["content-type", "set-cookie"] # headers sent back to the client when request is allowed.
             headersToDownstreamOnDeny: ["content-type", "set-cookie"] # headers sent back to the client when request is denied.
     {{< /text >}}
 

--- a/content/en/docs/tasks/security/authorization/authz-custom/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-custom/index.md
@@ -143,6 +143,7 @@ allows requests with the header `x-ext-authz: allow`.
             port: "4180" # The default port used by oauth2-proxy.
             includeRequestHeadersInCheck: ["authorization", "cookie"] # headers sent to the oauth2-proxy in the check request.
             headersToUpstreamOnAllow: ["authorization", "path", "x-auth-request-user", "x-auth-request-email", "x-auth-request-access-token"] # headers sent to backend application when request is allowed.
+            headersToDownstreamOnAllow: ["content-type", "set-cookie"] # headers sent back to the client when request is allowed.
             headersToDownstreamOnDeny: ["content-type", "set-cookie"] # headers sent back to the client when request is denied.
     {{< /text >}}
 

--- a/content/en/docs/tasks/security/authorization/authz-custom/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-custom/index.md
@@ -143,7 +143,7 @@ allows requests with the header `x-ext-authz: allow`.
             port: "4180" # The default port used by oauth2-proxy.
             includeRequestHeadersInCheck: ["authorization", "cookie"] # headers sent to the oauth2-proxy in the check request.
             headersToUpstreamOnAllow: ["authorization", "path", "x-auth-request-user", "x-auth-request-email", "x-auth-request-access-token"] # headers sent to backend application when request is allowed.
-            headersToDownstreamOnAllow: ["content-type", "set-cookie"] # headers sent back to the client when request is allowed.
+            headersToDownstreamOnAllow:["content-type", "set-cookie"] # headers sent back to the client when request is allowed.
             headersToDownstreamOnDeny: ["content-type", "set-cookie"] # headers sent back to the client when request is denied.
     {{< /text >}}
 

--- a/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
@@ -100,6 +100,7 @@ data:
         port: "4180" # The default port used by oauth2-proxy.
         includeRequestHeadersInCheck: ["authorization", "cookie"] # headers sent to the oauth2-proxy in the check request.
         headersToUpstreamOnAllow: ["authorization", "path", "x-auth-request-user", "x-auth-request-email", "x-auth-request-access-token"] # headers sent to backend application when request is allowed.
+        headersToDownstreamOnAllow:["content-type", "set-cookie"] # headers sent back to the client when request is allowed.
         headersToDownstreamOnDeny: ["content-type", "set-cookie"] # headers sent back to the client when request is denied.
 ENDSNIP
 

--- a/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
@@ -100,7 +100,7 @@ data:
         port: "4180" # The default port used by oauth2-proxy.
         includeRequestHeadersInCheck: ["authorization", "cookie"] # headers sent to the oauth2-proxy in the check request.
         headersToUpstreamOnAllow: ["authorization", "path", "x-auth-request-user", "x-auth-request-email", "x-auth-request-access-token"] # headers sent to backend application when request is allowed.
-        headersToDownstreamOnAllow:["content-type", "set-cookie"] # headers sent back to the client when request is allowed.
+        headersToDownstreamOnAllow: ["content-type", "set-cookie"] # headers sent back to the client when request is allowed.
         headersToDownstreamOnDeny: ["content-type", "set-cookie"] # headers sent back to the client when request is denied.
 ENDSNIP
 


### PR DESCRIPTION
Added headersToDownstreamOnAllow to https://istio.io/latest/docs/tasks/security/authorization/authz-custom/#define-the-external-authorizer.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

Closes #12764 