### PR TITLE
accesslog: example of Telemetry API with cluster_name

### DIFF
--- a/content/en/docs/tasks/observability/logs/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/logs/telemetry-api/index.md
@@ -105,7 +105,7 @@ The following configuration displays access logs only when the response code is 
 Note: The xds.cluster_name is only available with Istio release 1.16.2 and higher
 
 {{< text bash >}}
-$ cat <<EOF | kubectl apply -n default -f -
+$ cat <<EOF | kubectl apply -f -
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
@@ -116,7 +116,7 @@ spec:
   - providers:
     - name: envoy
     filter:
-      expression: "response.code >= 400 || xds.cluster_name == 'BlackHoleCluster' ||  xds.cluster_name == 'PassthroughCluster' "       
+      expression: "response.code >= 400 || xds.cluster_name == 'BlackHoleCluster' ||  xds.cluster_name == 'PassthroughCluster' "
 
 EOF
 {{< /text >}}

--- a/content/en/docs/tasks/observability/logs/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/logs/telemetry-api/index.md
@@ -102,7 +102,7 @@ EOF
 1. Set default filter access log with CEL expression
 
 The following configuration displays access logs only when the response code is greater or equal to 400 or the request went to the BlackHoleCluster or the PassthroughCluster:
-Note: The xds.cluster_name is only available with Istio release 1.16.2 and higher
+Note: The `xds.cluster_name` is only available with Istio release 1.16.2 and higher
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -

--- a/content/en/docs/tasks/observability/logs/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/logs/telemetry-api/index.md
@@ -109,7 +109,7 @@ $ cat <<EOF | kubectl apply -f -
 apiVersion: telemetry.istio.io/v1alpha1
 kind: Telemetry
 metadata:
-name: disable-details-logging
+name: default-exception-logging
 namespace: istio-system
 spec:
   accessLogging:

--- a/content/en/docs/tasks/observability/logs/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/logs/telemetry-api/index.md
@@ -99,8 +99,30 @@ spec:
 EOF
 {{< /text >}}
 
+1. Set default filter access log with CEL expression
+
+The following configuration displays access logs only when the response code is greater or equal to 400 or the request went to the BlackHoleCluster or the PassthroughCluster:
+Note: The xds.cluster_name is only available with Istio release 1.16.2 and higher
+
+{{< text bash >}}
+$ cat <<EOF | kubectl apply -n default -f -
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+name: disable-details-logging
+namespace: istio-system
+spec:
+  accessLogging:
+  - providers:
+    - name: envoy
+    filter:
+      expression: "response.code >= 400 || xds.cluster_name == 'BlackHoleCluster' ||  xds.cluster_name == 'PassthroughCluster' "       
+
+EOF
+{{< /text >}}
+
 For more information, see [Use expressions for values](/docs/tasks/observability/metrics/customize-metrics/#use-expressions-for-values)
 
 ## Work with OpenTelemetry provider
 
-Istio supports sending access logs with [OpenTelemetry](https://opentelemetry.io/) protocol,  as explained [here](/docs/tasks/observability/logs/otel-provider).
+Istio supports sending access logs with [OpenTelemetry](https://opentelemetry.io/) protocol, as explained [here](/docs/tasks/observability/logs/otel-provider).


### PR DESCRIPTION
Add telemetry api example with xds.cluster_name

Please provide a description for what this PR is for.

This PR adds an example that takes advantage of the recent envoy PR's: https://github.com/envoyproxy/envoy/pull/24851 and https://github.com/envoyproxy/envoy/pull/24302

These PR's to envoy allow the telemetry api to filter on xds.cluster_name which can contain values like BlackHoleCluster and PassthroughCluster. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
