### PR TITLE
Update feature status for Experimental/Alpha

### DIFF
--- a/content/en/boilerplates/alpha.md
+++ b/content/en/boilerplates/alpha.md
@@ -1,0 +1,6 @@
+---
+---
+{{< warning >}}
+This feature is targeted at developers / expert users and is considered
+[alpha](https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE.md).
+{{< /warning >}}

--- a/content/en/docs/ops/configuration/extensibility/wasm-pull-policy/index.md
+++ b/content/en/docs/ops/configuration/extensibility/wasm-pull-policy/index.md
@@ -8,6 +8,8 @@ test: n/a
 status: Alpha
 ---
 
+{{< boilerplate alpha >}}
+
 The [WasmPlugin API](/docs/reference/config/proxy_extensions/wasm-plugin) provides a method for [distributing Wasm modules](/docs/tasks/extensibility/wasm-module-distribution) to proxies.
 Since each proxy will pull Wasm modules from a remote registry or an HTTP server, understanding how Istio chooses to pull modules is important in terms of usability as well as performance.
 

--- a/content/en/docs/ops/configuration/security/harden-docker-images/index.md
+++ b/content/en/docs/ops/configuration/security/harden-docker-images/index.md
@@ -7,7 +7,10 @@ aliases:
   - /docs/ops/security/harden-docker-images
 owner: istio/wg-security-maintainers
 test: n/a
+status: Alpha
 ---
+
+{{< boilerplate alpha >}}
 
 Istio's [default images](https://hub.docker.com/r/istio/base) are based on `ubuntu` with some extra tools added.
 An alternative image based on [distroless images](https://github.com/GoogleContainerTools/distroless) is also available.

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -8,6 +8,8 @@ test: yes
 status: Alpha
 ---
 
+{{< boilerplate alpha >}}
+
 ## Forwarding external client attributes (IP address, certificate info) to destination workloads
 
 Many applications require knowing the client IP address and certificate information of the originating request to behave

--- a/content/en/docs/reference/config/proxy_extensions/wasm_telemetry/index.md
+++ b/content/en/docs/reference/config/proxy_extensions/wasm_telemetry/index.md
@@ -9,6 +9,8 @@ aliases:
 status: Experimental
 ---
 
+{{< boilerplate experimental >}}
+
 By default, telemetry generation is enabled as compiled-in Istio proxy filters. The same filters are also compiled to WebAssembly (Wasm) modules and shipped with Istio proxy. To enable telemetry generation with the Wasm runtime, install Istio with the `preview` profile:
 
 {{< text bash >}}

--- a/content/en/docs/tasks/extensibility/wasm-module-distribution/index.md
+++ b/content/en/docs/tasks/extensibility/wasm-module-distribution/index.md
@@ -12,6 +12,8 @@ test: yes
 status: Alpha
 ---
 
+{{< boilerplate alpha >}}
+
 Istio provides the ability to [extend proxy functionality using WebAssembly (Wasm)](/blog/2020/wasm-announce/).
 One of the key advantages of Wasm extensibility is that extensions can be loaded dynamically at runtime.
 These extensions must first be distributed to the Envoy proxy.

--- a/content/en/docs/tasks/observability/distributed-tracing/mesh-and-proxy-config/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/mesh-and-proxy-config/index.md
@@ -8,7 +8,7 @@ aliases:
  - /docs/tasks/observability/distributed-tracing/configurability/mesh-and-proxy-config/
 owner: istio/wg-policies-and-telemetry-maintainers
 test: no
-status: Beta/Experimental
+status: Beta
 ---
 
 {{< boilerplate telemetry-tracing-tips >}}

--- a/content/en/docs/tasks/observability/telemetry/index.md
+++ b/content/en/docs/tasks/observability/telemetry/index.md
@@ -5,7 +5,10 @@ weight: 0
 keywords: [telemetry]
 owner: istio/wg-policies-and-telemetry-maintainers
 test: no
+status: Experimental
 ---
+
+{{< boilerplate experimental >}}
 
 Istio provides a [Telemetry API](/docs/reference/config/telemetry/) that enables flexible configuration of
 [metrics](/docs/tasks/observability/metrics/), [access logs](/docs/tasks/observability/logs/), and [tracing](/docs/tasks/observability/distributed-tracing/).

--- a/content/en/docs/tasks/security/authentication/claim-to-header/index.md
+++ b/content/en/docs/tasks/security/authentication/claim-to-header/index.md
@@ -11,13 +11,13 @@ test: yes
 status: Experimental
 ---
 
+{{< boilerplate experimental >}}
+
 This task shows you how to copy valid JWT claims to HTTP headers after JWT authentication is successfully completed via an Istio request authentication policy.
 
 {{< warning >}}
 Only claims of type string, boolean, and integer are supported. Array type claims are not supported at this time.
 {{< /warning >}}
-
-{{< boilerplate experimental-feature-warning >}}
 
 ## Before you begin
 

--- a/content/en/docs/tasks/security/authentication/jwt-route/index.md
+++ b/content/en/docs/tasks/security/authentication/jwt-route/index.md
@@ -5,8 +5,10 @@ weight: 10
 keywords: [security,authentication,jwt,route]
 owner: istio/wg-security-maintainers
 test: yes
-status: Experimental
+status: Alpha
 ---
+
+{{< boilerplate alpha >}}
 
 This task shows you how to route requests based on JWT claims on an Istio ingress gateway using the request authentication
 and virtual service.

--- a/content/en/docs/tasks/security/authorization/authz-dry-run/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-dry-run/index.md
@@ -5,16 +5,16 @@ weight: 65
 keywords: [security,access-control,rbac,authorization,dry-run]
 owner: istio/wg-security-maintainers
 test: yes
-status: Experimental
+status: Alpha
 ---
+
+{{< boilerplate alpha >}}
 
 This task shows you how to set up an Istio authorization policy using a new [experimental annotation `istio.io/dry-run`](/docs/reference/config/annotations/)
 to dry-run the policy without actually enforcing it.
 
 The dry-run annotation allows you to better understand the effect of an authorization policy before applying it to
 the production traffic. This helps to reduce the risk of breaking the production traffic caused by an incorrect authorization policy.
-
-{{< boilerplate experimental-feature-warning >}}
 
 ## Before you begin
 

--- a/content/zh/docs/ops/configuration/extensibility/wasm-pull-policy/index.md
+++ b/content/zh/docs/ops/configuration/extensibility/wasm-pull-policy/index.md
@@ -8,6 +8,8 @@ test: n/a
 status: Alpha
 ---
 
+{{< boilerplate alpha >}}
+
 [WasmPlugin API](/zh/docs/reference/config/proxy_extensions/wasm-plugin)
 提供了一种[将 Wasm 模块分发给](/zh/docs/tasks/extensibility/wasm-module-distribution)代理的方法。
 由于每个代理将从远程镜像仓库或 HTTP 服务器中拉取 Wasm 模块，所以了解 Istio 如何选择拉取模块的机制在可用性和性能方面都很重要。

--- a/content/zh/docs/ops/configuration/security/harden-docker-images/index.md
+++ b/content/zh/docs/ops/configuration/security/harden-docker-images/index.md
@@ -7,7 +7,10 @@ aliases:
   - /zh/docs/ops/security/harden-docker-images
 owner: istio/wg-security-maintainers
 test: n/a
+status: Alpha
 ---
+
+{{< boilerplate alpha >}}
 
 Istio 的[默认镜像](https://hub.docker.com/r/istio/base)基于 `ubuntu` 添加了一些额外的工具。
 也可以使用基于 [Distroless 镜像](https://github.com/GoogleContainerTools/distroless)的替代镜像。

--- a/content/zh/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/zh/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -8,6 +8,8 @@ test: yes
 status: Alpha
 ---
 
+{{< boilerplate alpha >}}
+
 ## 向目的地的工作负载转发外部客户端属性（IP 地址、证书信息）{#forwarding-external-client-attributes-to-destination-workloads}
 
 许多应用程序需要知道发起源请求的客户端 IP 地址和证书信息才能正常工作。值得注意的是填充了客户端 IP 的日志、验证工具以及安全工具。例如 Web Application Firewalls (WAF)，它应用这些信息来运行正确的规则集。

--- a/content/zh/docs/reference/config/proxy_extensions/wasm_telemetry/index.md
+++ b/content/zh/docs/reference/config/proxy_extensions/wasm_telemetry/index.md
@@ -9,6 +9,8 @@ aliases:
 status: Experimental
 ---
 
+{{< boilerplate experimental >}}
+
 默认情况下，遥测默认启用并作为一个 `filter` 被编译在 Istio 代理中，同时也被编译成 WebAssembly (Wasm) 模块，并随 Istio proxy 一起发布。若要使用 Wasm 进行遥测，请使用 `preview` 属性安装 Istio 。
 
 {{< text bash >}}

--- a/content/zh/docs/tasks/extensibility/wasm-module-distribution/index.md
+++ b/content/zh/docs/tasks/extensibility/wasm-module-distribution/index.md
@@ -12,6 +12,8 @@ test: yes
 status: Alpha
 ---
 
+{{< boilerplate alpha >}}
+
 Istio 提供了[使用 WebAssembly（Wasm）扩展代理功能](/zh/blog/2020/wasm-announce/)的能力。
 Wasm 可扩展性的关键优势之一是扩展可以在运行时动态加载。
 这些扩展必须首先分发到 Envoy 代理。

--- a/content/zh/docs/tasks/observability/distributed-tracing/mesh-and-proxy-config/index.md
+++ b/content/zh/docs/tasks/observability/distributed-tracing/mesh-and-proxy-config/index.md
@@ -8,7 +8,7 @@ aliases:
  - /zh/docs/tasks/observability/distributed-tracing/configurability/mesh-and-proxy-config/
 owner: istio/wg-policies-and-telemetry-maintainers
 test: no
-status: Beta/Experimental
+status: Beta
 ---
 
 {{< tip >}}

--- a/content/zh/docs/tasks/security/authentication/claim-to-header/index.md
+++ b/content/zh/docs/tasks/security/authentication/claim-to-header/index.md
@@ -11,13 +11,13 @@ test: yes
 status: Experimental
 ---
 
+{{< boilerplate experimental >}}
+
 本任务向您展示通过 Istio 请求身份验证策略成功完成 JWT 身份验证之后如何将 JWT 声明复制到 HTTP 头。
 
 {{< warning >}}
 仅支持 string、boolean 和 integer 类型的声明。此时不支持 array 类型的声明。
 {{< /warning >}}
-
-{{< boilerplate experimental-feature-warning >}}
 
 ## 开始之前{#before-you-begin}
 

--- a/content/zh/docs/tasks/security/authentication/jwt-route/index.md
+++ b/content/zh/docs/tasks/security/authentication/jwt-route/index.md
@@ -5,16 +5,16 @@ weight: 10
 keywords: [security,authentication,jwt,route]
 owner: istio/wg-security-maintainers
 test: yes
-status: Experimental
+status: Alpha
 ---
+
+{{< boilerplate alpha >}}
 
 本任务向您展示如何实现基于 Istio 入口网关上的 JWT 声明路由请求，来使用请求身份认证
 和虚拟服务。
 
 注意：该特性只支持 Istio 入口网关，并且需要使用请求身份验证和虚拟
 服务来根据 JWT 声明进行正确的验证和路由。
-
-{{< boilerplate experimental-feature-warning >}}
 
 ## 开始之前{#before-you-begin}
 

--- a/layouts/partials/navigation_level.html
+++ b/layouts/partials/navigation_level.html
@@ -30,9 +30,11 @@
             {{ $desc := .Description }}
             {{ $linktitle := .LinkTitle }}
             {{ if isset .Params "status" }}
-                {{ $status := .Params.status }}
-                {{ $linktitle = printf "%s %s" ($linktitle) "*" }}
-                {{ $desc = printf "%s (%s)" (trim $desc ".") (.Params.status) }}
+                {{ if or (eq .Params.status "Experimental") (eq .Params.status "Alpha") }}
+                    {{ $status := .Params.status }}
+                    {{ $linktitle = printf "%s %s" ($linktitle) "*" }}
+                    {{ $desc = printf "%s (%s)" (trim $desc ".") (.Params.status) }}
+                {{ end }}
             {{ end }}
 
             {{- if ne .PublishDate.Year 0001 -}}


### PR DESCRIPTION
> Please provide a description for what this PR is for.

Addresses Part 1 of this issue https://github.com/istio/istio.io/issues/12698#issuecomment-1451031403

---

Based off of the feature status in features.yaml, update the corresponding doc page.

Update navigation_level.html to only flag Experimental and Alpha features with an asterisk '*', rather than all docs with _any_ status set.

Add new 'alpha.md' boilerplate, similar to 'experimental.md', with a link to https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE.md

Add either 'boilerplate alpha' or 'boilerplate experimental' to all pages which have Alpha or Experimental status set.

Tidy up pages which already had
'boilerplate experimental-feature-warning' and be consistent with 'boilerplate experimental'

Update tasks/observability/distributed-tracing/mesh-and-proxy-config status from 'Beta/Experimental' to 'Beta', to match what's in features.yaml (all others only have a single value here)

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
