### PR TITLE
Cleanup some old documention left over in Egress task

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
@@ -38,8 +38,6 @@ without the need to specify every language's site separately.
     [enable Envoy’s access logging](/docs/tasks/observability/logs/access-log/#enable-envoy-s-access-logging), and
     [apply the blocking-by-default outbound traffic policy](/docs/tasks/traffic-management/egress/egress-control/#change-to-the-blocking-by-default-policy)
     in your installation.
-    You will also need to add the second gateway using your own `IstioOperator` CR instead of the one
-    shown in [setup egress gateway with SNI proxy](#setup-egress-gateway-with-sni-proxy).
     {{< /tip >}}
 
 *   Deploy the [sleep]({{< github_tree >}}/samples/sleep) sample app to use as a test source for sending requests.


### PR DESCRIPTION
`Configure traffic through egress gateway with SNI proxy` section was removed from the docs in the 1.14 release but that is still mentioned in the setup instructions for the task `Egress using Wildcard Hosts`.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
