### PR TITLE
Remove 'Experimental features..' text from feature-stages page

### DIFF
--- a/content/en/docs/releases/feature-stages/index.md
+++ b/content/en/docs/releases/feature-stages/index.md
@@ -41,7 +41,6 @@ labels mean.
 ## Istio features
 
 Below is our list of existing features and their current phases. This information will be updated after every release.
-Experimental features are purposefully not listed on this page.
 
 ### Traffic management
 


### PR DESCRIPTION
Remove the text 'Experimental features are purposefully not listed on this page' from the feature-stages page, as Experimental and Alpha features _are_ listed on the page.

Fixes https://github.com/istio/istio.io/issues/12829

- [ ] Configuration Infrastructure
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
