### PR TITLE
gateway: run as non-root in example

### DIFF
--- a/content/en/docs/setup/additional-setup/gateway/index.md
+++ b/content/en/docs/setup/additional-setup/gateway/index.md
@@ -148,9 +148,21 @@ spec:
         # Enable gateway injection. If connecting to a revisioned control plane, replace with "istio.io/rev: revision-name"
         sidecar.istio.io/inject: "true"
     spec:
+      # Allow binding to all ports (such as 80 and 443)
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
       containers:
       - name: istio-proxy
         image: auto # The image will automatically update each time the pod starts.
+        # Drop all privileges, allowing to run as non-root
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsUser: 1337
+          runAsGroup: 1337
 ---
 # Set up roles to allow reading credentials for TLS
 apiVersion: rbac.authorization.k8s.io/v1

--- a/content/en/docs/setup/additional-setup/gateway/snips.sh
+++ b/content/en/docs/setup/additional-setup/gateway/snips.sh
@@ -89,9 +89,21 @@ spec:
         # Enable gateway injection. If connecting to a revisioned control plane, replace with "istio.io/rev: revision-name"
         sidecar.istio.io/inject: "true"
     spec:
+      # Allow binding to all ports (such as 80 and 443)
+      securityContext:
+        sysctls:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: "0"
       containers:
       - name: istio-proxy
         image: auto # The image will automatically update each time the pod starts.
+        # Drop all privileges, allowing to run as non-root
+        securityContext:
+          capabilities:
+            drop:
+            - ALL
+          runAsUser: 1337
+          runAsGroup: 1337
 ---
 # Set up roles to allow reading credentials for TLS
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Before the Deployment was kept as minimal as possible. This is mostly good, because users can set any Deployment settings and things work. However, running as non-root is a bit quirky, and very very strongly recommended, so I think its worth calling out here.

This is one of the #1 sources of confusion we get.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Configuration Infrastructure
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Policies and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
