### PR TITLE
[release-1.17] Redirect fix for `go get`

### DIFF
--- a/layouts/index.redir
+++ b/layouts/index.redir
@@ -16,6 +16,10 @@
 /release-builder/* go-get=1 /latest/golang/release-builder.html 200
 /proxy/*  go-get=1 /latest/golang/proxy.html 200
 
+# Added redirects to possibly fix a go get issue
+/api go-get=1 /latest/golang/api.html 200
+/client-go go-get=1 /latest/golang/client-go.html 200
+
 # Redirect default Netlify subdomain to primary domain
 https://istio.netlify.com/* https://istio.io/:splat 301!
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

I'm not sure what causes the issue, but occasionally there is a problem running things like `go get istio/api@master`
```
> go get istio.io/api@master
go: istio.io/api@master: unrecognized import path "istio.io/api": reading https://istio.io/api?go-get=1: 404 Not Found
```

Trying to do a curl against the https address (which has redirects on out page) with and with a trailing `/` yields the expected behavior and a 404:
```
> curl  "https://istio.io/client-go/?go-get=1"
<html><head>
    <meta name="go-import" content="istio.io/client-go git https://github.com/istio/client-go">
    <meta name="go-source" content="istio.io/client-go     https://github.com/istio/client-go https://github.com/istio/client-go/tree/master{/dir} https://github.com/istio/client-go/blob/master{/dir}/{file}#L{line}">
</head></html>
> curl  "https://istio.io/client-go?go-get=1"
<!doctype html><html lang=en itemscope itemtype=https://schema.org/WebPage><head><meta charset=utf-8><meta http-equiv=x-ua-compatible content="IE=edge"><meta name=viewport content="width=device-width,initial-scale=1,shrink-to-fit=no"><meta name=theme-color content="#466BB0"><meta name=title content="404 Page not found"><meta name=description content="Connect, secure, control, and observe services."><meta name=keywords content="microservices,services,mesh"><meta property="og:title" content="404 Page not found"><meta property="og:type" content="website"><meta property="og:description" content="Connect, secure, control, and observe services."><meta property="og:url" content="/latest/404.html"><meta property="og:image" content="https://raw.githubusercontent.com/istio/istio.io/master/static/img/istio-social.svg"><meta property="og:image:alt" content="Istio Logo"><meta property="og:image:width" content="1200"><meta property="og:image:height" content="600"><meta property="og:site_name" content="Istio"><meta name=twitter:card content="summary"><meta name=twitter:site content="@IstioMesh"><title>Istio / 404 Page not found</title><script async src="https://www.googletagmanager.com/gtag/js?id=UA-98480406-1"></script>
....
```
Does this have to do with the redirection? I'm not sure and haven't found someone who knows for sure.

It's interesting to note the the istio.io/istio works with and without the `/` which makes this confusing.

If anyone has other thoughts, I'm open for any ideas.