### PR TITLE
Update Supportted k8s release table for main branch

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -6,7 +6,7 @@
   releaseDate:
   eolDate:
   k8sVersions: ["1.23", "1.24", "1.25", "1.26"]
-  testedK8sVersions:
+  testedK8sVersions: ["1.20", "1.21", "1.22"]
 - version: "1.17"
   supported: "Yes"
   releaseDate: "February 14, 2023"


### PR DESCRIPTION
Please provide a description for what this PR is for.

Looking at the Supported/K8s tested table for the main branch we used to have both blank. With a recent change we updated the supported k8s version for the main branch, I think so that they show correctly in the docs where we list the supported k8s version. This leaves the tested field looking lonely. This updates the line to at least cover what we are testing today.
