### PR TITLE
Reformat dates to use a consistent format

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -9,20 +9,20 @@
   testedK8sVersions:
 - version: "1.17"
   supported: "Yes"
-  releaseDate: "February 14, 2023"
+  releaseDate: "Feb 14, 2023"
   eolDate: "~Sept 2023 (Expected)"
   k8sVersions: ["1.23", "1.24", "1.25", "1.26"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "1.22"]
 - version: "1.16"
   supported: "Yes"
-  releaseDate: "November 15, 2022"
-  eolDate: "~June 2023 (Expected)"
+  releaseDate: "Nov 15, 2022"
+  eolDate: "~Jun 2023 (Expected)"
   k8sVersions: ["1.22", "1.23", "1.24", "1.25"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
 - version: "1.15"
   supported: "Yes"
-  releaseDate: "August 31, 2022"
-  eolDate: "~March 2023 (Expected)"
+  releaseDate: "Aug 31, 2022"
+  eolDate: "~Mar 2023 (Expected)"
   k8sVersions: ["1.22", "1.23", "1.24", "1.25"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
 - version: "1.14"
@@ -33,19 +33,19 @@
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20"]
 - version: "1.13"
   supported: "No"
-  releaseDate: "February 11, 2022"
+  releaseDate: "Feb 11, 2022"
   eolDate: "Oct 12, 2022"
   k8sVersions: ["1.20", "1.21", "1.22", "1.23"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19"]
 - version: "1.12"
   supported: "No"
-  releaseDate: "November 18, 2021"
+  releaseDate: "Nov 18, 2021"
   eolDate: "Jul 12, 2022"
   k8sVersions: ["1.19", "1.20", "1.21", "1.22"]
   testedK8sVersions: ["1.16", "1.17", "1.18"]
 - version: "1.11"
   supported: "No"
-  releaseDate: "August 12, 2021"
+  releaseDate: "Aug 12, 2021"
   eolDate: "Mar 25, 2022"
   k8sVersions: ["1.18", "1.19", "1.20", "1.21", "1.22"]
   testedK8sVersions: ["1.16", "1.17"]
@@ -57,19 +57,19 @@
   testedK8sVersions: ["1.16", "1.17", "1.22"]
 - version: "1.9"
   supported: "No"
-  releaseDate: "February 9, 2021"
+  releaseDate: "Feb 9, 2021"
   eolDate: "Oct 8, 2021"
   k8sVersions: ["1.17", "1.18", "1.19", "1.20"]
   testedK8sVersions: ["1.15", "1.16"]
 - version: "1.8"
   supported: "No"
-  releaseDate: "November 10, 2020"
+  releaseDate: "Nov 10, 2020"
   eolDate: "May 12, 2021"
   k8sVersions: ["1.16", "1.17", "1.18", "1.19"]
   testedK8sVersions: ["1.15"]
 - version: "1.7"
   supported: "No"
-  releaseDate: "August 21, 2020"
+  releaseDate: "Aug 21, 2020"
   eolDate: "Feb 25, 2021"
   k8sVersions: ["1.16", "1.17", "1.18"]
   testedK8sVersions: ["1.15"]

--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -9,68 +9,68 @@
   testedK8sVersions:
 - version: "1.17"
   supported: "Yes"
-  releaseDate: "Feb 14, 2023"
-  eolDate: "~Sep 2023 (Expected)"
+  releaseDate: "Feb. 14, 2023"
+  eolDate: "~Sep. 2023 (Expected)"
   k8sVersions: ["1.23", "1.24", "1.25", "1.26"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "1.22"]
 - version: "1.16"
   supported: "Yes"
-  releaseDate: "Nov 15, 2022"
-  eolDate: "~Jun 2023 (Expected)"
+  releaseDate: "Nov. 15, 2022"
+  eolDate: "~Jun. 2023 (Expected)"
   k8sVersions: ["1.22", "1.23", "1.24", "1.25"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
 - version: "1.15"
   supported: "Yes"
-  releaseDate: "Aug 31, 2022"
-  eolDate: "~Mar 2023 (Expected)"
+  releaseDate: "Aug. 31, 2022"
+  eolDate: "~Mar. 2023 (Expected)"
   k8sVersions: ["1.22", "1.23", "1.24", "1.25"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
 - version: "1.14"
   supported: "No"
   releaseDate: "May 24, 2022"
-  eolDate: "Dec 27, 2022"
+  eolDate: "Dec. 27, 2022"
   k8sVersions: ["1.21", "1.22", "1.23", "1.24"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20"]
 - version: "1.13"
   supported: "No"
-  releaseDate: "Feb 11, 2022"
-  eolDate: "Oct 12, 2022"
+  releaseDate: "Feb. 11, 2022"
+  eolDate: "Oct. 12, 2022"
   k8sVersions: ["1.20", "1.21", "1.22", "1.23"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19"]
 - version: "1.12"
   supported: "No"
-  releaseDate: "Nov 18, 2021"
-  eolDate: "Jul 12, 2022"
+  releaseDate: "Nov. 18, 2021"
+  eolDate: "Jul. 12, 2022"
   k8sVersions: ["1.19", "1.20", "1.21", "1.22"]
   testedK8sVersions: ["1.16", "1.17", "1.18"]
 - version: "1.11"
   supported: "No"
-  releaseDate: "Aug 12, 2021"
-  eolDate: "Mar 25, 2022"
+  releaseDate: "Aug. 12, 2021"
+  eolDate: "Mar. 25, 2022"
   k8sVersions: ["1.18", "1.19", "1.20", "1.21", "1.22"]
   testedK8sVersions: ["1.16", "1.17"]
 - version: "1.10"
   supported: "No"
   releaseDate: "May 18, 2021"
-  eolDate: "Jan 7, 2022"
+  eolDate: "Jan. 7, 2022"
   k8sVersions: ["1.18", "1.19", "1.20", "1.21"]
   testedK8sVersions: ["1.16", "1.17", "1.22"]
 - version: "1.9"
   supported: "No"
-  releaseDate: "Feb 9, 2021"
-  eolDate: "Oct 8, 2021"
+  releaseDate: "Feb. 9, 2021"
+  eolDate: "Oct. 8, 2021"
   k8sVersions: ["1.17", "1.18", "1.19", "1.20"]
   testedK8sVersions: ["1.15", "1.16"]
 - version: "1.8"
   supported: "No"
-  releaseDate: "Nov 10, 2020"
+  releaseDate: "Nov. 10, 2020"
   eolDate: "May 12, 2021"
   k8sVersions: ["1.16", "1.17", "1.18", "1.19"]
   testedK8sVersions: ["1.15"]
 - version: "1.7"
   supported: "No"
-  releaseDate: "Aug 21, 2020"
-  eolDate: "Feb 25, 2021"
+  releaseDate: "Aug. 21, 2020"
+  eolDate: "Feb. 25, 2021"
   k8sVersions: ["1.16", "1.17", "1.18"]
   testedK8sVersions: ["1.15"]
 - version: "1.6 and earlier"

--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -10,7 +10,7 @@
 - version: "1.17"
   supported: "Yes"
   releaseDate: "Feb 14, 2023"
-  eolDate: "~Sept 2023 (Expected)"
+  eolDate: "~Sep 2023 (Expected)"
   k8sVersions: ["1.23", "1.24", "1.25", "1.26"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "1.22"]
 - version: "1.16"

--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -9,68 +9,68 @@
   testedK8sVersions:
 - version: "1.17"
   supported: "Yes"
-  releaseDate: "Feb. 14, 2023"
-  eolDate: "~Sep. 2023 (Expected)"
+  releaseDate: "Feb 14, 2023"
+  eolDate: "~Sep 2023 (Expected)"
   k8sVersions: ["1.23", "1.24", "1.25", "1.26"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "1.22"]
 - version: "1.16"
   supported: "Yes"
-  releaseDate: "Nov. 15, 2022"
-  eolDate: "~Jun. 2023 (Expected)"
+  releaseDate: "Nov 15, 2022"
+  eolDate: "~Jun 2023 (Expected)"
   k8sVersions: ["1.22", "1.23", "1.24", "1.25"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
 - version: "1.15"
   supported: "Yes"
-  releaseDate: "Aug. 31, 2022"
-  eolDate: "~Mar. 2023 (Expected)"
+  releaseDate: "Aug 31, 2022"
+  eolDate: "~Mar 2023 (Expected)"
   k8sVersions: ["1.22", "1.23", "1.24", "1.25"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
 - version: "1.14"
   supported: "No"
   releaseDate: "May 24, 2022"
-  eolDate: "Dec. 27, 2022"
+  eolDate: "Dec 27, 2022"
   k8sVersions: ["1.21", "1.22", "1.23", "1.24"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20"]
 - version: "1.13"
   supported: "No"
-  releaseDate: "Feb. 11, 2022"
-  eolDate: "Oct. 12, 2022"
+  releaseDate: "Feb 11, 2022"
+  eolDate: "Oct 12, 2022"
   k8sVersions: ["1.20", "1.21", "1.22", "1.23"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19"]
 - version: "1.12"
   supported: "No"
-  releaseDate: "Nov. 18, 2021"
-  eolDate: "Jul. 12, 2022"
+  releaseDate: "Nov 18, 2021"
+  eolDate: "Jul 12, 2022"
   k8sVersions: ["1.19", "1.20", "1.21", "1.22"]
   testedK8sVersions: ["1.16", "1.17", "1.18"]
 - version: "1.11"
   supported: "No"
-  releaseDate: "Aug. 12, 2021"
-  eolDate: "Mar. 25, 2022"
+  releaseDate: "Aug 12, 2021"
+  eolDate: "Mar 25, 2022"
   k8sVersions: ["1.18", "1.19", "1.20", "1.21", "1.22"]
   testedK8sVersions: ["1.16", "1.17"]
 - version: "1.10"
   supported: "No"
   releaseDate: "May 18, 2021"
-  eolDate: "Jan. 7, 2022"
+  eolDate: "Jan 7, 2022"
   k8sVersions: ["1.18", "1.19", "1.20", "1.21"]
   testedK8sVersions: ["1.16", "1.17", "1.22"]
 - version: "1.9"
   supported: "No"
-  releaseDate: "Feb. 9, 2021"
-  eolDate: "Oct. 8, 2021"
+  releaseDate: "Feb 9, 2021"
+  eolDate: "Oct 8, 2021"
   k8sVersions: ["1.17", "1.18", "1.19", "1.20"]
   testedK8sVersions: ["1.15", "1.16"]
 - version: "1.8"
   supported: "No"
-  releaseDate: "Nov. 10, 2020"
+  releaseDate: "Nov 10, 2020"
   eolDate: "May 12, 2021"
   k8sVersions: ["1.16", "1.17", "1.18", "1.19"]
   testedK8sVersions: ["1.15"]
 - version: "1.7"
   supported: "No"
-  releaseDate: "Aug. 21, 2020"
-  eolDate: "Feb. 25, 2021"
+  releaseDate: "Aug 21, 2020"
+  eolDate: "Feb 25, 2021"
   k8sVersions: ["1.16", "1.17", "1.18"]
   testedK8sVersions: ["1.15"]
 - version: "1.6 and earlier"


### PR DESCRIPTION
Please provide a description for what this PR is for.

Continuing discussion from https://github.com/istio/istio.io/pull/12919#discussion_r1146431994

Reformatted dates in support status of Istio releases to use the same format. Formatting to a short month keeps things on a single line, except when (Expected) is added to the End of Life fields. Opted for short month names over yyyy-mm-dd as the it helps readability regardless of locale date formats, and maintains readability for individuals not used to reading that format.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
