### PR TITLE
Update releases with CVES removing 1.14

### DIFF
--- a/content/en/docs/releases/supported-releases/index.md
+++ b/content/en/docs/releases/supported-releases/index.md
@@ -77,9 +77,7 @@ Please keep up-to-date and use a supported version.
 | 1.17.x           | 1.17.2+                                               |
 | 1.16.x           | 1.16.4+                                               |
 | 1.15.x           | 1.15.7 - End of life. A new CVE will NOT be patched  |
-| 1.14.x           | 1.14.5 - End of life. A new CVE will NOT be patched. |
-| 1.13.x           | 1.13.9 - End of life. A new CVE will NOT be patched. |
-| 1.12 and earlier | None, all versions have known vulnerabilities.       |
+| 1.14 and earlier | None, all versions have known vulnerabilities.       |
 
 ## Supported Envoy Versions
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

With the latest CVE release, I know that 1.14 was not patched with the updated Envoy so that is certainly not without CVEs. Shortening the table.