### PR TITLE
Fix test docs for _verify_like environment variables

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -242,7 +242,7 @@ expected output. The framework includes the following built-in verify functions:
      1. different elapsed time values (e.g., `30s` is like `5m`)
      1. different ip values (e.g., `172.21.0.1` is like `10.0.0.31`). Disallows
          `<none>` and `<pending>` by default. This can be customized by setting
-         the `ALLOW_NONE_IP` and `ALLOW_PENDING_IP` environment variables,
+         the `CMP_MATCH_IP_NONE` and `CMP_MATCH_IP_PENDING` environment variables,
          respectively.
      1. prefix match ending with a dash character (e.g., `reviews-v1-12345...` is like `reviews-v1-67890...`)
      1. expected `...` is a wildcard token, matches anything


### PR DESCRIPTION
Fix test docs mentioning wrong environment variables `ALLOW_NONE_IP` and `ALLOW_PENDING_IP` required by `_verify_like` to pass if the IP is `<pending>` or `<none>` according to `tests/util/verify.sh` https://github.com/istio/istio.io/blob/8baf6d521be1d0924d431d14b3a7d762ff6e5ddd/tests/util/verify.sh#L125

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
