### PR TITLE
Enable tests and remove hardcoded versions for operator install doc

### DIFF
--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -239,12 +239,38 @@ $ kubectl get pods --namespace istio-system \
 
 The process for canary upgrade is similar to the [canary upgrade with `istioctl`](/docs/setup/upgrade/canary/).
 
-For example, to upgrade Istio {{< istio_previous_version >}}.0 to {{< istio_full_version >}}, first install {{< istio_previous_version >}}.0 and verify that the `IstioOperator` CR named `example-istiocontrolplane` exists in your cluster:
+For example, to upgrade Istio {{< istio_previous_version >}}.0 to {{< istio_full_version >}}, first install {{< istio_previous_version >}}.0 :
+
+{{< text syntax=bash snip_id=download_istio_previous_version >}}
+$ curl -L https://istio.io/downloadIstio | ISTIO_VERSION={{< istio_previous_version >}}.0 sh -
+{{< /text >}}
+
+Deploy the operator using Istio version {{< istio_previous_version >}}.0:
+
+{{< text syntax=bash snip_id=deploy_operator_previous_version >}}
+$ istio-{{< istio_previous_version >}}.0/bin/istioctl operator init
+{{< /text >}}
+
+Install Istio control plane demo profile:
+
+{{< text syntax=bash snip_id=install_istio_previous_version >}}
+$ kubectl apply -f - <<EOF
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+  name: example-istiocontrolplane-{{< istio_previous_version_revision >}}-0
+spec:
+  profile: default
+EOF
+{{< /text >}}
+
+Verify that the `IstioOperator` CR named `example-istiocontrolplane` exists in your cluster:
 
 {{< text syntax=bash snip_id=verify_operator_cr >}}
 $ kubectl get iop --all-namespaces
-NAMESPACE      NAME                        REVISION   STATUS    AGE
-istio-system   example-istiocontrolplane              HEALTHY   11m
+NAMESPACE      NAME                              REVISION   STATUS    AGE
+istio-system   example-istiocontrolplane{{< istio_previous_version_revision >}}-0              HEALTHY   11m
 {{< /text >}}
 
 Download and extract the `istioctl` corresponding to the version of Istio you wish to upgrade to.
@@ -258,11 +284,11 @@ $ istio-{{< istio_full_version >}}/bin/istioctl operator init --revision {{< ist
 {{< tip >}}
 You can alternatively use Helm to deploy another operator with a different revision setting:
 
-{{< text syntax=bash snip_id=canary_upgrade_helm_install >}}
+{{< text syntax=bash snip_id=none >}}
 $ helm install istio-operator manifests/charts/istio-operator \
   --set watchedNamespaces=istio-system \
   -n istio-operator \
-  --set revision={{< istio_previous_version_revision >}}-1
+  --set revision={{< istio_full_version_revision >}}
 {{< /text >}}
 
 Note that you need to [download the Istio release](/docs/setup/getting-started/#download)

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -308,7 +308,7 @@ metadata:
   name: example-istiocontrolplane-{{< istio_full_version_revision >}}
 spec:
   revision: {{< istio_full_version_revision >}}
-  profile: demo
+  profile: default
 {{< /text >}}
 
 Apply the updated `IstioOperator` CR to the cluster. After that, you will have two control plane deployments and services running side-by-side:

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -239,7 +239,7 @@ $ kubectl get pods --namespace istio-system \
 
 The process for canary upgrade is similar to the [canary upgrade with `istioctl`](/docs/setup/upgrade/canary/).
 
-For example, to upgrade the revision of Istio installed in the previous section, first verify that the `IstioOperator` CR named `example-istiocontrolplane` exists in your cluster:
+For example, to upgrade Istio {{< istio_previous_version >}}.0 to {{< istio_full_version >}}, first install {{< istio_previous_version >}}.0 and verify that the `IstioOperator` CR named `example-istiocontrolplane` exists in your cluster:
 
 {{< text syntax=bash snip_id=verify_operator_cr >}}
 $ kubectl get iop --all-namespaces
@@ -249,10 +249,10 @@ istio-system   example-istiocontrolplane              HEALTHY   11m
 
 Download and extract the `istioctl` corresponding to the version of Istio you wish to upgrade to.
 Then, run the following command to install the new target revision of the Istio control plane based on the in-cluster
-`IstioOperator` CR (here, we assume the target revision is {{< istio_previous_version >}}):
+`IstioOperator` CR (here, we assume the target revision is {{< istio_full_version_revision >}}):
 
 {{< text syntax=bash snip_id=canary_upgrade_init >}}
-$ istio-{{< istio_previous_version >}}.1/bin/istioctl operator init --revision {{< istio_previous_version_revision >}}-1
+$ istio-{{< istio_full_version_revision >}}/bin/istioctl operator init --revision {{< istio_full_version_revision >}}
 {{< /text >}}
 
 {{< tip >}}
@@ -262,26 +262,26 @@ You can alternatively use Helm to deploy another operator with a different revis
 $ helm install istio-operator manifests/charts/istio-operator \
   --set watchedNamespaces=istio-system \
   -n istio-operator \
-  --set revision={{< istio_full_version_revision >}}
+  --set revision={{< istio_previous_version_revision >}}-1
 {{< /text >}}
 
 Note that you need to [download the Istio release](/docs/setup/getting-started/#download)
 to run the above command.
 {{< /tip >}}
 
-Make a copy of the `example-istiocontrolplane` CR and save it in a file named `example-istiocontrolplane-{{< istio_previous_version_revision >}}-1.yaml`.
-Change the name to `example-istiocontrolplane-{{< istio_previous_version_revision >}}-1` and add `revision: {{< istio_previous_version_revision >}}-1` to the CR.
+Make a copy of the `example-istiocontrolplane` CR and save it in a file named `example-istiocontrolplane-{{< istio_full_version_revision >}}.yaml`.
+Change the name to `example-istiocontrolplane-{{< istio_full_version_revision >}}` and add `revision: {{< istio_full_version_revision >}}` to the CR.
 Your updated `IstioOperator` CR should look something like this:
 
 {{< text syntax=bash snip_id=cat_operator_yaml >}}
-$ cat example-istiocontrolplane-{{< istio_previous_version_revision >}}-1.yaml
+$ cat example-istiocontrolplane-{{< istio_full_version_revision >}}.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   namespace: istio-system
-  name: example-istiocontrolplane-{{< istio_previous_version_revision >}}-1
+  name: example-istiocontrolplane-{{< istio_full_version_revision >}}
 spec:
-  revision: {{< istio_previous_version_revision >}}-1
+  revision: {{< istio_full_version_revision >}}
   profile: demo
 {{< /text >}}
 
@@ -290,7 +290,7 @@ Apply the updated `IstioOperator` CR to the cluster. After that, you will have t
 {{< text syntax=bash snip_id=get_pods_istio_system >}}
 $ kubectl get pod -n istio-system -l app=istiod
 NAME                            READY   STATUS    RESTARTS   AGE
-istiod-{{< istio_previous_version_revision >}}-1-597475f4f6-bgtcz   1/1     Running   0          64s
+istiod-{{< istio_full_version_revision >}}-597475f4f6-bgtcz   1/1     Running   0          64s
 istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
 {{< /text >}}
 
@@ -298,10 +298,10 @@ istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
 $ kubectl get services -n istio-system -l app=istiod
 NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
 istiod         ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
-istiod-{{< istio_previous_version_revision >}}-1   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
+istiod-{{< istio_full_version_revision >}}   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
 {{< /text >}}
 
-To complete the upgrade, label the workload namespaces with `istio.io/rev={{< istio_previous_version_revision >}}-1` and restart the workloads, as
+To complete the upgrade, label the workload namespaces with `istio.io/rev={{< istio_full_version_revision >}}` and restart the workloads, as
 explained in the [Data plane upgrade](/docs/setup/upgrade/canary/#data-plane) documentation.
 
 ## Uninstall

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -6,7 +6,7 @@ keywords: [kubernetes, operator]
 aliases:
     - /docs/setup/install/standalone-operator
 owner: istio/wg-environments-maintainers
-test: no
+test: yes
 status: Beta
 ---
 
@@ -327,5 +327,5 @@ To clean up anything not removed by the operator:
 
 {{< text syntax=bash snip_id=cleanup >}}
 $ istioctl uninstall -y --purge
-$ kubectl delete ns istio-system --grace-period=0 --force
+$ kubectl delete ns istio-system istio-operator
  {{< /text >}}

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -249,39 +249,39 @@ istio-system   example-istiocontrolplane              HEALTHY   11m
 
 Download and extract the `istioctl` corresponding to the version of Istio you wish to upgrade to.
 Then, run the following command to install the new target revision of the Istio control plane based on the in-cluster
-`IstioOperator` CR (here, we assume the target revision is 1.17.1):
+`IstioOperator` CR (here, we assume the target revision is {{< istio_previous_version >}}):
 
-{{< text syntax=bash snip_id=canary_upgrade_init_1_17_1 >}}
-$ istio-1.17.1/bin/istioctl operator init --revision 1-17-1
+{{< text syntax=bash snip_id=canary_upgrade_init >}}
+$ istio-{{< istio_previous_version >}}.1/bin/istioctl operator init --revision {{< istio_previous_version_revision >}}-1
 {{< /text >}}
 
 {{< tip >}}
 You can alternatively use Helm to deploy another operator with a different revision setting:
 
-{{< text syntax=bash snip_id=canary_upgrade_helm_install_1_17_2 >}}
+{{< text syntax=bash snip_id=canary_upgrade_helm_install >}}
 $ helm install istio-operator manifests/charts/istio-operator \
   --set watchedNamespaces=istio-system \
   -n istio-operator \
-  --set revision=1-17-2
+  --set revision={{< istio_full_version_revision >}}
 {{< /text >}}
 
 Note that you need to [download the Istio release](/docs/setup/getting-started/#download)
 to run the above command.
 {{< /tip >}}
 
-Make a copy of the `example-istiocontrolplane` CR and save it in a file named `example-istiocontrolplane-1-17-1.yaml`.
-Change the name to `example-istiocontrolplane-1-17-1` and add `revision: 1-17-1` to the CR.
+Make a copy of the `example-istiocontrolplane` CR and save it in a file named `example-istiocontrolplane-{{< istio_previous_version_revision >}}-1.yaml`.
+Change the name to `example-istiocontrolplane-{{< istio_previous_version_revision >}}-1` and add `revision: {{< istio_previous_version_revision >}}-1` to the CR.
 Your updated `IstioOperator` CR should look something like this:
 
 {{< text syntax=bash snip_id=cat_operator_yaml >}}
-$ cat example-istiocontrolplane-1-17-1.yaml
+$ cat example-istiocontrolplane-{{< istio_previous_version_revision >}}-1.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   namespace: istio-system
-  name: example-istiocontrolplane-1-17-1
+  name: example-istiocontrolplane-{{< istio_previous_version_revision >}}-1
 spec:
-  revision: 1-17-1
+  revision: {{< istio_previous_version_revision >}}-1
   profile: demo
 {{< /text >}}
 
@@ -290,7 +290,7 @@ Apply the updated `IstioOperator` CR to the cluster. After that, you will have t
 {{< text syntax=bash snip_id=get_pods_istio_system >}}
 $ kubectl get pod -n istio-system -l app=istiod
 NAME                            READY   STATUS    RESTARTS   AGE
-istiod-1-17-1-597475f4f6-bgtcz   1/1     Running   0          64s
+istiod-{{< istio_previous_version_revision >}}-1-597475f4f6-bgtcz   1/1     Running   0          64s
 istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
 {{< /text >}}
 
@@ -298,10 +298,10 @@ istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
 $ kubectl get services -n istio-system -l app=istiod
 NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
 istiod         ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
-istiod-1-17-1   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
+istiod-{{< istio_previous_version_revision >}}-1   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
 {{< /text >}}
 
-To complete the upgrade, label the workload namespaces with `istio.io/rev=1-17-1` and restart the workloads, as
+To complete the upgrade, label the workload namespaces with `istio.io/rev={{< istio_previous_version_revision >}}-1` and restart the workloads, as
 explained in the [Data plane upgrade](/docs/setup/upgrade/canary/#data-plane) documentation.
 
 ## Uninstall

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -49,7 +49,7 @@ To avoid a vulnerability, ensure that the operator deployment is sufficiently se
 
 The `istioctl` command can be used to automatically deploy the Istio operator:
 
-{{< text syntax=bash snip_id=create_istio_operator >}}
+{{< text syntax=bash snip_id=deploy_istio_operator >}}
 $ istioctl operator init
 {{< /text >}}
 
@@ -62,7 +62,7 @@ This command runs the operator by creating the following resources in the `istio
 
 You can configure which namespace the operator controller is installed in, the namespace(s) the operator watches, the installed Istio image sources and versions, and more. For example, you can pass one or more namespaces to watch using the `--watchedNamespaces` flag:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=deploy_istio_operator_watch_ns >}}
 $ istioctl operator init --watchedNamespaces=istio-namespace1,istio-namespace2
 {{< /text >}}
 
@@ -73,13 +73,13 @@ You can alternatively deploy the operator using Helm:
 
 1. Create a namespace `istio-operator`.
 
-    {{< text bash >}}
+    {{< text syntax=bash snip_id=create_ns_istio_operator >}}
     $ kubectl create namespace istio-operator
     {{< /text >}}
 
 1. Install operator using Helm.
 
-    {{< text bash >}}
+    {{< text syntax=bash snip_id=deploy_istio_operator_helm >}}
     $ helm install istio-operator manifests/charts/istio-operator \
         --set watchedNamespaces="istio-namespace1\,istio-namespace2" \
         -n istio-operator
@@ -101,7 +101,7 @@ With the operator installed, you can now create a mesh by deploying an `IstioOpe
 To install the Istio `demo` [configuration profile](/docs/setup/additional-setup/config-profiles/)
 using the operator, run the following command:
 
-{{< text syntax=bash snip_id=create_demo_profile >}}
+{{< text syntax=bash snip_id=install_istio_demo_profile >}}
 $ kubectl apply -f - <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -122,7 +122,7 @@ If you used `--watchedNamespaces` when you initialized the Istio operator, apply
 
 The Istio control plane (istiod) will be installed in the `istio-system` namespace by default. To install it in a different location, specify the namespace using the `values.global.istioNamespace` field as follows:
 
-{{< text yaml >}}
+{{< text syntax=yaml snip_id=none >}}
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 ...
@@ -166,7 +166,7 @@ the Istio installation correspondingly.
 For example, you can switch the installation to the `default`
 profile with the following command:
 
-{{< text syntax=bash >}}
+{{< text syntax=bash snip_id=update_to_default_profile >}}
 $ kubectl apply -f - <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -181,7 +181,7 @@ EOF
 You can also enable or disable components and modify resource settings.
 For example, to enable the `istio-egressgateway` component and increase pilot memory requests:
 
-{{< text syntax=bash snip_id=update_operator >}}
+{{< text syntax=bash snip_id=update_to_default_profile_egress >}}
 $ kubectl apply -f - <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -205,7 +205,7 @@ EOF
 You can observe the changes that the controller makes in the cluster in response to `IstioOperator` CR updates by
 checking the operator controller logs:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ kubectl logs -f -n istio-operator "$(kubectl get pods -n istio-operator -lname=istio-operator -o jsonpath='{.items[0].metadata.name}')"
 {{< /text >}}
 
@@ -217,20 +217,20 @@ for the complete set of configuration settings.
 Download and extract the `istioctl` corresponding to the version of Istio you wish to upgrade to. Reinstall the operator
 at the target Istio version:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ <extracted-dir>/bin/istioctl operator init
 {{< /text >}}
 
 You should see that the `istio-operator` pod has restarted and its version has changed to the target version:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ kubectl get pods --namespace istio-operator \
   -o=jsonpath='{range .items[*]}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{"\n"}{end}'
 {{< /text >}}
 
 After a minute or two, the Istio control plane components should also be restarted at the new version:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ kubectl get pods --namespace istio-system \
   -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{"\n"}{end}'
 {{< /text >}}
@@ -241,7 +241,7 @@ The process for canary upgrade is similar to the [canary upgrade with `istioctl`
 
 For example, to upgrade the revision of Istio installed in the previous section, first verify that the `IstioOperator` CR named `example-istiocontrolplane` exists in your cluster:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=verify_operator_cr >}}
 $ kubectl get iop --all-namespaces
 NAMESPACE      NAME                        REVISION   STATUS    AGE
 istio-system   example-istiocontrolplane              HEALTHY   11m
@@ -251,14 +251,14 @@ Download and extract the `istioctl` corresponding to the version of Istio you wi
 Then, run the following command to install the new target revision of the Istio control plane based on the in-cluster
 `IstioOperator` CR (here, we assume the target revision is 1.8.1):
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ istio-1.8.1/bin/istioctl operator init --revision 1-8-1
 {{< /text >}}
 
 {{< tip >}}
 You can alternatively use Helm to deploy another operator with a different revision setting:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ helm install istio-operator manifests/charts/istio-operator \
   --set watchedNamespaces=istio-system \
   -n istio-operator \
@@ -273,7 +273,7 @@ Make a copy of the `example-istiocontrolplane` CR and save it in a file named `e
 Change the name to `example-istiocontrolplane-1-8-1` and add `revision: 1-8-1` to the CR.
 Your updated `IstioOperator` CR should look something like this:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ cat example-istiocontrolplane-1-8-1.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -287,14 +287,14 @@ spec:
 
 Apply the updated `IstioOperator` CR to the cluster. After that, you will have two control plane deployments and services running side-by-side:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ kubectl get pod -n istio-system -l app=istiod
 NAME                            READY   STATUS    RESTARTS   AGE
 istiod-1-8-1-597475f4f6-bgtcz   1/1     Running   0          64s
 istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
 {{< /text >}}
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ kubectl get services -n istio-system -l app=istiod
 NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
 istiod         ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -252,7 +252,7 @@ Then, run the following command to install the new target revision of the Istio 
 `IstioOperator` CR (here, we assume the target revision is {{< istio_full_version_revision >}}):
 
 {{< text syntax=bash snip_id=canary_upgrade_init >}}
-$ istio-{{< istio_full_version_revision >}}/bin/istioctl operator init --revision {{< istio_full_version_revision >}}
+$ istio-{{< istio_full_version >}}/bin/istioctl operator init --revision {{< istio_full_version_revision >}}
 {{< /text >}}
 
 {{< tip >}}

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -289,15 +289,15 @@ Apply the updated `IstioOperator` CR to the cluster. After that, you will have t
 
 {{< text syntax=bash snip_id=get_pods_istio_system >}}
 $ kubectl get pod -n istio-system -l app=istiod
-NAME                            READY   STATUS    RESTARTS   AGE
+NAME                             READY   STATUS    RESTARTS   AGE
 istiod-{{< istio_full_version_revision >}}-597475f4f6-bgtcz   1/1     Running   0          64s
-istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
+istiod-6ffcc65b96-bxzv5          1/1     Running   0          2m11s
 {{< /text >}}
 
 {{< text syntax=bash snip_id=get_svc_istio_system >}}
 $ kubectl get services -n istio-system -l app=istiod
-NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
-istiod         ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
+NAME            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
+istiod          ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
 istiod-{{< istio_full_version_revision >}}   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
 {{< /text >}}
 

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -133,7 +133,7 @@ istio-system   example-istiocontrolplane              HEALTHY   11m
 ENDSNIP
 
 snip_canary_upgrade_init() {
-istio-1-18-0/bin/istioctl operator init --revision 1-18-0
+istio-1.18.0/bin/istioctl operator init --revision 1-18-0
 }
 
 snip_canary_upgrade_helm_install() {

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -123,24 +123,37 @@ kubectl get pods --namespace istio-system \
   -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{"\n"}{end}'
 }
 
+snip_download_istio_previous_version() {
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.17.0 sh -
+}
+
+snip_deploy_operator_previous_version() {
+istio-1.17.0/bin/istioctl operator init
+}
+
+snip_install_istio_previous_version() {
+kubectl apply -f - <<EOF
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+metadata:
+  namespace: istio-system
+  name: example-istiocontrolplane-1-17-0
+spec:
+  profile: default
+EOF
+}
+
 snip_verify_operator_cr() {
 kubectl get iop --all-namespaces
 }
 
 ! read -r -d '' snip_verify_operator_cr_out <<\ENDSNIP
-NAMESPACE      NAME                        REVISION   STATUS    AGE
-istio-system   example-istiocontrolplane              HEALTHY   11m
+NAMESPACE      NAME                              REVISION   STATUS    AGE
+istio-system   example-istiocontrolplane1-17-0              HEALTHY   11m
 ENDSNIP
 
 snip_canary_upgrade_init() {
 istio-1.18.0/bin/istioctl operator init --revision 1-18-0
-}
-
-snip_canary_upgrade_helm_install() {
-helm install istio-operator manifests/charts/istio-operator \
-  --set watchedNamespaces=istio-system \
-  -n istio-operator \
-  --set revision=1-17-1
 }
 
 snip_cat_operator_yaml() {
@@ -163,9 +176,9 @@ kubectl get pod -n istio-system -l app=istiod
 }
 
 ! read -r -d '' snip_get_pods_istio_system_out <<\ENDSNIP
-NAME                            READY   STATUS    RESTARTS   AGE
+NAME                             READY   STATUS    RESTARTS   AGE
 istiod-1-18-0-597475f4f6-bgtcz   1/1     Running   0          64s
-istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
+istiod-6ffcc65b96-bxzv5          1/1     Running   0          2m11s
 ENDSNIP
 
 snip_get_svc_istio_system() {
@@ -173,8 +186,8 @@ kubectl get services -n istio-system -l app=istiod
 }
 
 ! read -r -d '' snip_get_svc_istio_system_out <<\ENDSNIP
-NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
-istiod         ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
+NAME            TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
+istiod          ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
 istiod-1-18-0   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
 ENDSNIP
 

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -20,25 +20,25 @@
 #          docs/setup/install/operator/index.md
 ####################################################################################################
 
-snip_create_istio_operator() {
+snip_deploy_istio_operator() {
 istioctl operator init
 }
 
-snip_deploy_the_istio_operator_2() {
+snip_deploy_istio_operator_watch_ns() {
 istioctl operator init --watchedNamespaces=istio-namespace1,istio-namespace2
 }
 
-snip_deploy_the_istio_operator_3() {
+snip_create_ns_istio_operator() {
 kubectl create namespace istio-operator
 }
 
-snip_deploy_the_istio_operator_4() {
+snip_deploy_istio_operator_helm() {
 helm install istio-operator manifests/charts/istio-operator \
     --set watchedNamespaces="istio-namespace1\,istio-namespace2" \
     -n istio-operator
 }
 
-snip_create_demo_profile() {
+snip_install_istio_demo_profile() {
 kubectl apply -f - <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -49,17 +49,6 @@ spec:
   profile: demo
 EOF
 }
-
-! read -r -d '' snip_install_istio_with_the_operator_2 <<\ENDSNIP
-apiVersion: install.istio.io/v1alpha1
-kind: IstioOperator
-...
-spec:
-  profile: demo
-  values:
-    global:
-      istioNamespace: istio-namespace1
-ENDSNIP
 
 snip_kubectl_get_svc() {
 kubectl get services -n istio-system
@@ -83,7 +72,7 @@ istio-ingressgateway-86cb4b6795-9jlrk   1/1     Running   0          68s
 istiod-b47586647-sf6sw                  1/1     Running   0          74s
 ENDSNIP
 
-snip_update_1() {
+snip_update_to_default_profile() {
 kubectl apply -f - <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -95,7 +84,7 @@ spec:
 EOF
 }
 
-snip_update_operator() {
+snip_update_to_default_profile_egress() {
 kubectl apply -f - <<EOF
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -116,77 +105,13 @@ spec:
 EOF
 }
 
-snip_update_3() {
-kubectl logs -f -n istio-operator "$(kubectl get pods -n istio-operator -lname=istio-operator -o jsonpath='{.items[0].metadata.name}')"
-}
-
-snip_inplace_upgrade_1() {
-<extracted-dir>/bin/istioctl operator init
-}
-
-snip_inplace_upgrade_2() {
-kubectl get pods --namespace istio-operator \
-  -o=jsonpath='{range .items[*]}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{"\n"}{end}'
-}
-
-snip_inplace_upgrade_3() {
-kubectl get pods --namespace istio-system \
-  -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{"\n"}{end}'
-}
-
-snip_canary_upgrade_1() {
+snip_verify_operator_cr() {
 kubectl get iop --all-namespaces
 }
 
-! read -r -d '' snip_canary_upgrade_1_out <<\ENDSNIP
+! read -r -d '' snip_verify_operator_cr_out <<\ENDSNIP
 NAMESPACE      NAME                        REVISION   STATUS    AGE
 istio-system   example-istiocontrolplane              HEALTHY   11m
-ENDSNIP
-
-snip_canary_upgrade_2() {
-istio-1.8.1/bin/istioctl operator init --revision 1-8-1
-}
-
-snip_canary_upgrade_3() {
-helm install istio-operator manifests/charts/istio-operator \
-  --set watchedNamespaces=istio-system \
-  -n istio-operator \
-  --set revision=1-9-0
-}
-
-snip_canary_upgrade_4() {
-cat example-istiocontrolplane-1-8-1.yaml
-}
-
-! read -r -d '' snip_canary_upgrade_4_out <<\ENDSNIP
-apiVersion: install.istio.io/v1alpha1
-kind: IstioOperator
-metadata:
-  namespace: istio-system
-  name: example-istiocontrolplane-1-8-1
-spec:
-  revision: 1-8-1
-  profile: demo
-ENDSNIP
-
-snip_canary_upgrade_5() {
-kubectl get pod -n istio-system -l app=istiod
-}
-
-! read -r -d '' snip_canary_upgrade_5_out <<\ENDSNIP
-NAME                            READY   STATUS    RESTARTS   AGE
-istiod-1-8-1-597475f4f6-bgtcz   1/1     Running   0          64s
-istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
-ENDSNIP
-
-snip_canary_upgrade_6() {
-kubectl get services -n istio-system -l app=istiod
-}
-
-! read -r -d '' snip_canary_upgrade_6_out <<\ENDSNIP
-NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
-istiod         ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
-istiod-1-8-1   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
 ENDSNIP
 
 snip_cleanup() {

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -132,15 +132,15 @@ NAMESPACE      NAME                        REVISION   STATUS    AGE
 istio-system   example-istiocontrolplane              HEALTHY   11m
 ENDSNIP
 
-snip_canary_upgrade_init_1_17_1() {
+snip_canary_upgrade_init() {
 istio-1.17.1/bin/istioctl operator init --revision 1-17-1
 }
 
-snip_canary_upgrade_helm_install_1_17_2() {
+snip_canary_upgrade_helm_install() {
 helm install istio-operator manifests/charts/istio-operator \
   --set watchedNamespaces=istio-system \
   -n istio-operator \
-  --set revision=1-17-2
+  --set revision=1-18-0
 }
 
 snip_cat_operator_yaml() {

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -133,18 +133,18 @@ istio-system   example-istiocontrolplane              HEALTHY   11m
 ENDSNIP
 
 snip_canary_upgrade_init() {
-istio-1.17.1/bin/istioctl operator init --revision 1-17-1
+istio-1-18-0/bin/istioctl operator init --revision 1-18-0
 }
 
 snip_canary_upgrade_helm_install() {
 helm install istio-operator manifests/charts/istio-operator \
   --set watchedNamespaces=istio-system \
   -n istio-operator \
-  --set revision=1-18-0
+  --set revision=1-17-1
 }
 
 snip_cat_operator_yaml() {
-cat example-istiocontrolplane-1-17-1.yaml
+cat example-istiocontrolplane-1-18-0.yaml
 }
 
 ! read -r -d '' snip_cat_operator_yaml_out <<\ENDSNIP
@@ -152,9 +152,9 @@ apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 metadata:
   namespace: istio-system
-  name: example-istiocontrolplane-1-17-1
+  name: example-istiocontrolplane-1-18-0
 spec:
-  revision: 1-17-1
+  revision: 1-18-0
   profile: demo
 ENDSNIP
 
@@ -164,7 +164,7 @@ kubectl get pod -n istio-system -l app=istiod
 
 ! read -r -d '' snip_get_pods_istio_system_out <<\ENDSNIP
 NAME                            READY   STATUS    RESTARTS   AGE
-istiod-1-17-1-597475f4f6-bgtcz   1/1     Running   0          64s
+istiod-1-18-0-597475f4f6-bgtcz   1/1     Running   0          64s
 istiod-6ffcc65b96-bxzv5         1/1     Running   0          2m11s
 ENDSNIP
 
@@ -175,7 +175,7 @@ kubectl get services -n istio-system -l app=istiod
 ! read -r -d '' snip_get_svc_istio_system_out <<\ENDSNIP
 NAME           TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)                                         AGE
 istiod         ClusterIP   10.104.129.150   <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP,853/TCP   2m35s
-istiod-1-17-1   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
+istiod-1-18-0   ClusterIP   10.111.17.49     <none>        15010/TCP,15012/TCP,443/TCP,15014/TCP           88s
 ENDSNIP
 
 snip_delete_example_istiocontrolplane() {

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -168,7 +168,7 @@ metadata:
   name: example-istiocontrolplane-1-18-0
 spec:
   revision: 1-18-0
-  profile: demo
+  profile: default
 ENDSNIP
 
 snip_get_pods_istio_system() {

--- a/content/en/docs/setup/install/operator/snips.sh
+++ b/content/en/docs/setup/install/operator/snips.sh
@@ -24,14 +24,18 @@ snip_create_istio_operator() {
 istioctl operator init
 }
 
-snip_prerequisites_2() {
+snip_deploy_the_istio_operator_2() {
 istioctl operator init --watchedNamespaces=istio-namespace1,istio-namespace2
 }
 
-snip_prerequisites_3() {
+snip_deploy_the_istio_operator_3() {
+kubectl create namespace istio-operator
+}
+
+snip_deploy_the_istio_operator_4() {
 helm install istio-operator manifests/charts/istio-operator \
-  --set watchedNamespaces="istio-namespace1\,istio-namespace2" \
-  -n istio-operator
+    --set watchedNamespaces="istio-namespace1\,istio-namespace2" \
+    -n istio-operator
 }
 
 snip_create_demo_profile() {
@@ -46,7 +50,7 @@ spec:
 EOF
 }
 
-! read -r -d '' snip_install_2 <<\ENDSNIP
+! read -r -d '' snip_install_istio_with_the_operator_2 <<\ENDSNIP
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 ...
@@ -187,5 +191,5 @@ ENDSNIP
 
 snip_cleanup() {
 istioctl uninstall -y --purge
-kubectl delete ns istio-system --grace-period=0 --force
+kubectl delete ns istio-system istio-operator
 }

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -24,7 +24,6 @@ set -o pipefail
 
 previousVersion=$(type snip_canary_upgrade_init | sed '1,3d;$d' | sed 's/\/.*//' | cut -d "-" -f2 )
 previousVersionMinorUpgrade="${previousVersion%.1}.2"
-fullVersion=$(type snip_canary_upgrade_helm_install | sed '1,3d;$d' | sed -e 's#.*revision=\(\)#\1#' | sed -r 's/[-]+/./g' )
 
 function testOperatorDeployWatchNs(){
     # print out body of the function and execute with flag
@@ -95,7 +94,7 @@ function testInplaceUpgrade(){
 function testCanaryUpgrade(){
     istioDownload "$previousVersion"
     snip_canary_upgrade_init
-    rm -rf "istio-"$previousVersion""
+    rm -rf "istio-$previousVersion"
 
     istioDownload "$previousVersionMinorUpgrade"
     snip_canary_upgrade_helm_install

--- a/layouts/shortcodes/istio_full_version_revision.html
+++ b/layouts/shortcodes/istio_full_version_revision.html
@@ -1,0 +1,1 @@
+{{ replace .Site.Data.args.full_version "." "-" }}

--- a/layouts/shortcodes/istio_previous_version_revision.html
+++ b/layouts/shortcodes/istio_previous_version_revision.html
@@ -1,0 +1,1 @@
+{{ replace .Site.Data.args.previous_version "." "-" }}

--- a/scripts/snip.py
+++ b/scripts/snip.py
@@ -89,6 +89,9 @@ try:
     source_branch_name = docs_config['source_branch_name']
     istio_version = docs_config['version']
     istio_full_version = docs_config['full_version']
+    istio_previous_version = docs_config['previous_version']
+    istio_full_version_revision = istio_full_version.replace(".", "-")
+    istio_previous_version_revision = istio_previous_version.replace(".", "-")
     k8s_gateway_api_version = docs_config['k8s_gateway_api_version']
 except:
     sys.stderr.write('failed to retrieve data from "data/args.yml"\n')
@@ -178,6 +181,9 @@ with open(markdown, 'rt', encoding='utf-8') as mdfile:
                         multiline_cmd = True
                 line = line.replace("{{< istio_version >}}", istio_version)
                 line = line.replace("{{< istio_full_version >}}", istio_full_version)
+                line = line.replace("{{< istio_previous_version >}}", istio_previous_version)
+                line = line.replace("{{< istio_full_version_revision >}}", istio_full_version_revision)
+                line = line.replace("{{< istio_previous_version_revision >}}", istio_previous_version_revision)
                 line = line.replace("{{< k8s_gateway_api_version >}}", k8s_gateway_api_version)
                 current_snip["script"].append(line)
 


### PR DESCRIPTION
Enable test for operator install, the following scenarios are tested:

* deploy operator via `istioctl operator init` and using watchNamespaces
* deploy operator via helm
* install Istio
* update Istio profile / specs
* update operator
* inplace and canary upgrade

Additional changes:

* remove all hardcoded versions in operator install doc
* add istio_previous_version and full/previous revision to `snip.py`
* add `shorcodes` for revision versions

- [ ] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
