### PR TITLE
[zh] Sync the page weight of releases/contribute/github

### DIFF
--- a/content/zh/docs/releases/contribute/github/index.md
+++ b/content/zh/docs/releases/contribute/github/index.md
@@ -9,14 +9,18 @@ aliases:
     - /zh/about/contribute/creating-a-pull-request
     - /zh/about/contribute/editing
     - /zh/about/contribute/staging-your-changes
+    - /zh/about/contribute/github
+    - /zh/latest/about/contribute/github
 keywords: [contribute,community,github,pr]
+owner: istio/wg-docs-maintainers
+test: n/a
 ---
 
 Istio 文档协作遵循标准的 [GitHub 协作流](https://guides.github.com/introduction/flow/)。这种成熟的协作模式有助于开源项目管理以下类型的贡献：
 
-- [添加](/zh/about/contribute/add-content)新文件到存储库。
+- [添加](/zh/docs/releases/contribute/add-content)新文件到存储库。
 - [编辑](#quick-edit)现有文件。
-- [审阅](/zh/about/contribute/review)添加或修改的文件。
+- [审阅](/zh/docs/releases/contribute/review)添加或修改的文件。
 - 管理多个发布或开发[分支](#branching-strategy)。
 
 该贡献指南假定您可以完成以下任务：
@@ -48,7 +52,7 @@ Istio 文档协作遵循标准的 [GitHub 协作流](https://guides.github.com/i
 1. 在 GitHub UI 上进行编辑。
 1. 创建 Pull Request 提交您的修改。
 
-请参阅我们在[贡献新内容](/zh/about/contribute/add-content)或[内容审查](/zh/about/contribute/review)中的指南，
+请参阅我们在[贡献新内容](/zh/docs/releases/contribute/add-content)或[内容审查](/zh/docs/releases/contribute/review)中的指南，
 以了解有关提交更多实质性更改的详细信息。
 
 ## 分支策略{#branching-strategy}

--- a/content/zh/docs/releases/contribute/github/index.md
+++ b/content/zh/docs/releases/contribute/github/index.md
@@ -1,7 +1,7 @@
 ---
 title: 使用 GitHub 参与社区活动
 description: 向您展示如何使用 GitHub 参与贡献 Istio 文档。
-weight: 30
+weight: 2
 aliases:
     - /zh/docs/welcome/contribute/creating-a-pull-request.html
     - /zh/docs/welcome/contribute/staging-your-changes.html


### PR DESCRIPTION
Please provide a description for what this PR is for.

Sync the page weight of releases/contribute/github to https://github.com/istio/istio.io/blob/5705e8d69ab4532fa253d370fa6ac48bdb2ffb4b/content/en/docs/releases/contribute/github/index.md?plain=1#L4

To improve clarity and consistency, it would be beneficial to move the content of this section to the first item, similar to the structure of the English version.


And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
