### PR TITLE
multi-cluster with multi-network setup flow fix

### DIFF
--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -185,34 +185,6 @@ Apply the configuration to `cluster2`:
 $ istioctl install --context="${CTX_CLUSTER2}" -f cluster2.yaml
 {{< /text >}}
 
-## Install the east-west gateway in `cluster2`
-
-As we did with `cluster1` above, install a gateway in `cluster2` that is dedicated
-to east-west traffic and expose user services.
-
-{{< text bash >}}
-$ @samples/multicluster/gen-eastwest-gateway.sh@ \
-    --mesh mesh1 --cluster cluster2 --network network2 | \
-    istioctl --context="${CTX_CLUSTER2}" install -y -f -
-{{< /text >}}
-
-Wait for the east-west gateway to be assigned an external IP address:
-
-{{< text bash >}}
-$ kubectl --context="${CTX_CLUSTER2}" get svc istio-eastwestgateway -n istio-system
-NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
-istio-eastwestgateway   LoadBalancer   10.0.12.121   34.122.91.98   ...       51s
-{{< /text >}}
-
-## Expose services in `cluster2`
-
-As we did with `cluster1` above, expose services via the east-west gateway.
-
-{{< text bash >}}
-$ kubectl --context="${CTX_CLUSTER2}" apply -n istio-system -f \
-    @samples/multicluster/expose-services.yaml@
-{{< /text >}}
-
 ## Attach `cluster2` as a remote cluster of `cluster1`
 
 To attach the remote cluster to its control plane, we give the control
@@ -240,6 +212,34 @@ $ istioctl x create-remote-secret \
     --context="${CTX_CLUSTER2}" \
     --name=cluster2 | \
     kubectl apply -f - --context="${CTX_CLUSTER1}"
+{{< /text >}}
+
+## Install the east-west gateway in `cluster2`
+
+As we did with `cluster1` above, install a gateway in `cluster2` that is dedicated
+to east-west traffic and expose user services.
+
+{{< text bash >}}
+$ @samples/multicluster/gen-eastwest-gateway.sh@ \
+    --mesh mesh1 --cluster cluster2 --network network2 | \
+    istioctl --context="${CTX_CLUSTER2}" install -y -f -
+{{< /text >}}
+
+Wait for the east-west gateway to be assigned an external IP address:
+
+{{< text bash >}}
+$ kubectl --context="${CTX_CLUSTER2}" get svc istio-eastwestgateway -n istio-system
+NAME                    TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)   AGE
+istio-eastwestgateway   LoadBalancer   10.0.12.121   34.122.91.98   ...       51s
+{{< /text >}}
+
+## Expose services in `cluster2`
+
+As we did with `cluster1` above, expose services via the east-west gateway.
+
+{{< text bash >}}
+$ kubectl --context="${CTX_CLUSTER2}" apply -n istio-system -f \
+    @samples/multicluster/expose-services.yaml@
 {{< /text >}}
 
 **Congratulations!** You successfully installed an Istio mesh across primary

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
@@ -102,6 +102,13 @@ snip_configure_cluster2_as_a_remote_3() {
 istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING=true --context="${CTX_CLUSTER2}" -f cluster2.yaml
 }
 
+snip_attach_cluster2_as_a_remote_cluster_of_cluster1_1() {
+istioctl x create-remote-secret \
+    --context="${CTX_CLUSTER2}" \
+    --name=cluster2 | \
+    kubectl apply -f - --context="${CTX_CLUSTER1}"
+}
+
 snip_install_the_eastwest_gateway_in_cluster2_1() {
 samples/multicluster/gen-eastwest-gateway.sh \
     --mesh mesh1 --cluster cluster2 --network network2 | \
@@ -120,11 +127,4 @@ ENDSNIP
 snip_expose_services_in_cluster2_1() {
 kubectl --context="${CTX_CLUSTER2}" apply -n istio-system -f \
     samples/multicluster/expose-services.yaml
-}
-
-snip_attach_cluster2_as_a_remote_cluster_of_cluster1_1() {
-istioctl x create-remote-secret \
-    --context="${CTX_CLUSTER2}" \
-    --name=cluster2 | \
-    kubectl apply -f - --context="${CTX_CLUSTER1}"
 }

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/test.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/test.sh
@@ -42,10 +42,6 @@ function install_istio_on_cluster1 {
     snip_expose_services_in_cluster1_1
 }
 
-function enable_api_server_access {
-    snip_attach_cluster2_as_a_remote_cluster_of_cluster1_1
-}
-
 function install_istio_on_cluster2 {
     echo "Installing Istio on Remote cluster: ${CTX_CLUSTER2}"
     snip_set_the_control_plane_cluster_for_cluster2_1
@@ -53,6 +49,9 @@ function install_istio_on_cluster2 {
     snip_configure_cluster2_as_a_remote_1
     snip_configure_cluster2_as_a_remote_2
     echo y | snip_configure_cluster2_as_a_remote_3
+
+    echo "Enabling API server access to remote cluster"
+    snip_attach_cluster2_as_a_remote_cluster_of_cluster1_1
 
     echo "Creating the east-west gateway"
     snip_install_the_eastwest_gateway_in_cluster2_1
@@ -66,7 +65,6 @@ function install_istio_on_cluster2 {
 
 time install_istio_on_cluster1
 time install_istio_on_cluster2
-time enable_api_server_access
 time verify_load_balancing
 
 # @cleanup


### PR DESCRIPTION
Please provide a description for what this PR is for.

Issue Description:
Installation of east-west gateway fails on remote cluster with primary-remote multi-network setup(Any combination of AKS, EKS and GKE).

Resolution:
This issue is caused by not having proper certificate on remote cluster. Hence, remote cluster secret to access remote API server need to be deployed on primary cluster before installing east-west gateway on remote cluster.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
