### PR TITLE
Create generic args.md with common args consumed by test scripts

### DIFF
--- a/content/en/boilerplates/args.md
+++ b/content/en/boilerplates/args.md
@@ -1,15 +1,20 @@
 ---
 ---
+
 {{< text syntax=plain snip_id=gateway_api_version >}}
 {{< k8s_gateway_api_version >}}
 {{< /text >}}
+
 ---
 ---
+
 {{< text syntax=plain snip_id=istio_previous_version >}}
 {{< istio_previous_version >}}
 {{< /text >}}
+
 ---
 ---
+
 {{< text syntax=plain snip_id=istio_full_version >}}
 {{< istio_full_version >}}
 {{< /text >}}

--- a/content/en/boilerplates/args.md
+++ b/content/en/boilerplates/args.md
@@ -1,0 +1,15 @@
+---
+---
+{{< text syntax=plain snip_id=gateway_api_version >}}
+{{< k8s_gateway_api_version >}}
+{{< /text >}}
+---
+---
+{{< text syntax=plain snip_id=istio_previous_version >}}
+{{< istio_previous_version >}}
+{{< /text >}}
+---
+---
+{{< text syntax=plain snip_id=istio_full_version >}}
+{{< istio_full_version >}}
+{{< /text >}}

--- a/content/en/boilerplates/gateway-api-version.md
+++ b/content/en/boilerplates/gateway-api-version.md
@@ -1,5 +1,0 @@
----
----
-{{< text syntax=plain snip_id=value >}}
-{{< k8s_gateway_api_version >}}
-{{< /text >}}

--- a/content/en/boilerplates/snips/args.sh
+++ b/content/en/boilerplates/snips/args.sh
@@ -17,9 +17,17 @@
 
 ####################################################################################################
 # WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
-#          boilerplates/gateway-api-version.md
+#          boilerplates/args.md
 ####################################################################################################
 
-! read -r -d '' bpsnip_gateway_api_version_value <<\ENDSNIP
+! read -r -d '' bpsnip_args_gateway_api_version <<\ENDSNIP
 v0.6.2
+ENDSNIP
+
+! read -r -d '' bpsnip_args_istio_previous_version <<\ENDSNIP
+1.17
+ENDSNIP
+
+! read -r -d '' bpsnip_args_istio_full_version <<\ENDSNIP
+1.18.0
 ENDSNIP

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -22,9 +22,11 @@ set -e
 set -u
 set -o pipefail
 
-fullVersion=$(type snip_canary_upgrade_init | sed '1,3d;$d' | sed 's/.*istio-\(.*\)\/bin.*/\1/') # 1.18.0
+source "content/en/boilerplates/snips/args.sh"
+
+fullVersion="${bpsnip_args_istio_full_version}"
 fullVersionRevision=$(echo "$fullVersion" | sed -r 's/[.]+/-/g' ) # 1-18-0
-previousVersion=$(type snip_deploy_operator_previous_version | sed '1,3d;$d' | sed 's/.*istio-\(.*\)\/bin.*/\1/')
+previousVersion="${bpsnip_args_istio_previous_version}.0"
 previousVersionMinorUpgrade="${previousVersion%.0}.1"
 
 function testOperatorDeployWatchNs(){

--- a/content/en/docs/setup/install/operator/test.sh
+++ b/content/en/docs/setup/install/operator/test.sh
@@ -25,7 +25,7 @@ set -o pipefail
 source "content/en/boilerplates/snips/args.sh"
 
 fullVersion="${bpsnip_args_istio_full_version}"
-fullVersionRevision=$(echo "$fullVersion" | sed -r 's/[.]+/-/g' ) # 1-18-0
+fullVersionRevision="${fullVersion//./-}"
 previousVersion="${bpsnip_args_istio_previous_version}.0"
 previousVersionMinorUpgrade="${previousVersion%.0}.1"
 

--- a/tests/util/gateway-api.sh
+++ b/tests/util/gateway-api.sh
@@ -14,9 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-source "content/en/boilerplates/snips/gateway-api-version.sh"
+source "content/en/boilerplates/snips/args.sh"
 
-K8S_GATEWAY_API_CRDS="github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${bpsnip_gateway_api_version_value}"
+K8S_GATEWAY_API_CRDS="github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${bpsnip_args_gateway_api_version}"
 GATEWAY_API="true"
 
 function install_gateway_api_crds() {


### PR DESCRIPTION
* create generic boilerplates/args.md
* include gw_api_version, full_version, previous_version
* update install/operator/test.sh to source and use new vars
* update test/util/gateway-api.sh to source and use new gw var
* remove gateway-api-version.md

Fixes #13085

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
