### PR TITLE
update istio autocompletion instructions to use zsh for mac

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1150,5 +1150,6 @@ Zhu
 Zipkin
 Ziyang
 Zolotusky
+Zsh
 ztunnel
 ztunnels

--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -101,7 +101,7 @@ See [Debugging Envoy and Istiod](/docs/ops/diagnostic-tools/proxy-cmd/) for more
 
 {{< tab name="macOS" category-value="macos" >}}
 
-If you are using the macOS operating system with the Bash terminal shell, make sure that the `zsh-completions` package is installed. With the [brew](https://brew.sh) package manager for macOS, you can check to see if the `zsh-completions` package is installed with the following command:
+If you are using the macOS operating system with the zsh terminal shell, make sure that the `zsh-completions` package is installed. With the [brew](https://brew.sh) package manager for macOS, you can check to see if the `zsh-completions` package is installed with the following command:
 
 {{< text bash >}}
 $ brew info zsh-completions

--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -117,11 +117,11 @@ $ brew install zsh-completions
 Once the `zsh-completions package` has been installed on your macOS system, add the following to your `~/.zshrc` file:
 
 {{< text plain >}}
-   if type brew &>/dev/null; then
-     FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
+    if type brew &>/dev/null; then
+      FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
 
-     autoload -Uz compinit
-     compinit
+      autoload -Uz compinit
+      compinit
     fi
 {{< /text >}}
 

--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -101,23 +101,40 @@ See [Debugging Envoy and Istiod](/docs/ops/diagnostic-tools/proxy-cmd/) for more
 
 {{< tab name="macOS" category-value="macos" >}}
 
-If you are using the macOS operating system with the Bash terminal shell, make sure that the `bash-completion` package is installed. With the [brew](https://brew.sh) package manager for macOS, you can check to see if the `bash-completion` package is installed with the following command:
+If you are using the macOS operating system with the Bash terminal shell, make sure that the `zsh-completions` package is installed. With the [brew](https://brew.sh) package manager for macOS, you can check to see if the `zsh-completions` package is installed with the following command:
 
 {{< text bash >}}
-$ brew info bash-completion
-bash-completion: stable 1.3 (bottled)
+$ brew info zsh-completions
+zsh-completions: stable 0.34.0 (bottled)
 {{< /text >}}
 
-If you find that the `bash-completion` package is _not_ installed, proceed with installing the `bash-completion` package with the following command:
+If you find that the `zsh-completions` package is _not_ installed, proceed with installing the `zsh-completions` package with the following command:
 
 {{< text bash >}}
-$ brew install bash-completion
+$ brew install zsh-completions
 {{< /text >}}
 
-Once the `bash-completion package` has been installed on your macOS system, add the following line to your `~/.bash_profile` file:
+Once the `zsh-completions package` has been installed on your macOS system, add the following to your `~/.zshrc` file:
 
 {{< text plain >}}
-[[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
+   if type brew &>/dev/null; then
+     FPATH=$(brew --prefix)/share/zsh-completions:$FPATH
+
+     autoload -Uz compinit
+     compinit
+    fi
+{{< /text >}}
+
+You may also need to force rebuild `zcompdump`:
+
+{{< text bash >}}
+$ rm -f ~/.zcompdump; compinit
+{{< /text >}}
+
+Additionally, if you receive "zsh compinit: insecure directories" warnings when attempting to load these completions, you may need to run this:
+
+{{< text bash >}}
+$ chmod -R go-w '$HOMEBREW_PREFIX/share/zsh'
 {{< /text >}}
 
 {{< /tab >}}

--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -101,7 +101,7 @@ See [Debugging Envoy and Istiod](/docs/ops/diagnostic-tools/proxy-cmd/) for more
 
 {{< tab name="macOS" category-value="macos" >}}
 
-If you are using the macOS operating system with the zsh terminal shell, make sure that the `zsh-completions` package is installed. With the [brew](https://brew.sh) package manager for macOS, you can check to see if the `zsh-completions` package is installed with the following command:
+If you are using the macOS operating system with the ZSH terminal shell, make sure that the `zsh-completions` package is installed. With the [brew](https://brew.sh) package manager for macOS, you can check to see if the `zsh-completions` package is installed with the following command:
 
 {{< text bash >}}
 $ brew info zsh-completions
@@ -131,7 +131,7 @@ You may also need to force rebuild `zcompdump`:
 $ rm -f ~/.zcompdump; compinit
 {{< /text >}}
 
-Additionally, if you receive "zsh compinit: insecure directories" warnings when attempting to load these completions, you may need to run this:
+Additionally, if you receive "ZSH compinit: insecure directories" warnings when attempting to load these completions, you may need to run this:
 
 {{< text bash >}}
 $ chmod -R go-w '$HOMEBREW_PREFIX/share/zsh'

--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -14,7 +14,7 @@ You can gain insights into what individual components are doing by inspecting th
 or peering inside via [introspection](/docs/ops/diagnostic-tools/controlz/). If that's insufficient, the steps below explain
 how to get under the hood.
 
-The [`istioctl`](/docs/reference/commands/istioctl) tool is a configuration command line utility that allows service operators to debug and diagnose their Istio service mesh deployments. The Istio project also includes two helpful scripts for `istioctl` that enable auto-completion for Bash and ZSH. Both of these scripts provide support for the currently available `istioctl` commands.
+The [`istioctl`](/docs/reference/commands/istioctl) tool is a configuration command line utility that allows service operators to debug and diagnose their Istio service mesh deployments. The Istio project also includes two helpful scripts for `istioctl` that enable auto-completion for Bash and Zsh. Both of these scripts provide support for the currently available `istioctl` commands.
 
 {{< tip >}}
 `istioctl` only has auto-completion enabled for non-deprecated commands.
@@ -45,7 +45,7 @@ Install the `istioctl` binary with `curl`:
     $ export PATH=$HOME/.istioctl/bin:$PATH
     {{< /text >}}
 
-1. You can optionally enable the [auto-completion option](#enabling-auto-completion) when working with a bash or ZSH console.
+1. You can optionally enable the [auto-completion option](#enabling-auto-completion) when working with a bash or Zsh console.
 
 ## Get an overview of your mesh
 
@@ -101,14 +101,14 @@ See [Debugging Envoy and Istiod](/docs/ops/diagnostic-tools/proxy-cmd/) for more
 
 {{< tab name="macOS" category-value="macos" >}}
 
-If you are using the macOS operating system with the ZSH terminal shell, make sure that the `zsh-completions` package is installed. With the [brew](https://brew.sh) package manager for macOS, you can check to see if the `zsh-completions` package is installed with the following command:
+If you are using the macOS operating system with the Zsh terminal shell, make sure that the `zsh-completions` package is installed. With the [brew](https://brew.sh) package manager for macOS, you can check to see if the `zsh-completions` package is installed with the following command:
 
 {{< text bash >}}
-$ brew info zsh-completions
-zsh-completions: stable 0.34.0 (bottled)
+$ brew list zsh-completions
+/usr/local/Cellar/zsh-completions/0.34.0/share/zsh-completions/ (147 files)
 {{< /text >}}
 
-If you find that the `zsh-completions` package is _not_ installed, proceed with installing the `zsh-completions` package with the following command:
+If you receive `Error: No such keg: /usr/local/Cellar/zsh-completion`, proceed with installing the `zsh-completions` package with the following command:
 
 {{< text bash >}}
 $ brew install zsh-completions
@@ -131,7 +131,7 @@ You may also need to force rebuild `zcompdump`:
 $ rm -f ~/.zcompdump; compinit
 {{< /text >}}
 
-Additionally, if you receive `ZSH compinit: insecure directories` warnings when attempting to load these completions, you may need to run this:
+Additionally, if you receive `Zsh compinit: insecure directories` warnings when attempting to load these completions, you may need to run this:
 
 {{< text bash >}}
 $ chmod -R go-w '$HOMEBREW_PREFIX/share/zsh'
@@ -175,11 +175,11 @@ $ source ~/istioctl.bash
 
 {{< /tab >}}
 
-{{< tab name="ZSH" category-value="zsh" >}}
+{{< tab name="Zsh" category-value="zsh" >}}
 
-Installing the ZSH auto-completion file
+Installing the Zsh auto-completion file
 
-For ZSH users, the `istioctl` auto-completion file is located in the `tools` directory. Copy the `_istioctl` file to your home directory, or any directory of your choosing (update directory in script snippet below), and source the `istioctl` auto-completion file in your `.zshrc` file as follows:
+For Zsh users, the `istioctl` auto-completion file is located in the `tools` directory. Copy the `_istioctl` file to your home directory, or any directory of your choosing (update directory in script snippet below), and source the `istioctl` auto-completion file in your `.zshrc` file as follows:
 
 {{< text zsh >}}
 source ~/_istioctl

--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -131,7 +131,7 @@ You may also need to force rebuild `zcompdump`:
 $ rm -f ~/.zcompdump; compinit
 {{< /text >}}
 
-Additionally, if you receive "ZSH compinit: insecure directories" warnings when attempting to load these completions, you may need to run this:
+Additionally, if you receive `ZSH compinit: insecure directories` warnings when attempting to load these completions, you may need to run this:
 
 {{< text bash >}}
 $ chmod -R go-w '$HOMEBREW_PREFIX/share/zsh'


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fixes this issue https://github.com/istio/istio.io/issues/12631

Tested locally with the updated instructions:
```
…. ~ % istioctl proxy-
proxy-config  -- Retrieve information about proxy configuration from Envoy [kube only]
proxy-status  -- Retrieves the synchronization status of each Envoy in the mesh [kube only]
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
