### PR TITLE
Remove defaultRevision - should be set in values.yaml

### DIFF
--- a/content/en/docs/reference/config/istio.operator.v1alpha1/index.html
+++ b/content/en/docs/reference/config/istio.operator.v1alpha1/index.html
@@ -125,18 +125,6 @@ This option is currently experimental.</p>
 No
 </td>
 </tr>
-<tr id="IstioOperatorSpec-defaultRevision">
-<td><code>defaultRevision</code></td>
-<td><code>bool</code></td>
-<td>
-<p>Identify whether this revision is the default revision for the cluster
-This option is currently experimental.</p>
-
-</td>
-<td>
-No
-</td>
-</tr>
 <tr id="IstioOperatorSpec-meshConfig">
 <td><code>meshConfig</code></td>
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#struct">Struct</a></code></td>


### PR DESCRIPTION
Setting `defaultRevision` as described does not function as intended or described (not boolean). It should be set as seen below. 
```
values:
  defaultRevision: 1-16
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [ X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
