### PR TITLE
Add livenessProbe rewrite example

### DIFF
--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -38,7 +38,8 @@ so that the probe request is sent to the [sidecar agent](/docs/reference/command
 The rewrite is visible at the application pod level. For example, using [liveness-http-same-port sample]({{< github_file >}}/samples/health-check/liveness-http-same-port.yaml), we see it working. First, create and label a namespace:
 
 {{< text bash >}}
-$ kubectl create namespace istio-io-health-rewrite; kubectl label namespace istio-io-health-rewrite istio-injection=enabled
+$ kubectl create namespace istio-io-health-rewrite
+$ kubectl label namespace istio-io-health-rewrite istio-injection=enabled
 {{< /text >}}
 
 And deploy the sample app:

--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -35,7 +35,7 @@ so that the probe request is sent to the [sidecar agent](/docs/reference/command
 
 ## Liveness probe rewrite example
 
-To demonstrate how the readiness/liveness probe is rewritten at the application PodSpec level, let us use the [liveness-http-same-port sample]({{< github_file >}}/samples/health-check/liveness-http-same-port.yaml).
+To demonstrate how the readiness/liveness probe is rewritten at the application `PodSpec` level, let us use the [liveness-http-same-port sample]({{< github_file >}}/samples/health-check/liveness-http-same-port.yaml).
 
 First create and label a namespace for the example:
 

--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -35,7 +35,9 @@ so that the probe request is sent to the [sidecar agent](/docs/reference/command
 
 ## Liveness probe rewrite example
 
-The rewrite is visible at the application pod level. For example, using [liveness-http-same-port sample]({{< github_file >}}/samples/health-check/liveness-http-same-port.yaml), we see it working. First, create and label a namespace:
+To demonstrate how the readiness/liveness probe is rewritten at the application PodSpec level, let us use the [liveness-http-same-port sample]({{< github_file >}}/samples/health-check/liveness-http-same-port.yaml).
+
+First create and label a namespace for the example:
 
 {{< text bash >}}
 $ kubectl create namespace istio-io-health-rewrite

--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -76,7 +76,7 @@ EOF
 Once deployed, you can inspect the pod's application container to see the changed path:
 
 {{< text bash json >}}
-$ export LIVENESS_POD=$(kubectl get pod -n istio-io-health-rewrite | awk 'NR>1 {print $1}'); kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o json | jq '.spec.containers[0].livenessProbe.httpGet'
+$ kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o json | jq '.spec.containers[0].livenessProbe.httpGet'
 {
   "path": "/app-health/liveness-http/livez",
   "port": 15020,

--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -33,7 +33,9 @@ TCP probe checks need special handling, because Istio redirects all incoming tra
 Istio solves both these problems by rewriting the application `PodSpec` readiness/liveness probe,
 so that the probe request is sent to the [sidecar agent](/docs/reference/commands/pilot-agent/).
 
-The rewrite is visible at the application pod level. For example, using the [liveness-http-same-port sample]({{< github_file >}}/samples/health-check/liveness-http-same-port.yaml) sample, we see it working. First, create a namespace:
+## LivenessProbe rewrite example
+
+The rewrite is visible at the application pod level. For example, using [liveness-http-same-port sample]({{< github_file >}}/samples/health-check/liveness-http-same-port.yaml), we see it working. First, create and label a namespace:
 
 {{< text bash >}}
 $ kubectl create namespace istio-io-health-rewrite; kubectl label namespace istio-io-health-rewrite istio-injection=enabled

--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -33,7 +33,7 @@ TCP probe checks need special handling, because Istio redirects all incoming tra
 Istio solves both these problems by rewriting the application `PodSpec` readiness/liveness probe,
 so that the probe request is sent to the [sidecar agent](/docs/reference/commands/pilot-agent/).
 
-## LivenessProbe rewrite example
+## Liveness probe rewrite example
 
 The rewrite is visible at the application pod level. For example, using [liveness-http-same-port sample]({{< github_file >}}/samples/health-check/liveness-http-same-port.yaml), we see it working. First, create and label a namespace:
 

--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -42,7 +42,7 @@ $ kubectl create namespace istio-io-health-rewrite
 $ kubectl label namespace istio-io-health-rewrite istio-injection=enabled
 {{< /text >}}
 
-And deploy the sample app:
+And deploy the sample application:
 
 {{< text bash yaml >}}
 $ kubectl apply -f - <<EOF

--- a/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
@@ -57,7 +57,7 @@ EOF
 }
 
 snip__3() {
-export LIVENESS_POD=$(kubectl get po | awk 'NR>1 {print $1}'); kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o json | jq '.spec.containers[0].livenessProbe.httpGet'
+export LIVENESS_POD=$(kubectl get pod -n istio-io-health-rewrite | awk 'NR>1 {print $1}'); kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o json | jq '.spec.containers[0].livenessProbe.httpGet'
 }
 
 ! read -r -d '' snip__3_out <<\ENDSNIP
@@ -66,15 +66,17 @@ export LIVENESS_POD=$(kubectl get po | awk 'NR>1 {print $1}'); kubectl get pod "
   "port": 15020,
   "scheme": "HTTP"
 }
-
 ENDSNIP
 
 snip__4() {
-kubectl get pod "$LIVENESS_POD" -o=jsonpath="{.spec.containers[1].env[?(@.name=='ISTIO_KUBE_APP_PROBERS')]}"
+kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o=jsonpath="{.spec.containers[1].env[?(@.name=='ISTIO_KUBE_APP_PROBERS')]}"
 }
 
 ! read -r -d '' snip__4_out <<\ENDSNIP
-{"name":"ISTIO_KUBE_APP_PROBERS","value":"{\"/app-health/liveness-http/livez\":{\"httpGet\":{\"path\":\"/foo\",\"port\":8001,\"scheme\":\"HTTP\"},\"timeoutSeconds\":1}}"}
+{
+  "name":"ISTIO_KUBE_APP_PROBERS",
+  "value":"{\"/app-health/liveness-http/livez\":{\"httpGet\":{\"path\":\"/foo\",\"port\":8001,\"scheme\":\"HTTP\"},\"timeoutSeconds\":1}}"
+}
 ENDSNIP
 
 snip_liveness_and_readiness_probes_using_the_command_approach_1() {

--- a/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
@@ -20,11 +20,11 @@
 #          docs/ops/configuration/mesh/app-health-check/index.md
 ####################################################################################################
 
-snip_livenessprobe_rewrite_example_1() {
+snip_liveness_probe_rewrite_example_1() {
 kubectl create namespace istio-io-health-rewrite; kubectl label namespace istio-io-health-rewrite istio-injection=enabled
 }
 
-snip_livenessprobe_rewrite_example_2() {
+snip_liveness_probe_rewrite_example_2() {
 kubectl apply -f - <<EOF
 apiVersion: apps/v1
 kind: Deployment
@@ -56,11 +56,11 @@ spec:
 EOF
 }
 
-snip_livenessprobe_rewrite_example_3() {
+snip_liveness_probe_rewrite_example_3() {
 kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o json | jq '.spec.containers[0].livenessProbe.httpGet'
 }
 
-! read -r -d '' snip_livenessprobe_rewrite_example_3_out <<\ENDSNIP
+! read -r -d '' snip_liveness_probe_rewrite_example_3_out <<\ENDSNIP
 {
   "path": "/app-health/liveness-http/livez",
   "port": 15020,
@@ -68,11 +68,11 @@ kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o json | jq '.spec.c
 }
 ENDSNIP
 
-snip_livenessprobe_rewrite_example_4() {
+snip_liveness_probe_rewrite_example_4() {
 kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o=jsonpath="{.spec.containers[1].env[?(@.name=='ISTIO_KUBE_APP_PROBERS')]}"
 }
 
-! read -r -d '' snip_livenessprobe_rewrite_example_4_out <<\ENDSNIP
+! read -r -d '' snip_liveness_probe_rewrite_example_4_out <<\ENDSNIP
 {
   "name":"ISTIO_KUBE_APP_PROBERS",
   "value":"{\"/app-health/liveness-http/livez\":{\"httpGet\":{\"path\":\"/foo\",\"port\":8001,\"scheme\":\"HTTP\"},\"timeoutSeconds\":1}}"

--- a/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
@@ -20,11 +20,11 @@
 #          docs/ops/configuration/mesh/app-health-check/index.md
 ####################################################################################################
 
-snip__1() {
+snip_livenessprobe_rewrite_example_1() {
 kubectl create namespace istio-io-health-rewrite; kubectl label namespace istio-io-health-rewrite istio-injection=enabled
 }
 
-snip__2() {
+snip_livenessprobe_rewrite_example_2() {
 kubectl apply -f - <<EOF
 apiVersion: apps/v1
 kind: Deployment
@@ -56,11 +56,11 @@ spec:
 EOF
 }
 
-snip__3() {
+snip_livenessprobe_rewrite_example_3() {
 kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o json | jq '.spec.containers[0].livenessProbe.httpGet'
 }
 
-! read -r -d '' snip__3_out <<\ENDSNIP
+! read -r -d '' snip_livenessprobe_rewrite_example_3_out <<\ENDSNIP
 {
   "path": "/app-health/liveness-http/livez",
   "port": 15020,
@@ -68,11 +68,11 @@ kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o json | jq '.spec.c
 }
 ENDSNIP
 
-snip__4() {
+snip_livenessprobe_rewrite_example_4() {
 kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o=jsonpath="{.spec.containers[1].env[?(@.name=='ISTIO_KUBE_APP_PROBERS')]}"
 }
 
-! read -r -d '' snip__4_out <<\ENDSNIP
+! read -r -d '' snip_livenessprobe_rewrite_example_4_out <<\ENDSNIP
 {
   "name":"ISTIO_KUBE_APP_PROBERS",
   "value":"{\"/app-health/liveness-http/livez\":{\"httpGet\":{\"path\":\"/foo\",\"port\":8001,\"scheme\":\"HTTP\"},\"timeoutSeconds\":1}}"

--- a/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
@@ -57,7 +57,7 @@ EOF
 }
 
 snip__3() {
-export LIVENESS_POD=$(kubectl get pod -n istio-io-health-rewrite | awk 'NR>1 {print $1}'); kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o json | jq '.spec.containers[0].livenessProbe.httpGet'
+kubectl get pod "$LIVENESS_POD" -n istio-io-health-rewrite -o json | jq '.spec.containers[0].livenessProbe.httpGet'
 }
 
 ! read -r -d '' snip__3_out <<\ENDSNIP

--- a/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
@@ -21,7 +21,8 @@
 ####################################################################################################
 
 snip_liveness_probe_rewrite_example_1() {
-kubectl create namespace istio-io-health-rewrite; kubectl label namespace istio-io-health-rewrite istio-injection=enabled
+kubectl create namespace istio-io-health-rewrite
+kubectl label namespace istio-io-health-rewrite istio-injection=enabled
 }
 
 snip_liveness_probe_rewrite_example_2() {

--- a/content/en/docs/ops/configuration/mesh/app-health-check/test.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/test.sh
@@ -21,18 +21,18 @@ set -o pipefail
 
 # @setup profile=default
 
-snip__1 # Create and label namespace
+snip_liveness_probe_rewrite_example_1
 
-snip__2 # Deploy liveness-http
+snip_liveness_probe_rewrite_example_2
 
 _wait_for_deployment istio-io-health-rewrite liveness-http
 
 LIVENESS_POD="$(kubectl get pod -n istio-io-health-rewrite -l app=liveness-http -o jsonpath='{.items[0].metadata.name}')"
 export LIVENESS_POD
 
-_verify_contains snip__3 "/app-health/liveness-http/livez"
+_verify_contains snip_liveness_probe_rewrite_example_3 "/app-health/liveness-http/livez"
 
-_verify_contains snip__4 "ISTIO_KUBE_APP_PROBERS"
+_verify_contains snip_liveness_probe_rewrite_example_4 "ISTIO_KUBE_APP_PROBERS"
 
 snip_liveness_and_readiness_probes_using_the_command_approach_1
 

--- a/content/en/docs/ops/configuration/mesh/app-health-check/test.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/test.sh
@@ -27,6 +27,9 @@ snip__2 # Deploy liveness-http
 
 _wait_for_deployment istio-io-health-rewrite liveness-http
 
+LIVENESS_POD="$(kubectl get pod -n istio-io-health-rewrite -l app=liveness-http -o jsonpath='{.items[0].metadata.name}')"
+export LIVENESS_POD
+
 _verify_contains snip__3 "/app-health/liveness-http/livez"
 
 _verify_contains snip__4 "ISTIO_KUBE_APP_PROBERS"

--- a/content/en/docs/ops/configuration/mesh/app-health-check/test.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/test.sh
@@ -21,6 +21,16 @@ set -o pipefail
 
 # @setup profile=default
 
+snip__1 # Create and label namespace
+
+snip__2 # Deploy liveness-http
+
+_wait_for_deployment istio-io-health-rewrite liveness-http
+
+_verify_like snip__3 "$snip__3_out"
+
+_verify_like snip__4 "$snip__4_out"
+
 snip_liveness_and_readiness_probes_using_the_command_approach_1
 
 snip_liveness_and_readiness_probes_using_the_command_approach_2

--- a/content/en/docs/ops/configuration/mesh/app-health-check/test.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/test.sh
@@ -27,9 +27,9 @@ snip__2 # Deploy liveness-http
 
 _wait_for_deployment istio-io-health-rewrite liveness-http
 
-_verify_like snip__3 "$snip__3_out"
+_verify_contains snip__3 "/app-health/liveness-http/livez"
 
-_verify_like snip__4 "$snip__4_out"
+_verify_contains snip__4 "ISTIO_KUBE_APP_PROBERS"
 
 snip_liveness_and_readiness_probes_using_the_command_approach_1
 


### PR DESCRIPTION
This PR extends health check documentation by adding an example on how and where the `httpProbe` is rewritten.
The example uses a `samples/health-check/liveness-http-same-port.yaml` manifest.

The insight is useful to prevent Istio users get confused with the automatic changes made by Istio in this matter. 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
