### PR TITLE
Fix broken link for subzone

### DIFF
--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/_index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/_index.md
@@ -32,7 +32,7 @@ triplet defines a locality:
 - **Sub-zone**: Allows administrators to further subdivide zones for more
   fine-grained control, such as "same rack". The sub-zone concept doesn't exist
   in Kubernetes. As a result, Istio introduced the custom node label
-  [`topology.istio.io/subzone`](https://github.com/istio/api/blob/master/label/label.go#L42)
+  [`topology.istio.io/subzone`](/docs/reference/config/labels/#:~:text=topology.istio.io/subzone)
   to define a sub-zone.
 
 {{< tip >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.

https://github.com/istio/istio.io/pull/10453 mentioned a broken link. The endpoint to the link no longer exists, and we can point to the label in the reference docs instead. If we point to a specific line in a file, that line may need to be updated if the file is updated, so was fragile before the file was removed.

Note that the labels page does not create links per label, so I added a `Scroll to text fragment` to the URL. This won't have an effect in many browsers, but at least Chrome will highlight the label.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
