### PR TITLE
[zh] Sync a missed aliases file into Chinese

### DIFF
--- a/content/zh/docs/reference/config/proxy_extensions/_index.md
+++ b/content/zh/docs/reference/config/proxy_extensions/_index.md
@@ -1,0 +1,8 @@
+---
+title: 代理扩展
+description: 描述如何配置 Istio 代理扩展。
+weight: 30
+aliases:
+    - /zh/docs/reference/config/proxy_extensions/
+test: n/a
+---


### PR DESCRIPTION
Sync a missed aliases file into Chinese:
```
content\zh\docs\reference\config\proxy_extensions\_index.md
```

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
