### PR TITLE
[zh] Sync 1.11.8, 1.13.9 and 1.14.5 release notes into Chinese

### DIFF
--- a/content/zh/news/releases/1.11.x/announcing-1.11.8/index.md
+++ b/content/zh/news/releases/1.11.x/announcing-1.11.8/index.md
@@ -11,8 +11,7 @@ aliases:
 
 此版本修复了我们 3 月 9 日的帖子
 [ISTIO-SECURITY-2022-004](/zh/news/security/istio-security-2022-004)
-中描述的安全漏洞。
-本发布说明描述了 Istio 1.11.7 和
+中描述的安全漏洞。本发布说明描述了 Istio 1.11.7 和
 Istio 1.11.8 之间的不同之处。
 
 {{< relnote >}}
@@ -24,8 +23,8 @@ Istio 1.11.8 之间的不同之处。
 
 ### Envoy CVE 漏洞{#envoy-cves}
 
-目前不认为 Istio 容易受到 Envoy 中这些
-CVE 漏洞的攻击。然而，它们被列出是为了披露。
+目前不认为 Istio 容易受到 Envoy 中这些 CVE 漏洞的攻击。
+然而，它们被列出是为了披露。
 
 - __[CVE-2022-21657](https://github.com/envoyproxy/envoy/security/advisories/GHSA-837m-wjrv-vm5g)__
   (CVSS Score 3.1, Low)：X.509 扩展密钥使用和信任目的旁路。

--- a/content/zh/news/releases/1.11.x/announcing-1.11.8/index.md
+++ b/content/zh/news/releases/1.11.x/announcing-1.11.8/index.md
@@ -1,0 +1,31 @@
+---
+title: Istio 1.11.8 发布公告
+linktitle: 1.11.8
+subtitle: 补丁发布
+description: Istio 1.11.8 补丁发布。
+publishdate: 2022-03-09
+release: 1.11.8
+aliases:
+    - /zh/news/announcing-1.11.8
+---
+
+此版本修复了我们 3 月 9 日的帖子
+[ISTIO-SECURITY-2022-004](/zh/news/security/istio-security-2022-004)
+中描述的安全漏洞。
+本发布说明描述了 Istio 1.11.7 和
+Istio 1.11.8 之间的不同之处。
+
+{{< relnote >}}
+
+## 安全更新{#security-update}
+
+- __[CVE-2022-24726](https://github.com/istio/istio/security/advisories/GHSA-8w5h-qr4r-2h6g)__:
+  (CVSS Score 7.5, High)：由于堆栈耗尽导致未经身份验证的控制平面拒绝服务攻击。
+
+### Envoy CVE 漏洞{#envoy-cves}
+
+目前不认为 Istio 容易受到 Envoy 中这些
+CVE 漏洞的攻击。然而，它们被列出是为了披露。
+
+- __[CVE-2022-21657](https://github.com/envoyproxy/envoy/security/advisories/GHSA-837m-wjrv-vm5g)__
+  (CVSS Score 3.1, Low)：X.509 扩展密钥使用和信任目的旁路。

--- a/content/zh/news/releases/1.13.x/announcing-1.13.9/index.md
+++ b/content/zh/news/releases/1.13.x/announcing-1.13.9/index.md
@@ -8,17 +8,15 @@ release: 1.13.9
 ---
 
 该版本包含了对 [CVE-2022-39278](/zh/news/security/istio-security-2022-007/#cve-2022-39278)
-的修复以及改进稳健性的漏洞修复。
-本发布说明描述了 Istio 1.13.8 和
-Istio 1.13.9 之间的不同之处。
+的修复以及改进稳健性的漏洞修复。本发布说明描述了
+Istio 1.13.8 和 Istio 1.13.9 之间的不同之处。
 
 {{< relnote >}}
 
 ## 安全更新{#security-updates}
 
 - [CVE-2022-41715](https://github.com/golang/go/issues/55949) 的补丁。
-  用 Go 1.19.2 `stdlib` 实现替换所有对
-  `stdlib`，`regexp` 的使用。
+  用 Go 1.19.2 `stdlib` 实现替换所有对 `stdlib`，`regexp` 的使用。
   这将通过格式错误的正则表达式来防止 DOS。
 
 ## 变更{#changes}
@@ -27,10 +25,9 @@ Istio 1.13.9 之间的不同之处。
   用户无法删除带有修订版的 Istio Operator 资源的问题。
   ([Issue #40796](https://github.com/istio/istio/issues/40796))
 
-- **修复** 修复了 `jwks` 动态生成的返回值不是 base64
-  编码导致 Envoy 无法解析它的错误。
+- **修复** 修复了 `jwks` 动态生成的返回值不是 base64 编码导致
+  Envoy 无法解析它的错误。
 
 - **修复** 修复了根命名空间 `Sidecar` 配置会被忽略的问题。
 
-- **修复** 修复了移除 `v1alpha2` 版本时
-  Gateway API 集成不失败的问题。
+- **修复** 修复了移除 `v1alpha2` 版本时 Gateway API 集成不失败的问题。

--- a/content/zh/news/releases/1.13.x/announcing-1.13.9/index.md
+++ b/content/zh/news/releases/1.13.x/announcing-1.13.9/index.md
@@ -1,0 +1,36 @@
+---
+title: Istio 1.13.9 发布公告
+linktitle: 1.13.9
+subtitle: 补丁发布
+description: Istio 1.13.9 补丁发布。
+publishdate: 2022-10-11
+release: 1.13.9
+---
+
+该版本包含了对 [CVE-2022-39278](/zh/news/security/istio-security-2022-007/#cve-2022-39278)
+的修复以及改进稳健性的漏洞修复。
+本发布说明描述了 Istio 1.13.8 和
+Istio 1.13.9 之间的不同之处。
+
+{{< relnote >}}
+
+## 安全更新{#security-updates}
+
+- [CVE-2022-41715](https://github.com/golang/go/issues/55949) 的补丁。
+  用 Go 1.19.2 `stdlib` 实现替换所有对
+  `stdlib`，`regexp` 的使用。
+  这将通过格式错误的正则表达式来防止 DOS。
+
+## 变更{#changes}
+
+- **修复** 修复了如果 istiod 未运行，
+  用户无法删除带有修订版的 Istio Operator 资源的问题。
+  ([Issue #40796](https://github.com/istio/istio/issues/40796))
+
+- **修复** 修复了 `jwks` 动态生成的返回值不是 base64
+  编码导致 Envoy 无法解析它的错误。
+
+- **修复** 修复了根命名空间 `Sidecar` 配置会被忽略的问题。
+
+- **修复** 修复了移除 `v1alpha2` 版本时
+  Gateway API 集成不失败的问题。

--- a/content/zh/news/releases/1.14.x/announcing-1.14.5/index.md
+++ b/content/zh/news/releases/1.14.x/announcing-1.14.5/index.md
@@ -1,0 +1,49 @@
+---
+title: Istio 1.14.5 发布公告
+linktitle: 1.14.5
+subtitle: 补丁发布
+description: Istio 1.14.5 补丁发布。
+publishdate: 2022-10-11
+release: 1.14.5
+---
+
+该版本包含了对 [CVE-2022-39278](/zh/news/security/istio-security-2022-007/#cve-2022-39278)
+的修复以及改进稳健性的漏洞修复。
+本发布说明描述了 Istio 1.14.4 和
+Istio 1.14.5 之间的不同之处。
+
+供参考，该版本包括（2022-10-04 发布的）Go 1.18.7
+中对 `archive/tar`、`net/http/httputil`
+和 `regexp` 包的安全修复。
+
+{{< relnote >}}
+
+## 变更{#changes}
+
+- **修复** 修复了一些 `ServiceEntry`
+  主机名可能导致不确定的 Envoy 路由的问题。
+  ([Issue #38678](https://github.com/istio/istio/issues/38678))
+
+- **修复** 修复了 `kube-inject` 在设置 Pod
+  注解 `proxy.istio.io/config` 时崩溃的问题。
+
+- **修复** 修复了如果 istiod 未运行，
+  用户无法删除带有修订版的 Istio Operator 资源的问题。
+  ([Issue #40796](https://github.com/istio/istio/issues/40796))
+
+- **修复** 修复了在 1.14.0 中 Passthrough 集群的默认
+  `idleTimeout` 更改为 `0s` 会禁用超时的问题。
+  将其恢复为之前的行为，即 Envoy 的默认值 1 小时。
+  ([Issue #41114](https://github.com/istio/istio/issues/41114))
+
+- **修复** 修复了 `jwks` 动态生成的返回值不是 base64
+  编码导致 Envoy 无法解析它的错误。
+
+- **修复** 修复了添加 `ServiceEntry`
+  可能会影响具有相同主机名的现有 `ServiceEntry` 的问题。
+  ([Issue #40166](https://github.com/istio/istio/issues/40166))
+
+- **修复** 修复了根命名空间 `Sidecar` 配置会被忽略的问题。
+
+- **修复** 修复了移除 `v1alpha2` 版本时
+  Gateway API 集成不失败的问题。

--- a/content/zh/news/releases/1.14.x/announcing-1.14.5/index.md
+++ b/content/zh/news/releases/1.14.x/announcing-1.14.5/index.md
@@ -8,13 +8,11 @@ release: 1.14.5
 ---
 
 该版本包含了对 [CVE-2022-39278](/zh/news/security/istio-security-2022-007/#cve-2022-39278)
-的修复以及改进稳健性的漏洞修复。
-本发布说明描述了 Istio 1.14.4 和
-Istio 1.14.5 之间的不同之处。
+的修复以及改进稳健性的漏洞修复。本发布说明描述了
+Istio 1.14.4 和 Istio 1.14.5 之间的不同之处。
 
-供参考，该版本包括（2022-10-04 发布的）Go 1.18.7
-中对 `archive/tar`、`net/http/httputil`
-和 `regexp` 包的安全修复。
+供参考，该版本包括（2022-10-04 发布的）Go 1.18.7 中对 `archive/tar`、
+`net/http/httputil` 和 `regexp` 包的安全修复。
 
 {{< relnote >}}
 
@@ -24,20 +22,19 @@ Istio 1.14.5 之间的不同之处。
   主机名可能导致不确定的 Envoy 路由的问题。
   ([Issue #38678](https://github.com/istio/istio/issues/38678))
 
-- **修复** 修复了 `kube-inject` 在设置 Pod
-  注解 `proxy.istio.io/config` 时崩溃的问题。
+- **修复** 修复了 `kube-inject` 在设置 Pod 注解 `proxy.istio.io/config`
+  时崩溃的问题。
 
-- **修复** 修复了如果 istiod 未运行，
-  用户无法删除带有修订版的 Istio Operator 资源的问题。
+- **修复** 修复了如果 istiod 未运行，用户无法删除带有修订版的
+  Istio Operator 资源的问题。
   ([Issue #40796](https://github.com/istio/istio/issues/40796))
 
-- **修复** 修复了在 1.14.0 中 Passthrough 集群的默认
-  `idleTimeout` 更改为 `0s` 会禁用超时的问题。
-  将其恢复为之前的行为，即 Envoy 的默认值 1 小时。
+- **修复** 修复了在 1.14.0 中 Passthrough 集群的默认 `idleTimeout`
+  更改为 `0s` 会禁用超时的问题。将其恢复为之前的行为，即 Envoy 的默认值 1 小时。
   ([Issue #41114](https://github.com/istio/istio/issues/41114))
 
-- **修复** 修复了 `jwks` 动态生成的返回值不是 base64
-  编码导致 Envoy 无法解析它的错误。
+- **修复** 修复了 `jwks` 动态生成的返回值不是 base64 编码导致
+  Envoy 无法解析它的错误。
 
 - **修复** 修复了添加 `ServiceEntry`
   可能会影响具有相同主机名的现有 `ServiceEntry` 的问题。
@@ -45,5 +42,4 @@ Istio 1.14.5 之间的不同之处。
 
 - **修复** 修复了根命名空间 `Sidecar` 配置会被忽略的问题。
 
-- **修复** 修复了移除 `v1alpha2` 版本时
-  Gateway API 集成不失败的问题。
+- **修复** 修复了移除 `v1alpha2` 版本时 Gateway API 集成不失败的问题。


### PR DESCRIPTION
Sync 1.11.8, 1.13.9 and 1.14.5 release notes into Chinese:
```
content\zh\news\releases\1.11.x\announcing-1.11.8\index.md
content\zh\news\releases\1.13.x\announcing-1.13.9\index.md
content\zh\news\releases\1.14.x\announcing-1.14.5\index.md
```

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
