### PR TITLE
updates to dual stack blog to make following easier

### DIFF
--- a/content/en/blog/2023/experimental-dual-stack/index.md
+++ b/content/en/blog/2023/experimental-dual-stack/index.md
@@ -43,7 +43,7 @@ announce experimental support for dual stack in Istio 1.17!
 ## A Quick Experiment using Dual Stack
 
 {{< tip >}}
-If you want to use KinD for your test, you can setup a dual stack cluster with the following command:
+If you want to use KinD for your test, you can set up a dual stack cluster with the following command:
 
 {{< text bash >}}
 $ kind create cluster --name istio-ds --config - <<EOF

--- a/content/en/blog/2023/experimental-dual-stack/index.md
+++ b/content/en/blog/2023/experimental-dual-stack/index.md
@@ -42,10 +42,21 @@ announce experimental support for dual stack in Istio 1.17!
 
 ## A Quick Experiment using Dual Stack
 
+**note:** If you want to use KinD for your test you can setup a dual stack cluster with the following:
+
+    {{< text bash >}}
+    kind create cluster --name istio-ds --config - <<EOF
+    kind: Cluster
+    apiVersion: kind.x-k8s.io/v1alpha4
+    networking:
+    ipFamily: dual
+    EOF
+    {{< /text >}}
+
 1. Enable dual stack experimental support on Istio 1.17.0+ with the following:
 
     {{< text bash >}}
-    $ istioctl install -f - <<EOF
+    $ istioctl install -y -f - <<EOF
     apiVersion: install.istio.io/v1alpha1
     kind: IstioOperator
     spec:
@@ -92,7 +103,7 @@ announce experimental support for dual stack in Istio 1.17!
 1. Create sleep deployment in the default namespace:
 
     {{< text bash >}}
-    $ kubectl apply -f {{< github_file >}}/master/samples/sleep/sleep.yaml
+    $ kubectl apply -f {{< github_file >}}/samples/sleep/sleep.yaml
     {{< /text >}}
 
 1. Verify the traffic:

--- a/content/en/blog/2023/experimental-dual-stack/index.md
+++ b/content/en/blog/2023/experimental-dual-stack/index.md
@@ -42,17 +42,19 @@ announce experimental support for dual stack in Istio 1.17!
 
 ## A Quick Experiment using Dual Stack
 
-**note:** If you want to use KinD for your test you can setup a dual stack cluster with the following:
+{{< tip >}}
+If you want to use KinD for your test, you can setup a dual stack cluster with the following command:
 
-    {{< text bash >}}
-    $ kind create cluster --name istio-ds --config - <<EOF
-    kind: Cluster
-    apiVersion: kind.x-k8s.io/v1alpha4
-    networking:
-    ipFamily: dual
-    EOF
-    {{< /text >}}
+{{< text bash >}}
+$ kind create cluster --name istio-ds --config - <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  ipFamily: dual
+EOF
+{{< /text >}}
 
+{{< /tip >}}
 1. Enable dual stack experimental support on Istio 1.17.0+ with the following:
 
     {{< text bash >}}

--- a/content/en/blog/2023/experimental-dual-stack/index.md
+++ b/content/en/blog/2023/experimental-dual-stack/index.md
@@ -45,7 +45,7 @@ announce experimental support for dual stack in Istio 1.17!
 **note:** If you want to use KinD for your test you can setup a dual stack cluster with the following:
 
     {{< text bash >}}
-    kind create cluster --name istio-ds --config - <<EOF
+    $ kind create cluster --name istio-ds --config - <<EOF
     kind: Cluster
     apiVersion: kind.x-k8s.io/v1alpha4
     networking:


### PR DESCRIPTION
Makes a few small changes to the Mar 2023 dual stack blog post for ease of following your test steps.

- adds section about setting up KinD for the test
- add `-y` flag to istioctl command to avoid having the install fail when asking for user input
- remove `/master` from path to the sleep manifest which caused it to be invalid

As a side note, the tcp-echo files we're asking folks to use aren't in release-1.17 but as far as I can tell this should update when 1.18 is released. This is already reflected on preliminary.istio.io so I don't think it needs to be adjusted in the PR.

If there is interest I wouldn't mind adding in httpbin testing steps as well. I have some tests I've been using on my end which pretty closely model yours but use a slightly modified httpbin manifest to deploy. I did not add them in this PR but would be happy to if folks would like.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure
