### PR TITLE
bumped k8s_gateway_api_versions to latest version in args.yml

### DIFF
--- a/data/args.yml
+++ b/data/args.yml
@@ -49,4 +49,4 @@ supported_languages:
     code: "zh"
 
 # Kubernetes Gateway API
-k8s_gateway_api_version: "v0.6.2"
+k8s_gateway_api_version: "v0.7.1"


### PR DESCRIPTION
The latest version of kubernetes gateway API is v0.7.1 instead of the previous v0.6.1.
I have updated the `k8s_gateway_api_version` in  `data/args.yml` to "apply" this change,

Source: https://github.com/kubernetes-sigs/gateway-api/releases/tag/v0.7.1


- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
