### PR TITLE
Update doc for internal IP ranges for egress control

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -363,6 +363,8 @@ Set the value of `values.global.proxy.includeIPRanges` according to your cluster
 
 #### IBM Cloud Kubernetes Service
 
+To see which CIDR is used in the cluster use `ibmcloud ks cluster get -c <CLUSTER-NAME>` and look for the `Service Subnet`. On very old clusters, this may not work and so using `kubectl get svc -o wide -A` would be a way to narrow down the CIDR from the original option of `"172.30.0.0/16,172.21.0.0/16,10.10.10.0/24"`.
+
 Use `--set values.global.proxy.includeIPRanges="172.30.0.0/16\,172.21.0.0/16\,10.10.10.0/24"`
 
 #### Google Kubernetes Engine (GKE)


### PR DESCRIPTION
This PR is to add clarification on how to get the CIDRs in the IBM Cloud Kubernetes Service mentioned [here](https://istio.io/latest/docs/tasks/traffic-management/egress/egress-control/#determine-the-internal-ip-ranges-for-your-platform).

Doc link: [Accessing External Services](https://istio.io/latest/docs/tasks/traffic-management/egress/egress-control/)
Issue link: https://github.com/istio/istio.io/issues/13272

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
