### PR TITLE
Enhance mTLS origination example

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -336,6 +336,7 @@ Follow [these steps](/docs/tasks/traffic-management/egress/egress-gateway-tls-or
     $ kubectl delete service my-nginx -n mesh-external
     $ kubectl delete deployment my-nginx -n mesh-external
     $ kubectl delete namespace mesh-external
+    $ kubectl delete serviceentry originate-mtls-for-nginx
     $ kubectl delete destinationrule originate-mtls-for-nginx
     {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
@@ -208,6 +208,7 @@ kubectl delete configmap nginx-configmap -n mesh-external
 kubectl delete service my-nginx -n mesh-external
 kubectl delete deployment my-nginx -n mesh-external
 kubectl delete namespace mesh-external
+kubectl delete serviceentry originate-mtls-for-nginx
 kubectl delete destinationrule originate-mtls-for-nginx
 }
 


### PR DESCRIPTION
As described in https://github.com/istio/istio/issues/45259#issuecomment-1577044718 it is better to align the egress mtls origination example to align with the previous section of tls origination by using port 80 itself, to avoid confusions