### PR TITLE
cleanup more usages of EnvoyFilter

### DIFF
--- a/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
@@ -17,24 +17,8 @@ your mesh. For example, dashboards that support Istio include:
 * [Prometheus](/docs/tasks/observability/metrics/querying-metrics/)
 
 By default, Istio defines and generates a set of standard metrics (e.g.
-`requests_total`), but you can also customize them and create new metrics.
-
-## Custom statistics configuration
-
-Istio uses the Envoy proxy to generate metrics and provides its configuration in
-the `EnvoyFilter` at
-[manifests/charts/istio-control/istio-discovery/templates/telemetryv2_{{< istio_version >}}.yaml]({{<github_blob>}}/manifests/charts/istio-control/istio-discovery/templates/telemetryv2_{{< istio_version >}}.yaml).
-
-Configuring custom statistics involves two sections of the
-`EnvoyFilter`: `definitions` and `metrics`. The `definitions` section
-supports creating new metrics by name, the expected value expression, and the
-metric type (`counter`, `gauge`, and `histogram`). The `metrics` section
-provides values for the metric dimensions as expressions, and allows you to
-remove or override the existing metric dimensions. You can modify the standard
-metric definitions using `tags_to_remove` or by re-defining a dimension. These
-configuration settings are also exposed as istioctl installation options, which
-allow you to customize different metrics for gateways and sidecars as well as
-for the inbound or outbound direction.
+`requests_total`), but you can also customize them and create new metrics
+using [Telemetry API](/docs/tasks/observability/telemetry/).
 
 ## Before you begin
 
@@ -47,97 +31,31 @@ the example application throughout this task. For installation instructions, see
 
 ## Enable custom metrics
 
-1. The default telemetry v2 `EnvoyFilter` configuration is equivalent to the following installation options:
+To customize telemetry v2 metrics, for example, to add `request_host`
+and `destination_port` dimensions to the `requests_total` metric emitted by both
+gateways and sidecars in the inbound and outbound direction, use the following:
 
-    {{< text yaml >}}
-    apiVersion: install.istio.io/v1alpha1
-    kind: IstioOperator
-    spec:
-      values:
-        telemetry:
-          v2:
-            prometheus:
-              configOverride:
-                inboundSidecar:
-                  disable_host_header_fallback: false
-                outboundSidecar:
-                  disable_host_header_fallback: false
-                gateway:
-                  disable_host_header_fallback: true
-    {{< /text >}}
-
-    To customize telemetry v2 metrics, for example, to add `request_host`
-    and `destination_port` dimensions to the `requests_total` metric emitted by both
-    gateways and sidecars in the inbound and outbound direction, change the installation
-    options as follows:
-
-    {{< tip >}}
-    You only need to specify the configuration for the settings that you want to customize.
-    For example, to only customize the sidecar inbound `requests_count` metric, you can omit
-    the `outboundSidecar` and `gateway` sections in the configuration. Unspecified
-    settings will retain the default configuration, equivalent to the explicit settings shown above.
-    {{< /tip >}}
-
-    {{< text bash >}}
-    $ cat <<EOF > ./custom_metrics.yaml
-    apiVersion: install.istio.io/v1alpha1
-    kind: IstioOperator
-    spec:
-      values:
-        telemetry:
-          v2:
-            prometheus:
-              configOverride:
-                inboundSidecar:
-                  metrics:
-                    - name: requests_total
-                      dimensions:
-                        destination_port: string(destination.port)
-                        request_host: request.host
-                outboundSidecar:
-                  metrics:
-                    - name: requests_total
-                      dimensions:
-                        destination_port: string(destination.port)
-                        request_host: request.host
-                gateway:
-                  metrics:
-                    - name: requests_total
-                      dimensions:
-                        destination_port: string(destination.port)
-                        request_host: request.host
-    EOF
-    # istioctl install -f custom_metrics.yaml
-    {{< /text >}}
-
-1. Apply the following annotation to all injected pods with the list of the
-   dimensions to extract into a Prometheus
-   [time series](https://en.wikipedia.org/wiki/Time_series) using the following command:
-
-    {{< tip >}}
-    This step is needed only  if your dimensions are not already in
-    [DefaultStatTags list]({{<github_blob>}}/pkg/bootstrap/config.go)
-    {{< /tip >}}
-
-    {{< text yaml >}}
-    apiVersion: apps/v1
-    kind: Deployment
-    spec:
-      template: # pod template
-        metadata:
-          annotations:
-            sidecar.istio.io/extraStatTags: destination_port,request_host
-    {{< /text >}}
-
-    To enable extra tags mesh wide, you can add `extraStatTags` to your mesh config:
-
-    {{< text yaml >}}
-    meshConfig:
-      defaultConfig:
-        extraStatTags:
-         - destination_port
-         - request_host
-    {{< /text >}}
+{{< text bash >}}
+$ cat <<EOF > ./custom_metrics.yaml
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: namespace-metrics
+spec:
+  metrics:
+  - providers:
+    - name: prometheus
+    overrides:
+    - match:
+        metric: REQUEST_COUNT
+      tagOverrides:
+        destination_port:
+          value: "string(destination.port)"
+        request_host:
+          value: "request.host"
+EOF
+$ kubectl apply -f custom_metrics.yaml
+{{< /text >}}
 
 ## Verify the results
 

--- a/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
@@ -18,7 +18,7 @@ your mesh. For example, dashboards that support Istio include:
 
 By default, Istio defines and generates a set of standard metrics (e.g.
 `requests_total`), but you can also customize them and create new metrics
-using [Telemetry API](/docs/tasks/observability/telemetry/).
+using the [Telemetry API](/docs/tasks/observability/telemetry/).
 
 ## Before you begin
 

--- a/content/en/docs/tasks/observability/metrics/customize-metrics/test.sh
+++ b/content/en/docs/tasks/observability/metrics/customize-metrics/test.sh
@@ -22,7 +22,7 @@ set -o pipefail
 source "tests/util/samples.sh"
 
 # @setup profile=none
-echo "$snip_enable_custom_metrics_1" | istioctl install --set tag="$TAG" --set hub="$HUB" -y -f -
+istioctl install --set tag="$TAG" --set hub="$HUB" -y
 
 ## Setting up application
 # Set to known setting of sidecar injection
@@ -46,11 +46,7 @@ send_productpage_requests
 _verify_not_contains snip_verify_the_results_2 "destination_port"
 _verify_not_contains snip_verify_the_results_2 "request_host"
 
-snip_enable_custom_metrics_2 && istioctl install --set tag="$TAG" --set hub="$HUB" -y -f custom_metrics.yaml
-
-kubectl get istiooperator installed-state -n istio-system -o yaml
-_wait_for_istio envoyfilter istio-system stats-filter-1.8
-_wait_for_istio envoyfilter istio-system stats-filter-1.9
+snip_enable_custom_metrics_1
 
 # TODO: remove this delay once we can reliably detect the stats extension configuration update
 # has been applied.

--- a/content/en/docs/tasks/observability/metrics/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/metrics/telemetry-api/index.md
@@ -18,7 +18,7 @@ This task shows you how to customize the metrics that Istio generates with Telem
 
 Telemetry API can not work together with `EnvoyFilter`. For more details please checkout this [issue](https://github.com/istio/istio/issues/39772).
 
-* Starting with Istio version `1.18`, Prometheus `EnvoyFilter` will not be
+* Starting with Istio version `1.18`, the Prometheus `EnvoyFilter` will not be
   installed by default, and instead `meshConfig.defaultProviders` is used to
   enable it. Telemetry API should be used to further customize the telemetry
   pipeline.

--- a/content/en/docs/tasks/observability/metrics/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/metrics/telemetry-api/index.md
@@ -21,21 +21,7 @@ Telemetry API can not work together with `EnvoyFilter`. For more details please 
 * Starting with Istio version `1.18`, Prometheus `EnvoyFilter` will not be
   installed by default, and instead `meshConfig.defaultProviders` is used to
   enable it. Telemetry API should be used to further customize the telemetry
-  pipeline, e.g. to disable it:
-
-    {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
-    kind: Telemetry
-    metadata:
-      name: mesh-default
-      namespace: istio-system
-    spec:
-      metrics:
-      - providers:
-        - name: prometheus
-        overrides:
-        - disabled: true
-    {{< /text >}}
+  pipeline.
 
 * For versions of Istio before `1.18`, you should install with the following `IstioOperator` configuration:
 

--- a/content/en/docs/tasks/observability/metrics/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/metrics/telemetry-api/index.md
@@ -18,7 +18,24 @@ This task shows you how to customize the metrics that Istio generates with Telem
 
 Telemetry API can not work together with `EnvoyFilter`. For more details please checkout this [issue](https://github.com/istio/istio/issues/39772).
 
-* Starting with Istio version `1.18`, the stats `EnvoyFilter` will not be installed by default.
+* Starting with Istio version `1.18`, Prometheus `EnvoyFilter` will not be
+  installed by default, and instead `meshConfig.defaultProviders` is used to
+  enable it. Telemetry API should be used to further customize the telemetry
+  pipeline, e.g. to disable it:
+
+    {{< text yaml >}}
+    apiVersion: telemetry.istio.io/v1alpha1
+    kind: Telemetry
+    metadata:
+      name: mesh-default
+      namespace: istio-system
+    spec:
+      metrics:
+      - providers:
+        - name: prometheus
+        overrides:
+        - disabled: true
+    {{< /text >}}
 
 * For versions of Istio before `1.18`, you should install with the following `IstioOperator` configuration:
 

--- a/content/en/docs/tasks/observability/metrics/telemetry-api/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/telemetry-api/snips.sh
@@ -21,20 +21,6 @@
 ####################################################################################################
 
 ! read -r -d '' snip_before_you_begin_1 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
-kind: Telemetry
-metadata:
-  name: mesh-default
-  namespace: istio-system
-spec:
-  metrics:
-  - providers:
-    - name: prometheus
-    overrides:
-    - disabled: true
-ENDSNIP
-
-! read -r -d '' snip_before_you_begin_2 <<\ENDSNIP
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:

--- a/content/en/docs/tasks/observability/metrics/telemetry-api/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/telemetry-api/snips.sh
@@ -21,6 +21,20 @@
 ####################################################################################################
 
 ! read -r -d '' snip_before_you_begin_1 <<\ENDSNIP
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+spec:
+  metrics:
+  - providers:
+    - name: prometheus
+    overrides:
+    - disabled: true
+ENDSNIP
+
+! read -r -d '' snip_before_you_begin_2 <<\ENDSNIP
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -193,13 +193,13 @@ metadata:
   namespace: istio-system
 spec:
   configPatches:
-  - applyTo: LISTENER
+  - applyTo: LISTENER_FILTER
     patch:
-      operation: MERGE
+      operation: INSERT_FIRST
       value:
-        listener_filters:
-        - name: envoy.listener.proxy_protocol
-        - name: envoy.listener.tls_inspector
+        name: proxy_protocol
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol"
   workloadSelector:
     labels:
       istio: ingressgateway
@@ -217,13 +217,13 @@ metadata:
   namespace: foo
 spec:
   configPatches:
-  - applyTo: LISTENER
+  - applyTo: LISTENER_FILTER
     patch:
-      operation: MERGE
+      operation: INSERT_FIRST
       value:
-        listener_filters:
-        - name: envoy.listener.proxy_protocol
-        - name: envoy.listener.tls_inspector
+        name: proxy_protocol
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol"
   workloadSelector:
     labels:
       istio.io/gateway-name: httpbin-gateway

--- a/content/en/docs/tasks/security/authorization/authz-ingress/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/snips.sh
@@ -95,13 +95,13 @@ metadata:
   namespace: istio-system
 spec:
   configPatches:
-  - applyTo: LISTENER
+  - applyTo: LISTENER_FILTER
     patch:
-      operation: MERGE
+      operation: INSERT_FIRST
       value:
-        listener_filters:
-        - name: envoy.listener.proxy_protocol
-        - name: envoy.listener.tls_inspector
+        name: proxy_protocol
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol"
   workloadSelector:
     labels:
       istio: ingressgateway
@@ -115,13 +115,13 @@ metadata:
   namespace: foo
 spec:
   configPatches:
-  - applyTo: LISTENER
+  - applyTo: LISTENER_FILTER
     patch:
-      operation: MERGE
+      operation: INSERT_FIRST
       value:
-        listener_filters:
-        - name: envoy.listener.proxy_protocol
-        - name: envoy.listener.tls_inspector
+        name: proxy_protocol
+        typed_config:
+          "@type": "type.googleapis.com/envoy.extensions.filters.listener.proxy_protocol.v3.ProxyProtocol"
   workloadSelector:
     labels:
       istio.io/gateway-name: httpbin-gateway


### PR DESCRIPTION
- Update to use Telemetry API
- Replace proxy-proto EnvoyFilter
- Note the change in 1.18.