### PR TITLE
Revert "OpenShift: Remove NetworkAttachmentDefinition section (#13054)"

### DIFF
--- a/content/en/docs/setup/platform-setup/openshift/index.md
+++ b/content/en/docs/setup/platform-setup/openshift/index.md
@@ -47,3 +47,22 @@ When removing your application, remove the permissions as follows.
 {{< text bash >}}
 $ oc adm policy remove-scc-from-group anyuid system:serviceaccounts:<target-namespace>
 {{< /text >}}
+
+## Additional requirements for the application namespace
+
+CNI on OpenShift is managed by `Multus`, and it requires a `NetworkAttachmentDefinition` to be present in the application namespace in order to invoke the `istio-cni` plugin. Execute the following commands. Replace `<target-namespace>` with the appropriate namespace.
+
+{{< text bash >}}
+$ cat <<EOF | oc -n <target-namespace> create -f -
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: istio-cni
+EOF
+{{< /text >}}
+
+When removing your application, remove the `NetworkAttachmentDefinition` as follows.
+
+{{< text bash >}}
+$ oc -n <target-namespace> delete network-attachment-definition istio-cni
+{{< /text >}}


### PR DESCRIPTION
This reverts commit 652f1caa0c2cbf6752dd0202780b596960dd87fc.

This is content for 1.19.
