### PR TITLE
Updated the link for wasm plugin

### DIFF
--- a/content/en/docs/reference/config/proxy_extensions/wasm-plugin/index.html
+++ b/content/en/docs/reference/config/proxy_extensions/wasm-plugin/index.html
@@ -7,7 +7,7 @@ location: https://istio.io/docs/reference/config/proxy_extensions/wasm-plugin.ht
 layout: protoc-gen-docs
 generator: protoc-gen-docs
 schema: istio.extensions.v1alpha1.WasmPlugin
-aliases: [/docs/reference/config/extensions/v1alpha1/wasm-plugin]
+aliases: [/docs/reference/config/proxy_extensions/wasm-plugin/]
 number_of_entries: 7
 ---
 <p>WasmPlugins provides a mechanism to extend the functionality provided by


### PR DESCRIPTION
This PR has fixed the alias link for Wasm Plugin.
Fixes #13311 


- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
