### PR TITLE
[release-1.18] Minor documentation fixes

### DIFF
--- a/content/en/docs/ops/ambient/_index.md
+++ b/content/en/docs/ops/ambient/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Ambient Mesh [WIP]
+title: Ambient Mesh
 description: Information for setting up and operating Istio ambient mesh.
 weight: 60
 keywords: [ambient]

--- a/content/en/news/releases/1.18.x/announcing-1.18/change-notes/index.md
+++ b/content/en/news/releases/1.18.x/announcing-1.18/change-notes/index.md
@@ -174,7 +174,7 @@ This change only impacts users explicitly enabling `PILOT_USE_ENDPOINT_SLICE` on
 - **Improved** the default telemetry installation to configure `meshConfig.defaultProviders` instead of custom `EnvoyFilter`s
 when advanced customizations are not used, improving performance.
 
-- **Updated** the proxies `concurrency` configuration to always be detected based on CPU limits, unless explicitly configured. See upgrade notes for more info. ([PR #36884](https://github.com/istio/istio/pull/36884))
+- **Updated** the proxies `concurrency` configuration to always be detected based on CPU limits, unless explicitly configured. See upgrade notes for more info. ([PR #43865](https://github.com/istio/istio/pull/43865))
 
 - **Updated** `Kiali` addon to version `v1.67.0`. ([PR #44498](https://github.com/istio/istio/pull/44498))
 


### PR DESCRIPTION
This PR corrects a couple of errors made in the first release of the 1.18.0 documentation.  It removes the WIP tag from Ambient Mesh, and corrects a PR link that was added manually in error.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [x ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
