### PR TITLE
fix a typo in authz-ingress

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -186,7 +186,7 @@ If you are using a TCP/UDP Proxy external load balancer (AWS Classic ELB), it ca
 {{< tab name="Istio classic" category-value="istio-classic" >}}
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alp ha3
+apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: proxy-protocol
@@ -210,7 +210,7 @@ spec:
 {{< tab name="Gateway API" category-value="gateway-api" >}}
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alp ha3
+apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: proxy-protocol

--- a/content/en/docs/tasks/security/authorization/authz-ingress/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/snips.sh
@@ -88,7 +88,7 @@ spec:
 ENDSNIP
 
 ! read -r -d '' snip_tcpudp_proxy_load_balancer_1 <<\ENDSNIP
-apiVersion: networking.istio.io/v1alp ha3
+apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: proxy-protocol
@@ -108,7 +108,7 @@ spec:
 ENDSNIP
 
 ! read -r -d '' snip_tcpudp_proxy_load_balancer_2 <<\ENDSNIP
-apiVersion: networking.istio.io/v1alp ha3
+apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
   name: proxy-protocol


### PR DESCRIPTION
changed from `v1alp ha3` to `v1alpha3`

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
