### PR TITLE
Fix helm values link in reference as it was hardcoded to v1.5

### DIFF
--- a/content/en/docs/reference/config/istio.operator.v1alpha1/index.html
+++ b/content/en/docs/reference/config/istio.operator.v1alpha1/index.html
@@ -165,7 +165,7 @@ No
 <td><code><a href="https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#struct">Struct</a></code></td>
 <td>
 <p>Overrides for default <code>values.yaml</code>. This is a validated pass-through to Helm templates.
-See the <a href="https://istio.io/v1.5/docs/reference/config/installation-options/">Helm installation options</a> for schema details.
+See the <a href="https://istio.io/latest/docs/reference/config/installation-options/">Helm installation options</a> for schema details.
 Anything that is available in <code>IstioOperatorSpec</code> should be set above rather than using the passthrough. This
 includes Kubernetes resource settings for components in <code>KubernetesResourcesSpec</code>.</p>
 


### PR DESCRIPTION
Please provide a description for what this PR is for.

There was a hard coded link in the `content/en/docs/reference/config/istio.operator.v1alpha1/index.html` file linking to helm values in v1.5 instead of latest

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
