### PR TITLE
1.16 30 Day EOL Notice

### DIFF
--- a/content/en/news/support/announcing-1.16-eol/index.md
+++ b/content/en/news/support/announcing-1.16-eol/index.md
@@ -1,0 +1,12 @@
+---
+title: Support for Istio 1.16 ends on July 19th, 2023
+subtitle: Support Announcement
+description: Upcoming Istio 1.16 end of life announcement.
+publishdate: 2023-06-19
+---
+
+According to Istio's [support policy](/docs/releases/supported-releases#supported-releases/), minor releases like 1.16 are supported until six weeks after the N+2 minor release (1.18 in this case). [Istio 1.18 was released on June 7th](/news/releases/1.18.x/announcing-1.18/), and support for 1.16 will end on July 19th, 2023.
+
+At that point we will stop back-porting fixes for security issues and critical bugs to 1.16, so we encourage you to upgrade to the latest version of Istio ({{<istio_release_name>}}). If you don't do this you may put yourself in the position of having to do a major upgrade on a short timeframe to pick up a critical fix.
+
+We care about you and your clusters, so please be kind to yourself and upgrade.


### PR DESCRIPTION
Please provide a description for what this PR is for.

1.16 goes EOL July 19th, 2023. This adds the 30 day prior announcement.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
