### PR TITLE
Warn and do not copy duplicate reference docs

### DIFF
--- a/content/en/docs/reference/commands/install-cni/index.html
+++ b/content/en/docs/reference/commands/install-cni/index.html
@@ -1312,12 +1312,6 @@ Only applies when traffic from all groups (i.e. &#34;*&#34;) is being redirected
 <td>Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. Default is 1.0.</td>
 </tr>
 <tr>
-<td><code>PILOT_USE_ENDPOINT_SLICE</code></td>
-<td>Boolean</td>
-<td><code>false</code></td>
-<td>If enabled, Pilot will use EndpointSlices as the source of endpoints for Kubernetes services. By default, this is false, and Endpoints will be used. This requires the Kubernetes EndpointSlice controller to be enabled. Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used</td>
-</tr>
-<tr>
 <td><code>PILOT_WORKLOAD_ENTRY_GRACE_PERIOD</code></td>
 <td>Time Duration</td>
 <td><code>10s</code></td>

--- a/content/en/docs/reference/commands/istioctl/index.html
+++ b/content/en/docs/reference/commands/istioctl/index.html
@@ -7662,12 +7662,6 @@ These environment variables affect the behavior of the <code>istioctl</code> com
 <td>Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. Default is 1.0.</td>
 </tr>
 <tr>
-<td><code>PILOT_USE_ENDPOINT_SLICE</code></td>
-<td>Boolean</td>
-<td><code>false</code></td>
-<td>If enabled, Pilot will use EndpointSlices as the source of endpoints for Kubernetes services. By default, this is false, and Endpoints will be used. This requires the Kubernetes EndpointSlice controller to be enabled. Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used</td>
-</tr>
-<tr>
 <td><code>PILOT_WORKLOAD_ENTRY_GRACE_PERIOD</code></td>
 <td>Time Duration</td>
 <td><code>10s</code></td>

--- a/content/en/docs/reference/commands/operator/index.html
+++ b/content/en/docs/reference/commands/operator/index.html
@@ -971,12 +971,6 @@ These environment variables affect the behavior of the <code>operator</code> com
 <td>Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. Default is 1.0.</td>
 </tr>
 <tr>
-<td><code>PILOT_USE_ENDPOINT_SLICE</code></td>
-<td>Boolean</td>
-<td><code>false</code></td>
-<td>If enabled, Pilot will use EndpointSlices as the source of endpoints for Kubernetes services. By default, this is false, and Endpoints will be used. This requires the Kubernetes EndpointSlice controller to be enabled. Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used</td>
-</tr>
-<tr>
 <td><code>PILOT_WORKLOAD_ENTRY_GRACE_PERIOD</code></td>
 <td>Time Duration</td>
 <td><code>10s</code></td>

--- a/content/en/docs/reference/commands/pilot-agent/index.html
+++ b/content/en/docs/reference/commands/pilot-agent/index.html
@@ -1884,12 +1884,6 @@ Only applies when traffic from all groups (i.e. &#34;*&#34;) is being redirected
 <td>Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. Default is 1.0.</td>
 </tr>
 <tr>
-<td><code>PILOT_USE_ENDPOINT_SLICE</code></td>
-<td>Boolean</td>
-<td><code>false</code></td>
-<td>If enabled, Pilot will use EndpointSlices as the source of endpoints for Kubernetes services. By default, this is false, and Endpoints will be used. This requires the Kubernetes EndpointSlice controller to be enabled. Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used</td>
-</tr>
-<tr>
 <td><code>PILOT_WORKLOAD_ENTRY_GRACE_PERIOD</code></td>
 <td>Time Duration</td>
 <td><code>10s</code></td>

--- a/content/en/docs/reference/commands/pilot-discovery/index.html
+++ b/content/en/docs/reference/commands/pilot-discovery/index.html
@@ -1163,12 +1163,6 @@ These environment variables affect the behavior of the <code>pilot-discovery</co
 <td>Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. Default is 1.0.</td>
 </tr>
 <tr>
-<td><code>PILOT_USE_ENDPOINT_SLICE</code></td>
-<td>Boolean</td>
-<td><code>false</code></td>
-<td>If enabled, Pilot will use EndpointSlices as the source of endpoints for Kubernetes services. By default, this is false, and Endpoints will be used. This requires the Kubernetes EndpointSlice controller to be enabled. Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used</td>
-</tr>
-<tr>
 <td><code>PILOT_WORKLOAD_ENTRY_GRACE_PERIOD</code></td>
 <td>Time Duration</td>
 <td><code>10s</code></td>

--- a/content/en/docs/reference/config/security/authorization-policy/index.html
+++ b/content/en/docs/reference/config/security/authorization-policy/index.html
@@ -6,7 +6,7 @@ description: Configuration for access control on workloads.
 location: https://istio.io/docs/reference/config/security/authorization-policy.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
-schema: istio.security.v1beta1.AuthorizationPolicy
+schema: istio.security.v1.AuthorizationPolicy
 weight: 20
 aliases: [/docs/reference/config/authorization/authorization-policy]
 number_of_entries: 9
@@ -44,7 +44,7 @@ but it is useful to be explicit in the policy.</p>
 </ul>
 <p>when the request has a valid JWT token issued by <code>https://accounts.google.com</code>.</p>
 <p>Any other requests will be denied.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin
@@ -71,7 +71,7 @@ spec:
 <p>The following is another example that sets <code>action</code> to <code>DENY</code> to create a deny policy.
 It denies requests from the <code>dev</code> namespace to the <code>POST</code> method on all workloads
 in the <code>foo</code> namespace.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin
@@ -89,7 +89,7 @@ spec:
 <p>The following is another example that sets <code>action</code> to <code>DENY</code> to create a deny policy.
 It denies all the requests with <code>POST</code> method on port <code>8080</code> on all workloads
 in the <code>foo</code> namespace.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizaionPolicy
 metadata:
   name: httpbin
@@ -106,9 +106,9 @@ spec:
 For a <code>DENY</code> rule, missing attributes are treated as matches. This means all TCP traffic on port <code>8080</code> would be denied in the example above.
 If we were to remove the <code>ports</code> match, all TCP traffic would be denied. As a result, it is recommended to always scope <code>DENY</code> policies to a specific port,
 especially when using HTTP attributes <a href="/docs/tasks/security/authorization/authz-tcp/">Authorization Policy for TCP Ports</a>.</p>
-<p>The following authorization policy sets the <code>action</code> to <code>AUDIT</code>. It will audit any <code>GET</code> requests to the path with the
+<p>The following authorization policy sets the <code>action</code> to <code>AUDIT</code>. It will audit any GET requests to the path with the
 prefix <code>/user/profile</code>.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   namespace: ns1
@@ -133,7 +133,7 @@ namespace, the policy applies to all namespaces in a mesh.</li>
 </ul>
 <p>For example, the following authorization policy applies to all workloads in namespace <code>foo</code>. It allows nothing and effectively denies
 all requests to workloads in namespace <code>foo</code>.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
  name: allow-nothing
@@ -142,7 +142,7 @@ spec:
   {}
 </code></pre>
 <p>The following authorization policy allows all requests to workloads in namespace <code>foo</code>.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
  name: allow-all
@@ -153,7 +153,7 @@ spec:
 </code></pre>
 <p>The following authorization policy applies to workloads containing label <code>app: httpbin</code> in namespace <code>bar</code>. It allows
 nothing and effectively denies all requests to the selected workloads.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: allow-nothing
@@ -165,7 +165,7 @@ spec:
 </code></pre>
 <p>The following authorization policy applies to workloads containing label <code>version: v1</code> in all namespaces in the mesh.
 (Assuming the root namespace is configured to <code>istio-system</code>).</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
  name: allow-nothing

--- a/content/en/docs/reference/config/security/jwt/index.html
+++ b/content/en/docs/reference/config/security/jwt/index.html
@@ -6,8 +6,8 @@ description: Configuration to validate JWT.
 location: https://istio.io/docs/reference/config/security/jwt.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
-schema: istio.security.v1beta1.JWTRule
-aliases: [/docs/reference/config/security/v1beta1/jwt]
+schema: istio.security.v1.JWTRule
+aliases: [/docs/reference/config/security/v1/jwt]
 number_of_entries: 3
 ---
 <h2 id="JWTRule">JWTRule</h2>

--- a/content/en/docs/reference/config/security/request_authentication/index.html
+++ b/content/en/docs/reference/config/security/request_authentication/index.html
@@ -6,8 +6,8 @@ description: Request authentication configuration for workloads.
 location: https://istio.io/docs/reference/config/security/request_authentication.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
-schema: istio.security.v1beta1.RequestAuthentication
-aliases: [/docs/reference/config/security/v1beta1/request_authentication]
+schema: istio.security.v1.RequestAuthentication
+aliases: [/docs/reference/config/security/v1/request_authentication]
 number_of_entries: 1
 ---
 <h2 id="RequestAuthentication">RequestAuthentication</h2>
@@ -21,7 +21,7 @@ Examples:</p>
 <ul>
 <li>Require JWT for all request for workloads that have label <code>app:httpbin</code></li>
 </ul>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: httpbin
@@ -34,7 +34,7 @@ spec:
   - issuer: &quot;issuer-foo&quot;
     jwksUri: https://example.com/.well-known/jwks.json
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin
@@ -53,7 +53,7 @@ spec:
 in a mesh. The following policy makes all workloads only accept requests that contain a
 valid JWT token.</li>
 </ul>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: req-authn-for-all
@@ -63,7 +63,7 @@ spec:
   - issuer: &quot;issuer-foo&quot;
     jwksUri: https://example.com/.well-known/jwks.json
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: require-jwt-for-all
@@ -79,7 +79,7 @@ spec:
 declares it can accept JWTs issued by either <code>issuer-foo</code> or <code>issuer-bar</code> (the public key set is implicitly
 set from the OpenID Connect spec).</li>
 </ul>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: httpbin
@@ -92,7 +92,7 @@ spec:
   - issuer: &quot;issuer-foo&quot;
   - issuer: &quot;issuer-bar&quot;
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin
@@ -120,7 +120,7 @@ spec:
 to require JWT on all paths, except /healthz, the same <code>RequestAuthentication</code> can be used, but the
 authorization policy could be:</li>
 </ul>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin
@@ -150,7 +150,7 @@ currently does not support the <code>.</code> character. Examples: <code>request
 <li>AuthorizationPolicy to check for valid principals in the request. This makes the JWT required for the request.</li>
 <li>VirtualService to route the request based on the &ldquo;sub&rdquo; claim.</li>
 </ul>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: jwt-on-ingress
@@ -163,7 +163,7 @@ spec:
   - issuer: &quot;example.com&quot;
     jwksUri: https://example.com/.well-known/jwks.json
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: require-jwt

--- a/content/zh/docs/reference/commands/install-cni/index.html
+++ b/content/zh/docs/reference/commands/install-cni/index.html
@@ -1312,12 +1312,6 @@ Only applies when traffic from all groups (i.e. &#34;*&#34;) is being redirected
 <td>Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. Default is 1.0.</td>
 </tr>
 <tr>
-<td><code>PILOT_USE_ENDPOINT_SLICE</code></td>
-<td>Boolean</td>
-<td><code>false</code></td>
-<td>If enabled, Pilot will use EndpointSlices as the source of endpoints for Kubernetes services. By default, this is false, and Endpoints will be used. This requires the Kubernetes EndpointSlice controller to be enabled. Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used</td>
-</tr>
-<tr>
 <td><code>PILOT_WORKLOAD_ENTRY_GRACE_PERIOD</code></td>
 <td>Time Duration</td>
 <td><code>10s</code></td>

--- a/content/zh/docs/reference/commands/istioctl/index.html
+++ b/content/zh/docs/reference/commands/istioctl/index.html
@@ -7662,12 +7662,6 @@ These environment variables affect the behavior of the <code>istioctl</code> com
 <td>Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. Default is 1.0.</td>
 </tr>
 <tr>
-<td><code>PILOT_USE_ENDPOINT_SLICE</code></td>
-<td>Boolean</td>
-<td><code>false</code></td>
-<td>If enabled, Pilot will use EndpointSlices as the source of endpoints for Kubernetes services. By default, this is false, and Endpoints will be used. This requires the Kubernetes EndpointSlice controller to be enabled. Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used</td>
-</tr>
-<tr>
 <td><code>PILOT_WORKLOAD_ENTRY_GRACE_PERIOD</code></td>
 <td>Time Duration</td>
 <td><code>10s</code></td>

--- a/content/zh/docs/reference/commands/operator/index.html
+++ b/content/zh/docs/reference/commands/operator/index.html
@@ -971,12 +971,6 @@ These environment variables affect the behavior of the <code>operator</code> com
 <td>Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. Default is 1.0.</td>
 </tr>
 <tr>
-<td><code>PILOT_USE_ENDPOINT_SLICE</code></td>
-<td>Boolean</td>
-<td><code>false</code></td>
-<td>If enabled, Pilot will use EndpointSlices as the source of endpoints for Kubernetes services. By default, this is false, and Endpoints will be used. This requires the Kubernetes EndpointSlice controller to be enabled. Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used</td>
-</tr>
-<tr>
 <td><code>PILOT_WORKLOAD_ENTRY_GRACE_PERIOD</code></td>
 <td>Time Duration</td>
 <td><code>10s</code></td>

--- a/content/zh/docs/reference/commands/pilot-agent/index.html
+++ b/content/zh/docs/reference/commands/pilot-agent/index.html
@@ -1884,12 +1884,6 @@ Only applies when traffic from all groups (i.e. &#34;*&#34;) is being redirected
 <td>Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. Default is 1.0.</td>
 </tr>
 <tr>
-<td><code>PILOT_USE_ENDPOINT_SLICE</code></td>
-<td>Boolean</td>
-<td><code>false</code></td>
-<td>If enabled, Pilot will use EndpointSlices as the source of endpoints for Kubernetes services. By default, this is false, and Endpoints will be used. This requires the Kubernetes EndpointSlice controller to be enabled. Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used</td>
-</tr>
-<tr>
 <td><code>PILOT_WORKLOAD_ENTRY_GRACE_PERIOD</code></td>
 <td>Time Duration</td>
 <td><code>10s</code></td>

--- a/content/zh/docs/reference/commands/pilot-discovery/index.html
+++ b/content/zh/docs/reference/commands/pilot-discovery/index.html
@@ -1163,12 +1163,6 @@ These environment variables affect the behavior of the <code>pilot-discovery</co
 <td>Sets the mesh-wide trace sampling percentage. Should be 0.0 - 100.0. Precision to 0.01. Default is 1.0.</td>
 </tr>
 <tr>
-<td><code>PILOT_USE_ENDPOINT_SLICE</code></td>
-<td>Boolean</td>
-<td><code>false</code></td>
-<td>If enabled, Pilot will use EndpointSlices as the source of endpoints for Kubernetes services. By default, this is false, and Endpoints will be used. This requires the Kubernetes EndpointSlice controller to be enabled. Currently this is mutual exclusive - either Endpoints or EndpointSlices will be used</td>
-</tr>
-<tr>
 <td><code>PILOT_WORKLOAD_ENTRY_GRACE_PERIOD</code></td>
 <td>Time Duration</td>
 <td><code>10s</code></td>

--- a/content/zh/docs/reference/config/security/authorization-policy/index.html
+++ b/content/zh/docs/reference/config/security/authorization-policy/index.html
@@ -6,7 +6,7 @@ description: Configuration for access control on workloads.
 location: https://istio.io/docs/reference/config/security/authorization-policy.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
-schema: istio.security.v1beta1.AuthorizationPolicy
+schema: istio.security.v1.AuthorizationPolicy
 weight: 20
 aliases: [/zh/docs/reference/config/authorization/authorization-policy]
 number_of_entries: 9
@@ -44,7 +44,7 @@ but it is useful to be explicit in the policy.</p>
 </ul>
 <p>when the request has a valid JWT token issued by <code>https://accounts.google.com</code>.</p>
 <p>Any other requests will be denied.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin
@@ -71,7 +71,7 @@ spec:
 <p>The following is another example that sets <code>action</code> to <code>DENY</code> to create a deny policy.
 It denies requests from the <code>dev</code> namespace to the <code>POST</code> method on all workloads
 in the <code>foo</code> namespace.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin
@@ -89,7 +89,7 @@ spec:
 <p>The following is another example that sets <code>action</code> to <code>DENY</code> to create a deny policy.
 It denies all the requests with <code>POST</code> method on port <code>8080</code> on all workloads
 in the <code>foo</code> namespace.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizaionPolicy
 metadata:
   name: httpbin
@@ -106,9 +106,9 @@ spec:
 For a <code>DENY</code> rule, missing attributes are treated as matches. This means all TCP traffic on port <code>8080</code> would be denied in the example above.
 If we were to remove the <code>ports</code> match, all TCP traffic would be denied. As a result, it is recommended to always scope <code>DENY</code> policies to a specific port,
 especially when using HTTP attributes <a href="/latest/docs/tasks/security/authorization/authz-tcp/">Authorization Policy for TCP Ports</a>.</p>
-<p>The following authorization policy sets the <code>action</code> to <code>AUDIT</code>. It will audit any <code>GET</code> requests to the path with the
+<p>The following authorization policy sets the <code>action</code> to <code>AUDIT</code>. It will audit any GET requests to the path with the
 prefix <code>/user/profile</code>.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   namespace: ns1
@@ -133,7 +133,7 @@ namespace, the policy applies to all namespaces in a mesh.</li>
 </ul>
 <p>For example, the following authorization policy applies to all workloads in namespace <code>foo</code>. It allows nothing and effectively denies
 all requests to workloads in namespace <code>foo</code>.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
  name: allow-nothing
@@ -142,7 +142,7 @@ spec:
   {}
 </code></pre>
 <p>The following authorization policy allows all requests to workloads in namespace <code>foo</code>.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
  name: allow-all
@@ -153,7 +153,7 @@ spec:
 </code></pre>
 <p>The following authorization policy applies to workloads containing label <code>app: httpbin</code> in namespace <code>bar</code>. It allows
 nothing and effectively denies all requests to the selected workloads.</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: allow-nothing
@@ -165,7 +165,7 @@ spec:
 </code></pre>
 <p>The following authorization policy applies to workloads containing label <code>version: v1</code> in all namespaces in the mesh.
 (Assuming the root namespace is configured to <code>istio-system</code>).</p>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
  name: allow-nothing

--- a/content/zh/docs/reference/config/security/jwt/index.html
+++ b/content/zh/docs/reference/config/security/jwt/index.html
@@ -6,8 +6,8 @@ description: Configuration to validate JWT.
 location: https://istio.io/docs/reference/config/security/jwt.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
-schema: istio.security.v1beta1.JWTRule
-aliases: [/zh/docs/reference/config/security/v1beta1/jwt]
+schema: istio.security.v1.JWTRule
+aliases: [/zh/docs/reference/config/security/v1/jwt]
 number_of_entries: 3
 ---
 <h2 id="JWTRule">JWTRule</h2>

--- a/content/zh/docs/reference/config/security/request_authentication/index.html
+++ b/content/zh/docs/reference/config/security/request_authentication/index.html
@@ -6,8 +6,8 @@ description: Request authentication configuration for workloads.
 location: https://istio.io/docs/reference/config/security/request_authentication.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
-schema: istio.security.v1beta1.RequestAuthentication
-aliases: [/zh/docs/reference/config/security/v1beta1/request_authentication]
+schema: istio.security.v1.RequestAuthentication
+aliases: [/zh/docs/reference/config/security/v1/request_authentication]
 number_of_entries: 1
 ---
 <h2 id="RequestAuthentication">RequestAuthentication</h2>
@@ -21,7 +21,7 @@ Examples:</p>
 <ul>
 <li>Require JWT for all request for workloads that have label <code>app:httpbin</code></li>
 </ul>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: httpbin
@@ -34,7 +34,7 @@ spec:
   - issuer: &quot;issuer-foo&quot;
     jwksUri: https://example.com/.well-known/jwks.json
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin
@@ -53,7 +53,7 @@ spec:
 in a mesh. The following policy makes all workloads only accept requests that contain a
 valid JWT token.</li>
 </ul>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: req-authn-for-all
@@ -63,7 +63,7 @@ spec:
   - issuer: &quot;issuer-foo&quot;
     jwksUri: https://example.com/.well-known/jwks.json
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: require-jwt-for-all
@@ -79,7 +79,7 @@ spec:
 declares it can accept JWTs issued by either <code>issuer-foo</code> or <code>issuer-bar</code> (the public key set is implicitly
 set from the OpenID Connect spec).</li>
 </ul>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: httpbin
@@ -92,7 +92,7 @@ spec:
   - issuer: &quot;issuer-foo&quot;
   - issuer: &quot;issuer-bar&quot;
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin
@@ -120,7 +120,7 @@ spec:
 to require JWT on all paths, except /healthz, the same <code>RequestAuthentication</code> can be used, but the
 authorization policy could be:</li>
 </ul>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin
@@ -150,7 +150,7 @@ currently does not support the <code>.</code> character. Examples: <code>request
 <li>AuthorizationPolicy to check for valid principals in the request. This makes the JWT required for the request.</li>
 <li>VirtualService to route the request based on the &ldquo;sub&rdquo; claim.</li>
 </ul>
-<pre><code class="language-yaml">apiVersion: security.istio.io/v1beta1
+<pre><code class="language-yaml">apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: jwt-on-ingress
@@ -163,7 +163,7 @@ spec:
   - issuer: &quot;example.com&quot;
     jwksUri: https://example.com/.well-known/jwks.json
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: require-jwt

--- a/scripts/grab_reference_docs.sh
+++ b/scripts/grab_reference_docs.sh
@@ -84,6 +84,15 @@ locate_file() {
     PP=$(echo "${FNP}" | rev | cut -d'/' -f2- | rev)
     mkdir -p "${ROOTDIR}/content/en/docs${PP}/${FN}"
     mkdir -p "${ROOTDIR}/content/zh/docs${PP}/${FN}"
+
+    # Verify that we aren't overwriting another file.
+    # At some point, this should be a failure.
+    # We have known failures at this time, https://github.com/istio/istio.io/issues/12693, so just log a message.
+    if [[ -e "${ROOTDIR}/content/en/docs${PP}/${FN}/index.html" ]]; then
+        echo "WARNING: File already exists: ${ROOTDIR}/content/en/docs${PP}/${FN}. Not copying ${FILENAME}"
+        return
+    fi
+
     sed -E -e 's/(href="https:\/\/istio.io.*)\.html/\1\//' -e 's/href="https:\/\/istio.io(\/[^vV])/href="\1/g' -e 's/href="\/latest\//href="\//g' "${FILENAME}" >"${ROOTDIR}/content/en/docs${PP}/${FN}/index.html"
     sed -E -e 's/(href="https:\/\/istio.io.*)\.html/\1\//' -e 's/href="https:\/\/istio.io(\/[^vV])/href="\1/g' -e 's/href="\/latest\/zh\//href="\/zh\//g' -e 's/href="\/docs\//href="\/zh\/docs\//g' -e 's/\[\/docs\//\[\/zh\/docs\//g' "${FILENAME}" >"${ROOTDIR}/content/zh/docs${PP}/${FN}/index.html"
 

--- a/scripts/grab_reference_docs_zh.sh
+++ b/scripts/grab_reference_docs_zh.sh
@@ -82,6 +82,15 @@ locate_file() {
     FN=${FN%.html}
     PP=$(echo "${FNP}" | rev | cut -d'/' -f2- | rev)
     mkdir -p "${ROOTDIR}/content/zh/docs${PP}/${FN}"
+
+    # Verify that we aren't overwriting another file.
+    # At some point, this should be a failure.
+    # We have known failures at this time, https://github.com/istio/istio.io/issues/12693, so just log a message.
+    if [[ -e "${ROOTDIR}/content/en/docs${PP}/${FN}/index.html" ]]; then
+        echo "WARNING: File already exists: ${ROOTDIR}/content/en/docs${PP}/${FN}. Not copying ${FILENAME}"
+        return
+    fi
+
     sed -E -e 's/(href="https:\/\/istio.io.*)\.html/\1\//' -e 's/href="https:\/\/istio.io(\/[^vV])/href="\1/g' -e 's/href="\/latest\/zh\//href="\/zh\//g' -e 's/href="\/docs\//href="\/zh\/docs\//g' -e 's/\[\/docs\//\[\/zh\/docs\//g' "${FILENAME}" >"${ROOTDIR}/content/zh/docs${PP}/${FN}/index.html"
 
     LEN=${#WORK_DIR}


### PR DESCRIPTION
Please provide a description for what this PR is for.

As part of https://github.com/istio/istio.io/issues/12693 add a WARNING and do not replace duplicate reference docs. Additional work for that issue should remove the WARNING messages from the output and which time we can change the return to an `exit 1` to fail the script.