### PR TITLE
keep the same ip:port as above

### DIFF
--- a/content/en/docs/setup/getting-started/index.md
+++ b/content/en/docs/setup/getting-started/index.md
@@ -332,7 +332,7 @@ $ export INGRESS_HOST=$(kubectl get po -l istio=ingressgateway -n istio-system -
 
     {{< text bash >}}
     $ echo "$GATEWAY_URL"
-    192.168.99.100:32194
+    127.0.0.1:80
     {{< /text >}}
 
 ### Verify external access {#confirm}

--- a/content/en/docs/setup/getting-started/snips.sh
+++ b/content/en/docs/setup/getting-started/snips.sh
@@ -215,7 +215,7 @@ echo "$GATEWAY_URL"
 }
 
 ! read -r -d '' snip_determining_the_ingress_ip_and_ports_16_out <<\ENDSNIP
-192.168.99.100:32194
+127.0.0.1:80
 ENDSNIP
 
 snip_verify_external_access_1() {


### PR DESCRIPTION
Please provide a description for what this PR is for:

when i read setup/getting-started as my first guide,  i can see that:
INGRESS_HOST = 127.0.0.1, INGRESS_PORT = 80 
and then we set export GATEWAY_URL=$INGRESS_HOST:$INGRESS_PORT，
and next step we echo "$GATEWAY_URL"， but the result is 192.168.99.100:32194.
There may be a historical legacy, but It's very confusing to see for the  first time.

I think the result look more friendly if it is  "127.0.0.1:80" .




And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
