### PR TITLE
Change Istio Classic terminology to Istio APIs

### DIFF
--- a/content/en/boilerplates/gateway-api-choose.md
+++ b/content/en/boilerplates/gateway-api-choose.md
@@ -1,5 +1,5 @@
 ---
 ---
 The following instructions allow you to choose to use either the Gateway API or the Istio configuration API when configuring
-traffic management in the mesh. Follow instructions under either the `Gateway API` or `Istio classic` tab,
+traffic management in the mesh. Follow instructions under either the `Gateway API` or `Istio APIs` tab,
 according to your preference.

--- a/content/en/boilerplates/gateway-api-choose.md
+++ b/content/en/boilerplates/gateway-api-choose.md
@@ -1,5 +1,5 @@
 ---
 ---
 The following instructions allow you to choose to use either the Gateway API or the Istio configuration API when configuring
-traffic management in the mesh. Follow instructions under either the `Gateway API` or the `Istio APIs` tab,
+traffic management in the mesh. Follow instructions under either the `Gateway API` or `Istio APIs` tab,
 according to your preference.

--- a/content/en/boilerplates/gateway-api-choose.md
+++ b/content/en/boilerplates/gateway-api-choose.md
@@ -1,5 +1,5 @@
 ---
 ---
 The following instructions allow you to choose to use either the Gateway API or the Istio configuration API when configuring
-traffic management in the mesh. Follow instructions under either the `Gateway API` or `Istio APIs` tab,
+traffic management in the mesh. Follow instructions under either the `Gateway API` or the `Istio APIs` tab,
 according to your preference.

--- a/content/en/docs/examples/bookinfo/index.md
+++ b/content/en/docs/examples/bookinfo/index.md
@@ -153,7 +153,7 @@ Kubernetes cluster, e.g., from a browser. A gateway is used for this purpose.
 
     {{< tabset category-name="config-api" >}}
 
-    {{< tab name="Istio classic" category-value="istio-classic" >}}
+    {{< tab name="Istio APIs" category-value="istio-apis" >}}
 
     Create an [Istio Gateway](/docs/concepts/traffic-management/#gateways) using the following command:
 
@@ -234,7 +234,7 @@ versions.
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Istio uses *subsets*, in [destination rules](/docs/concepts/traffic-management/#destination-rules),
 to define versions of a service.

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -67,7 +67,7 @@ Follow these steps to get started with ambient:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ istioctl install --set profile=ambient --set components.ingressGateways[0].enabled=true --set components.ingressGateways[0].name=istio-ingressgateway --skip-confirmation
@@ -112,7 +112,7 @@ four components (including {{< gloss "ztunnel" >}}Ztunnel{{< /gloss >}}) have be
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl get pods -n istio-system
@@ -183,7 +183,7 @@ Make sure the default namespace does not include the label `istio-injection=enab
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Create an Istio [Gateway](/docs/reference/config/networking/gateway/) and
 [VirtualService](/docs/reference/config/networking/virtual-service/):
@@ -415,7 +415,7 @@ Configure traffic routing to send 90% of requests to `reviews` v1 and 10% to `re
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f @samples/bookinfo/networking/virtual-service-reviews-90-10.yaml@

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -120,7 +120,7 @@ to understand how `X-Forwarded-For` headers and trusted client addresses are det
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=deploy_httpbin_gateway >}}
 $ kubectl apply -n httpbin -f @samples/httpbin/httpbin-gateway.yaml@
@@ -143,7 +143,7 @@ $ kubectl wait --for=condition=programmed gtw -n httpbin httpbin-gateway
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=export_gateway_url >}}
 $ export GATEWAY_URL=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
@@ -250,7 +250,7 @@ If your external TCP load balancer is configured to forward TCP traffic and use 
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=yaml snip_id=none >}}
 apiVersion: networking.istio.io/v1alpha3

--- a/content/en/docs/setup/additional-setup/getting-started/index.md
+++ b/content/en/docs/setup/additional-setup/getting-started/index.md
@@ -14,7 +14,7 @@ test: yes
 {{< tip >}}
 {{< boilerplate gateway-api-future >}}
 The following instructions allow you to get started with Istio using the Gateway API.
-If you prefer to use the tried-and-proven Istio classic API for traffic management, you should use
+If you prefer to use the tried-and-proven Istio APIs API for traffic management, you should use
 [these instructions](/docs/setup/getting-started/) instead.
 {{< /tip >}}
 

--- a/content/en/docs/setup/additional-setup/getting-started/index.md
+++ b/content/en/docs/setup/additional-setup/getting-started/index.md
@@ -14,7 +14,7 @@ test: yes
 {{< tip >}}
 {{< boilerplate gateway-api-future >}}
 The following instructions allow you to get started with Istio using the Gateway API.
-If you prefer to use the tried-and-proven Istio APIs API for traffic management, you should use
+If you prefer to use the tried-and-proven Istio APIs for traffic management, you should use
 [these instructions](/docs/setup/getting-started/) instead.
 {{< /tip >}}
 

--- a/content/en/docs/setup/install/external-controlplane/index.md
+++ b/content/en/docs/setup/install/external-controlplane/index.md
@@ -616,7 +616,7 @@ See [Installing Gateways](/docs/setup/additional-setup/gateway/) for in-depth do
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Confirm that the Istio ingress gateway is running:
 
@@ -646,7 +646,7 @@ $ kubectl get crd gateways.gateway.networking.k8s.io --context="${CTX_REMOTE_CLU
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f @samples/helloworld/helloworld-gateway.yaml@ -n sample --context="${CTX_REMOTE_CLUSTER}"
@@ -669,7 +669,7 @@ $ kubectl apply -f @samples/helloworld/gateway-api/helloworld-gateway.yaml@ -n s
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ export INGRESS_HOST=$(kubectl -n external-istiod --context="${CTX_REMOTE_CLUSTER}" get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -31,7 +31,7 @@ Before you begin this task, do the following:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Configure the gateway:
 
@@ -124,7 +124,7 @@ You can instruct AWS EKS to create a Network Load Balancer with an annotation on
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text yaml >}}
 apiVersion: install.istio.io/v1alpha1
@@ -172,7 +172,7 @@ If you are using a TCP/UDP Proxy external load balancer (AWS Classic ELB), it ca
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text yaml >}}
 apiVersion: networking.istio.io/v1alp ha3
@@ -226,7 +226,7 @@ Here is a sample configuration that shows how to make an ingress gateway on AWS 
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text yaml >}}
 apiVersion: install.istio.io/v1alpha1
@@ -293,7 +293,7 @@ original client source IP on the ingress gateway using the following command:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl patch svc istio-ingressgateway -n istio-system -p '{"spec":{"externalTrafficPolicy":"Local"}}'
@@ -344,7 +344,7 @@ IP addresses not in the list will be denied. The `ipBlocks` supports both single
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 ***ipBlocks:***
 
@@ -450,7 +450,7 @@ EOF
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 ***ipBlocks:***
 
@@ -492,7 +492,7 @@ $ CLIENT_IP=$(kubectl get pods -n foo -o name -l istio.io/gateway-name=httpbin-g
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 ***ipBlocks:***
 
@@ -599,7 +599,7 @@ not allowed to access the ingress gateway:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 ***ipBlocks:***
 
@@ -707,7 +707,7 @@ different client IP to verify the request is allowed.
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system; done
@@ -731,7 +731,7 @@ $ kubectl get pods -n foo -o name -l istio.io/gateway-name=httpbin-gateway | sed
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl delete authorizationpolicy ingress-policy -n istio-system

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -56,7 +56,7 @@ Let's see how you can configure a `Gateway` on port 80 for HTTP traffic.
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Create an [Istio Gateway](/docs/reference/config/networking/gateway/):
 
@@ -222,7 +222,7 @@ Set the `INGRESS_HOST` and `INGRESS_PORT` environment variables according to the
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Set the following environment variables to the name and namespace where the Istio ingress gateway is located in your cluster:
 
@@ -335,7 +335,7 @@ You can work around this problem for simple tests and demos as follows:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Use a wildcard `*` value for the host in the `Gateway`
 and `VirtualService` configurations. For example, change your ingress configuration to the following:
@@ -519,7 +519,7 @@ they have valid values, according to the output of the following commands:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Delete the `Gateway` and `VirtualService` configuration, and shutdown the [httpbin]({{< github_tree >}}/samples/httpbin) service:
 

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
@@ -182,7 +182,7 @@ to hold the configuration of the NGINX server:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -238,7 +238,7 @@ EOF
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -294,7 +294,7 @@ EOF
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Follow the instructions in
 [Determining the ingress IP and ports](/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports)
@@ -342,7 +342,7 @@ $ export SECURE_INGRESS_PORT=$(kubectl get gtw mygateway -o jsonpath='{.spec.lis
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl delete gateway mygateway

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -112,7 +112,7 @@ example.com.key         httpbin.example.com.csr
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 First, define a gateway with a `servers:` section for port 443, and specify values for
 `credentialName` to be `httpbin-credential`. The values are the same as the
@@ -341,7 +341,7 @@ is configured with unique credentials corresponding to each host.
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Define a gateway with two server sections for port 443. Set the value of
 `credentialName` on each port to `httpbin-credential` and `helloworld-credential`
@@ -526,7 +526,7 @@ You can extend your gateway's definition to support [mutual TLS](https://en.wiki
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Change the gateway's definition to set the TLS mode to `MUTUAL`.
 
@@ -711,7 +711,7 @@ See [configuring SNI routing](/docs/ops/common-problems/network-issues/#configur
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl delete gateway mygateway

--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -143,7 +143,7 @@ In this step, you will change that behavior so that all traffic goes to `v1`.
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -269,7 +269,7 @@ log entries for `v1` and none for `v2`:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -373,7 +373,7 @@ forget", which means that the responses are discarded.
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl delete virtualservice httpbin

--- a/content/en/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/en/docs/tasks/traffic-management/request-routing/index.md
@@ -50,7 +50,7 @@ If you haven't already, follow the instructions in [define the service versions]
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Istio uses virtual services to define route rules.
 Run the following command to apply virtual services that will route all traffic to `v1` of each microservice:
@@ -92,7 +92,7 @@ EOF
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash yaml >}}
 $ kubectl get virtualservices -o yaml
@@ -235,7 +235,7 @@ Remember, `reviews:v2` is the version that includes the star ratings feature.
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f @samples/bookinfo/networking/virtual-service-reviews-test-v2.yaml@
@@ -332,7 +332,7 @@ gradually send traffic from one version of a service to another.
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl delete -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@

--- a/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
+++ b/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
@@ -55,7 +55,7 @@ weighted routing feature.
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f @samples/tcp-echo/tcp-echo-all-v1.yaml@ -n istio-io-tcp-traffic-shifting
@@ -77,7 +77,7 @@ $ kubectl apply -f @samples/tcp-echo/gateway-api/tcp-echo-all-v1.yaml@ -n istio-
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Follow the instructions in
 [Determining the ingress IP and ports](/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports)
@@ -126,7 +126,7 @@ $ export TCP_INGRESS_PORT=$(kubectl get gtw tcp-echo-gateway -n istio-io-tcp-tra
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f @samples/tcp-echo/tcp-echo-20-v2.yaml@ -n istio-io-tcp-traffic-shifting
@@ -148,7 +148,7 @@ $ kubectl apply -f @samples/tcp-echo/gateway-api/tcp-echo-20-v2.yaml@ -n istio-i
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash yaml >}}
 $ kubectl get virtualservice tcp-echo -o yaml -n istio-io-tcp-traffic-shifting
@@ -253,7 +253,7 @@ article [Canary Deployments using Istio](/blog/2017/0.1-canary/).
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl delete -f @samples/tcp-echo/tcp-echo-all-v1.yaml@ -n istio-io-tcp-traffic-shifting

--- a/content/en/docs/tasks/traffic-management/traffic-shifting/index.md
+++ b/content/en/docs/tasks/traffic-management/traffic-shifting/index.md
@@ -39,7 +39,7 @@ If you haven't already, follow the instructions in [define the service versions]
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=config_all_v1 >}}
 $ kubectl apply -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
@@ -69,7 +69,7 @@ the [Bookinfo](/docs/examples/bookinfo/#determine-the-ingress-ip-and-port) doc.
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=config_50_v3 >}}
 $ kubectl apply -f @samples/bookinfo/networking/virtual-service-reviews-50-v3.yaml@
@@ -92,7 +92,7 @@ confirm the rule was replaced:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash outputis=yaml snip_id=verify_config_50_v3 >}}
 $ kubectl get virtualservice reviews -o yaml
@@ -176,7 +176,7 @@ route 100% of the traffic to `reviews:v3` by applying this virtual service:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=config_100_v3 >}}
 $ kubectl apply -f @samples/bookinfo/networking/virtual-service-reviews-v3.yaml@
@@ -212,7 +212,7 @@ article [Canary Deployments using Istio](/blog/2017/0.1-canary/).
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=cleanup >}}
 $ kubectl delete -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@

--- a/content/zh/boilerplates/gateway-api-choose.md
+++ b/content/zh/boilerplates/gateway-api-choose.md
@@ -2,4 +2,4 @@
 ---
 
 以下说明指导您在网格中配置流量管理时如何选择使用 Gateway API 或 Istio 配置 API。
-请按照您的首选项遵循 `Gateway API` 或 `Istio classic` 页签中的指示说明。
+请按照您的首选项遵循 `Gateway API` 或 `Istio APIs` 页签中的指示说明。

--- a/content/zh/docs/examples/bookinfo/index.md
+++ b/content/zh/docs/examples/bookinfo/index.md
@@ -134,7 +134,7 @@ Bookinfo 应用中的几个微服务是由不同的语言编写的。
 
     {{< tabset category-name="config-api" >}}
 
-    {{< tab name="Istio classic" category-value="istio-classic" >}}
+    {{< tab name="Istio APIs" category-value="istio-apis" >}}
 
     使用以下命令创建 [Istio Gateway](/zh/docs/concepts/traffic-management/#gateways)：
 
@@ -207,7 +207,7 @@ $ curl -s "http://${GATEWAY_URL}/productpage" | grep -o "<title>.*</title>"
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Istio 在[目标规则](/zh/docs/concepts/traffic-management/#destination-rules)中使用 *subsets* 定义服务的版本。
 运行以下命令为 Bookinfo 服务创建默认的目标规则：

--- a/content/zh/docs/ops/ambient/getting-started/index.md
+++ b/content/zh/docs/ops/ambient/getting-started/index.md
@@ -66,7 +66,7 @@ Ambient 目前处于 [Alpha 状态](/zh/docs/releases/feature-stages/#feature-ph
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ istioctl install --set profile=ambient --set components.ingressGateways[0].enabled=true --set components.ingressGateways[0].name=istio-ingressgateway --skip-confirmation
@@ -111,7 +111,7 @@ $ istioctl install --set profile=ambient --skip-confirmation
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl get pods -n istio-system
@@ -177,7 +177,7 @@ $ kubectl apply -f @samples/sleep/notsleep.yaml@
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 创建 Istio [Gateway](/zh/docs/reference/config/networking/gateway/) 和
 [VirtualService](/zh/docs/reference/config/networking/virtual-service/)，
@@ -411,7 +411,7 @@ waypoint default/bookinfo-reviews applied
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 应用评审虚拟服务以控制 90% 流量到 reviews-v1，控制 10% 流量到 reviews-v2。
 

--- a/content/zh/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/zh/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -115,7 +115,7 @@ Envoy 就直接回调下游地址作为可信客户地址。
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=deploy_httpbin_gateway >}}
 $ kubectl apply -n httpbin -f @samples/httpbin/httpbin-gateway.yaml@
@@ -138,7 +138,7 @@ $ kubectl wait --for=condition=programmed gtw -n httpbin httpbin-gateway
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=export_gateway_url >}}
 $ export GATEWAY_URL=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
@@ -250,7 +250,7 @@ PROXY 协议不应该用于 L7 流量，也不应该在 L7 负载均衡器后使
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=yaml snip_id=none >}}
 apiVersion: networking.istio.io/v1alpha3

--- a/content/zh/docs/setup/install/external-controlplane/index.md
+++ b/content/zh/docs/setup/install/external-controlplane/index.md
@@ -579,7 +579,7 @@ $ helm install istio-egressgateway istio/gateway -n external-istiod --kube-conte
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 确认 Istio Ingress Gateway 正在运行：
 
@@ -608,7 +608,7 @@ $ kubectl get crd gateways.gateway.networking.k8s.io --context="${CTX_REMOTE_CLU
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f @samples/helloworld/helloworld-gateway.yaml@ -n sample --context="${CTX_REMOTE_CLUSTER}"
@@ -630,7 +630,7 @@ $ kubectl apply -f @samples/helloworld/gateway-api/helloworld-gateway.yaml@ -n s
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ export INGRESS_HOST=$(kubectl -n external-istiod --context="${CTX_REMOTE_CLUSTER}" get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')

--- a/content/zh/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -45,7 +45,7 @@ Ingress `Gateway` 描述在网格边界运作的负载均衡器，用于接收�
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 创建 [Istio Gateway](/zh/docs/reference/config/networking/gateway/)：
 
@@ -196,7 +196,7 @@ EOF
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 将以下环境变量设置到您集群中 Istio Ingress Gateway 所用的名称及其所在的命名空间：
 
@@ -306,7 +306,7 @@ $ export SECURE_INGRESS_PORT=$(kubectl get gtw my-gateway -o jsonpath='{.spec.li
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 在 `Gateway` 和 `VirtualService` 配置中使用通配符 `*`。例如如下修改 Ingress 配置：
 
@@ -480,7 +480,7 @@ $ export TCP_INGRESS_PORT=$(kubectl -n "${INGRESS_NS}" get service "${INGRESS_NA
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 删除 `Gateway` 和 `VirtualService` 配置，并关闭 [httpbin]({{< github_tree >}}/samples/httpbin) 服务：
 

--- a/content/zh/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -106,7 +106,7 @@ example.com.key         httpbin.example.com.csr
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 首先，使用 `servers:` 为 443 端口定义一个网关，并将 `credentialName` 的值设置为 `httpbin-credential`。该值与 Secret 的名称相同。TLS 模式的值应为 `SIMPLE`。
 
@@ -325,7 +325,7 @@ $ export SECURE_INGRESS_PORT=$(kubectl get gtw mygateway -n istio-system -o json
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 为 443 端口定义一个具有两个服务器部分的网关。将每个端口上的 `credentialName` 值分别设置为 `httpbin-credential` 和 `helloworld-credential`。将 TLS 模式设置为 `SIMPLE`。
 
@@ -507,7 +507,7 @@ EOF
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 更改网关的定义以将 TLS 模式设置为 `MUTUAL`。
 
@@ -664,7 +664,7 @@ HTTPS `Gateway` 将在转发请求之前对其配置的主机执行 [SNI](https:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl delete gateway mygateway

--- a/content/zh/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/zh/docs/tasks/traffic-management/mirroring/index.md
@@ -138,7 +138,7 @@ test: yes
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -263,7 +263,7 @@ EOF
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
@@ -360,7 +360,7 @@ EOF
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl delete virtualservice httpbin

--- a/content/zh/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/zh/docs/tasks/traffic-management/request-routing/index.md
@@ -42,7 +42,7 @@ URL 是 `http://$GATEWAY_URL/productpage`，
 1. 运行以下命令以创建路由规则：
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 Istio 使用 Virtual Service 来定义路由规则。
 运行以下命令以应用 Virtual Service，
@@ -84,7 +84,7 @@ EOF
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash yaml >}}
 $ kubectl get virtualservices -o yaml
@@ -217,7 +217,7 @@ Istio 还支持在入口网关上基于强认证 JWT 的路由，参考 [JWT 基
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f @samples/bookinfo/networking/virtual-service-reviews-test-v2.yaml@
@@ -305,7 +305,7 @@ EOF
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl delete -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@

--- a/content/zh/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
+++ b/content/zh/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
@@ -53,7 +53,7 @@ test: yes
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f @samples/tcp-echo/tcp-echo-all-v1.yaml@ -n istio-io-tcp-traffic-shifting
@@ -75,7 +75,7 @@ $ kubectl apply -f @samples/tcp-echo/gateway-api/tcp-echo-all-v1.yaml@ -n istio-
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 遵循[确定 Ingress IP 和端口](/zh/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports)中的指示说明来设置 `TCP_INGRESS_PORT` 和 `INGRESS_HOST` 环境变量。
 
@@ -121,7 +121,7 @@ $ export TCP_INGRESS_PORT=$(kubectl get gtw tcp-echo-gateway -n istio-io-tcp-tra
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl apply -f @samples/tcp-echo/tcp-echo-20-v2.yaml@ -n istio-io-tcp-traffic-shifting
@@ -143,7 +143,7 @@ $ kubectl apply -f @samples/tcp-echo/gateway-api/tcp-echo-20-v2.yaml@ -n istio-i
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash yaml >}}
 $ kubectl get virtualservice tcp-echo -o yaml -n istio-io-tcp-traffic-shifting
@@ -240,7 +240,7 @@ spec:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text bash >}}
 $ kubectl delete -f @samples/tcp-echo/tcp-echo-all-v1.yaml@ -n istio-io-tcp-traffic-shifting

--- a/content/zh/docs/tasks/traffic-management/traffic-shifting/index.md
+++ b/content/zh/docs/tasks/traffic-management/traffic-shifting/index.md
@@ -35,7 +35,7 @@ test: yes
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=config_all_v1 >}}
 $ kubectl apply -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
@@ -61,7 +61,7 @@ $ kubectl apply -f @samples/bookinfo/gateway-api/route-reviews-v1.yaml@
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=config_50_v3 >}}
 $ kubectl apply -f @samples/bookinfo/networking/virtual-service-reviews-50-v3.yaml@
@@ -83,7 +83,7 @@ $ kubectl apply -f @samples/bookinfo/gateway-api/route-reviews-50-v3.yaml@
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash outputis=yaml snip_id=verify_config_50_v3 >}}
 $ kubectl get virtualservice reviews -o yaml
@@ -162,7 +162,7 @@ status:
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=config_100_v3 >}}
 $ kubectl apply -f @samples/bookinfo/networking/virtual-service-reviews-v3.yaml@
@@ -196,7 +196,7 @@ $ kubectl apply -f @samples/bookinfo/gateway-api/route-reviews-v3.yaml@
 
 {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio classic" category-value="istio-classic" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< text syntax=bash snip_id=cleanup >}}
 $ kubectl delete -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@


### PR DESCRIPTION
Please provide a description for what this PR is for.

Per the TOC meeting earlier this week, we are removing references to "Istio classic" (i.e. Istio traffic routing resources as opposed to Gateway API) from the docs site and replacing it with "Istio APIs" to make sure our message to users is clear. This PR fixes the Chinese and English versions of the Istio docs.

/cc @louiscryan @istio/technical-oversight-committee 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
