### PR TITLE
Add warning for TLS verification in TLS origination guide

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -151,12 +151,14 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
     EOF
     {{< /text >}}
 
-    {{< warning >}} The `DestinationRule` above shall not verify the server's certificate, which might not be the expected behaviour.
-    Please follow the [Security Best Practices](https://istio.io/latest/docs/ops/best-practices/security/#configure-tls-verification-in-destination-rule-when-using-tls-origination)
-    to configure TLS verification. {{< /warning >}}
-
     The above `DestinationRule` will perform TLS origination for HTTP requests on port 80 and the `ServiceEntry`
     will then redirect the requests on port 80 to target port 443.
+
+    {{< warning >}}
+    The `DestinationRule` above shall not verify the server's certificate, which might not be the expected behaviour.
+
+    Please follow the [Security Best Practices](https://istio.io/latest/docs/ops/best-practices/security/#configure-tls-verification-in-destination-rule-when-using-tls-origination) to configure TLS verification.
+    {{< /warning >}}
 
 1. Send an HTTP request to `http://edition.cnn.com/politics`, as in the previous section:
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -153,7 +153,7 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
 
     {{< warning >}} The `DestinationRule` above shall not verify the server's certificate, which might not be the expected behaviour.
     Please follow the [Security Best Practices](https://istio.io/latest/docs/ops/best-practices/security/#configure-tls-verification-in-destination-rule-when-using-tls-origination)
-    to configure TLS verification.{{< /warning >}}
+    to configure TLS verification. {{< /warning >}}
 
     The above `DestinationRule` will perform TLS origination for HTTP requests on port 80 and the `ServiceEntry`
     will then redirect the requests on port 80 to target port 443.

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -151,6 +151,10 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
     EOF
     {{< /text >}}
 
+    {{< warning >}} The `DestinationRule` above shall not verify the server's certificate, which might not be the expected behaviour.
+    Please follow the [Security Best Practices](https://istio.io/latest/docs/ops/best-practices/security/#configure-tls-verification-in-destination-rule-when-using-tls-origination)
+    to configure TLS verification.{{< /warning >}}
+
     The above `DestinationRule` will perform TLS origination for HTTP requests on port 80 and the `ServiceEntry`
     will then redirect the requests on port 80 to target port 443.
 


### PR DESCRIPTION
The guide does not clearly state that the server certificate is not verified. Personally, I expected that the server certificate is checked according to the CA certificates of the envoy proxy as it is with utilities such as `curl`. However, that is not the case; this could lead to security risks and should be clearly stated in the guide as it is easy to miss this detail as the TLS origination works without checking the server certificate.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
