### PR TITLE
Update netlify.toml to match tools versions in the build-tools image.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,8 +6,8 @@
     NODE_VERSION = "18.16.0"
     BUILD_WITH_CONTAINER = "0"
     GO_VERSION = "1.20.5"
-    PYTHON_VERSION = "3.8"
-    RUBY_VERSION = "3.0.6"
+    PYTHON_VERSION = "3.10.6"
+    RUBY_VERSION = "3.0.2"
 
 [[headers]]
   for = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
     HUGO_VERSION = "0.115.1"
     NODE_VERSION = "18.16.0"
     BUILD_WITH_CONTAINER = "0"
-    GO_VERSION = "1.20.4"
+    GO_VERSION = "1.20.5"
     PYTHON_VERSION = "3.8"
     RUBY_VERSION = "3.0.6"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
     publish = "public"
 
 [build.environment]
-    HUGO_VERSION = "0.114.1"
+    HUGO_VERSION = "0.115.1"
     NODE_VERSION = "18.16.0"
     BUILD_WITH_CONTAINER = "0"
     GO_VERSION = "1.20.4"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
     NODE_VERSION = "18.16.0"
     BUILD_WITH_CONTAINER = "0"
     GO_VERSION = "1.20.5"
-    PYTHON_VERSION = "3.10.6"
+    PYTHON_VERSION = "3.10"
     RUBY_VERSION = "3.0.2"
 
 [[headers]]

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
     NODE_VERSION = "18.16.0"
     BUILD_WITH_CONTAINER = "0"
     GO_VERSION = "1.20.5"
-    PYTHON_VERSION = "3.10"
+    PYTHON_VERSION = "3.8"
     RUBY_VERSION = "3.0.2"
 
 [[headers]]


### PR DESCRIPTION
Please provide a description for what this PR is for.

Update Hugo and Go to match tools. I also reverted ruby to match the version in the tools image. I could not match the python version as Netlify did not support it.
