### PR TITLE
Tweak long lines in istioctl and istioctl-analyze

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
@@ -43,7 +43,8 @@ $ istioctl analyze --namespace default
 
 ## Analyzing live clusters, local files, or both
 
-Analyze the current live cluster, simulating the effect of applying additional yaml files like `bookinfo-gateway.yaml` and `destination-rule-all.yaml` in the `samples/bookinfo/networking` directory:
+Analyze the current live cluster, simulating the effect of applying additional yaml files
+like `bookinfo-gateway.yaml` and `destination-rule-all.yaml` in the `samples/bookinfo/networking` directory:
 
 {{< text syntax=bash snip_id=analyze_sample_destrule >}}
 $ istioctl analyze @samples/bookinfo/networking/bookinfo-gateway.yaml@ @samples/bookinfo/networking/destination-rule-all.yaml@
@@ -65,9 +66,11 @@ Analyze all yaml files in the `networking` folder:
 $ istioctl analyze samples/bookinfo/networking/*.yaml
 {{< /text >}}
 
-The above examples are doing analysis on a live cluster. The tool also supports performing analysis of a set of local Kubernetes yaml configuration files,
-or on a combination of local files and a live cluster. When analyzing a set of local files, the file-set is expected to be fully self-contained.
-Typically, this is used to analyze the entire set of configuration files that are intended to be deployed to a cluster. To use this feature, simply add the `--use-kube=false` flag.
+The above examples are doing analysis on a live cluster. The tool also supports performing analysis
+of a set of local Kubernetes yaml configuration files, or on a combination of local files and a
+live cluster. When analyzing a set of local files, the file-set is expected to be fully self-contained.
+Typically, this is used to analyze the entire set of configuration files that are intended to be deployed
+to a cluster. To use this feature, simply add the `--use-kube=false` flag.
 
 Analyze all yaml files in the `networking` folder:
 
@@ -83,10 +86,13 @@ You can run `istioctl analyze --help` to see the full set of options.
 
 {{< boilerplate experimental-feature-warning >}}
 
-Starting with Istio 1.5, Galley can be set up to perform configuration analysis alongside the configuration distribution that it is primarily responsible for, via the `istiod.enableAnalysis` flag.
-This analysis uses the same logic and error messages as when using `istioctl analyze`. Validation messages from the analysis are written to the status subresource of the affected Istio resource.
+Starting with Istio 1.5, Galley can be set up to perform configuration analysis alongside
+the configuration distribution that it is primarily responsible for, via the `istiod.enableAnalysis` flag.
+This analysis uses the same logic and error messages as when using `istioctl analyze`.
+Validation messages from the analysis are written to the status subresource of the affected Istio resource.
 
-For example. if you have a misconfigured gateway on your "ratings" virtual service, running `kubectl get virtualservice ratings` would give you something like:
+For example. if you have a misconfigured gateway on your "ratings" virtual service,
+running `kubectl get virtualservice ratings` would give you something like:
 
 {{< text syntax=yaml snip_id=vs_yaml_with_status >}}
 apiVersion: networking.istio.io/v1beta1
@@ -107,11 +113,15 @@ status:
       code: IST0101
 {{< /text >}}
 
-`enableAnalysis` runs in the background, and will keep the status field of a resource up to date with its current validation status. Note that this isn't a replacement for `istioctl analyze`:
+`enableAnalysis` runs in the background, and will keep the status field of a resource up to date
+with its current validation status. Note that this isn't a replacement for `istioctl analyze`:
 
-- Not all resources have a custom status field (e.g. Kubernetes `namespace` resources), so messages attached to those resources won't show validation messages.
-- `enableAnalysis` only works on Istio versions starting with 1.5, while `istioctl analyze` can be used with older versions.
-- While it makes it easy to see what's wrong with a particular resource, it's harder to get a holistic view of validation status in the mesh.
+- Not all resources have a custom status field (e.g. Kubernetes `namespace` resources),
+  so messages attached to those resources won't show validation messages.
+- `enableAnalysis` only works on Istio versions starting with 1.5, while
+  `istioctl analyze` can be used with older versions.
+- While it makes it easy to see what's wrong with a particular resource,
+  it's harder to get a holistic view of validation status in the mesh.
 
 You can enable this feature with:
 
@@ -121,21 +131,25 @@ $ istioctl install --set values.global.istiod.enableAnalysis=true
 
 ### Ignoring specific analyzer messages via CLI
 
-Sometimes you might find it useful to hide or ignore analyzer messages in certain cases. For example, imagine a situation where a message is emitted about a resource you don't have permissions to update:
+Sometimes you might find it useful to hide or ignore analyzer messages in certain cases.
+For example, imagine a situation where a message is emitted about a resource you don't have permissions to update:
 
 {{< text syntax=bash snip_id=analyze_k_frod >}}
 $ istioctl analyze -k --namespace frod
 Info [IST0102] (Namespace frod) The namespace is not enabled for Istio injection. Run 'kubectl label namespace frod istio-injection=enabled' to enable it, or 'kubectl label namespace frod istio-injection=disabled' to explicitly mark it as not needing injection.
 {{< /text >}}
 
-Because you don't have permissions to update the namespace, you cannot resolve the message by annotating the namespace. Instead, you can direct `istioctl analyze` to suppress the above message on the resource:
+Because you don't have permissions to update the namespace, you cannot resolve the message
+by annotating the namespace. Instead, you can direct `istioctl analyze` to suppress the above message on the resource:
 
 {{< text syntax=bash snip_id=analyze_suppress0102 >}}
 $ istioctl analyze -k --namespace frod --suppress "IST0102=Namespace frod"
 ✔ No validation issues found when analyzing namespace: frod.
 {{< /text >}}
 
-The syntax used for suppression is the same syntax used throughout `istioctl` when referring to resources: `<kind> <name>.<namespace>`, or just `<kind> <name>` for cluster-scoped resources like `Namespace`. If you want to suppress multiple objects, you can either repeat the `--suppress` argument or use wildcards:
+The syntax used for suppression is the same syntax used throughout `istioctl` when referring to
+resources: `<kind> <name>.<namespace>`, or just `<kind> <name>` for cluster-scoped resources like
+`Namespace`. If you want to suppress multiple objects, you can either repeat the `--suppress` argument or use wildcards:
 
 {{< text syntax=bash snip_id=analyze_suppress_frod_0107_baz >}}
 $ # Suppress code IST0102 on namespace frod and IST0107 on all pods in namespace baz
@@ -144,7 +158,8 @@ $ istioctl analyze -k --all-namespaces --suppress "IST0102=Namespace frod" --sup
 
 ### Ignoring specific analyzer messages via annotations
 
-You can also ignore specific analyzer messages using an annotation on the resource. For example, to ignore code IST0107 (`MisplacedAnnotation`) on resource `deployment/my-deployment`:
+You can also ignore specific analyzer messages using an annotation on the resource.
+For example, to ignore code IST0107 (`MisplacedAnnotation`) on resource `deployment/my-deployment`:
 
 {{< text syntax=bash snip_id=annotate_for_deployment_suppression >}}
 $ kubectl annotate deployment my-deployment galley.istio.io/analyze-suppress=IST0107
@@ -176,27 +191,38 @@ kind of information you should provide.
 
 - **What Istio release does this tool target?**
 
-    Like other `istioctl` tools, we generally recommend using a downloaded version that matches the version deployed in your cluster.
+    Like other `istioctl` tools, we generally recommend using a downloaded version
+    that matches the version deployed in your cluster.
 
-    For the time being, analysis is generally backwards compatible, so that you can, for example, run the {{< istio_version >}} version of `istioctl analyze` against a cluster running an older Istio 1.x version and expect to get useful feedback. Analysis rules that are not meaningful with an older Istio release will be skipped.
+    For the time being, analysis is generally backwards compatible, so that you can,
+    for example, run the {{< istio_version >}} version of `istioctl analyze` against
+    a cluster running an older Istio 1.x version and expect to get useful feedback.
+    Analysis rules that are not meaningful with an older Istio release will be skipped.
 
-    If you decide to use the latest `istioctl` for analysis purposes on a cluster running an older Istio version, we suggest that you keep it in a separate folder from the version of the binary used to manage your deployed Istio release.
+    If you decide to use the latest `istioctl` for analysis purposes on a cluster
+    running an older Istio version, we suggest that you keep it in a separate folder
+    from the version of the binary used to manage your deployed Istio release.
 
 - **What analyzers are supported today?**
 
-    We're still working to documenting the analyzers. In the meantime, you can see all the analyzers in the [Istio source]({{< github_tree >}}/pkg/config/analysis/analyzers).
+    We're still working to documenting the analyzers. In the meantime, you can see
+    all the analyzers in the [Istio source]({{< github_tree >}}/pkg/config/analysis/analyzers).
 
     You can also see what [configuration analysis messages](/docs/reference/config/analysis/)
     are supported to get an idea of what is currently covered.
 
 - **Can analysis do anything harmful to my cluster?**
 
-    Analysis never changes configuration state. It is a completely read-only operation that will never alter the state of a cluster.
+    Analysis never changes configuration state. It is a completely read-only operation
+    that will never alter the state of a cluster.
 
 - **What about analysis that goes beyond configuration?**
 
-    Today, the analysis is purely based on Kubernetes configuration, but in the future we’d like to expand beyond that. For example, we could allow analyzers to also look at logs to generate recommendations.
+    Today, the analysis is purely based on Kubernetes configuration, but in the future
+    we’d like to expand beyond that. For example, we could allow analyzers to also look
+    at logs to generate recommendations.
 
 - **Where can I find out how to fix the errors I'm getting?**
 
-    The set of [configuration analysis messages](/docs/reference/config/analysis/) contains descriptions of each message along with suggested fixes.
+    The set of [configuration analysis messages](/docs/reference/config/analysis/)
+    contains descriptions of each message along with suggested fixes.

--- a/content/en/docs/ops/diagnostic-tools/istioctl/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl/index.md
@@ -10,11 +10,15 @@ owner: istio/wg-user-experience-maintainers
 test: no
 ---
 
-You can gain insights into what individual components are doing by inspecting their [logs](/docs/ops/diagnostic-tools/component-logging/)
-or peering inside via [introspection](/docs/ops/diagnostic-tools/controlz/). If that's insufficient, the steps below explain
-how to get under the hood.
+You can gain insights into what individual components are doing by inspecting their
+[logs](/docs/ops/diagnostic-tools/component-logging/) or peering inside via
+[introspection](/docs/ops/diagnostic-tools/controlz/). If that's insufficient,
+the steps below explain how to get under the hood.
 
-The [`istioctl`](/docs/reference/commands/istioctl) tool is a configuration command line utility that allows service operators to debug and diagnose their Istio service mesh deployments. The Istio project also includes two helpful scripts for `istioctl` that enable auto-completion for Bash and Zsh. Both of these scripts provide support for the currently available `istioctl` commands.
+The [`istioctl`](/docs/reference/commands/istioctl) tool is a configuration command line utility
+that allows service operators to debug and diagnose their Istio service mesh deployments.
+The Istio project also includes two helpful scripts for `istioctl` that enable auto-completion
+for Bash and Zsh. Both of these scripts provide support for the currently available `istioctl` commands.
 
 {{< tip >}}
 `istioctl` only has auto-completion enabled for non-deprecated commands.
@@ -22,7 +26,8 @@ The [`istioctl`](/docs/reference/commands/istioctl) tool is a configuration comm
 
 ## Before you begin
 
-We recommend you use an `istioctl` version that is the same version as your Istio control plane. Using matching versions helps avoid unforeseen issues.
+We recommend you use an `istioctl` version that is the same version as your Istio control plane.
+Using matching versions helps avoid unforeseen issues.
 
 {{< tip >}}
 If you have already [downloaded the Istio release](/docs/setup/getting-started/#download), you should
@@ -61,7 +66,8 @@ Pilot needs to be scaled.
 
 ## Get proxy configuration
 
-[`istioctl`](/docs/reference/commands/istioctl) allows you to retrieve information about proxy configuration using the `proxy-config` or `pc` command.
+[`istioctl`](/docs/reference/commands/istioctl) allows you to retrieve information
+about proxy configuration using the `proxy-config` or `pc` command.
 
 For example, to retrieve information about cluster configuration for the Envoy instance in a specific pod:
 
@@ -101,14 +107,17 @@ See [Debugging Envoy and Istiod](/docs/ops/diagnostic-tools/proxy-cmd/) for more
 
 {{< tab name="macOS" category-value="macos" >}}
 
-If you are using the macOS operating system with the Zsh terminal shell, make sure that the `zsh-completions` package is installed. With the [brew](https://brew.sh) package manager for macOS, you can check to see if the `zsh-completions` package is installed with the following command:
+If you are using the macOS operating system with the Zsh terminal shell, make sure that
+the `zsh-completions` package is installed. With the [brew](https://brew.sh) package manager
+for macOS, you can check to see if the `zsh-completions` package is installed with the following command:
 
 {{< text bash >}}
 $ brew list zsh-completions
 /usr/local/Cellar/zsh-completions/0.34.0/share/zsh-completions/ (147 files)
 {{< /text >}}
 
-If you receive `Error: No such keg: /usr/local/Cellar/zsh-completion`, proceed with installing the `zsh-completions` package with the following command:
+If you receive `Error: No such keg: /usr/local/Cellar/zsh-completion`,
+proceed with installing the `zsh-completions` package with the following command:
 
 {{< text bash >}}
 $ brew install zsh-completions
@@ -131,7 +140,8 @@ You may also need to force rebuild `zcompdump`:
 $ rm -f ~/.zcompdump; compinit
 {{< /text >}}
 
-Additionally, if you receive `Zsh compinit: insecure directories` warnings when attempting to load these completions, you may need to run this:
+Additionally, if you receive `Zsh compinit: insecure directories` warnings
+when attempting to load these completions, you may need to run this:
 
 {{< text bash >}}
 $ chmod -R go-w '$HOMEBREW_PREFIX/share/zsh'
@@ -141,9 +151,12 @@ $ chmod -R go-w '$HOMEBREW_PREFIX/share/zsh'
 
 {{< tab name="Linux" category-value="linux" >}}
 
-If you are using a Linux-based operating system, you can install the Bash completion package with the `apt-get install bash-completion` command for Debian-based Linux distributions or `yum install bash-completion` for RPM-based Linux distributions, the two most common occurrences.
+If you are using a Linux-based operating system, you can install the Bash completion package
+with the `apt-get install bash-completion` command for Debian-based Linux distributions or
+`yum install bash-completion` for RPM-based Linux distributions, the two most common occurrences.
 
-Once the `bash-completion` package has been installed on your Linux system, add the following line to your `~/.bash_profile` file:
+Once the `bash-completion` package has been installed on your Linux system,
+add the following line to your `~/.bash_profile` file:
 
 {{< text plain >}}
 [[ -r "/usr/local/etc/profile.d/bash_completion.sh" ]] && . "/usr/local/etc/profile.d/bash_completion.sh"
@@ -158,7 +171,8 @@ Once the `bash-completion` package has been installed on your Linux system, add 
 To enable `istioctl` completion on your system, follow the steps for your preferred shell:
 
 {{< warning >}}
-You will need to download the full Istio release containing the auto-completion files (in the `/tools` directory). If you haven't already done so, [download the full release](/docs/setup/getting-started/#download) now.
+You will need to download the full Istio release containing the auto-completion files (in the `/tools` directory).
+If you haven't already done so, [download the full release](/docs/setup/getting-started/#download) now.
 {{< /warning >}}
 
 {{< tabset category-name="profile" >}}
@@ -167,7 +181,9 @@ You will need to download the full Istio release containing the auto-completion 
 
 Installing the bash auto-completion file
 
-If you are using bash, the `istioctl` auto-completion file is located in the `tools` directory. To use it, copy the `istioctl.bash` file to your home directory, then add the following line to source the `istioctl` tab completion file from your `.bashrc` file:
+If you are using bash, the `istioctl` auto-completion file is located in the `tools` directory.
+To use it, copy the `istioctl.bash` file to your home directory, then add the following line to
+source the `istioctl` tab completion file from your `.bashrc` file:
 
 {{< text bash >}}
 $ source ~/istioctl.bash
@@ -179,24 +195,32 @@ $ source ~/istioctl.bash
 
 Installing the Zsh auto-completion file
 
-For Zsh users, the `istioctl` auto-completion file is located in the `tools` directory. Copy the `_istioctl` file to your home directory, or any directory of your choosing (update directory in script snippet below), and source the `istioctl` auto-completion file in your `.zshrc` file as follows:
+For Zsh users, the `istioctl` auto-completion file is located in the `tools` directory.
+Copy the `_istioctl` file to your home directory, or any directory of your choosing
+(update directory in script snippet below), and source the `istioctl` auto-completion file
+in your `.zshrc` file as follows:
 
 {{< text zsh >}}
 source ~/_istioctl
 {{< /text >}}
 
-You may also add the `_istioctl` file to a directory listed in the `fpath` variable. To achieve this, place the `_istioctl` file in an existing directory in the `fpath`, or create a new directory and add it to the `fpath` variable in your `~/.zshrc` file.
+You may also add the `_istioctl` file to a directory listed in the `fpath` variable.
+To achieve this, place the `_istioctl` file in an existing directory in the `fpath`,
+or create a new directory and add it to the `fpath` variable in your `~/.zshrc` file.
 
 {{< tip >}}
 
-If you get an error like `complete:13: command not found: compdef`, then add the following to the beginning of your `~/.zshrc` file:
+If you get an error like `complete:13: command not found: compdef`,
+then add the following to the beginning of your `~/.zshrc` file:
 
 {{< text bash >}}
 $ autoload -Uz compinit
 $ compinit
 {{< /text >}}
 
-If your auto-completion is not working, try again after restarting your terminal. If auto-completion still does not work, try resetting the completion cache using the above commands in your terminal.
+If your auto-completion is not working, try again after restarting your terminal.
+If auto-completion still does not work, try resetting the completion cache using
+the above commands in your terminal.
 
 {{< /tip >}}
 
@@ -206,7 +230,9 @@ If your auto-completion is not working, try again after restarting your terminal
 
 ### Using auto-completion
 
-If the `istioctl` completion file has been installed correctly, press the Tab key while writing an `istioctl` command, and it should return a set of command suggestions for you to choose from:
+If the `istioctl` completion file has been installed correctly, press the Tab key
+while writing an `istioctl` command, and it should return a set of command suggestions
+for you to choose from:
 
 {{< text bash >}}
 $ istioctl proxy-<TAB>


### PR DESCRIPTION
Tweaked long lines around col 80-120 to make it prettier, without any other changes:

```
modified:   content/en/docs/ops/diagnostic-tools/istioctl-analyze/index.md
modified:   content/en/docs/ops/diagnostic-tools/istioctl/index.md
```

- [x] Docs

