### PR TITLE
Update supported versions for master

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -5,8 +5,8 @@
   supported: "No, development only"
   releaseDate:
   eolDate:
-  k8sVersions: ["1.24", "1.25", "1.26", "1.27"]
-  testedK8sVersions: ["1.20", "1.21", "1.22", "1.23"]
+  k8sVersions: ["1.25", "1.26", "1.27", "1.28"]
+  testedK8sVersions: ["1.21", "1.22", "1.23", "1.24"]
 - version: "1.18"
   supported: "Yes"
   releaseDate: "Jun 3, 2023"


### PR DESCRIPTION
We dropped support for 1.20 which was the main part of this PR. But I also think we can shift to 1.28 - we are already testinng pre-releases, and k8s will release before we do so should be fine. We can always change it once we ship 1.19, this doesn't commit us to anything. its only for preliminary.istio.io.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
