### PR TITLE
update istio-ingress installation name in helm install instructions

### DIFF
--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -127,7 +127,7 @@ You can display the default values of configuration parameters using the `helm s
 
     {{< text syntax=bash snip_id=install_ingressgateway >}}
     $ kubectl create namespace istio-ingress
-    $ helm install istio-ingress istio/gateway -n istio-ingress --wait
+    $ helm install istio-ingressgateway istio/gateway -n istio-ingress --wait
     {{< /text >}}
 
     See [Installing Gateways](/docs/setup/additional-setup/gateway/) for in-depth documentation on gateway installation.

--- a/content/en/docs/setup/install/helm/snips.sh
+++ b/content/en/docs/setup/install/helm/snips.sh
@@ -98,7 +98,7 @@ ENDSNIP
 
 snip_install_ingressgateway() {
 kubectl create namespace istio-ingress
-helm install istio-ingress istio/gateway -n istio-ingress --wait
+helm install istio-ingressgateway istio/gateway -n istio-ingress --wait
 }
 
 snip_helm_ls() {

--- a/content/en/docs/setup/install/helm/test.sh
+++ b/content/en/docs/setup/install/helm/test.sh
@@ -27,7 +27,7 @@ _rewrite_helm_repo snip_install_discovery
 _wait_for_deployment istio-system istiod
 
 _rewrite_helm_repo snip_install_ingressgateway
-_wait_for_deployment istio-ingress istio-ingress
+_wait_for_deployment istio-ingress istio-ingressgateway
 
 # shellcheck disable=SC2154
 _verify_like snip_helm_ls "$snip_helm_ls_out"

--- a/content/zh/docs/setup/install/helm/index.md
+++ b/content/zh/docs/setup/install/helm/index.md
@@ -133,7 +133,7 @@ $ helm install <release> <chart> --namespace <namespace> --create-namespace [--s
 
     {{< text syntax=bash snip_id=install_ingressgateway >}}
     $ kubectl create namespace istio-ingress
-    $ helm install istio-ingress istio/gateway -n istio-ingress --wait
+    $ helm install istio-ingressgateway istio/gateway -n istio-ingress --wait
     {{< /text >}}
 
     参阅[安装网关](/zh/docs/setup/additional-setup/gateway/)以获得关于网关安装的详细文档。


### PR DESCRIPTION
Please provide a description for what this PR is for.

Mesh Config has a default of looking for `istio-ingressgateway`, which is the name elsewhere and by other methods for installation. This PR changes the installation instructions to match the name used elsewhere. For example: https://istio.io/latest/docs/setup/additional-setup/gateway/#deploying-a-gateway, https://istio.io/latest/docs/setup/install/istioctl/#check-whats-installed.

Fixes #13497 

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
