### PR TITLE
[zh] fix localization of metrics in faq

### DIFF
--- a/content/zh/about/faq/metrics-and-logs/index.md
+++ b/content/zh/about/faq/metrics-and-logs/index.md
@@ -1,7 +1,7 @@
 ---
-title: 度量和日志的常见问题
-linktitle: 度量和日志
-description: 度量和日志的常见问题。
+title: 指标和日志的常见问题
+linktitle: 指标和日志
+description: 指标和日志的常见问题。
 weight: 45
 layout: faq
 aliases:


### PR DESCRIPTION
Replace `度量` with `指标` for `metrics`

- [x] Docs

