### PR TITLE
the Dual Stack feature flag has been uniformed as ISTIO_DUAL_STACK

### DIFF
--- a/content/en/blog/2023/experimental-dual-stack/index.md
+++ b/content/en/blog/2023/experimental-dual-stack/index.md
@@ -65,7 +65,7 @@ EOF
       meshConfig:
         defaultConfig:
           proxyMetadata:
-            ISTIO_AGENT_DUAL_STACK: "true"
+            ISTIO_DUAL_STACK: "true"
       values:
         pilot:
           env:

--- a/content/zh/blog/2023/experimental-dual-stack/index.md
+++ b/content/zh/blog/2023/experimental-dual-stack/index.md
@@ -80,7 +80,7 @@ EOF
       meshConfig:
         defaultConfig:
           proxyMetadata:
-            ISTIO_AGENT_DUAL_STACK: "true"
+            ISTIO_DUAL_STACK: "true"
       values:
         pilot:
           env:


### PR DESCRIPTION
the Dual Stack feature flag has been uniformed as **ISTIO_DUAL_STACK** based on PR#43892, so the blog need to be changed as well.

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
