### PR TITLE
Tweak line wrappings in setup files

### DIFF
--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -28,10 +28,15 @@ The variables specified in the command are as follows:
 * `<release>` A name to identify and manage the Helm chart once installed.
 * `<namespace>` The namespace in which the chart is to be installed.
 
-Default configuration values can be changed using one or more `--set <parameter>=<value>` arguments. Alternatively, you can specify several parameters in a custom values file using the `--values <file>` argument.
+Default configuration values can be changed using one or more `--set <parameter>=<value>` arguments.
+Alternatively, you can specify several parameters in a custom values file using the `--values <file>` argument.
 
 {{< tip >}}
-You can display the default values of configuration parameters using the `helm show values <chart>` command or refer to `artifacthub` chart documentation at [Custom Resource Definition parameters](https://artifacthub.io/packages/helm/istio-official/base?modal=values), [Istiod chart configuration parameters](https://artifacthub.io/packages/helm/istio-official/istiod?modal=values) and [Gateway chart configuration parameters](https://artifacthub.io/packages/helm/istio-official/gateway?modal=values).
+You can display the default values of configuration parameters using the `helm show values <chart>` command
+or refer to `artifacthub` chart documentation at
+[Custom Resource Definition parameters](https://artifacthub.io/packages/helm/istio-official/base?modal=values),
+[Istiod chart configuration parameters](https://artifacthub.io/packages/helm/istio-official/istiod?modal=values)
+and [Gateway chart configuration parameters](https://artifacthub.io/packages/helm/istio-official/gateway?modal=values).
 {{< /tip >}}
 
 1. Create the namespace, `istio-system`, for the Istio components:
@@ -43,7 +48,8 @@ You can display the default values of configuration parameters using the `helm s
     $ kubectl create namespace istio-system
     {{< /text >}}
 
-1. Install the Istio base chart which contains cluster-wide Custom Resource Definitions (CRDs) which must be installed prior to the deployment of the Istio control plane:
+1. Install the Istio base chart which contains cluster-wide Custom Resource Definitions (CRDs)
+   which must be installed prior to the deployment of the Istio control plane:
 
     {{< warning >}}
     When performing a revisioned installation, the base chart requires the `--set defaultRevision=<revision>` value to be set for resource
@@ -64,7 +70,8 @@ You can display the default values of configuration parameters using the `helm s
 
     In the output locate the entry for `istio-base` and make sure the status is set to `deployed`.
 
-1. If you intend to use Istio CNI chart you must do so now. See [Install Istio with the CNI plugin](/docs/setup/additional-setup/cni/#installing-with-helm) for more info.
+1. If you intend to use Istio CNI chart you must do so now. See
+   [Install Istio with the CNI plugin](/docs/setup/additional-setup/cni/#installing-with-helm) for more info.
 
 1. Install the Istio discovery chart which deploys the `istiod` service:
 
@@ -138,8 +145,8 @@ You can display the default values of configuration parameters using the `helm s
     {{< /warning >}}
 
 {{< tip >}}
-See [Advanced Helm Chart Customization](/docs/setup/additional-setup/customize-installation-helm/) for in-depth documentation on how to use
-Helm post-renderer to customize the Helm charts.
+See [Advanced Helm Chart Customization](/docs/setup/additional-setup/customize-installation-helm/)
+for in-depth documentation on how to use Helm post-renderer to customize the Helm charts.
 {{< /tip >}}
 
 ## Updating your Istio configuration
@@ -218,7 +225,8 @@ you can uninstall the newer revision and its tag by first issuing
 `helm template istiod istio/istiod -s templates/revision-tags.yaml --set revisionTags={prod-canary} --set revision=canary -n istio-system | kubectl delete -f -`.
 You must them uninstall the revision of Istio that it pointed to by following the uninstall procedure above.
 
-If you installed the gateway(s) for this revision using in-place upgrades, you must also reinstall the gateway(s) for the previous revision manually,
+If you installed the gateway(s) for this revision using in-place upgrades,
+you must also reinstall the gateway(s) for the previous revision manually,
 Removing the previous revision and its tags will not automatically revert the previously in-place upgraded gateway(s).
 
 ### (Optional) Deleting CRDs installed by Istio

--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -91,10 +91,10 @@ the `manifests` flag to a local file system path:
 $ istioctl install --manifests=manifests/
 {{< /text >}}
 
-If using the `istioctl` {{< istio_full_version >}} binary, this command will result in the same installation as `istioctl install` alone, because it points to the
-same charts as the compiled-in ones.
-Other than for experimenting with or testing new features, we recommend using the compiled-in charts rather than external ones to ensure compatibility of the
-`istioctl` binary with the charts.
+If using the `istioctl` {{< istio_full_version >}} binary, this command will result in the
+same installation as `istioctl install` alone, because it points to the same charts as the compiled-in ones.
+Other than for experimenting with or testing new features, we recommend using the compiled-in charts
+rather than external ones to ensure compatibility of the `istioctl` binary with the charts.
 
 ## Install a different profile
 
@@ -300,7 +300,8 @@ Then run the following `verify-install` command to see if the installation was s
 $ istioctl verify-install -f $HOME/generated-manifest.yaml
 {{< /text >}}
 
-See [Customizing the installation configuration](/docs/setup/additional-setup/customize-installation/) for additional information on customizing the install.
+See [Customizing the installation configuration](/docs/setup/additional-setup/customize-installation/)
+for additional information on customizing the install.
 
 ## Uninstall Istio
 
@@ -311,7 +312,8 @@ $ istioctl uninstall --purge
 {{< /text >}}
 
 {{< warning >}}
-The optional `--purge` flag will remove all Istio resources, including cluster-scoped resources that may be shared with other Istio control planes.
+The optional `--purge` flag will remove all Istio resources, including cluster-scoped resources
+that may be shared with other Istio control planes.
 {{< /warning >}}
 
 Alternatively, to remove only a specific Istio control plane, run the following command:

--- a/content/en/docs/setup/platform-setup/minikube/index.md
+++ b/content/en/docs/setup/platform-setup/minikube/index.md
@@ -18,8 +18,12 @@ resources to run Istio and some basic applications.
 
 - Administrative privileges are required to run minikube.
 
-- To enable the [Secret Discovery Service](https://www.envoyproxy.io/docs/envoy/latest/configuration/security/secret#sds-configuration) (SDS) for your mesh, you must add [extra configurations](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) to your Kubernetes deployment.
-Refer to the [`api-server` reference docs](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) for the most up-to-date flags.
+- To enable the [Secret Discovery Service](https://www.envoyproxy.io/docs/envoy/latest/configuration/security/secret#sds-configuration) (SDS)
+  for your mesh, you must add
+  [extra configurations](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection)
+  to your Kubernetes deployment. Refer to the
+  [`api-server` reference docs](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/)
+  for the most up-to-date flags.
 
 ## Installation steps
 

--- a/content/en/docs/setup/platform-setup/openshift/index.md
+++ b/content/en/docs/setup/platform-setup/openshift/index.md
@@ -36,7 +36,9 @@ $ oc -n istio-system expose svc/istio-ingressgateway --port=http2
 
 ## Security context constraints for application sidecars
 
-The Istio sidecar injected into each application pod runs with user ID 1337, which is not allowed by default in OpenShift. To allow this user ID to be used, execute the following commands. Replace `<target-namespace>` with the appropriate namespace.
+The Istio sidecar injected into each application pod runs with user ID 1337,
+which is not allowed by default in OpenShift. To allow this user ID to be used,
+execute the following commands. Replace `<target-namespace>` with the appropriate namespace.
 
 {{< text bash >}}
 $ oc adm policy add-scc-to-group anyuid system:serviceaccounts:<target-namespace>

--- a/content/en/docs/setup/platform-setup/tencent-cloud-mesh/index.md
+++ b/content/en/docs/setup/platform-setup/tencent-cloud-mesh/index.md
@@ -10,26 +10,33 @@ test: n/a
 
 ## Prerequisites
 
-Follow these instructions to prepare a [Tencent Kubernetes Engine](https://intl.cloud.tencent.com/products/tke) or [Elastic Kubernetes Service](https://intl.cloud.tencent.com/product/eks) cluster for Istio.
+Follow these instructions to prepare a [Tencent Kubernetes Engine](https://intl.cloud.tencent.com/products/tke)
+or [Elastic Kubernetes Service](https://intl.cloud.tencent.com/product/eks) cluster for Istio.
 
-You can deploy a Kubernetes cluster to Tencent Cloud via [Tencent Kubernetes Engine](https://intl.cloud.tencent.com/document/product/457/40029) or [Elastic Kubernetes Service](https://intl.cloud.tencent.com/document/product/457/34048) which fully supports Istio.
+You can deploy a Kubernetes cluster to Tencent Cloud via
+[Tencent Kubernetes Engine](https://intl.cloud.tencent.com/document/product/457/40029)
+or [Elastic Kubernetes Service](https://intl.cloud.tencent.com/document/product/457/34048)
+which fully supports Istio.
 
 {{< image link="./tke.png" caption="Create Cluster" >}}
 
 ## Procedure
 
-After creating a Tencent Kubernetes Engine or Elastic Kubernetes Service cluster, you can quickly start to deploy and use Istio by [Tencent Cloud Mesh](https://cloud.tencent.com/product/tcm):
+After creating a Tencent Kubernetes Engine or Elastic Kubernetes Service cluster,
+you can quickly start to deploy and use Istio by [Tencent Cloud Mesh](https://cloud.tencent.com/product/tcm):
 
 {{< image link="./tcm.png" caption="Create Tencent Cloud Mesh" >}}
 
-1. Log on to the `Container Service console`, and click **Service Mesh** in the left-side navigation pane to enter the **Service Mesh** page.
+1. Log on to the `Container Service console`, and click **Service Mesh** in the
+   left-side navigation pane to enter the **Service Mesh** page.
 
 1. Click the **Create** button in the upper-left corner.
 
 1. Enter the mesh name.
 
     {{< tip >}}
-    The mesh name can be 1–60 characters long and it can contain numbers, Chinese characters, English letters, and hyphens (-).
+    The mesh name can be 1–60 characters long and it can contain numbers, Chinese characters,
+    English letters, and hyphens (-).
     {{< /tip >}}
 
 1. Select the **Region** and **Zone** in which the cluster resides.
@@ -39,7 +46,8 @@ After creating a Tencent Kubernetes Engine or Elastic Kubernetes Service cluster
 1. Choose the service mesh mode: `Managed Mesh` or `Stand-Alone Mesh`.
 
     {{< tip >}}
-    Tencent Cloud Mesh supports **Stand-Alone Mesh** (Istiod is running in the user cluster and managed by users) and **Managed Mesh** (Istiod is managed by Tencent Cloud Mesh Team).
+    Tencent Cloud Mesh supports **Stand-Alone Mesh** (Istiod is running in the user cluster
+    and managed by users) and **Managed Mesh** (Istiod is managed by Tencent Cloud Mesh Team).
     {{< /tip >}}
 
 1. Configure the Egress traffic policy:  `Register Only` or `Allow Any` .
@@ -48,7 +56,8 @@ After creating a Tencent Kubernetes Engine or Elastic Kubernetes Service cluster
 
 1. Choose to open sidecar injection in the selected namespaces.
 
-1. Configure external requests to bypass the IP address block directly accessed by the sidecar, and external request traffic will not be able to use Istio traffic management, observability and other features.
+1. Configure external requests to bypass the IP address block directly accessed by the sidecar,
+   and external request traffic will not be able to use Istio traffic management, observability and other features.
 
 1. Choose to open **SideCar Readiness Guarantee** or not. If it is open, app containers will be created after sidecar is running.
 
@@ -59,7 +68,9 @@ After creating a Tencent Kubernetes Engine or Elastic Kubernetes Service cluster
 1. Configure the Observability of Metrics, Tracing and Logging.
 
     {{< tip >}}
-    Besides the default Cloud Monitor services, You can choose to open the advanced external services like [Managed Service for Prometheus](https://intl.cloud.tencent.com/document/product/457/38824?has_map=1) and the [Cloud Log Service](https://intl.cloud.tencent.com/product/cls).
+    Besides the default Cloud Monitor services, You can choose to open the advanced external services
+    like [Managed Service for Prometheus](https://intl.cloud.tencent.com/document/product/457/38824?has_map=1)
+    and the [Cloud Log Service](https://intl.cloud.tencent.com/product/cls).
     {{< /tip >}}
 
 After finishing these steps, you can confirm to create Istio and start to use Istio in Tencent Cloud Mesh.

--- a/content/en/docs/setup/upgrade/canary/index.md
+++ b/content/en/docs/setup/upgrade/canary/index.md
@@ -19,7 +19,8 @@ with its own `Deployment`, `Service`, etc.
 
 ## Before you upgrade
 
-Before upgrading Istio, it is recommended to run the `istioctl x precheck` command to make sure the upgrade is compatible with your environment.
+Before upgrading Istio, it is recommended to run the `istioctl x precheck` command
+to make sure the upgrade is compatible with your environment.
 
 {{< text bash >}}
 $ istioctl x precheck
@@ -29,9 +30,9 @@ $ istioctl x precheck
 
 {{< idea >}}
 
-When using revision-based upgrades jumping across two minor versions is supported (e.g. upgrading directly from
-version `1.15` to `1.17`). This is in contrast to in-place upgrades where it is required to upgrade to each intermediate minor
-release.
+When using revision-based upgrades jumping across two minor versions is supported
+(e.g. upgrading directly from version `1.15` to `1.17`). This is in contrast to
+in-place upgrades where it is required to upgrade to each intermediate minor release.
 
 {{< /idea >}}
 
@@ -41,7 +42,8 @@ To install a new revision called `canary`, you would set the `revision` field as
 
 {{< tip >}}
 In a production environment, a better revision name would correspond to the Istio version.
-However, you must replace `.` characters in the revision name, for example, `revision={{< istio_full_version_revision >}}` for Istio `{{< istio_full_version >}}`,
+However, you must replace `.` characters in the revision name, for example,
+`revision={{< istio_full_version_revision >}}` for Istio `{{< istio_full_version >}}`,
 because `.` is not a valid revision name character.
 {{< /tip >}}
 
@@ -76,19 +78,24 @@ istio-sidecar-injector-canary   2          114s
 
 ## Data plane
 
-Refer to [Gateway Canary Upgrade](/docs/setup/additional-setup/gateway/#canary-upgrade-advanced) to understand how to run revision specific instances of Istio gateway.
-In this example, since we use the `default` Istio profile, Istio gateways do not run revision-specific instances, but are instead in-place upgraded to use the new control plane revision. You can verify that the `istio-ingress` gateway is using the `canary` revision by running the following command:
+Refer to [Gateway Canary Upgrade](/docs/setup/additional-setup/gateway/#canary-upgrade-advanced)
+to understand how to run revision specific instances of Istio gateway. In this example,
+since we use the `default` Istio profile, Istio gateways do not run revision-specific instances,
+but are instead in-place upgraded to use the new control plane revision. You can verify
+that the `istio-ingress` gateway is using the `canary` revision by running the following command:
 
 {{< text bash >}}
 $ istioctl proxy-status | grep "$(kubectl -n istio-system get pod -l app=istio-ingressgateway -o jsonpath='{.items..metadata.name}')" | awk '{print $10}'
 istiod-canary-6956db645c-vwhsk
 {{< /text >}}
 
-However, simply installing the new revision has no impact on the existing sidecar proxies. To upgrade these,
-you must configure them to point to the new `istiod-canary` control plane. This is controlled during sidecar injection
-based on the namespace label `istio.io/rev`.
+However, simply installing the new revision has no impact on the existing sidecar proxies.
+To upgrade these, you must configure them to point to the new `istiod-canary` control plane.
+This is controlled during sidecar injection based on the namespace label `istio.io/rev`.
 
-To upgrade the namespace `test-ns`, remove the `istio-injection` label, and add the `istio.io/rev` label to point to the `canary` revision. The `istio-injection` label must be removed because it takes precedence over the `istio.io/rev` label for backward compatibility.
+To upgrade the namespace `test-ns`, remove the `istio-injection` label, and add the
+`istio.io/rev` label to point to the `canary` revision. The `istio-injection` label
+must be removed because it takes precedence over the `istio.io/rev` label for backward compatibility.
 
 {{< text bash >}}
 $ kubectl label namespace test-ns istio-injection- istio.io/rev=canary
@@ -101,7 +108,8 @@ One way to restart all pods in namespace `test-ns` is using:
 $ kubectl rollout restart deployment -n test-ns
 {{< /text >}}
 
-When the pods are re-injected, they will be configured to point to the `istiod-canary` control plane. You can verify this by using `istioctl proxy-status`.
+When the pods are re-injected, they will be configured to point to the `istiod-canary` control plane.
+You can verify this by using `istioctl proxy-status`.
 
 {{< text bash >}}
 $ istioctl proxy-status | grep "\.test-ns "
@@ -199,7 +207,8 @@ $ istioctl tag set default --revision {{< istio_full_version_revision >}}
 
 ## Uninstall old control plane
 
-After upgrading both the control plane and data plane, you can uninstall the old control plane. For example, the following command uninstalls a control plane of revision `{{< istio_previous_version_revision >}}-1`:
+After upgrading both the control plane and data plane, you can uninstall the old control plane.
+For example, the following command uninstalls a control plane of revision `{{< istio_previous_version_revision >}}-1`:
 
 {{< text bash >}}
 $ istioctl uninstall --revision {{< istio_previous_version_revision >}}-1 -y
@@ -219,7 +228,9 @@ NAME                             READY   STATUS    RESTARTS   AGE
 istiod-canary-55887f699c-t8bh8   1/1     Running   0          27m
 {{< /text >}}
 
-Note that the above instructions only removed the resources for the specified control plane revision, but not cluster-scoped resources shared with other control planes. To uninstall Istio completely, refer to the [uninstall guide](/docs/setup/install/istioctl/#uninstall-istio).
+Note that the above instructions only removed the resources for the specified control plane revision,
+but not cluster-scoped resources shared with other control planes. To uninstall Istio completely,
+refer to the [uninstall guide](/docs/setup/install/istioctl/#uninstall-istio).
 
 ## Uninstall canary control plane
 

--- a/content/en/docs/setup/upgrade/helm/index.md
+++ b/content/en/docs/setup/upgrade/helm/index.md
@@ -18,7 +18,8 @@ Follow this guide to upgrade and configure an Istio mesh using
 
 ## Upgrade steps
 
-Before upgrading Istio, it is recommended to run the `istioctl x precheck` command to make sure the upgrade is compatible with your environment.
+Before upgrading Istio, it is recommended to run the `istioctl x precheck` command
+to make sure the upgrade is compatible with your environment.
 
 {{< text bash >}}
 $ istioctl x precheck
@@ -27,7 +28,8 @@ $ istioctl x precheck
 {{< /text >}}
 
 {{< warning >}}
-[Helm does not upgrade or delete CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations) when performing an upgrade. Because of this restriction, an additional step is required when upgrading Istio with Helm.
+[Helm does not upgrade or delete CRDs](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#some-caveats-and-explanations)
+when performing an upgrade. Because of this restriction, an additional step is required when upgrading Istio with Helm.
 {{< /warning >}}
 
 ### Canary upgrade (recommended)
@@ -66,7 +68,8 @@ primary and canary installations.
       istiod-canary-9cc9fd96f-jpc7n   1/1     Running   0          34m   canary
     {{< /text >}}
 
-1. If you are using [Istio gateways](/docs/setup/additional-setup/gateway/#deploying-a-gateway), install a canary revision of the Gateway chart by setting the revision value:
+1. If you are using [Istio gateways](/docs/setup/additional-setup/gateway/#deploying-a-gateway),
+   install a canary revision of the Gateway chart by setting the revision value:
 
     {{< text bash >}}
     $ helm install istio-ingress-canary istio/gateway \
@@ -83,7 +86,8 @@ primary and canary installations.
       istio-ingress-canary-5d649bd644-4m8lp   1/1     Running   0          3m24s   canary
     {{< /text >}}
 
-    See [Upgrading Gateways](/docs/setup/additional-setup/gateway/#canary-upgrade-advanced) for in-depth documentation on gateway canary upgrade.
+    See [Upgrading Gateways](/docs/setup/additional-setup/gateway/#canary-upgrade-advanced)
+    for in-depth documentation on gateway canary upgrade.
 
 1. Follow the steps [here](/docs/setup/upgrade/canary/#data-plane) to test or migrate
    existing workloads to use the canary control plane.
@@ -115,8 +119,9 @@ $ helm template istiod istio/istiod -s templates/revision-tags.yaml --set revisi
 {{< /text >}}
 
 {{< warning >}}
-These commands create new `MutatingWebhookConfiguration` resources in your cluster, however, they are not owned by any Helm chart due to `kubectl` manually applying the templates. See the instructions
-below to uninstall revision tags.
+These commands create new `MutatingWebhookConfiguration` resources in your cluster,
+however, they are not owned by any Helm chart due to `kubectl` manually applying the templates.
+See the instructions below to uninstall revision tags.
 {{< /warning >}}
 
 {{< boilerplate revision-tags-middle >}}


### PR DESCRIPTION
Only wrapped long lines without any other changes:

```
modified:   content/en/docs/setup/install/helm/index.md
modified:   content/en/docs/setup/install/istioctl/index.md
modified:   content/en/docs/setup/install/multiple-controlplanes/index.md
modified:   content/en/docs/setup/platform-setup/minikube/index.md
modified:   content/en/docs/setup/platform-setup/openshift/index.md
modified:   content/en/docs/setup/platform-setup/tencent-cloud-mesh/index.md
modified:   content/en/docs/setup/upgrade/canary/index.md
modified:   content/en/docs/setup/upgrade/helm/index.md
```

- [x] Docs

