### PR TITLE
[zh] Sync move Telemetry API to alpha in Chinese doc

### DIFF
--- a/content/zh/docs/tasks/observability/telemetry/index.md
+++ b/content/zh/docs/tasks/observability/telemetry/index.md
@@ -5,10 +5,10 @@ weight: 0
 keywords: [telemetry]
 owner: istio/wg-policies-and-telemetry-maintainers
 test: no
-status: Experimental
+status: Alpha
 ---
 
-{{< boilerplate experimental >}}
+{{< boilerplate alpha >}}
 
 Istio 提供 [Telemetry API](/zh/docs/reference/config/telemetry/)，
 能够灵活地配置[指标](/zh/docs/tasks/observability/metrics/)、


### PR DESCRIPTION
Sync move Telemetry API to alpha #13585 

```
content/zh/docs/tasks/observability/telemetry/index.md
```

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
