### PR TITLE
Move remote secret command out of experimental

### DIFF
--- a/content/en/docs/setup/install/external-controlplane/index.md
+++ b/content/en/docs/setup/install/external-controlplane/index.md
@@ -259,7 +259,7 @@ and installing the sidecar injector webhook configuration on the remote cluster 
 
     {{< text bash >}}
     $ kubectl create sa istiod-service-account -n external-istiod --context="${CTX_EXTERNAL_CLUSTER}"
-    $ istioctl x create-remote-secret \
+    $ istioctl create-remote-secret \
       --context="${CTX_REMOTE_CLUSTER}" \
       --type=config \
       --namespace=external-istiod \
@@ -785,7 +785,7 @@ $ export SECOND_CLUSTER_NAME=<your second remote cluster name>
     and install it:
 
     {{< text bash >}}
-    $ istioctl x create-remote-secret \
+    $ istioctl create-remote-secret \
       --context="${CTX_SECOND_CLUSTER}" \
       --name="${SECOND_CLUSTER_NAME}" \
       --type=remote \

--- a/content/en/docs/setup/install/external-controlplane/snips.sh
+++ b/content/en/docs/setup/install/external-controlplane/snips.sh
@@ -133,7 +133,7 @@ kubectl create namespace external-istiod --context="${CTX_EXTERNAL_CLUSTER}"
 
 snip_set_up_the_control_plane_in_the_external_cluster_2() {
 kubectl create sa istiod-service-account -n external-istiod --context="${CTX_EXTERNAL_CLUSTER}"
-istioctl x create-remote-secret \
+istioctl create-remote-secret \
   --context="${CTX_REMOTE_CLUSTER}" \
   --type=config \
   --namespace=external-istiod \
@@ -485,7 +485,7 @@ istio-sidecar-injector-external-istiod   4          4m13s
 ENDSNIP
 
 snip_register_the_new_cluster_6() {
-istioctl x create-remote-secret \
+istioctl create-remote-secret \
   --context="${CTX_SECOND_CLUSTER}" \
   --name="${SECOND_CLUSTER_NAME}" \
   --type=remote \

--- a/content/en/docs/setup/install/multicluster/multi-primary/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary/index.md
@@ -77,7 +77,7 @@ $ istioctl install --context="${CTX_CLUSTER2}" -f cluster2.yaml
 Install a remote secret in `cluster2` that provides access to `cluster1`’s API server.
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
     --context="${CTX_CLUSTER1}" \
     --name=cluster1 | \
     kubectl apply -f - --context="${CTX_CLUSTER2}"
@@ -86,7 +86,7 @@ $ istioctl x create-remote-secret \
 Install a remote secret in `cluster1` that provides access to `cluster2`’s API server.
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
     --context="${CTX_CLUSTER2}" \
     --name=cluster2 | \
     kubectl apply -f - --context="${CTX_CLUSTER1}"

--- a/content/en/docs/setup/install/multicluster/multi-primary/snips.sh
+++ b/content/en/docs/setup/install/multicluster/multi-primary/snips.sh
@@ -57,14 +57,14 @@ istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKIN
 }
 
 snip_enable_endpoint_discovery_1() {
-istioctl x create-remote-secret \
+istioctl create-remote-secret \
     --context="${CTX_CLUSTER1}" \
     --name=cluster1 | \
     kubectl apply -f - --context="${CTX_CLUSTER2}"
 }
 
 snip_enable_endpoint_discovery_2() {
-istioctl x create-remote-secret \
+istioctl create-remote-secret \
     --context="${CTX_CLUSTER2}" \
     --name=cluster2 | \
     kubectl apply -f - --context="${CTX_CLUSTER1}"

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -168,7 +168,7 @@ $ kubectl --context="${CTX_CLUSTER2}" apply -n istio-system -f \
 Install a remote secret in `cluster2` that provides access to `cluster1`’s API server.
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
   --context="${CTX_CLUSTER1}" \
   --name=cluster1 | \
   kubectl apply -f - --context="${CTX_CLUSTER2}"
@@ -177,7 +177,7 @@ $ istioctl x create-remote-secret \
 Install a remote secret in `cluster1` that provides access to `cluster2`’s API server.
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
   --context="${CTX_CLUSTER2}" \
   --name=cluster2 | \
   kubectl apply -f - --context="${CTX_CLUSTER1}"

--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/snips.sh
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/snips.sh
@@ -107,14 +107,14 @@ kubectl --context="${CTX_CLUSTER2}" apply -n istio-system -f \
 }
 
 snip_enable_endpoint_discovery_1() {
-istioctl x create-remote-secret \
+istioctl create-remote-secret \
   --context="${CTX_CLUSTER1}" \
   --name=cluster1 | \
   kubectl apply -f - --context="${CTX_CLUSTER2}"
 }
 
 snip_enable_endpoint_discovery_2() {
-istioctl x create-remote-secret \
+istioctl create-remote-secret \
   --context="${CTX_CLUSTER2}" \
   --name=cluster2 | \
   kubectl apply -f - --context="${CTX_CLUSTER1}"

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -177,7 +177,7 @@ To provide API Server access to `cluster2`, we generate a remote secret and
 apply it to `cluster1`:
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
     --context="${CTX_CLUSTER2}" \
     --name=cluster2 | \
     kubectl apply -f - --context="${CTX_CLUSTER1}"

--- a/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
@@ -89,7 +89,7 @@ istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKIN
 }
 
 snip_attach_cluster2_as_a_remote_cluster_of_cluster1_1() {
-istioctl x create-remote-secret \
+istioctl create-remote-secret \
     --context="${CTX_CLUSTER2}" \
     --name=cluster2 | \
     kubectl apply -f - --context="${CTX_CLUSTER1}"

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -208,7 +208,7 @@ To provide API Server access to `cluster2`, we generate a remote secret and
 apply it to `cluster1`:
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
     --context="${CTX_CLUSTER2}" \
     --name=cluster2 | \
     kubectl apply -f - --context="${CTX_CLUSTER1}"

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
@@ -103,7 +103,7 @@ istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKIN
 }
 
 snip_attach_cluster2_as_a_remote_cluster_of_cluster1_1() {
-istioctl x create-remote-secret \
+istioctl create-remote-secret \
     --context="${CTX_CLUSTER2}" \
     --name=cluster2 | \
     kubectl apply -f - --context="${CTX_CLUSTER1}"


### PR DESCRIPTION
Please provide a description for what this PR is for.

This has been in `istioctl` command for a while

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
