### PR TITLE
Bump gateway api version used in examples

### DIFF
--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -53,7 +53,7 @@ Follow these steps to get started with ambient:
 
     {{< text bash >}}
     $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-      { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.1" | kubectl apply -f -; }
+      { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl apply -f -; }
     {{< /text >}}
 
     {{< tip >}}
@@ -471,5 +471,5 @@ $ kubectl delete -f @samples/sleep/notsleep.yaml@
 If you installed the Gateway API CRDs, remove them:
 
 {{< text bash >}}
-$ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.1" | kubectl delete -f -
+$ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl delete -f -
 {{< /text >}}

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -53,7 +53,7 @@ Follow these steps to get started with ambient:
 
     {{< text bash >}}
     $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-      { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl apply -f -; }
+      { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref={{< k8s_gateway_api_version >}}" | kubectl apply -f -; }
     {{< /text >}}
 
     {{< tip >}}
@@ -471,5 +471,5 @@ $ kubectl delete -f @samples/sleep/notsleep.yaml@
 If you installed the Gateway API CRDs, remove them:
 
 {{< text bash >}}
-$ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl delete -f -
+$ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref={{< k8s_gateway_api_version >}}" | kubectl delete -f -
 {{< /text >}}

--- a/content/en/docs/ops/ambient/getting-started/snips.sh
+++ b/content/en/docs/ops/ambient/getting-started/snips.sh
@@ -22,7 +22,7 @@
 
 snip_download_and_install_2() {
 kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.1" | kubectl apply -f -; }
+  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl apply -f -; }
 }
 
 snip_download_and_install_3() {
@@ -324,5 +324,5 @@ kubectl delete -f samples/sleep/notsleep.yaml
 }
 
 snip_uninstall_4() {
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.1" | kubectl delete -f -
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl delete -f -
 }

--- a/content/en/docs/ops/ambient/getting-started/snips.sh
+++ b/content/en/docs/ops/ambient/getting-started/snips.sh
@@ -22,7 +22,7 @@
 
 snip_download_and_install_2() {
 kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl apply -f -; }
+  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=6b9b7346ca5b54a50c3afb0a0573b16b1c84336a" | kubectl apply -f -; }
 }
 
 snip_download_and_install_3() {
@@ -324,5 +324,5 @@ kubectl delete -f samples/sleep/notsleep.yaml
 }
 
 snip_uninstall_4() {
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl delete -f -
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=6b9b7346ca5b54a50c3afb0a0573b16b1c84336a" | kubectl delete -f -
 }

--- a/content/zh/docs/ops/ambient/getting-started/index.md
+++ b/content/zh/docs/ops/ambient/getting-started/index.md
@@ -53,7 +53,7 @@ Ambient 目前处于 [Alpha 状态](/zh/docs/releases/feature-stages/#feature-ph
 
     {{< text bash >}}
     $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-      { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl apply -f -; }
+      { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref={{< k8s_gateway_api_version >}}" | kubectl apply -f -; }
     {{< /text >}}
 
     {{< tip >}}
@@ -482,5 +482,5 @@ $ kubectl delete -f @samples/sleep/notsleep.yaml@
 如果您安装了 Gateway API CRD，执行以下命令移除：
 
 {{< text bash >}}
-$ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl delete -f -
+$ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref={{< k8s_gateway_api_version >}}" | kubectl delete -f -
 {{< /text >}}

--- a/content/zh/docs/ops/ambient/getting-started/index.md
+++ b/content/zh/docs/ops/ambient/getting-started/index.md
@@ -53,7 +53,7 @@ Ambient 目前处于 [Alpha 状态](/zh/docs/releases/feature-stages/#feature-ph
 
     {{< text bash >}}
     $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-      { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.1" | kubectl apply -f -; }
+      { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl apply -f -; }
     {{< /text >}}
 
     {{< tip >}}
@@ -482,5 +482,5 @@ $ kubectl delete -f @samples/sleep/notsleep.yaml@
 如果您安装了 Gateway API CRD，执行以下命令移除：
 
 {{< text bash >}}
-$ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.6.1" | kubectl delete -f -
+$ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1" | kubectl delete -f -
 {{< /text >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.
Bump gateway-api version in the examples to 0.7.1

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
