### PR TITLE
Renable the update-gateway-version

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -85,7 +85,7 @@ site:
 snips:
 	@scripts/gen_snips.sh
 
-gen: tidy-go format-go snips
+gen: tidy-go format-go update-gateway-version snips
 
 gen-check: gen check-clean-repo check-localization
 

--- a/content/en/boilerplates/snips/args.sh
+++ b/content/en/boilerplates/snips/args.sh
@@ -21,7 +21,7 @@
 ####################################################################################################
 
 ! read -r -d '' bpsnip_args_gateway_api_version <<\ENDSNIP
-6b9b7346ca5b54a50c3afb0a0573b16b1c84336a
+v0.7.1-0.20230517171234-6b9b7346ca5b
 ENDSNIP
 
 ! read -r -d '' bpsnip_args_istio_previous_version <<\ENDSNIP

--- a/content/en/boilerplates/snips/gateway-api-experimental.sh
+++ b/content/en/boilerplates/snips/gateway-api-experimental.sh
@@ -21,5 +21,5 @@
 ####################################################################################################
 
 bpsnip_gateway_api_experimental_install_experimental_crds() {
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=6b9b7346ca5b54a50c3afb0a0573b16b1c84336a" | kubectl apply -f -
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1-0.20230517171234-6b9b7346ca5b" | kubectl apply -f -
 }

--- a/content/en/boilerplates/snips/gateway-api-gamma-support.sh
+++ b/content/en/boilerplates/snips/gateway-api-gamma-support.sh
@@ -21,5 +21,5 @@
 ####################################################################################################
 
 bpsnip_gateway_api_gamma_support_install_experimental_crds() {
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=6b9b7346ca5b54a50c3afb0a0573b16b1c84336a" | kubectl apply -f -
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.7.1-0.20230517171234-6b9b7346ca5b" | kubectl apply -f -
 }

--- a/content/en/boilerplates/snips/gateway-api-install-crds.sh
+++ b/content/en/boilerplates/snips/gateway-api-install-crds.sh
@@ -22,5 +22,5 @@
 
 bpsnip_gateway_api_install_crds_install_crds() {
 kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=6b9b7346ca5b54a50c3afb0a0573b16b1c84336a" | kubectl apply -f -; }
+  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.7.1-0.20230517171234-6b9b7346ca5b" | kubectl apply -f -; }
 }

--- a/content/en/docs/setup/additional-setup/getting-started/snips.sh
+++ b/content/en/docs/setup/additional-setup/getting-started/snips.sh
@@ -23,7 +23,7 @@ source "content/en/boilerplates/snips/trace-generation.sh"
 
 snip__1() {
 kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=6b9b7346ca5b54a50c3afb0a0573b16b1c84336a" | kubectl apply -f -; }
+  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.7.1-0.20230517171234-6b9b7346ca5b" | kubectl apply -f -; }
 }
 
 snip_download_istio_1() {

--- a/content/en/docs/setup/install/external-controlplane/snips.sh
+++ b/content/en/docs/setup/install/external-controlplane/snips.sh
@@ -411,7 +411,7 @@ ENDSNIP
 
 snip_install_crds() {
 kubectl get crd gateways.gateway.networking.k8s.io --context="${CTX_REMOTE_CLUSTER}" &> /dev/null || \
-  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=6b9b7346ca5b54a50c3afb0a0573b16b1c84336a" | kubectl apply -f - --context="${CTX_REMOTE_CLUSTER}"; }
+  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.7.1-0.20230517171234-6b9b7346ca5b" | kubectl apply -f - --context="${CTX_REMOTE_CLUSTER}"; }
 }
 
 snip_configure_and_test_an_ingress_gateway_3() {

--- a/content/en/docs/tasks/traffic-management/ingress/gateway-api/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/gateway-api/snips.sh
@@ -22,7 +22,7 @@
 
 snip_setup_1() {
 kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=6b9b7346ca5b54a50c3afb0a0573b16b1c84336a" | kubectl apply -f -; }
+  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.7.1-0.20230517171234-6b9b7346ca5b" | kubectl apply -f -; }
 }
 
 snip_setup_2() {
@@ -246,5 +246,5 @@ kubectl delete ns istio-ingress
 }
 
 snip_cleanup_2() {
-kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=6b9b7346ca5b54a50c3afb0a0573b16b1c84336a" | kubectl delete -f -
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.7.1-0.20230517171234-6b9b7346ca5b" | kubectl delete -f -
 }

--- a/data/args.yml
+++ b/data/args.yml
@@ -49,4 +49,4 @@ supported_languages:
     code: "zh"
 
 # Kubernetes Gateway API
-k8s_gateway_api_version: "6b9b7346ca5b54a50c3afb0a0573b16b1c84336a"
+k8s_gateway_api_version: "v0.7.1-0.20230517171234-6b9b7346ca5b"


### PR DESCRIPTION
Please provide a description for what this PR is for.

Renable the tag after it was removed when the main istio branch moved to a non GatewayApi release.