### PR TITLE
[zh] Sync Move remote secret command out of experimental for Chinese docs

### DIFF
--- a/content/zh/docs/setup/install/external-controlplane/index.md
+++ b/content/zh/docs/setup/install/external-controlplane/index.md
@@ -231,7 +231,7 @@ $ export REMOTE_CLUSTER_NAME=<your remote cluster name>
 
     {{< text bash >}}
     $ kubectl create sa istiod-service-account -n external-istiod --context="${CTX_EXTERNAL_CLUSTER}"
-    $ istioctl x create-remote-secret \
+    $ istioctl create-remote-secret \
       --context="${CTX_REMOTE_CLUSTER}" \
       --type=config \
       --namespace=external-istiod \
@@ -739,7 +739,7 @@ $ export SECOND_CLUSTER_NAME=<your second remote cluster name>
 1. 使用凭据创建一个 Secret，以允许控制平面访问第二个从集群上的端点并安装它：
 
     {{< text bash >}}
-    $ istioctl x create-remote-secret \
+    $ istioctl create-remote-secret \
       --context="${CTX_SECOND_CLUSTER}" \
       --name="${SECOND_CLUSTER_NAME}" \
       --type=remote \

--- a/content/zh/docs/setup/install/multicluster/multi-primary/index.md
+++ b/content/zh/docs/setup/install/multicluster/multi-primary/index.md
@@ -76,7 +76,7 @@ $ istioctl install --context="${CTX_CLUSTER2}" -f cluster2.yaml
 在 `cluster2` 中安装从集群的 secret，该 secret 提供 `cluster1` 的 API 服务器的访问权限。
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
     --context="${CTX_CLUSTER1}" \
     --name=cluster1 | \
     kubectl apply -f - --context="${CTX_CLUSTER2}"
@@ -85,7 +85,7 @@ $ istioctl x create-remote-secret \
 在 `cluster1` 中安装从集群的 secret，该 secret 提供 `cluster2` 的 API 服务器的访问权限。
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
     --context="${CTX_CLUSTER2}" \
     --name=cluster2 | \
     kubectl apply -f - --context="${CTX_CLUSTER1}"

--- a/content/zh/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/zh/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -163,7 +163,7 @@ $ kubectl --context="${CTX_CLUSTER2}" apply -n istio-system -f \
 在 `cluster2` 中安装一个提供 `cluster1` API Server 访问权限的远程 Secret。
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
   --context="${CTX_CLUSTER1}" \
   --name=cluster1 | \
   kubectl apply -f - --context="${CTX_CLUSTER2}"
@@ -172,7 +172,7 @@ $ istioctl x create-remote-secret \
 在 `cluster1` 中安装一个提供 `cluster2` API Server 访问权限的远程 Secret。
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
   --context="${CTX_CLUSTER2}" \
   --name=cluster2 | \
   kubectl apply -f - --context="${CTX_CLUSTER1}"

--- a/content/zh/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/zh/docs/setup/install/multicluster/primary-remote/index.md
@@ -168,7 +168,7 @@ $ istioctl install --context="${CTX_CLUSTER2}" -f cluster2.yaml
 我们生成一个远程 Secret 并将其应用于 `cluster1`：
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
     --context="${CTX_CLUSTER2}" \
     --name=cluster2 | \
     kubectl apply -f - --context="${CTX_CLUSTER1}"

--- a/content/zh/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/zh/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -197,7 +197,7 @@ $ istioctl install --context="${CTX_CLUSTER2}" -f cluster2.yaml
 我们生成一个从属 Secret 并将其应用于 `cluster1`：
 
 {{< text bash >}}
-$ istioctl x create-remote-secret \
+$ istioctl create-remote-secret \
     --context="${CTX_CLUSTER2}" \
     --name=cluster2 | \
     kubectl apply -f - --context="${CTX_CLUSTER1}"


### PR DESCRIPTION
Sync fixes of https://github.com/istio/istio.io/pull/13589

```
content/zh/docs/setup/install/external-controlplane/index.md
content/zh/docs/setup/install/multicluster/multi-primary/index.md
content/zh/docs/setup/install/multicluster/multi-primary_multi-network/index.md
content/zh/docs/setup/install/multicluster/primary-remote/index.md
content/zh/docs/setup/install/multicluster/primary-remote_multi-network/index.md
```

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
