### PR TITLE
Fix Improper Spacing When Displaying Multiple Banners

### DIFF
--- a/src/sass/misc/_banners.scss
+++ b/src/sass/misc/_banners.scss
@@ -9,7 +9,7 @@
 
     @media screen AND (min-width: $bp-md) {
         display: block;
-        position: fixed;
+        position: sticky;
         z-index: $banner-z;
         width: 100%;
         text-align: center;
@@ -55,10 +55,5 @@
     }
     @media screen AND (min-width: $bp-lg) {
         top: $headerHeightLg;
-    }
-}
-@media screen AND (min-width: $bp-md) {
-    .banner-padding {
-        padding-top: 5rem !important;
     }
 }

--- a/src/ts/events.ts
+++ b/src/ts/events.ts
@@ -83,13 +83,29 @@ function handleEvents(): void {
 
                 if (display) {
                     el.style.display = "block";
-                    const main = document.querySelector<HTMLElement>("main.primary");
-                    if (main) {
-                        main.classList.add("banner-padding");
+                    const heroSection = document.querySelector<HTMLElement>("main.landing section#banner");
+                    const banners = document.querySelector<HTMLElement>(".banner-container");
+                    
+                    if (banners && heroSection) {
+
+                        var activeBannerCount = 0;
+
+                        banners.childNodes.forEach(function (childNode) {
+                          if ((childNode as HTMLElement).style.display == "block" && (childNode as HTMLElement).classList.contains("banner")) {
+                            activeBannerCount += 1
+                          }
+                        })
+
+                        let remSpacing = 8.125 + (60/16)*(activeBannerCount)
+
+                        heroSection.style.marginTop="-"+String(remSpacing)+"rem";
+                        heroSection.style.paddingTop=String(remSpacing)+"rem"
+                        
                         if (timeout > 0) {
                             window.setTimeout(() => {
                                 el.style.display = "none";
-                                main.classList.remove("banner-padding");
+                                heroSection.style.marginTop="";
+                                heroSection.style.paddingTop=""
                             }, timeout * 1000);
                         }
                     }
@@ -97,10 +113,24 @@ function handleEvents(): void {
 
                 listen(el, click, () => {
                     el.style.display = "none";
-                    const main = document.querySelector<HTMLElement>("main.primary");
-                    if (main) {
-                        main.classList.remove("banner-padding");
-                    }
+                    const heroSection = document.querySelector<HTMLElement>("main.landing section#banner");
+                    const banners = document.querySelector<HTMLElement>(".banner-container");
+                    
+                    if (banners && heroSection) {
+
+                        var activeBannerCount = 0;
+
+                        banners.childNodes.forEach(function (childNode) {
+                          if ((childNode as HTMLElement).style.display == "block" && (childNode as HTMLElement).classList.contains("banner")) {
+                            activeBannerCount += 1
+                          }
+                        })
+
+                        let remSpacing = 8.125 + (60/16)*(activeBannerCount)
+
+                        heroSection.style.marginTop="-"+String(remSpacing)+"rem";
+                        heroSection.style.paddingTop=String(remSpacing)+"rem"
+                      }
                     remainingEventImpressions[title].impressions = 0;
                     saveRemainingEventImpressions();
                 });

--- a/src/ts/events.ts
+++ b/src/ts/events.ts
@@ -85,22 +85,22 @@ function handleEvents(): void {
                     el.style.display = "block";
                     const heroSection = document.querySelector<HTMLElement>("main.landing section#banner");
                     const banners = document.querySelector<HTMLElement>(".banner-container");
-                    
+
                     if (banners && heroSection) {
 
-                        var activeBannerCount = 0;
+                        let activeBannerCount = 0;
 
-                        banners.childNodes.forEach(function (childNode) {
-                          if ((childNode as HTMLElement).style.display == "block" && (childNode as HTMLElement).classList.contains("banner")) {
+                        banners.childNodes.forEach((childNode) => {
+                          if ((childNode as HTMLElement).style.display === "block" && (childNode as HTMLElement).classList.contains("banner")) {
                             activeBannerCount += 1
                           }
                         })
 
-                        let remSpacing = 8.125 + (60/16)*(activeBannerCount)
+                        const remSpacing = 8.125 + (60/16)*(activeBannerCount)
 
                         heroSection.style.marginTop="-"+String(remSpacing)+"rem";
                         heroSection.style.paddingTop=String(remSpacing)+"rem"
-                        
+
                         if (timeout > 0) {
                             window.setTimeout(() => {
                                 el.style.display = "none";
@@ -115,18 +115,18 @@ function handleEvents(): void {
                     el.style.display = "none";
                     const heroSection = document.querySelector<HTMLElement>("main.landing section#banner");
                     const banners = document.querySelector<HTMLElement>(".banner-container");
-                    
+
                     if (banners && heroSection) {
 
-                        var activeBannerCount = 0;
+                        let activeBannerCount = 0;
 
-                        banners.childNodes.forEach(function (childNode) {
-                          if ((childNode as HTMLElement).style.display == "block" && (childNode as HTMLElement).classList.contains("banner")) {
+                        banners.childNodes.forEach((childNode) => {
+                          if ((childNode as HTMLElement).style.display === "block" && (childNode as HTMLElement).classList.contains("banner")) {
                             activeBannerCount += 1
                           }
                         })
 
-                        let remSpacing = 8.125 + (60/16)*(activeBannerCount)
+                        const remSpacing = 8.125 + (60/16)*(activeBannerCount)
 
                         heroSection.style.marginTop="-"+String(remSpacing)+"rem";
                         heroSection.style.paddingTop=String(remSpacing)+"rem"


### PR DESCRIPTION
Related Issues: https://github.com/istio/istio.io/issues/13573 and https://github.com/istio/istio.io/issues/10304

This pull request addresses reported issues of improper spacing when there was more than 1 active banner on [isito.io](https://istio.io/). 

During investigation I also discovered that having _any_ banner active on the website covered up the breadcrumbs that exist on the **About** section of pages (e.g. [https://istio.io/latest/about/solutions/](https://istio.io/latest/about/solutions/))

The change to `src/sass/misc/_banners.scss` makes each event banner `sticky` instead of having a `fixed` position. `.banner-padding` is no longer needed as giving the event banners a `sticky` positioning ensure they are positioned according to the normal flow of the document. This resolved the spacing issues (screenshot below) and the covering of breadcrumbs on every page that I spot checked - except for the homepage because the homepage has the fancy hero section with the transparent background. 

<img width="1430" alt="Screenshot 2023-07-24 at 8 26 25 PM" src="https://github.com/istio/istio.io/assets/47571709/bca8344b-cbf0-4527-b086-a6b034feee71">
Demo of the fixed spacing when multiple breadcrumbs are active.

---

The change to `src/ts/events.ts` works to dynamically adjust the homepage's hero section's top margin up (to adjust for the banner bars) and to add padding between the banner bars the hero text (screenshot below). I realize that this is not the cleanest solution, but only having the homepage as the special "edge" case for banner spacing was more appealing since the `sticky` change fixed (as far as I could tell) the other pages.

<img width="1429" alt="Screenshot 2023-07-24 at 8 26 09 PM" src="https://github.com/istio/istio.io/assets/47571709/d86cd742-ee20-4ea8-9bff-977fb8101b73">
Demo of the fixed spacing on the homepage when multiple breadcrumbs are active.

---

The event banner functionality, besides these two changes, remains unchanged. Visitors clicking on a banner triggers then to disappear and they still adhere to the `max_impressions` limit. These changes do not impact mobile devices as banners are not displayed on mobile devices.

Long-term I think that there is some work needed to try and make the spacing between the menu bar and the page title on pages more uniform. This was a rather challenging problem to solve due to these spacing inconsistencies. (e.g. The spacing at the top of the [News](https://istio.io/latest/news/) page is larger than the [Documentation](https://istio.io/latest/docs/) page.) The header/menu bar has a fixed size so it's straightforward to adjust every page's margin to account for that. However, some pages have breadcrumbs, others have smaller/larger spacing from the header/menu bar, etc. and those differences made it difficult to find a good solution that worked on every page. 

All things considered, I think that this change strikes a good balance between living with the current spacing issue and doing a significantly larger code re-factor to adjust spacing and layout inconsistencies. I am open to any ideas about how to better address the homepage case.

Thanks!

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
