### PR TITLE
[release-1.18] Try running tests with actual 1.18.2 images

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -41,9 +41,9 @@ export ISTIO_LONG_SHA
 # we only need to export the pipeline HUB value.
 # If the images were built as part of the private pipeline (as for security releases),
 # we export the HUB and TAG for the images once they are published.
-HUB ?= gcr.io/istio-testing
-# export HUB := docker.io/istio
-# export TAG ?= 1.7.3
+# HUB ?= gcr.io/istio-testing
+export HUB := gcr.io/istio-release
+export TAG ?= 1.18.2
 
 ifeq ($(HUB),)
   $(error "HUB cannot be empty")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 require (
 	github.com/pmezard/go-difflib v1.0.0
 	golang.org/x/sync v0.1.0
-	istio.io/istio v0.0.0-20230713183549-b39cf4080772
+	istio.io/istio v0.0.0-20230721203100-0183f2886bc0
 	istio.io/pkg v0.0.0-20230524020242-1015535057be
 	k8s.io/apimachinery v0.27.0
 	k8s.io/client-go v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -1296,8 +1296,8 @@ istio.io/api v0.0.0-20230713061407-06047cce866f h1:Z+KCZ5Eo48Ea3ZrbqyCLvoyT30ZUz
 istio.io/api v0.0.0-20230713061407-06047cce866f/go.mod h1:dDMe1TsOtrRoUlBzdxqNolWXpXPQjLfbcXvqPMtQ6eo=
 istio.io/client-go v1.18.1-0.20230713061908-17d95fabac25 h1:fV6T5GcNXe688Le36srf35Ikuwvwy7pgmH9OnZjBlfc=
 istio.io/client-go v1.18.1-0.20230713061908-17d95fabac25/go.mod h1:ha62DtaYYStYdisMZw9OG5iG92irhr2sWK7C38qCdqI=
-istio.io/istio v0.0.0-20230713183549-b39cf4080772 h1:xFyLrLSXICF4PD0bO7DLv0TBTZjl9oNAYMkJb9ZA0O4=
-istio.io/istio v0.0.0-20230713183549-b39cf4080772/go.mod h1:MD6vtUgg32SZtPWnBEJyv7aDhN9KcArqrCZVWn2Docs=
+istio.io/istio v0.0.0-20230721203100-0183f2886bc0 h1:AScFl4J64keaJvMI3nEKUawClhnnu5IsSJCZT6ZIsY0=
+istio.io/istio v0.0.0-20230721203100-0183f2886bc0/go.mod h1:MD6vtUgg32SZtPWnBEJyv7aDhN9KcArqrCZVWn2Docs=
 istio.io/pkg v0.0.0-20230524020242-1015535057be h1:H+ww/6ysv++W5na8wIVNfoE01shRez0rXZXzLGoMIvg=
 istio.io/pkg v0.0.0-20230524020242-1015535057be/go.mod h1:ZcwaaLCBsaAszynqi6s8Bs6VL3yeTtuXDon9QuzSD5E=
 k8s.io/api v0.18.2/go.mod h1:SJCWI7OLzhZSvbY7U8zwNl9UA4o1fizoug34OV/2r78=


### PR DESCRIPTION
Please provide a description for what this PR is for.

Verify tests run with the 1.18.2 images. Update sha to the istio patched release branch and use the actual images (since the istio-testing ones were never created).