### PR TITLE
change support status of 1.16

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -20,9 +20,9 @@
   k8sVersions: ["1.23", "1.24", "1.25", "1.26"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "1.22"]
 - version: "1.16"
-  supported: "Yes"
+  supported: "No"
   releaseDate: "Nov 15, 2022"
-  eolDate: "~Jun 2023 (Expected)"
+  eolDate: "Jul 25, 2023"
   k8sVersions: ["1.22", "1.23", "1.24", "1.25"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21"]
 - version: "1.15"


### PR DESCRIPTION
Please provide a description for what this PR is for.

Change support status of 1.16 to EOL'd. Announcement was already published. https://istio.io/latest/news/support/announcing-1.16-eol-final/

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
