### PR TITLE
Wrap port options in single quotes so @ sign renders properly

### DIFF
--- a/content/en/docs/setup/platform-setup/k3d/index.md
+++ b/content/en/docs/setup/platform-setup/k3d/index.md
@@ -23,7 +23,7 @@ k3d makes it very easy to create single- and multi-node k3s clusters in docker, 
 1.  Create a cluster and disable `Traefik` with the following command:
 
     {{< text bash >}}
-    $ k3d cluster create --api-port 6550 -p "9080:80@loadbalancer"  -p "9443:443@loadbalancer" --agents 2 --k3s-arg '--disable=traefik@server:*'
+    $ k3d cluster create --api-port 6550 -p '9080:80@loadbalancer'  -p '9443:443@loadbalancer' --agents 2 --k3s-arg '--disable=traefik@server:*'
     {{< /text >}}
 
 1.  To see the list of k3d clusters, use the following command:


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fix double quotes preventing @loadbalancer from rendering properly in k3d cluster create command by wrapping port commands in single quotes.  As described in https://github.com/istio/istio.io/issues/13630

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
