### PR TITLE
Fix handling of @@ link notation

### DIFF
--- a/content/en/docs/setup/platform-setup/k3d/index.md
+++ b/content/en/docs/setup/platform-setup/k3d/index.md
@@ -23,7 +23,7 @@ k3d makes it very easy to create single- and multi-node k3s clusters in docker, 
 1.  Create a cluster and disable `Traefik` with the following command:
 
     {{< text bash >}}
-    $ k3d cluster create --api-port 6550 -p "9080:80@loadbalancer"  -p "9443:443@loadbalancer" --agents 2 --k3s-arg '--disable=traefik@server:*'
+    $ k3d cluster create --api-port 6550 -p '9080:80@loadbalancer' -p '9443:443@loadbalancer' --agents 2 --k3s-arg '--disable=traefik@server:*'
     {{< /text >}}
 
 1.  To see the list of k3d clusters, use the following command:

--- a/layouts/partials/code_block.html
+++ b/layouts/partials/code_block.html
@@ -134,7 +134,7 @@
     {{- if eq $expand_links "true" -}}
         {{- /* include a dummy link to the special embedded @@ references so the links are statically checked as we build the site */ -}}
         {{- $branch := .Site.Data.args.source_branch_name -}}
-        {{- $links := findRE "@(.*?)@" $text -}}
+        {{- $links := findRE "@([\\w\\.\\-_]*?)@" $text -}}
         {{- range $link := $links -}}
             {{- $target := trim $link "@" -}}
             {{- if gt (len $target) 0 -}}

--- a/src/ts/codeBlocks.ts
+++ b/src/ts/codeBlocks.ts
@@ -186,7 +186,7 @@ function handleCodeBlocks() {
 
             if (cmd !== "") {
                 if (code.dataset.expandlinks === "true") {
-                    cmd = cmd.replace(/@(.*?)@/g, "<a href='https://raw.githubusercontent.com/istio/" + code.dataset.repo + "/" + branchName + "/$1'>$1</a>");
+                    cmd = cmd.replace(/@([\w\.\-_]*?)@/g, "<a href='https://raw.githubusercontent.com/istio/" + code.dataset.repo + "/" + branchName + "/$1'>$1</a>");
                 }
 
                 let html = "<div class='command'>" + cmd + "</div>";


### PR DESCRIPTION
Please provide a description for what this PR is for.

Fix handling of @ link notation encountered in #13631.

The regex was @.*@ which will match anything between two @'s, including a command like: `k3d cluster create --api-port 6550 -p '9080:80@loadbalancer' -p '9443:443@loadbalancer' --agents 2 --k3s-arg '--disable=traefik@server:*'`

The regex should be something that matches valid URL syntaxes.

Closes https://github.com/istio/istio.io/issues/13630.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
