### PR TITLE
Add Ambient Alpha Banner to Homepage

### DIFF
--- a/content/en/events/banners/ambient-release.md
+++ b/content/en/events/banners/ambient-release.md
@@ -1,0 +1,9 @@
+---
+title: Ambient Alpha Release
+period_start: latest_release
+period_duration: 30
+max_impressions: 4
+link: https://istio.io/latest/news/releases/1.18.x/announcing-1.18/#ambient-mesh
+---
+
+Ambient is part of Istio {{< istio_version >}} as alpha status, try it out!

--- a/content/en/events/banners/ambient-release.md
+++ b/content/en/events/banners/ambient-release.md
@@ -3,7 +3,7 @@ title: Ambient Alpha Release
 period_start: latest_release
 period_duration: 30
 max_impressions: 4
-link: https://istio.io/latest/news/releases/1.18.x/announcing-1.18/#ambient-mesh
+link: https://istio.io/docs/ops/ambient/getting-started/
 ---
 
 Ambient is part of Istio {{< istio_version >}} as alpha status, try it out!


### PR DESCRIPTION
Fixes: #13478 

This PR adds a banner to the homepage that brings attention to the Ambient Alpha release apart of Istio v1.18. A screenshot below demonstrates what this banner will look like.

<img width="1571" alt="Screenshot 2023-07-28 at 3 44 36 PM" src="https://github.com/istio/istio.io/assets/47571709/f9e685b8-e35a-49b1-b64b-511502272817">

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
