### PR TITLE
Add supported info for istio 1.10-1.12

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -43,3 +43,21 @@
   eolDate: "Oct 12, 2022"
   k8sVersions: ["1.20", "1.21", "1.22", "1.23"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19"]
+- version: "1.12"
+  supported: "No"
+  releaseDate: "Nov 18, 2021"
+  eolDate: "June 27, 2022"
+  k8sVersions: ["1.20", "1.21", "1.22", "1.23"]
+  testedK8sVersions: ["1.16", "1.17", "1.18", "1.19"]
+- version: "1.11"
+  supported: "No"
+  releaseDate: "Aug 12, 2021"
+  eolDate: "March 25, 2021"
+  k8sVersions: ["1.19", "1.20", "1.21", "1.22"]
+  testedK8sVersions: ["1.16", "1.17", "1.18"]
+- version: "1.10"
+  supported: "No"
+  releaseDate: "May 18, 2021"
+  eolDate: "Jan 7, 2022"
+  k8sVersions: ["1.18", "1.19", "1.20", "1.21"]
+  testedK8sVersions: ["1.16", "1.17"]


### PR DESCRIPTION
See https://github.com/istio/istio/pull/46213 for more information. We should document these w/r/t possible revision changes.

These releases have been EOL for over a year.