### PR TITLE
Correct Istio Upgrade version step message

### DIFF
--- a/content/en/docs/setup/upgrade/_index.md
+++ b/content/en/docs/setup/upgrade/_index.md
@@ -7,5 +7,5 @@ test: n/a
 ---
 
 {{< warning >}}
-Upgrading across more than two minor versions (e.g., `1.6.x` to `1.9.x`) in one step is not officially tested or recommended.
+Upgrading across more than one minor version (e.g., `1.15.x` to `1.17.x`) in one step is not officially tested or recommended.
 {{< /warning >}}


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure

The existing message implies that upgrading two minor versions is supported, and indeed this has historically been the case, at least anecdotally.

The Istio 1.17 control plane however, is not compatible with Istio 1.15 proxies, breaking that soft rule. That should be reflected here, to prevent users from incorrectly jumping multiple minor versions.
