### PR TITLE
add ambient announcements to istio 1.18 change note

### DIFF
--- a/content/en/news/releases/1.18.x/announcing-1.18/change-notes/index.md
+++ b/content/en/news/releases/1.18.x/announcing-1.18/change-notes/index.md
@@ -8,6 +8,12 @@ release: 1.18.0
 weight: 20
 ---
 
+## Ambient Mesh
+
+Istio 1.18 marks the first release of ambient mesh, a new Istio data plane mode that’s designed for simplified operations, broader application compatibility, and reduced infrastructure cost. For more details see the [announcement blog](/blog/2022/introducing-ambient-mesh/).
+
+**Note**: Ambient Mesh is currently in alpha and is not recommended for production use.
+
 ## Deprecation Notices
 
 These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/docs/releases/feature-stages/#feature-phase-definitions). Please consider upgrading your environment to remove the deprecated functionality.


### PR DESCRIPTION
> hey everyone, in case it wasn't clear, ambient did make to Istio 1.18 - https://discuss.istio.io/t/did-ambient-mesh-make-it-into-1-8/15755, we will look into how to make it more clear
> 
> * if user reaches 1.18 change note, they don't see ambient in there, we should consider adding a reference pointing to the [announcement blog](https://preliminary.istio.io/latest/news/releases/1.18.x/announcing-1.18/) from the change note.
>   https://preliminary.istio.io/latest/news/releases/1.18.x/announcing-1.18/change-notes/
> * need to be clear it is alpha status on the announcement blog: https://preliminary.istio.io/latest/news/releases/1.18.x/announcing-1.18/, perhaps making it a warning/bold.

ambient is a major feature in istio 1.18.
I referred istio history major version like https://preliminary.istio.io/latest/news/releases/1.8.x/announcing-1.8/change-notes and directly add a reference here to highlight this feature.

Feel free to comments or modify directly if any concerns.

- [x] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure

trying to fix https://github.com/istio/istio.io/issues/13479
