### PR TITLE
Added a warning in the ambient getting started guide

### DIFF
--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -214,6 +214,11 @@ $ sed -e 's/from: Same/from: All/'\
 ' @samples/bookinfo/gateway-api/bookinfo-gateway.yaml@ | kubectl apply -f -
 {{< /text >}}
 
+{{< warning >}}
+Kindly make sure you have a IP address for the bookinfo-gateway service in Kind, you can install [MetalLB](https://kind.sigs.k8s.io/docs/user/loadbalancer/)
+ to do IP address allocation for Services.
+{{</ warning >}}
+
 Set the environment variables for the Kubernetes gateway:
 
 {{< text bash >}}

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -178,7 +178,13 @@ Make sure the default namespace does not include the label `istio-injection=enab
 
     Note: `sleep` and `notsleep` are two simple applications that can serve as curl clients.
 
-1. Deploy an ingress gateway so you can access the bookinfo app from outside the cluster:
+{{< warning >}}
+To get IP address assignment for `Loadbalancer` service types in `kind`, you may need to install a tool like
+[MetalLB](https://metallb.universe.tf/). Please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
+{{</ warning >}}
+
+
+2. Deploy an ingress gateway so you can access the bookinfo app from outside the cluster:
 
 {{< tabset category-name="config-api" >}}
 
@@ -213,11 +219,6 @@ $ sed -e 's/from: Same/from: All/'\
     namespace: istio-system\
 ' @samples/bookinfo/gateway-api/bookinfo-gateway.yaml@ | kubectl apply -f -
 {{< /text >}}
-
-{{< warning >}}
-Kindly make sure you have a IP address for the bookinfo-gateway service in Kind, you can install [MetalLB](https://kind.sigs.k8s.io/docs/user/loadbalancer/)
- to do IP address allocation for Services.
-{{</ warning >}}
 
 Set the environment variables for the Kubernetes gateway:
 

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -180,57 +180,57 @@ Make sure the default namespace does not include the label `istio-injection=enab
 
 1. Deploy an ingress gateway so you can access the bookinfo app from outside the cluster:
 
-{{< warning >}}
-To get IP address assignment for `Loadbalancer` service types in `kind`, you may need to install a tool like [MetalLB](https://metallb.universe.tf/). Please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
-{{</ warning >}}
+    {{< warning >}}
+    To get IP address assignment for `Loadbalancer` service types in `kind`, you may need to install a tool like [MetalLB](https://metallb.universe.tf/). Please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
+    {{</ warning >}}
 
-{{< tabset category-name="config-api" >}}
+    {{< tabset category-name="config-api" >}}
 
-{{< tab name="Istio APIs" category-value="istio-apis" >}}
+    {{< tab name="Istio APIs" category-value="istio-apis" >}}
 
-Create an Istio [Gateway](/docs/reference/config/networking/gateway/) and
-[VirtualService](/docs/reference/config/networking/virtual-service/):
+    Create an Istio [Gateway](/docs/reference/config/networking/gateway/) and
+    [VirtualService](/docs/reference/config/networking/virtual-service/):
 
-{{< text bash >}}
-$ kubectl apply -f @samples/bookinfo/networking/bookinfo-gateway.yaml@
-{{< /text >}}
+    {{< text bash >}}
+    $ kubectl apply -f @samples/bookinfo/networking/bookinfo-gateway.yaml@
+    {{< /text >}}
 
-Set the environment variables for the Istio ingress gateway:
+    Set the environment variables for the Istio ingress gateway:
 
-{{< text bash >}}
-$ export GATEWAY_HOST=istio-ingressgateway.istio-system
-$ export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/istio-ingressgateway-service-account
-{{< /text >}}
+    {{< text bash >}}
+    $ export GATEWAY_HOST=istio-ingressgateway.istio-system
+    $ export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/istio-ingressgateway-service-account
+    {{< /text >}}
 
-{{< /tab >}}
+    {{< /tab >}}
 
-{{< tab name="Gateway API" category-value="gateway-api" >}}
+    {{< tab name="Gateway API" category-value="gateway-api" >}}
 
-Create a [Kubernetes Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.Gateway)
-and [HTTPRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute):
+    Create a [Kubernetes Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.Gateway)
+    and [HTTPRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute):
 
-{{< text bash >}}
-$ sed -e 's/from: Same/from: All/'\
-      -e '/^  name: bookinfo-gateway/a\
-  namespace: istio-system\
-'     -e '/^  - name: bookinfo-gateway/a\
-    namespace: istio-system\
-' @samples/bookinfo/gateway-api/bookinfo-gateway.yaml@ | kubectl apply -f -
-{{< /text >}}
+    {{< text bash >}}
+    $ sed -e 's/from: Same/from: All/'\
+          -e '/^  name: bookinfo-gateway/a\
+      namespace: istio-system\
+    '     -e '/^  - name: bookinfo-gateway/a\
+        namespace: istio-system\
+    ' @samples/bookinfo/gateway-api/bookinfo-gateway.yaml@ | kubectl apply -f -
+    {{< /text >}}
 
-Set the environment variables for the Kubernetes gateway:
+    Set the environment variables for the Kubernetes gateway:
 
-{{< text bash >}}
-$ kubectl wait --for=condition=programmed gtw/bookinfo-gateway -n istio-system
-$ export GATEWAY_HOST=bookinfo-gateway-istio.istio-system
-$ export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/bookinfo-gateway-istio
-{{< /text >}}
+    {{< text bash >}}
+    $ kubectl wait --for=condition=programmed gtw/bookinfo-gateway -n istio-system
+    $ export GATEWAY_HOST=bookinfo-gateway-istio.istio-system
+    $ export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/bookinfo-gateway-istio
+    {{< /text >}}
 
-{{< /tab >}}
+    {{< /tab >}}
 
-{{< /tabset >}}
+    {{< /tabset >}}
 
-3) Test your bookinfo application, it should work with or without the gateway:
+1. Test your bookinfo application, it should work with or without the gateway:
 
     {{< text syntax=bash snip_id=verify_traffic_sleep_to_ingress >}}
     $ kubectl exec deploy/sleep -- curl -s "http://$GATEWAY_HOST/productpage" | grep -o "<title>.*</title>"

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -178,13 +178,11 @@ Make sure the default namespace does not include the label `istio-injection=enab
 
     Note: `sleep` and `notsleep` are two simple applications that can serve as curl clients.
 
+1. Deploy an ingress gateway so you can access the bookinfo app from outside the cluster:
+
 {{< warning >}}
-To get IP address assignment for `Loadbalancer` service types in `kind`, you may need to install a tool like
-[MetalLB](https://metallb.universe.tf/). Please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
+To get IP address assignment for `Loadbalancer` service types in `kind`, you may need to install a tool like [MetalLB](https://metallb.universe.tf/). Please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
 {{</ warning >}}
-
-
-2. Deploy an ingress gateway so you can access the bookinfo app from outside the cluster:
 
 {{< tabset category-name="config-api" >}}
 

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -180,9 +180,9 @@ Make sure the default namespace does not include the label `istio-injection=enab
 
 1. Deploy an ingress gateway so you can access the bookinfo app from outside the cluster:
 
-    {{< warning >}}
+    {{< tip >}}
     To get IP address assignment for `Loadbalancer` service types in `kind`, you may need to install a tool like [MetalLB](https://metallb.universe.tf/). Please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
-    {{</ warning >}}
+    {{</ tip >}}
 
 {{< tabset category-name="config-api" >}}
 

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -184,53 +184,53 @@ Make sure the default namespace does not include the label `istio-injection=enab
     To get IP address assignment for `Loadbalancer` service types in `kind`, you may need to install a tool like [MetalLB](https://metallb.universe.tf/). Please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
     {{</ warning >}}
 
-    {{< tabset category-name="config-api" >}}
+{{< tabset category-name="config-api" >}}
 
-    {{< tab name="Istio APIs" category-value="istio-apis" >}}
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
 
-    Create an Istio [Gateway](/docs/reference/config/networking/gateway/) and
-    [VirtualService](/docs/reference/config/networking/virtual-service/):
+Create an Istio [Gateway](/docs/reference/config/networking/gateway/) and
+[VirtualService](/docs/reference/config/networking/virtual-service/):
 
-    {{< text bash >}}
-    $ kubectl apply -f @samples/bookinfo/networking/bookinfo-gateway.yaml@
-    {{< /text >}}
+{{< text bash >}}
+$ kubectl apply -f @samples/bookinfo/networking/bookinfo-gateway.yaml@
+{{< /text >}}
 
-    Set the environment variables for the Istio ingress gateway:
+Set the environment variables for the Istio ingress gateway:
 
-    {{< text bash >}}
-    $ export GATEWAY_HOST=istio-ingressgateway.istio-system
-    $ export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/istio-ingressgateway-service-account
-    {{< /text >}}
+{{< text bash >}}
+$ export GATEWAY_HOST=istio-ingressgateway.istio-system
+$ export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/istio-ingressgateway-service-account
+{{< /text >}}
 
-    {{< /tab >}}
+{{< /tab >}}
 
-    {{< tab name="Gateway API" category-value="gateway-api" >}}
+{{< tab name="Gateway API" category-value="gateway-api" >}}
 
-    Create a [Kubernetes Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.Gateway)
-    and [HTTPRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute):
+Create a [Kubernetes Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1beta1.Gateway)
+and [HTTPRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1beta1.HTTPRoute):
 
-    {{< text bash >}}
-    $ sed -e 's/from: Same/from: All/'\
-          -e '/^  name: bookinfo-gateway/a\
-      namespace: istio-system\
-    '     -e '/^  - name: bookinfo-gateway/a\
-        namespace: istio-system\
-    ' @samples/bookinfo/gateway-api/bookinfo-gateway.yaml@ | kubectl apply -f -
-    {{< /text >}}
+{{< text bash >}}
+$ sed -e 's/from: Same/from: All/'\
+      -e '/^  name: bookinfo-gateway/a\
+  namespace: istio-system\
+'     -e '/^  - name: bookinfo-gateway/a\
+    namespace: istio-system\
+' @samples/bookinfo/gateway-api/bookinfo-gateway.yaml@ | kubectl apply -f -
+{{< /text >}}
 
-    Set the environment variables for the Kubernetes gateway:
+Set the environment variables for the Kubernetes gateway:
 
-    {{< text bash >}}
-    $ kubectl wait --for=condition=programmed gtw/bookinfo-gateway -n istio-system
-    $ export GATEWAY_HOST=bookinfo-gateway-istio.istio-system
-    $ export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/bookinfo-gateway-istio
-    {{< /text >}}
+{{< text bash >}}
+$ kubectl wait --for=condition=programmed gtw/bookinfo-gateway -n istio-system
+$ export GATEWAY_HOST=bookinfo-gateway-istio.istio-system
+$ export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/bookinfo-gateway-istio
+{{< /text >}}
 
-    {{< /tab >}}
+{{< /tab >}}
 
-    {{< /tabset >}}
+{{< /tabset >}}
 
-1. Test your bookinfo application, it should work with or without the gateway:
+3) Test your bookinfo application, it should work with or without the gateway:
 
     {{< text syntax=bash snip_id=verify_traffic_sleep_to_ingress >}}
     $ kubectl exec deploy/sleep -- curl -s "http://$GATEWAY_HOST/productpage" | grep -o "<title>.*</title>"

--- a/content/en/docs/setup/platform-setup/kind/index.md
+++ b/content/en/docs/setup/platform-setup/kind/index.md
@@ -70,10 +70,11 @@ Follow these instructions to prepare a kind cluster for Istio installation.
 
 ## Setup MetalLB for kind
 
-kind does not have any inbuilt way to provide IP addresses to your `Loadbalancer` type services, to ensure you get IP's you can install [MetalLB](https://kind.sigs.k8s.io/docs/user/loadbalancer/).
+Kind does not have any built-in way to provide IP addresses to your `Loadbalancer` service types, to ensure IP address assignments to `Gateway` Services please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
+
 ## Setup Dashboard UI for kind
 
-kind does not have a built in Dashboard UI like minikube. But you can still setup Dashboard, a web based Kubernetes UI, to view your cluster.
+Kind does not have a built-in Dashboard UI like minikube. But you can still setup Dashboard, a web based Kubernetes UI, to view your cluster.
 Follow these instructions to set up Dashboard for kind.
 
 1.  To deploy Dashboard, run the following command:

--- a/content/en/docs/setup/platform-setup/kind/index.md
+++ b/content/en/docs/setup/platform-setup/kind/index.md
@@ -74,7 +74,7 @@ kind does not have any built-in way to provide IP addresses to your `Loadbalance
 
 ## Setup Dashboard UI for kind
 
-kind does not have a built-in Dashboard UI like minikube. But you can still setup Dashboard, a web based Kubernetes UI, to view your cluster.
+kind does not have a built-in Dashboard UI like minikube. But you can still setup Dashboard, a web-based Kubernetes UI, to view your cluster.
 Follow these instructions to set up Dashboard for kind.
 
 1.  To deploy Dashboard, run the following command:

--- a/content/en/docs/setup/platform-setup/kind/index.md
+++ b/content/en/docs/setup/platform-setup/kind/index.md
@@ -68,6 +68,9 @@ Follow these instructions to prepare a kind cluster for Istio installation.
     Deleting cluster "istio-testing" ...
     {{< /text >}}
 
+## Setup MetalLB for kind
+
+kind does not have any inbuilt way to provide IP addresses to your `Loadbalancer` type services, to ensure you get IP's you can install [MetalLB](https://kind.sigs.k8s.io/docs/user/loadbalancer/).
 ## Setup Dashboard UI for kind
 
 kind does not have a built in Dashboard UI like minikube. But you can still setup Dashboard, a web based Kubernetes UI, to view your cluster.

--- a/content/en/docs/setup/platform-setup/kind/index.md
+++ b/content/en/docs/setup/platform-setup/kind/index.md
@@ -70,11 +70,11 @@ Follow these instructions to prepare a kind cluster for Istio installation.
 
 ## Setup MetalLB for kind
 
-Kind does not have any built-in way to provide IP addresses to your `Loadbalancer` service types, to ensure IP address assignments to `Gateway` Services please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
+kind does not have any built-in way to provide IP addresses to your `Loadbalancer` service types, to ensure IP address assignments to `Gateway` Services please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
 
 ## Setup Dashboard UI for kind
 
-Kind does not have a built-in Dashboard UI like minikube. But you can still setup Dashboard, a web based Kubernetes UI, to view your cluster.
+kind does not have a built-in Dashboard UI like minikube. But you can still setup Dashboard, a web based Kubernetes UI, to view your cluster.
 Follow these instructions to set up Dashboard for kind.
 
 1.  To deploy Dashboard, run the following command:


### PR DESCRIPTION
This commit adds a warning for users using the gateway API with kind and ambient.

Fixes #13756 

Please provide a description for what this PR is for.

The Gateway Custom Resource created gets stuck while installing ambient as mentioned in the above issue.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [X] Ambient
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
