### PR TITLE
[zh] Fix a left typo and improve content format

### DIFF
--- a/content/zh/about/case-studies/airbnb/index.md
+++ b/content/zh/about/case-studies/airbnb/index.md
@@ -18,7 +18,9 @@ type: 案例研究
 weight: 20
 ---
 
-在 [IstioCon 2021 的演讲中](https://events.istio.io/istiocon-2021/sessions/airbnb-on-istio/)，Airbnb 的 Stephen Chan 和 Weibo He 介绍了 Airbnb 的 Istio 之旅 - 为什么他们需要现代服务网格，他们是如何把 Istio 作为解决方案的，他们的现状，他们一路走来的经验教训，以及他们未来的计划。
+在 [IstioCon 2021 的演讲中](https://events.istio.io/istiocon-2021/sessions/airbnb-on-istio/)，
+Airbnb 的 Stephen Chan 和 Weibo He 介绍了 Airbnb 的 Istio 之旅 - 为什么他们需要现代服务网格，
+他们是如何把 Istio 作为解决方案的，他们的现状，他们一路走来的经验教训，以及他们未来的计划。
 
 <iframe width="696" height="392" src="https://www.youtube-nocookie.com/embed/6kDiDQW5YXQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/content/zh/about/case-studies/atlassian/index.md
+++ b/content/zh/about/case-studies/atlassian/index.md
@@ -18,7 +18,12 @@ type: 案例研究
 weight: 90
 ---
 
-Atlassian 在过去两年中一直在其内部 PaaS 的计算节点上部署 Envoy，以简化内部开发人员使用服务和服务间的通信。[他们在 IstioCon 2021 的发言中指出](https://events.istio.io/istiocon-2021/sessions/going-dynamic-with-envoy-at-atlassian/)，他们使用静态配置部署 Envoy，并且希望利用客户端路由、直接通信和故障注入等动态特性。Atlassian 认为 Istio 是在接下来的一年里交付该产品的最佳选择。Nicolas 讲述了 Atlassian 的服务到服务的通信之旅、Envoy 及其自研控制平面的发展历程。然后通过分析得出 Istio 是 Atlassian 业务向前发展的最佳选择。
+Atlassian 在过去两年中一直在其内部 PaaS 的计算节点上部署 Envoy，
+以简化内部开发人员使用服务和服务间的通信。[他们在 IstioCon 2021 的发言中指出](https://events.istio.io/istiocon-2021/sessions/going-dynamic-with-envoy-at-atlassian/)，
+他们使用静态配置部署 Envoy，并且希望利用客户端路由、直接通信和故障注入等动态特性。
+Atlassian 认为 Istio 是在接下来的一年里交付该产品的最佳选择。
+Nicolas 讲述了 Atlassian 的服务到服务的通信之旅、Envoy 及其自研控制平面的发展历程。
+然后通过分析得出 Istio 是 Atlassian 业务向前发展的最佳选择。
 
 <iframe width="696" height="392" src="https://www.youtube-nocookie.com/embed/iAyVhjuA1HE" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/content/zh/about/case-studies/cash-app/index.md
+++ b/content/zh/about/case-studies/cash-app/index.md
@@ -18,7 +18,12 @@ type: 案例研究
 weight: 50
 ---
 
-随着服务网格的广泛应用，越来越多的公司希望将 Istio 引入到他们的组织中。在 [IstioCon 2021 的演讲中](https://events.istio.io/istiocon-2021/sessions/istio-adoption:-planning-for-success-problem-solving/)，你将听到 Square Cash 团队的成功故事，关于他们决定从 Square 自有的 Envoy 服务网格迁移到 Istio。他们讨论为什么这对他们来说是正确的举措，他们如何执行这一举措，以及如果他们第二次这样做他们会采取什么不同的做法。然后，他们通过探索他们亲眼看到的成功将 Istio 引入组织的模式，来总结自己的学习成果。
+随着服务网格的广泛应用，越来越多的公司希望将 Istio 引入到他们的组织中。
+在 [IstioCon 2021 的演讲中](https://events.istio.io/istiocon-2021/sessions/istio-adoption:-planning-for-success-problem-solving/)，
+你将听到 Square Cash 团队的成功故事，关于他们决定从 Square 自有的 Envoy 服务网格迁移到 Istio。
+他们讨论为什么这对他们来说是正确的举措，他们如何执行这一举措，
+以及如果他们第二次这样做他们会采取什么不同的做法。然后，他们通过探索他们亲眼看到的成功将
+Istio 引入组织的模式，来总结自己的学习成果。
 
 <iframe width="696" height="392" src="https://www.youtube-nocookie.com/embed/TL97Id9j7F0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/content/zh/about/case-studies/ebay/index.md
+++ b/content/zh/about/case-studies/ebay/index.md
@@ -18,7 +18,10 @@ type: 案例研究
 weight: 80
 ---
 
-管理跨越全球数十万个容器的服务网格绝非易事。在大规模上，实现对数千个代理的快速配置收敛时间，同时限制控制平面和代理的 CPU 和内存利用率是一个具有挑战性的问题。[这个来自 IstioCon 2021 的演讲](https://events.istio.io/istiocon-2021/sessions/istio-at-scale-ebay/)描述了 eBay 最初构建可伸缩服务网格的过程，该服务网格利用 Istio 提供大规模的流量管理、负载平衡、安全性和可观察性功能。
+管理跨越全球数十万个容器的服务网格绝非易事。在大规模上，实现对数千个代理的快速配置收敛时间，
+同时限制控制平面和代理的 CPU 和内存利用率是一个具有挑战性的问题。
+[这个来自 IstioCon 2021 的演讲](https://events.istio.io/istiocon-2021/sessions/istio-at-scale-ebay/)描述了 eBay
+最初构建可伸缩服务网格的过程，该服务网格利用 Istio 提供大规模的流量管理、负载平衡、安全性和可观察性功能。
 
 <iframe width="696" height="392" src="https://www.youtube-nocookie.com/embed/Yo6x5Knv7Kc" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/content/zh/about/case-studies/fico/index.md
+++ b/content/zh/about/case-studies/fico/index.md
@@ -18,6 +18,10 @@ type: 案例探究
 weight: 70
 ---
 
-FICO 在 2019 年开始了它的网格之旅，当时 Istio 是 0.8 版本，Istio 在那段时间里已经成熟了很多，组织对 Istio 的部署和使用也显著成熟了。[在 IstioCon 2021 的演讲中](https://events.istio.io/istiocon-2021/sessions/fico-istio-journey/)，FICO 工程副总裁 Jeet Kaul 讲述了 FICO 从 2019 年到现在使用 Istio 的旅程，并且讨论了他们最初选择 Istio 的原因、他们经历的一些成长的痛苦以及他们通过 Istio 实现了哪些业务目标。
+FICO 在 2019 年开始了它的网格之旅，当时 Istio 是 0.8 版本，
+Istio 在那段时间里已经成熟了很多，组织对 Istio 的部署和使用也显著成熟了。
+[在 IstioCon 2021 的演讲中](https://events.istio.io/istiocon-2021/sessions/fico-istio-journey/)，
+FICO 工程副总裁 Jeet Kaul 讲述了 FICO 从 2019 年到现在使用 Istio 的旅程，
+并且讨论了他们最初选择 Istio 的原因、他们经历的一些成长的痛苦以及他们通过 Istio 实现了哪些业务目标。
 
 <iframe width="696" height="392" src="https://www.youtube-nocookie.com/embed/1iueSRNsUww" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>

--- a/content/zh/about/case-studies/salesforce/index.md
+++ b/content/zh/about/case-studies/salesforce/index.md
@@ -18,7 +18,12 @@ type: 实例探究
 weight: 40
 ---
 
-Istio 和 Envoy 是 Salesforce Service Mesh 的基本构建模块。在 [IstioCon 2021 的演讲中](https://events.istio.io/istiocon-2021/sessions/salesforce-service-mesh--our-istio-journey/)，Pratima Nambiar 介绍了 Salesforce 的服务网格之旅。她简要地介绍了他们为什么选择服务网格设计模式，他们最初如何使用 Envoy 和内部控制平面构建它，以及他们随后转向 Istio 的过程。同时她讨论了 Salesforce 目前如何利用 Istio 以及未来 Salesforce 会继续扩大 Istio 使用的计划，从而进一步增强他们的 Service Mesh 平台。
+Istio 和 Envoy 是 Salesforce Service Mesh 的基本构建模块。
+在 [IstioCon 2021 的演讲中](https://events.istio.io/istiocon-2021/sessions/salesforce-service-mesh--our-istio-journey/)，
+Pratima Nambiar 介绍了 Salesforce 的服务网格之旅。她简要地介绍了他们为什么选择服务网格设计模式，
+他们最初如何使用 Envoy 和内部控制平面构建它，以及他们随后转向 Istio 的过程。
+同时她讨论了 Salesforce 目前如何利用 Istio 以及未来 Salesforce 会继续扩大 Istio 使用的计划，
+从而进一步增强他们的 Service Mesh 平台。
 
 <iframe width="696" height="392" src="https://www.youtube-nocookie.com/embed/upYyX0E6Wwk" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/content/zh/about/case-studies/t-mobile/index.md
+++ b/content/zh/about/case-studies/t-mobile/index.md
@@ -18,9 +18,11 @@ type: 案例研究
 weight: 60
 ---
 
-这是一个关于奋斗、权衡和胜利的故事。正如您所知，Istio 是一个关键任务软件，用于保护和连接跨平台的微服务。然而，成功地引入、实施或采用它可能会令人畏缩。
+这是一个关于奋斗、权衡和胜利的故事。正如您所知，Istio 是一个关键任务软件，用于保护和连接跨平台的微服务。
+然而，成功地引入、实施或采用它可能会令人畏缩。
 
-在 [IstioCon 2021 的演讲中](https://events.istio.io/istiocon-2021/sessions/adopting-istio-across-100-clusters-at-t-mobile/)，Joe Searcy 深入探讨了 T-Mobile 在 100 多个集群中采用 Istio 的过程，以支持跨多个团队的欺诈检测、计费、销售和 API 等微服务。
+在 [IstioCon 2021 的演讲中](https://events.istio.io/istiocon-2021/sessions/adopting-istio-across-100-clusters-at-t-mobile/)，
+Joe Searcy 深入探讨了 T-Mobile 在 100 多个集群中采用 Istio 的过程，以支持跨多个团队的欺诈检测、计费、销售和 API 等微服务。
 
 <iframe width="696" height="392" src="https://www.youtube-nocookie.com/embed/gzrWEP87mKg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/content/zh/about/case-studies/zozo/index.md
+++ b/content/zh/about/case-studies/zozo/index.md
@@ -1,7 +1,7 @@
 ---
 title: "ZOZO"
 linkTitle: "ZOZO"
-quote: “无需新增开发人员的开销即可添加更多功能。”
+quote: "无需新增开发人员的开销即可添加更多功能。"
 author:
     name: "Yoichi Kawasaki"
     image: "/img/authors/yoichi-kawasaki.jpg"
@@ -18,9 +18,13 @@ type: case-studies
 weight: 54
 ---
 
-ZOZOTOWN 于 2004 年 12 月推出，目前是日本最大的时尚电子商务公司之一。在过去的 3 年中，一个现代化项目逐步迁移到基于 Kubernetes 的微服务架构。ZOZO 采用 Istio 作为新 ZOZOTOWN 平台的关键推动者。
+ZOZOTOWN 于 2004 年 12 月推出，目前是日本最大的时尚电子商务公司之一。
+在过去的 3 年中，一个现代化项目逐步迁移到基于 Kubernetes 的微服务架构。
+ZOZO 采用 Istio 作为新 ZOZOTOWN 平台的关键推动者。
 
-在 [IstioCon 2022 的这次演讲中](https://events.istio.io/istiocon-2022/sessions/accelerating-zozotown-modernization/)，Yoichi Kawasaki 讲述了了 ZOZO 的渐进迁移策略，包括他们如何将 Istio 与现有的内部 API 网关集成到一个平台上，他们的零停机迁移，以及如何计划进一步使用 Istio 来实现更复杂的 DevOps 经验。
+在 [IstioCon 2022 的这次演讲中](https://events.istio.io/istiocon-2022/sessions/accelerating-zozotown-modernization/)，
+Yoichi Kawasaki 讲述了了 ZOZO 的渐进迁移策略，包括他们如何将 Istio 与现有的内部
+API 网关集成到一个平台上，他们的零停机迁移，以及如何计划进一步使用 Istio 来实现更复杂的 DevOps 经验。
 
 <iframe width="696" height="392" src="https://www.youtube.com/embed/CKDuv9hwQPs" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 

--- a/content/zh/about/community/join/index.md
+++ b/content/zh/about/community/join/index.md
@@ -5,15 +5,17 @@ weight: 10
 keywords: [community]
 icon: community
 ---
-Istio 是一个开源项目，拥有一个活跃的社区支持它的使用和持续开发。我们非常欢迎您融入其中!
+Istio 是一个开源项目，拥有一个活跃的社区支持它的使用和持续开发。我们非常欢迎您融入其中！
 融入 Istio 社区有很多种方式：
 
 {{< community_item logo="./discourse.svg" alt="Discourse" >}}
-前往 [Istio 讨论板](https://discuss.istio.io) 提出问题、参与讨论或者寻求帮助解决问题。您可以使用 GitHub ID （或者 Google、Twitter 或 Yahoo）登录！
+前往 [Istio 讨论板](https://discuss.istio.io) 提出问题、参与讨论或者寻求帮助解决问题。
+您可以使用 GitHub ID （或者 Google、Twitter 或 Yahoo）登录！
 {{< /community_item >}}
 
 {{< community_item logo="./stackoverflow.svg" alt="Stack Overflow" >}}
-前往 [Stack Overflow](https://stackoverflow.com/questions/tagged/istio) 获取关于部署、配置和使用 Istio 实际问题的解答。
+前往 [Stack Overflow](https://stackoverflow.com/questions/tagged/istio)
+获取关于部署、配置和使用 Istio 实际问题的解答。
 {{< /community_item >}}
 
 {{< community_item logo="./slack.svg" alt="Slack" >}}
@@ -43,8 +45,8 @@ Istio 是一个开源项目，拥有一个活跃的社区支持它的使用和�
 {{< community_item logo="./group.svg" alt="Working Groups" >}}
 如果您想为 Istio 项目作出贡献, 请阅读我们的
 [行为规范](https://github.com/istio/community/blob/master/CONTRIBUTING.md#code-of-conduct) 和
-[贡献指南](https://github.com/istio/community/blob/master/CONTRIBUTING.md),
-并考虑参与我们的 [工作小组](https://github.com/istio/community/blob/master/WORKING-GROUPS.md)。
+[贡献指南](https://github.com/istio/community/blob/master/CONTRIBUTING.md)，
+并考虑参与我们的[工作小组](https://github.com/istio/community/blob/master/WORKING-GROUPS.md)。
 {{< /community_item >}}
 
 {{< community_item logo="./governance.svg" alt="Governance" >}}

--- a/content/zh/about/deployment/index.md
+++ b/content/zh/about/deployment/index.md
@@ -18,7 +18,7 @@ doc_type: about
 如果您没用过 Istio，可能要在测试环境中进行试用，请参阅我们的[入门指南](/zh/docs/setup/getting-started/)。
 这将使您对**流量管理**、**安全**和**可观察性**功能有所了解。
 
-## 自己动手，还是带个向导？{#do-it-yourself-or-bring-a-guide}
+## 自己动手，还是带个向导？ {#do-it-yourself-or-bring-a-guide}
 
 Istio 是开源软件，您可以自行下载和安装。在 Kubernetes 集群上安装网格就像运行一个命令一样简单：
 
@@ -37,13 +37,13 @@ Istio 还是许多商业服务管理产品的引擎，专家团队随时准备�
 如果您要与 Istio 生态系统的成员一起工作，我们建议您尽早熟悉。
 我们的许多合作伙伴和供应商已经在这个项目上工作了很长时间，并且在指导您的旅程中将发挥无价的作用。
 
-## 您应该先启用什么？{#what-should-you-enable-first}
+## 您应该先启用什么？ {#what-should-you-enable-first}
 
 采用 Istio 有很多重要理由：从为微服务增加安全性到提高应用程序的可靠性。
 无论您的目标是什么，最成功的 Istio 实施都是从确定一个用例并解决该用例开始的。
 一旦您配置了网格来解决一个问题，您可以轻松启用其他功能，从而增加部署的实用性。
 
-## 我如何将网格映射到我的架构上？{#how-do-i-map-the-mesh-to-my-architecture}
+## 我如何将网格映射到我的架构上？ {#how-do-i-map-the-mesh-to-my-architecture}
 
 通过一次添加一个命名空间，逐步将您的服务纳入网格。默认情况下，来自多个命名空间的服务可以相互通信，
 但您可以有目的地选择将哪些服务公开给其他命名空间来轻松提高隔离级别。
@@ -57,12 +57,12 @@ Istio 还是许多商业服务管理产品的引擎，专家团队随时准备�
 用于服务监控，并使用[与外部服务器的分层联合](/zh/docs/ops/best-practices/observability/)。
 如果您的公司的可观察性堆栈是由不同的团队运行的，现在是让他们加入的时候了。
 
-## 第一天，将服务添加到网格中{#adding-services-to-the-mesh-on-day1}
+## 第一天，将服务添加到网格中 {#adding-services-to-the-mesh-on-day1}
 
 您的网格现在已配置并准备好接受服务。要做到这一点，您只需在 Kubernetes 给您的命名空间添加标签，
 当这些服务被重新部署时，它们现在将包括配置为与 Istio 控制平面对话的 Envoy 代理。
 
-### 配置服务{#configuring-services}
+### 配置服务 {#configuring-services}
 
 许多服务开箱即用，但通过向您的 Kubernetes 清单添加一些信息，您可以使 Istio 更加智能。
 例如，为 `app` 和 `version` 设置标签将有助于稍后查询指标。
@@ -72,7 +72,7 @@ Istio 还是许多商业服务管理产品的引擎，专家团队随时准备�
 
 了解有关[启用应用程序以与 Istio 一起使用](/zh/docs/ops/deployment/requirements/)的更多信息。
 
-### 启用安全性{#enabling-security}
+### 启用安全性 {#enabling-security}
 
 Istio 将在网格中配置服务以在相互通信时尽可能使用 mTLS。
 默认情况下，Istio 将以 `permissive mTLS` 模式运行，这意味着服务将接受加密和未加密的流量，以允许来自非网格服务的流量保持功能。
@@ -83,42 +83,42 @@ Istio 将配置网格中的服务，使其在相互交谈时尽可能使用 mTLS
 Istio 默认以"允许的 mTLS" 模式运行，这意味着服务将同时接受加密和未加密的流量，以允许来自非网格服务的流量保持正常流通。
 在所有的服务都进入网格后，您可以改变认证策略，只允许加密的流量，然后您可以确定所有的流量都是加密的。
 
-### Istio 的两类 API{#istio's-two-types-of-apis}
+### Istio 的两类 API {#istio's-two-types-of-apis}
 
 Istio 为平台所有者和服务所有者提供 API。根据您扮演的角色，您只需要考虑一个子集。
 例如，平台所有者将拥有安装、认证和授权资源。流量管理资源将由服务所有者处理。[了解哪些 API 对您有用](/zh/docs/reference/config/)。
 
-### 在虚拟机上连接服务{#connect-services-on-virtual-machines}
+### 在虚拟机上连接服务 {#connect-services-on-virtual-machines}
 
 Istio 不仅适用于 Kubernetes；还可以将虚拟机（或裸机）上的[服务添加到网格](/zh/docs/setup/install/virtual-machine/)中，
 以获得 Istio 提供的所有功能，例如 TLS、丰富的遥测和高级流量管理功能。
 
-### 监测您的服务{#monitor-your-services}
+### 监测您的服务 {#monitor-your-services}
 
 使用 [Kiali](/zh/docs/ops/integrations/kiali/) 检查流经您的网格的流量，或者使用 [Zipkin](/zh/docs/tasks/observability/distributed-tracing/zipkin/)
 或 [Jaeger](/zh/docs/tasks/observability/distributed-tracing/jaeger/)追踪请求。
 
 使用 Istio 的默认 [Grafana](/zh/docs/ops/integrations/grafana/) 仪表板，自动报告在网格中运行的服务的关键信号。
 
-## 第二天，操作注意事项{#operational-considerations-and-day2}
+## 第二天，操作注意事项 {#operational-considerations-and-day2}
 
 作为平台所有者，您负责安装网格并使其保持最新状态，同时要对服务团队的影响很小。
 
-### 安装{#installation}
+### 安装 {#installation}
 
 借助 istioctl，您可以使用内置配置文件之一轻松安装 Istio。
-当您自定义安装以满足您的要求时，建议使用 IstioOperator 自定义资源 (CR) 定义您的配置。
+当您自定义安装以满足您的要求时，建议使用 IstioOperator 自定义资源（CR）定义您的配置。
 这使您可以选择将安装管理工作完全委托给 Istio Operator，而不是使用 istioctl 手动完成。
 仅将 IstioOperator CR 用于控制平面，将额外的 IstioOperator CR 用于网关，以提高升级的灵活性。
 
-### 安全升级{#upgrade-safely}
+### 安全升级 {#upgrade-safely}
 
 当发布新版本时，Istio 允许就地升级和金丝雀升级。
 在两者之间进行选择，是在简单性和潜在停机时间之间进行权衡。
 对于生产环境，推荐使用[金丝雀升级方式](/zh/docs/setup/upgrade/canary/)。
 在新的控制和数据平面版本被验证工作后，您可以升级您的网关。
 
-### 监控网格{#monitor-the-mesh}
+### 监控网格 {#monitor-the-mesh}
 
 Istio 为网格内的所有服务通信生成详细的遥测数据。
 这些指标、链路和访问日志对于了解您的应用程序如何交互以及识别所有性能瓶颈至关重要。
@@ -127,12 +127,12 @@ Istio 为网格内的所有服务通信生成详细的遥测数据。
 就像在网格中运行的应用程序一样，Istio 控制平面组件也会导出指标。
 利用这些指标和预配置的 Grafana 仪表板来调整您的资源请求、限制和扩展。
 
-## 加入 Istio 社区{#join-the-Istio-community}
+## 加入 Istio 社区 {#join-the-Istio-community}
 
 一旦您运行了 Istio，您就成为了一个大型全球社区的成员。您可以在[我们的论坛](https://discuss.istio.io/)或
 [hop on Slack](https://slack.istio.io/) 提问。如果您想改进一些东西，或者有一个功能请求，您可以直接去
 [GitHub](https://github.com/istio/istio)。
 
-快乐地网格化!
+快乐地网格化！
 
 {{< /centered_block >}}

--- a/content/zh/about/faq/distributed-tracing/how-distributed-tracing-works.md
+++ b/content/zh/about/faq/distributed-tracing/how-distributed-tracing-works.md
@@ -3,6 +3,10 @@ title: 如何使用 Istio 实现分布式追踪？
 weight: 0
 ---
 
-Istio 使用 [Envoy](#how-envoy-based-tracing-works)的分布式追踪系统集成。由[应用程序负责为后续传出请求转发追踪的 header 信息](#istio-copy-headers)。
+Istio 使用 [Envoy](#how-envoy-based-tracing-works)的分布式追踪系统集成。
+由[应用程序负责为后续传出请求转发追踪的 header 信息](#istio-copy-headers)。
 
-您可以在 Istio 分布式追踪（[Jaeger](/zh/docs/tasks/observability/distributed-tracing/jaeger/), [LightStep](/zh/docs/tasks/observability/distributed-tracing/lightstep/), [Zipkin](/zh/docs/tasks/observability/distributed-tracing/zipkin/)）任务以及 [Envoy 追踪文档](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/observability/tracing)中找到更多信息。
+您可以在 Istio 分布式追踪（[Jaeger](/zh/docs/tasks/observability/distributed-tracing/jaeger/)，
+[LightStep](/zh/docs/tasks/observability/distributed-tracing/lightstep/)，
+[Zipkin](/zh/docs/tasks/observability/distributed-tracing/zipkin/)）
+任务以及 [Envoy 追踪文档](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/observability/tracing)中找到更多信息。


### PR DESCRIPTION
Fix a typo:
<img width="913" alt="image" src="https://github.com/istio/istio.io/assets/1269496/56b4e428-8685-4d3b-94eb-3de7d480e243">
```
content/zh/about/case-studies/zozo/index.md
```

Improve format:
```
content/zh/about/case-studies/airbnb/index.md
content/zh/about/case-studies/atlassian/index.md
content/zh/about/case-studies/cash-app/index.md
content/zh/about/case-studies/ebay/index.md
content/zh/about/case-studies/fico/index.md
content/zh/about/case-studies/salesforce/index.md
content/zh/about/case-studies/t-mobile/index.md
content/zh/about/community/join/index.md
content/zh/about/deployment/index.md
content/zh/about/faq/distributed-tracing/how-distributed-tracing-works.md
```

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
