### PR TITLE
Call out pod labelling for sidecar injection explicitly

### DIFF
--- a/content/en/docs/setup/additional-setup/sidecar-injection/index.md
+++ b/content/en/docs/setup/additional-setup/sidecar-injection/index.md
@@ -118,6 +118,8 @@ on a per-pod basis, by configuring the `sidecar.istio.io/inject` label on a pod:
 | Namespace | `istio-injection` | `enabled` | `disabled` |
 | Pod | `sidecar.istio.io/inject` | `"true"` | `"false"` |
 
+For pod labelling, the label should be added to the corresponding deployment's `spec.template.metadata.labels` section.
+
 If you are using [control plane revisions](/docs/setup/upgrade/canary/), revision specific labels are instead used by a matching `istio.io/rev` label.
 For example, for a revision named `canary`:
 


### PR DESCRIPTION
Clarifies labelling for sidecar injection on a per-pod basis. Just a small call out since it may not be obvious to everyone (I tried to use `kubectl label deployment` instead)

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
