### PR TITLE
Add warning about enable alpha gateway API CRDs

### DIFF
--- a/content/en/boilerplates/gateway-api-enable-alpha-crds.md
+++ b/content/en/boilerplates/gateway-api-enable-alpha-crds.md
@@ -1,0 +1,7 @@
+---
+---
+{{< warning >}}
+This document uses alpha resources of the Kubernetes Gateway API. You must configure istiod to read these resources by setting the
+`PILOT_ENABLE_ALPHA_GATEWAY_API` environment variable to true on the istiod deployment.
+
+{{< /warning >}}

--- a/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
+++ b/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/index.md
@@ -23,6 +23,8 @@ weighted routing feature.
 
 {{< boilerplate gateway-api-experimental >}}
 
+{{< boilerplate gateway-api-enable-alpha-crds >}}
+
 ## Before you begin
 
 * Setup Istio by following the instructions in the [Installation guide](/docs/setup/).


### PR DESCRIPTION
Please provide a description for what this PR is for.
Since https://github.com/istio/istio/pull/44539, a special env var is required to enable the use of alpha Gateway API CRDs like TCPRoute. This PR adds a warning informing users about this before the TCP traffic shifting demo

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
