### PR TITLE
gateway-api: doc tests should not run with alpha CRDs by default

### DIFF
--- a/content/en/boilerplates/gateway-api-experimental.md
+++ b/content/en/boilerplates/gateway-api-experimental.md
@@ -2,10 +2,19 @@
 ---
 {{< warning >}}
 This document uses [experimental features](https://gateway-api.sigs.k8s.io/concepts/versioning/#release-channels-eg-experimental-standard)
-of the Kubernetes Gateway API. Make sure to install the experimental CRDs before using the Gateway API:
+of the Kubernetes Gateway API which require the alpha version of the CRDs. Before proceeding with this task, make sure to:
 
-{{< text syntax=bash snip_id=install_experimental_crds >}}
-$ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref={{< k8s_gateway_api_version >}}" | kubectl apply -f -
-{{< /text >}}
+1) Install the alpha version of the Gateway API CRDs:
+
+    {{< text syntax=bash snip_id=install_experimental_crds >}}
+    $ kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref={{< k8s_gateway_api_version >}}" | kubectl apply -f -
+    {{< /text >}}
+
+2) Configure Istio to read the alpha resources by setting the `PILOT_ENABLE_ALPHA_GATEWAY_API` environment variable to `true`
+    when installing Istio:
+
+    {{< text syntax=bash snip_id=enable_alpha_crds >}}
+    $ istioctl install --set values.pilot.env.PILOT_ENABLE_ALPHA_GATEWAY_API=true --set profile=minimal -y
+    {{< /text >}}
 
 {{< /warning >}}

--- a/content/en/boilerplates/snips/gateway-api-experimental.sh
+++ b/content/en/boilerplates/snips/gateway-api-experimental.sh
@@ -23,3 +23,7 @@
 bpsnip_gateway_api_experimental_install_experimental_crds() {
 kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.8.0-rc1" | kubectl apply -f -
 }
+
+bpsnip_gateway_api_experimental_enable_alpha_crds() {
+istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING=true --set values.pilot.env.PILOT_ENABLE_ALPHA_GATEWAY_API=true --set profile=minimal -y
+}

--- a/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
@@ -180,8 +180,8 @@ $ kubectl delete service my-httpbin
       name: my-wikipedia
     subsets:
       - addresses:
-          - ip: 91.198.174.192
           - ip: 198.35.26.96
+          - ip: 208.80.153.224
         ports:
           - port: 443
             name: tls

--- a/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/snips.sh
@@ -143,8 +143,8 @@ metadata:
   name: my-wikipedia
 subsets:
   - addresses:
-      - ip: 91.198.174.192
       - ip: 198.35.26.96
+      - ip: 208.80.153.224
     ports:
       - port: 443
         name: tls

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/gtwapi_test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/gtwapi_test.sh
@@ -18,7 +18,9 @@
 source "tests/util/gateway-api.sh"
 install_gateway_api_crds
 
-# @setup profile=minimal
+# @setup profile=none
+source "content/en/boilerplates/snips/gateway-api-experimental.sh"
+bpsnip_gateway_api_experimental_enable_alpha_crds
 source "content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/test.sh"
 
 # @cleanup

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/gtwapi_test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/gtwapi_test.sh
@@ -27,4 +27,7 @@ source "content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough
 snip_cleanup_2
 snip_cleanup_3
 snip_cleanup_4
+
+istioctl uninstall --purge -y
+kubectl delete ns istio-system
 remove_gateway_api_crds

--- a/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/gtwapi_test.sh
+++ b/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/gtwapi_test.sh
@@ -18,7 +18,9 @@
 source "tests/util/gateway-api.sh"
 install_gateway_api_crds
 
-# @setup profile=default
+# @setup profile=none
+source "content/en/boilerplates/snips/gateway-api-experimental.sh"
+bpsnip_gateway_api_experimental_enable_alpha_crds
 source "content/en/docs/tasks/traffic-management/tcp-traffic-shifting/test.sh"
 
 # @cleanup

--- a/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/gtwapi_test.sh
+++ b/content/en/docs/tasks/traffic-management/tcp-traffic-shifting/gtwapi_test.sh
@@ -26,4 +26,7 @@ source "content/en/docs/tasks/traffic-management/tcp-traffic-shifting/test.sh"
 # @cleanup
 snip_cleanup_2
 snip_cleanup_3
+
+istioctl uninstall --purge -y
+kubectl delete ns istio-system
 remove_gateway_api_crds

--- a/tests/setup/profile-default/doc_test.go
+++ b/tests/setup/profile-default/doc_test.go
@@ -42,5 +42,6 @@ values:
   pilot:
     env:
       PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING: true
+      PILOT_ENABLE_ALPHA_GATEWAY_API: false
 `
 }

--- a/tests/setup/profile-demo/doc_test.go
+++ b/tests/setup/profile-demo/doc_test.go
@@ -43,5 +43,6 @@ values:
   pilot:
     env:
       PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING: true
+      PILOT_ENABLE_ALPHA_GATEWAY_API: false
 `
 }

--- a/tests/setup/profile-minimal/doc_test.go
+++ b/tests/setup/profile-minimal/doc_test.go
@@ -44,6 +44,7 @@ values:
   pilot:
     env:
       PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING: true
+      PILOT_ENABLE_ALPHA_GATEWAY_API: false
 components:
   egressGateways:
   - enabled: false


### PR DESCRIPTION
Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
