### PR TITLE
[zh] Optimize translation into Chinese

### DIFF
--- a/content/zh/docs/tasks/security/authentication/authn-policy/index.md
+++ b/content/zh/docs/tasks/security/authentication/authn-policy/index.md
@@ -160,6 +160,7 @@ sleep.legacy to httpbin.legacy: 200
 
 您会发现除了从没有 Sidecar 的服务（`sleep.legacy`）到有 Sidecar
 的服务（`httpbin.foo` 或 `httpbin.bar`）的请求外，其他请求依然是返回成功的。
+这是符合预期的，因为现在严格要求使用双向 TLS，但是没有 Sidecar 的工作负载无法满足这一要求。
 
 ### 清除部分 1 {#cleanup-part-1}
 
@@ -557,7 +558,7 @@ EOF
 
 {{< /tabset >}}
 
-重新发送没有令牌的请求。现在，请求将失败，并返回错误码 `403`：
+重新发送没有令牌的请求。请求失败并返回错误码 `403`：
 
 {{< text bash >}}
 $ curl "$INGRESS_HOST:$INGRESS_PORT/headers" -s -o /dev/null -w "%{http_code}\n"


### PR DESCRIPTION
Please provide a description for what this PR is for.

```
content/zh/docs/tasks/security/authentication/authn-policy/index.md
```

original context:
```
You see requests still succeed, except for those from the client that doesn't have proxy, sleep.legacy, to the server with a proxy, httpbin.foo or httpbin.bar. This is expected because mutual TLS is now strictly required, but the workload without sidecar cannot comply.
```

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
