### PR TITLE
Update 1.17 EOL est date to Oct

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -16,7 +16,7 @@
 - version: "1.17"
   supported: "Yes"
   releaseDate: "Feb 14, 2023"
-  eolDate: "~Sep 2023 (Expected)"
+  eolDate: "~Oct 2023 (Expected)"
   k8sVersions: ["1.23", "1.24", "1.25", "1.26"]
   testedK8sVersions: ["1.16", "1.17", "1.18", "1.19", "1.20", "1.21", "1.22"]
 - version: "1.16"


### PR DESCRIPTION
Please provide a description for what this PR is for.

With it being Sept, assuming we release Tuesday would put 1.17's EOL date as mid/late October. Reword this so people don't think it's EOL this month.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
