### PR TITLE
Remove the SVG tips generated by draw.io

### DIFF
--- a/content/en/docs/setup/additional-setup/gateway/canary-upgrade.svg
+++ b/content/en/docs/setup/additional-setup/gateway/canary-upgrade.svg
@@ -1,1 +1,288 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="421" height="281" content="&lt;mxfile host=&quot;drawio-internal.googleplex.com&quot; modified=&quot;2021-05-12T22:53:07.330Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36&quot; etag=&quot;vssNbD2aHr66hq7zQlnP&quot; version=&quot;14.4.8&quot; type=&quot;google&quot; pages=&quot;4&quot;&gt;&lt;diagram id=&quot;P8ZkhgxdiRg3_sUfxNwi&quot; name=&quot;Page-1&quot;&gt;7VjLcpswFP0aL9Mxz5BlYqfuIm0y45m0WcpwAbUCUSEM9OsrgWTArzitXaeZrJDOfYDO0b3SMLImSTVjKIs/0wDIyBwH1ciajkzTcJyxeEikbhHPs1sgYjhQTh0wx79AgSouKnAA+cCRU0o4zoagT9MUfD7AEGO0HLqFlAzfmqEINoC5j8gm+hUHPFar0MuS+CfAUazfbIyVJUHaWQF5jAJa9iDrdmRNGKW8HSXVBIgkT/PSxn3cYV19GIOUHxKQ1vexf1356aP9JSzpjN1f3F+oLEtECrXgkemiJBtZN+kilw+ZIY0Y5LkYpSiBPEM+qCXxWvNUxpjDvDFZ01LsBREa84SImSGGS2AcC1avCY5SgXEqHQhaAHmgOeaYStQXSwHWc79bc0hwEMg33iCVh0DIm49c50IvTCSCqgcpbmZAE+CsFi5qYxqXSqeyk9nW2sU9iU1bgUhtrWiVq2NfDJQALxDDPEQMlGXGG1Wix7w53sL8qraOzrx1IPPmG2VeWVe96nxKuBusQiAasppSxmMa0RSR2w69YbRIA5BZx2LW+dxRyXDD/XfgvFanCyo4HSoDFebfZPgHR82eepZppTI3k1pPUrHcXpCcPvVtXVgz03E7ZcppwXzYQ406ODliEfA9fk7rJ3nbKzoDgjheDg+6owvqnVXQnpyduM8Iagzk7NQ9m6CXr0pQe1uvJLIDhVQw0Jfa/VlQbbjIG7GuhYPhZlVnFKNIPmeIQ4lqnUx8W5uvtW7som6PSL2eab26Va6aa4gJmVBCWZPMChzwAlvgOWf0B/QsnrmwXPfI7VVdOUxrs90a264c7qm6rXMiLaeQEVon0Oh3BjkReKG/TU7X92ARnkZOa8vp+W/lvDyRnBN5FQnFZYTDWfQMw9D0t+oZuAvXOVJ52q+tOg1jg9b3y5Di5urAs9N+VWfn1YkK9BEzXiAyB7bE/plq1PNhe40uPMd29qr9gp7rrvXcs9eo+b/U6J/Xmv4Xd7wiUqEPFDe7Xovr7ejAOkVb7SpqTbjVZ/yFluP38jzqEXrC6hTT7tdpuwG6H9DW7W8=&lt;/diagram&gt;&lt;diagram id=&quot;4JeC2udJRXLg3M3sNg4T&quot; name=&quot;Page-2&quot;&gt;zVjJcqMwEP0aHzNl1uBjYmc5JFWpcc2SowwNaEYgRggD+fqRQCCwXU6cCnFOqF8vSP2abtkza5lUdwxl8SMNgMzMeVDNrNXMNA3HmYuHROoW8Ty7BSKGA2WkgTV+AQUqv6jAAeQjQ04p4Tgbgz5NU/D5CEOM0XJsFlIyfmuGItgD1j4i++gvHPBYnaI7lsTvAUdx92ZjrjQJ6owVkMcooOUAsm5m1pJRyttVUi2ByOR1edkW9g8zW31fPJb3i/XLsrbL8qINdnuKS38EBin/2NBmG3qLSKHyNTNdlGQz6zrd5PIhacgysYV5ihLIM+SDSgevuxyXMeawblTWqhR1JPxinhAhGWK5BcaxYOSK4CgVGKfSgKANkCeaY46pRH1xOGAD84cdgwQHgXzjNVJxCIS82eGbsqOyKKNDNagNla07oAlwVguTUteJ3ZEfD2rEtBWIVG1Gva/Ov1goCk6gw9pLLQSimpVIGY9pRFNEbjR6zWiRBiCjzoWkbR6oTHNDwB/gvFafJio4HdMDFea/pfs3R0nPA82qUpEboe6EVBx34CTF56FOuzVS53caVzktmA9H7BzVUBCL4Fg8t7WTyTzKPAOCON6OW8eHs2yfleUBx5rxV1g2Rhxryr8Wy5dfimXnUGslsmGFVKRlyL/7r6Cd4iJvGLwSBoabVVopVpF83iEOJaq7YGJvbbxWu1daunAkia906q6z9r04xIQsKaGsCWYFDniBLfCcM/oXBhrP3FiuO0U3Vtp+DKt7iKvEQbM2DjVrd6pe7U7E7woyQusEGk7PQDECL/QPUez6HmzCT6TYcM7N8eVEHC/lFScUlxwOZyE5DEPTP0hy4G5cZ8rv2P5in7F33ivX5fDO1Q/g1+5c5ujS1U/nzxnHizeOY+ejx3HjesWYHH69QUZxyvNB5CcJ6HozrJ2mYu/8TNqxN52j9mLR7kBXXH+U9xfhYqI+8xMzXiCyBrbF/plajefD4Vaz8RzbOb0+391qphwnQtR/BLRVof9OsW7+Aw==&lt;/diagram&gt;&lt;diagram id=&quot;acmydcBVvZ5PIrEsXtoc&quot; name=&quot;Page-3&quot;&gt;7Vddc5swEPw1PKZjwODkMdhuOpkk9YynTdI3GR2gViAqhA399ZVAmA/TpOnYTWeaJ3Or0+p0uwLZsOdxccVRGt0yDNSwJrgw7IVhWabjTOSPQsoaObemNRBygnVSC6zJD9CgnhfmBEPWSxSMUUHSPuizJAFf9DDEOdv10wJG+6umKIQDYO0jeojeEywivYtmWwr/ACSMmpXNiR6JUZOsgSxCmO06kL007DlnTNRPcTEHqprX9KX0riJvfs3uXOvLamXPtp/jh7Oa7P1Lpuy3wCERx6W2auotornul2G5KE4N20s2mfpRDJkg7IwkIYcsk/ECUsrKWBVTN0aUTbd3ERGwTpGv4p10lGSIRExlZMrHLXBBpDaXlISJxARTCRRtgK5YRuQyCvUlM/BO+s0gISYYqxU9pHkoBKKqtdqMnAXFQP1nWmfu9ZQHAVgMgpdynva8OdUW2LUOmjY+iTrusZpEpF0b7rlaZeSDFucFQl2MCUXVpgOmdHDDugE1lqUo6Qnjfs9Zk3yWVYf0UiaYblq0gw3LUO8Vww2xrL3m7q+34UOkruo3KjDHKuCwJVmtNYYA5VR0Chjb8GEBB4kDp3KWJxiwNuYzvm18tndmQCidM8p4RWaDiR2YqcYLzr5BZ+TCndnIPYU3NYvl1DSNVS8OrWo6I1Z1T+VUc/pm1TerjlnVbO4E5eBt+Xpedf5Xr/ooQaqB/5RVf23JgYkXrne+WJ7yrWoPrHr+F636gLzg4y3n14Dv8P1jDp+KsrkEdnoNWF50dci4iFjIEkSXLeq1akxk1ObcMHXvqjT4CkKU+taOcsH6CkFBxIOa/s7R0WNnZFFo5ioodVDXqYr7A0HkBlnOfXiiEbrBAvEQnuKzxgXmQJEg235xR1dr8sx75VjvkDXwLZHteo0vSRAElu+PHVvsblzntF8S5/A4zo5zHGXY/qerxjr/jO3lTw==&lt;/diagram&gt;&lt;diagram id=&quot;ZL7lzrrOx4l-0F7w-HLO&quot; name=&quot;Page-4&quot;&gt;7VfbcpswEP0aP7pjIGDnMb70Mk0ymXGnl0cZLaBGsFQIG+frK4FkwHZz6cRJZ9In2KPVarXnsBIDb5ZWHwTJkyukwAfuiFYDbz5wXcf3R+qhkW2DTNyzBogFo8apBZbsDgxo5sUlo1D0HCUilyzvgyFmGYSyhxEhcNN3i5D3V81JDAfAMiT8EP3GqEzMLuy2NP4RWJzYlZ2RGUmJdTZAkRCKmw7kLQbeTCDK5i2tZsB18Wxdou3nL9d37m0+wevKZZefyq9XwybY+6dM2W1BQCafN7TbhF4TXpp6DdyApPnAm2arQj90hEIyHLIsFlAUyp5DznGb6mSawsitrfYmYRKWOQm1vVGKUhESmXJlOep1DUIyxc0FZ3GmMInagZMV8BssmFpGo6GKDKLjfrnnkDJK9YpTYuJwiGSda70ZNQuqPfYfKJ2z41N9CIApSLFV84zmnTMjgU2rINfqJOmqxzoSo9p4F6tlRr0Ycp5AlHeMKK43HaHmIYibAjRYkZOsR0zwq0TrPCzqj/RCOThBXrWDNso+3zdIbWCVexO7v95K7CNNVo/IwDmWgYA1KxquKUSk5LKTwLENHyZw4LinVIFlRoEaYT6gW6uznTIjxvkMOYo6mAcO9WGsCy8F3kJn5DwYeyQ4hTZNFNdvwlipnh9K1fGPSDU4lVKDg1IDVR3ZmChkgjFmhC9adNqSMVJW63OJukHUFPwEKbfmeCGlxD5BUDH5XU9/5xvrR2dkXpnItbE1RpOnTu4v+FAbxFKEcI/f2Jx2RMRwXzz3OL8COJFs3U/u2dmyx/R/uh5L1+Q16Ro/cAw8V8tfglgzVa7XaKZRFLlheKyZ0mAV+Kdspo53pHuOX7J7Tp58IRuGJCP1Jt7OvcyeffZq/u/c0/y3ek+zKvynrml/vo7t9Zx5MJ3MF6eU6tnL3dOU2f6V1mOdf3tv8Rs=&lt;/diagram&gt;&lt;/mxfile&gt;" version="1.1" viewBox="0 0 421 281" style="background-color:#fff"><g><rect width="200" height="140" x="0" y="140" fill="#fff" stroke="#000" pointer-events="all"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:147px;margin-left:2px"><div style="box-sizing:border-box;font-size:0;text-align:left"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">istio-ingress Deployment</div></div></div></foreignObject><text x="2" y="159" fill="#000" font-family="Helvetica" font-size="12">istio-ingress Deployment</text></switch></g><rect width="150" height="60" x="25" y="190" fill="#e1d5e7" stroke="#9673a6" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:220px;margin-left:26px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font><span style="font-size:16px">istio-ingress Pod</span><br/><font style="font-size:11px">revision=default</font><br/></font></div></div></div></foreignObject><text x="100" y="224" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress Pod...</text></switch></g><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 215 60 L 215 100 L 100 100 L 100 133.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 100 138.88 L 96.5 131.88 L 100 133.63 L 103.5 131.88 Z" pointer-events="all"/><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 215 60 L 215 100 L 320 100 L 320 133.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 320 138.88 L 316.5 131.88 L 320 133.63 L 323.5 131.88 Z" pointer-events="all"/><rect width="170" height="60" x="130" y="0" fill="#fff2cc" stroke="#d6b656" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:168px;height:1px;padding-top:30px;margin-left:131px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">istio-ingress Service</font></div></div></div></foreignObject><text x="215" y="34" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress Service</text></switch></g><rect width="200" height="140" x="220" y="140" fill="#fff" stroke="#000" pointer-events="all"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:147px;margin-left:222px"><div style="box-sizing:border-box;font-size:0;text-align:left"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">istio-ingress-canary Deployment</div></div></div></foreignObject><text x="222" y="159" fill="#000" font-family="Helvetica" font-size="12">istio-ingress-canary Deployment</text></switch></g><rect width="150" height="60" x="245" y="190" fill="#d6b8de" stroke="#9673a6" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:220px;margin-left:246px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font><span style="font-size:16px">istio-ingress Pod</span><br/><font style="font-size:11px">revision=canary</font><br/></font></div></div></div></foreignObject><text x="320" y="224" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress Pod...</text></switch></g></g><switch><a target="_blank" transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems"><text x="50%" y="100%" font-size="10" text-anchor="middle">Viewer does not support full SVG 1.1</text></a></switch></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="421"
+   height="281"
+   content="&lt;mxfile host=&quot;drawio-internal.googleplex.com&quot; modified=&quot;2021-05-12T22:53:07.330Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36&quot; etag=&quot;vssNbD2aHr66hq7zQlnP&quot; version=&quot;14.4.8&quot; type=&quot;google&quot; pages=&quot;4&quot;&gt;&lt;diagram id=&quot;P8ZkhgxdiRg3_sUfxNwi&quot; name=&quot;Page-1&quot;&gt;7VjLcpswFP0aL9Mxz5BlYqfuIm0y45m0WcpwAbUCUSEM9OsrgWTArzitXaeZrJDOfYDO0b3SMLImSTVjKIs/0wDIyBwH1ciajkzTcJyxeEikbhHPs1sgYjhQTh0wx79AgSouKnAA+cCRU0o4zoagT9MUfD7AEGO0HLqFlAzfmqEINoC5j8gm+hUHPFar0MuS+CfAUazfbIyVJUHaWQF5jAJa9iDrdmRNGKW8HSXVBIgkT/PSxn3cYV19GIOUHxKQ1vexf1356aP9JSzpjN1f3F+oLEtECrXgkemiJBtZN+kilw+ZIY0Y5LkYpSiBPEM+qCXxWvNUxpjDvDFZ01LsBREa84SImSGGS2AcC1avCY5SgXEqHQhaAHmgOeaYStQXSwHWc79bc0hwEMg33iCVh0DIm49c50IvTCSCqgcpbmZAE+CsFi5qYxqXSqeyk9nW2sU9iU1bgUhtrWiVq2NfDJQALxDDPEQMlGXGG1Wix7w53sL8qraOzrx1IPPmG2VeWVe96nxKuBusQiAasppSxmMa0RSR2w69YbRIA5BZx2LW+dxRyXDD/XfgvFanCyo4HSoDFebfZPgHR82eepZppTI3k1pPUrHcXpCcPvVtXVgz03E7ZcppwXzYQ406ODliEfA9fk7rJ3nbKzoDgjheDg+6owvqnVXQnpyduM8Iagzk7NQ9m6CXr0pQe1uvJLIDhVQw0Jfa/VlQbbjIG7GuhYPhZlVnFKNIPmeIQ4lqnUx8W5uvtW7som6PSL2eab26Va6aa4gJmVBCWZPMChzwAlvgOWf0B/QsnrmwXPfI7VVdOUxrs90a264c7qm6rXMiLaeQEVon0Oh3BjkReKG/TU7X92ARnkZOa8vp+W/lvDyRnBN5FQnFZYTDWfQMw9D0t+oZuAvXOVJ52q+tOg1jg9b3y5Di5urAs9N+VWfn1YkK9BEzXiAyB7bE/plq1PNhe40uPMd29qr9gp7rrvXcs9eo+b/U6J/Xmv4Xd7wiUqEPFDe7Xovr7ejAOkVb7SpqTbjVZ/yFluP38jzqEXrC6hTT7tdpuwG6H9DW7W8=&lt;/diagram&gt;&lt;diagram id=&quot;4JeC2udJRXLg3M3sNg4T&quot; name=&quot;Page-2&quot;&gt;zVjJcqMwEP0aHzNl1uBjYmc5JFWpcc2SowwNaEYgRggD+fqRQCCwXU6cCnFOqF8vSP2abtkza5lUdwxl8SMNgMzMeVDNrNXMNA3HmYuHROoW8Ty7BSKGA2WkgTV+AQUqv6jAAeQjQ04p4Tgbgz5NU/D5CEOM0XJsFlIyfmuGItgD1j4i++gvHPBYnaI7lsTvAUdx92ZjrjQJ6owVkMcooOUAsm5m1pJRyttVUi2ByOR1edkW9g8zW31fPJb3i/XLsrbL8qINdnuKS38EBin/2NBmG3qLSKHyNTNdlGQz6zrd5PIhacgysYV5ihLIM+SDSgevuxyXMeawblTWqhR1JPxinhAhGWK5BcaxYOSK4CgVGKfSgKANkCeaY46pRH1xOGAD84cdgwQHgXzjNVJxCIS82eGbsqOyKKNDNagNla07oAlwVguTUteJ3ZEfD2rEtBWIVG1Gva/Ov1goCk6gw9pLLQSimpVIGY9pRFNEbjR6zWiRBiCjzoWkbR6oTHNDwB/gvFafJio4HdMDFea/pfs3R0nPA82qUpEboe6EVBx34CTF56FOuzVS53caVzktmA9H7BzVUBCL4Fg8t7WTyTzKPAOCON6OW8eHs2yfleUBx5rxV1g2Rhxryr8Wy5dfimXnUGslsmGFVKRlyL/7r6Cd4iJvGLwSBoabVVopVpF83iEOJaq7YGJvbbxWu1daunAkia906q6z9r04xIQsKaGsCWYFDniBLfCcM/oXBhrP3FiuO0U3Vtp+DKt7iKvEQbM2DjVrd6pe7U7E7woyQusEGk7PQDECL/QPUez6HmzCT6TYcM7N8eVEHC/lFScUlxwOZyE5DEPTP0hy4G5cZ8rv2P5in7F33ivX5fDO1Q/g1+5c5ujS1U/nzxnHizeOY+ejx3HjesWYHH69QUZxyvNB5CcJ6HozrJ2mYu/8TNqxN52j9mLR7kBXXH+U9xfhYqI+8xMzXiCyBrbF/plajefD4Vaz8RzbOb0+391qphwnQtR/BLRVof9OsW7+Aw==&lt;/diagram&gt;&lt;diagram id=&quot;acmydcBVvZ5PIrEsXtoc&quot; name=&quot;Page-3&quot;&gt;7Vddc5swEPw1PKZjwODkMdhuOpkk9YynTdI3GR2gViAqhA399ZVAmA/TpOnYTWeaJ3Or0+p0uwLZsOdxccVRGt0yDNSwJrgw7IVhWabjTOSPQsoaObemNRBygnVSC6zJD9CgnhfmBEPWSxSMUUHSPuizJAFf9DDEOdv10wJG+6umKIQDYO0jeojeEywivYtmWwr/ACSMmpXNiR6JUZOsgSxCmO06kL007DlnTNRPcTEHqprX9KX0riJvfs3uXOvLamXPtp/jh7Oa7P1Lpuy3wCERx6W2auotornul2G5KE4N20s2mfpRDJkg7IwkIYcsk/ECUsrKWBVTN0aUTbd3ERGwTpGv4p10lGSIRExlZMrHLXBBpDaXlISJxARTCRRtgK5YRuQyCvUlM/BO+s0gISYYqxU9pHkoBKKqtdqMnAXFQP1nWmfu9ZQHAVgMgpdynva8OdUW2LUOmjY+iTrusZpEpF0b7rlaZeSDFucFQl2MCUXVpgOmdHDDugE1lqUo6Qnjfs9Zk3yWVYf0UiaYblq0gw3LUO8Vww2xrL3m7q+34UOkruo3KjDHKuCwJVmtNYYA5VR0Chjb8GEBB4kDp3KWJxiwNuYzvm18tndmQCidM8p4RWaDiR2YqcYLzr5BZ+TCndnIPYU3NYvl1DSNVS8OrWo6I1Z1T+VUc/pm1TerjlnVbO4E5eBt+Xpedf5Xr/ooQaqB/5RVf23JgYkXrne+WJ7yrWoPrHr+F636gLzg4y3n14Dv8P1jDp+KsrkEdnoNWF50dci4iFjIEkSXLeq1akxk1ObcMHXvqjT4CkKU+taOcsH6CkFBxIOa/s7R0WNnZFFo5ioodVDXqYr7A0HkBlnOfXiiEbrBAvEQnuKzxgXmQJEg235xR1dr8sx75VjvkDXwLZHteo0vSRAElu+PHVvsblzntF8S5/A4zo5zHGXY/qerxjr/jO3lTw==&lt;/diagram&gt;&lt;diagram id=&quot;ZL7lzrrOx4l-0F7w-HLO&quot; name=&quot;Page-4&quot;&gt;7VfbcpswEP0aP7pjIGDnMb70Mk0ymXGnl0cZLaBGsFQIG+frK4FkwHZz6cRJZ9In2KPVarXnsBIDb5ZWHwTJkyukwAfuiFYDbz5wXcf3R+qhkW2DTNyzBogFo8apBZbsDgxo5sUlo1D0HCUilyzvgyFmGYSyhxEhcNN3i5D3V81JDAfAMiT8EP3GqEzMLuy2NP4RWJzYlZ2RGUmJdTZAkRCKmw7kLQbeTCDK5i2tZsB18Wxdou3nL9d37m0+wevKZZefyq9XwybY+6dM2W1BQCafN7TbhF4TXpp6DdyApPnAm2arQj90hEIyHLIsFlAUyp5DznGb6mSawsitrfYmYRKWOQm1vVGKUhESmXJlOep1DUIyxc0FZ3GmMInagZMV8BssmFpGo6GKDKLjfrnnkDJK9YpTYuJwiGSda70ZNQuqPfYfKJ2z41N9CIApSLFV84zmnTMjgU2rINfqJOmqxzoSo9p4F6tlRr0Ycp5AlHeMKK43HaHmIYibAjRYkZOsR0zwq0TrPCzqj/RCOThBXrWDNso+3zdIbWCVexO7v95K7CNNVo/IwDmWgYA1KxquKUSk5LKTwLENHyZw4LinVIFlRoEaYT6gW6uznTIjxvkMOYo6mAcO9WGsCy8F3kJn5DwYeyQ4hTZNFNdvwlipnh9K1fGPSDU4lVKDg1IDVR3ZmChkgjFmhC9adNqSMVJW63OJukHUFPwEKbfmeCGlxD5BUDH5XU9/5xvrR2dkXpnItbE1RpOnTu4v+FAbxFKEcI/f2Jx2RMRwXzz3OL8COJFs3U/u2dmyx/R/uh5L1+Q16Ro/cAw8V8tfglgzVa7XaKZRFLlheKyZ0mAV+Kdspo53pHuOX7J7Tp58IRuGJCP1Jt7OvcyeffZq/u/c0/y3ek+zKvynrml/vo7t9Zx5MJ3MF6eU6tnL3dOU2f6V1mOdf3tv8Rs=&lt;/diagram&gt;&lt;/mxfile&gt;"
+   version="1.1"
+   viewBox="0 0 421 281"
+   style="background-color:#fff"
+   id="svg8"
+   sodipodi:docname="canary-upgrade.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.1877381"
+     inkscape:cx="192.38248"
+     inkscape:cy="140.60339"
+     inkscape:window-width="1456"
+     inkscape:window-height="837"
+     inkscape:window-x="117"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <g
+     id="g8">
+    <rect
+       width="200"
+       height="140"
+       x="0"
+       y="140"
+       fill="#fff"
+       stroke="#000"
+       pointer-events="all"
+       id="rect1" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g1">
+      <switch
+         id="switch1">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:147px;margin-left:2px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:left">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">istio-ingress Deployment</xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="2"
+           y="159"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           id="text1">istio-ingress Deployment</text>
+      </switch>
+    </g>
+    <rect
+       width="150"
+       height="60"
+       x="25"
+       y="190"
+       fill="#e1d5e7"
+       stroke="#9673a6"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect2" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g2">
+      <switch
+         id="switch2">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:220px;margin-left:26px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font>
+                  <xhtml:span
+                     style="font-size:16px">istio-ingress Pod</xhtml:span>
+                  <xhtml:br />
+                  <xhtml:font
+                     style="font-size:11px">revision=default</xhtml:font>
+                  <xhtml:br />
+                </xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="100"
+           y="224"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text2">istio-ingress Pod...</text>
+      </switch>
+    </g>
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 215 60 L 215 100 L 100 100 L 100 133.63"
+       pointer-events="stroke"
+       id="path2" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 100 138.88 L 96.5 131.88 L 100 133.63 L 103.5 131.88 Z"
+       pointer-events="all"
+       id="path3" />
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 215 60 L 215 100 L 320 100 L 320 133.63"
+       pointer-events="stroke"
+       id="path4" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 320 138.88 L 316.5 131.88 L 320 133.63 L 323.5 131.88 Z"
+       pointer-events="all"
+       id="path5" />
+    <rect
+       width="170"
+       height="60"
+       x="130"
+       y="0"
+       fill="#fff2cc"
+       stroke="#d6b656"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect5" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g5">
+      <switch
+         id="switch5">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:168px;height:1px;padding-top:30px;margin-left:131px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">istio-ingress Service</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="215"
+           y="34"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text5">istio-ingress Service</text>
+      </switch>
+    </g>
+    <rect
+       width="200"
+       height="140"
+       x="220"
+       y="140"
+       fill="#fff"
+       stroke="#000"
+       pointer-events="all"
+       id="rect6" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g6">
+      <switch
+         id="switch6">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:147px;margin-left:222px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:left">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">istio-ingress-canary Deployment</xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="222"
+           y="159"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           id="text6">istio-ingress-canary Deployment</text>
+      </switch>
+    </g>
+    <rect
+       width="150"
+       height="60"
+       x="245"
+       y="190"
+       fill="#d6b8de"
+       stroke="#9673a6"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect7" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g7">
+      <switch
+         id="switch7">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:220px;margin-left:246px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font>
+                  <xhtml:span
+                     style="font-size:16px">istio-ingress Pod</xhtml:span>
+                  <xhtml:br />
+                  <xhtml:font
+                     style="font-size:11px">revision=canary</xhtml:font>
+                  <xhtml:br />
+                </xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="320"
+           y="224"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text7">istio-ingress Pod...</text>
+      </switch>
+    </g>
+  </g>
+</svg>

--- a/content/en/docs/setup/additional-setup/gateway/high-level-canary.svg
+++ b/content/en/docs/setup/additional-setup/gateway/high-level-canary.svg
@@ -1,1 +1,405 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="421" height="431" content="&lt;mxfile host=&quot;drawio-internal.googleplex.com&quot; modified=&quot;2021-05-25T16:02:10.991Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36&quot; etag=&quot;yed_ux-m13XPFIT1P7DT&quot; version=&quot;14.4.8&quot; type=&quot;google&quot; pages=&quot;5&quot;&gt;&lt;diagram id=&quot;P8ZkhgxdiRg3_sUfxNwi&quot; name=&quot;Page-1&quot;&gt;7VjLcpswFP0aL9Mxz5BlYqfuIm0y45m0WcpwAbUCUSEM9OsrgWTArzitXaeZrJDOfYDO0b3SMLImSTVjKIs/0wDIyBwH1ciajkzTcJyxeEikbhHPumqBiOFAOXXAHP8CBaq4qMAB5ANHTinhOBuCPk1T8PkAQ4zRcugWUjJ8a4Yi2ADmPiKb6Fcc8FitQi9L4p8AR7F+szFWlgRpZwXkMQpo2YOs25E1YZTydpRUEyCSPM1LG/dxh3X1YQxSfkhAWt/H/nXlp4/2l7CkM3Z/cX+hsiwRKdSCR6aLkmxk3aSLXD5khjRikOdilKIE8gz5oJbEa81TGWMO88ZkTUuxF0RozBMiZoYYLoFxLFi9JjhKBcapdCBoAeSB5phjKlFfLAVYz/1uzSHBQSDfeINUHgIhbz5ynQu9MJEIqh6kuJkBTYCzWriojWlcKp3KTmZbaxf3JDZtBSK1taJVro59MVACvEAM8xAxUJYZb1SJHvPmeAvzq9o6OvPWgcybb5R5ZV31qvMp4W6wCoFoyGpKGY9pRFNEbjv0htEiDUBmHYtZ53NHJcMN99+B81qdLqjgdKgMVJh/k+EfHDV76lmmlcrcTGo9ScVye0Fy+tS3dWHNTMftlCmnBfNhDzW2Ov4Qi4Dv8XNaP8nbXtEZEMTxcnjQHV1Q76yC9uTsxH1GUGMgZ6fu2QS9fFWC2tt6JZEdKKSCgb7U7s+CasNF3oh1LRwMN6s6oxhF8jlDHEpU62Ti29p8rXVjF3V7ROr1TOvVrXLVXENMyIQSyppkVuCAF9gCzzmjP6Bn8cyF5bpHbq/qymFam+3W2HblcE/VbZ0TaTmFjNA6gUa/M8iJwAv9bXK6vgeL8DRyWltOz38r5+WJ5JzIq0goLiMczqJnGIamv1XPwF24zpHK035t1WkYG7S+X4YUN1cHnp32qzo7r05UoI+Y8QKRObAl9s9Uo54P22t04Tm2s1ftF/Rcd63nnr1Gzf+lRv+81vS/uOMVkQp9oLjZ9Vpcb0cH1inaaldRa8KtPuMvtBy/l+dRj9ATVqeYdr9O2w3Q/YC2bn8D&lt;/diagram&gt;&lt;diagram id=&quot;4JeC2udJRXLg3M3sNg4T&quot; name=&quot;Page-2&quot;&gt;zVjJcqMwEP0aHzNl1uBjYmc5JFWpcc2SowwNaEYgRggD+fqRQCCwXU6cCnFOqF8vSP2abtkza5lUdwxl8SMNgMzMeVDNrNXMNA3HmYuHROoW8Ty7BSKGA2WkgTV+AQUqv6jAAeQjQ04p4Tgbgz5NU/D5CEOM0XJsFlIyfmuGItgD1j4i++gvHPBYnaI7lsTvAUdx92ZjrjQJ6owVkMcooOUAsm5m1pJRyttVUi2ByOR1edkW9g8zW31fPJb3i/XLsrbL8qINdnuKS38EBin/2NBmG3qLSKHyNTNdlGQz6zrd5PIhacgysYV5ihLIM+SDSgevuxyXMeawblTWqhR1JPxinhAhGWK5BcaxYOSK4CgVGKfSgKANkCeaY46pRH1xOGAD84cdgwQHgXzjNVJxCIS82eGbsqOyKKNDNagNla07oAlwVguTUteJ3ZEfD2rEtBWIVG1Gva/Ov1goCk6gw9pLLQSimpVIGY9pRFNEbjR6zWiRBiCjzoWkbR6oTHNDwB/gvFafJio4HdMDFea/pfs3R0nPA82qUpEboe6EVBx34CTF56FOuzVS53caVzktmA9H7BzVUBCL4Fg8t7WTyTzKPAOCON6OW8eHs2yfleUBx5rxV1g2Rhxryr8Wy5dfimXnUGslsmGFVKRlyL/7r6Cd4iJvGLwSBoabVVopVpF83iEOJaq7YGJvbbxWu1daunAkia906q6z9r04xIQsKaGsCWYFDniBLfCcM/oXBhrP3FiuO0U3Vtp+DKt7iKvEQbM2DjVrd6pe7U7E7woyQusEGk7PQDECL/QPUez6HmzCT6TYcM7N8eVEHC/lFScUlxwOZyE5DEPTP0hy4G5cZ8rv2P5in7F33ivX5fDO1Q/g1+5c5ujS1U/nzxnHizeOY+ejx3HjesWYHH69QUZxyvNB5CcJ6HozrJ2mYu/8TNqxN52j9mLR7kBXXH+U9xfhYqI+8xMzXiCyBrbF/plajefD4Vaz8RzbOb0+391qphwnQtR/BLRVof9OsW7+Aw==&lt;/diagram&gt;&lt;diagram id=&quot;acmydcBVvZ5PIrEsXtoc&quot; name=&quot;Page-3&quot;&gt;7Vddc5swEPw1fkzHgMHOY7DddDJJ6hlPG6dvMjpArUBUCBv66yuBMB+mSdOxm840T+ZWp9XpdgXyyJpH+TVHSXjHMNCROcb5yFqMTNOw7bH8UUhRIbPZpAICTrBOaoA1+QEa1POCjGBIO4mCMSpI0gU9FsfgiQ6GOGf7bprPaHfVBAVwBKw9RI/RB4JFqHdRb0vhH4AEYb2yMdYjEaqTNZCGCLN9C7KWI2vOGRPVU5TPgarm1X0p3OvQnd+we8f8slpZ093naHNRkb1/yZTDFjjE4rTUZkW9QzTT/RqZDoqSkeXG21T9KIZUEHZB4oBDmsp4AQllRaSKqRojirrb+5AIWCfIU/FeOkoyhCKiMjLk4w64IFKbK0qCWGKCqQSKtkBXLCVyGYV6khl4K/22lxARjNWKLtI8FHxR1lpuRs6CvKf+M60zDnrKgwAsAsELOU973phoC+wbB01qn4Qt95h1ItKuDQ5cjTLyQYvzAqEuh4SiatM+Uzo4QdWACksTFHeEcb5nrE6+SMtDeiUTDCfJm8Gapa/3iuGaWNZecXfX2/I+UlX1GxUYQxVw2JG00hqDjzIqWgUMbfi4gKPEnlM5y2IMWBvzGd/WPjs40yeUzhllvCSzwMA2TFXjBWffoDVy6Uwt5JzDm5rFtCua2qqXx1Y17AGrOudyqjF5s+qbVYesatR3gqL3tnw9r9r/q1c9FCPVwH/Kqr+2ZM/EC8edLZbnfKtaPavO/qJVN8j1P95xfgP4Hj88ZvApL+pLYKvXgOVFV4eMi5AFLEZ02aBuo8ZYRk3OLVP3rlKDryBEoW/tKBOsqxDkRGzU9He2jh5bI4tcM5dBoYOqTlXcHwgiN8gy7sETjdANFogH8BSfOSwwB4oE2XWLO7la42feK6d6h6yB74hs12t8SXzfNz1v6NhiZ+vY5/2S2MfHcXqa4yjD5j9dOdb6Z2wtfwI=&lt;/diagram&gt;&lt;diagram id=&quot;ZL7lzrrOx4l-0F7w-HLO&quot; name=&quot;Canary&quot;&gt;7VfbcpswEP0aP7pjIGDnMb407TTJZMadXh5ltIAawVIhbMjXVzJSANu5eCZOM9M+mT1aVqs9x6tl4M3S6lKQPLlGCnzgjmg18OYD13V8f6R+NFI3yMQ7b4BYMGqcWmDJ7sGA5r24ZBSKnqNE5JLlfTDELINQ9jAiBG76bhHy/q45iWEPWIaE76PfGZWJOYU9lsY/AYsTu7MzMispsc4GKBJCcdOBvMXAmwlE2Tyl1Qy4Lp6tS1R/+Xpz797lE7ypXHb1ufx2PWyCfTzmlYcjCMjk64Z2m9BrwktTr4EbkDQfeNNsVegfHaGQDIcsiwUUhbLnkHOsU51MUxhZ22pvEiZhmZNQ2xulKBUhkSlXlqMe1yAkU9xccBZnCpOoHThZAb/FgqltNBqqyCA67lc7DimjVO84JSYOh0huc31RnUw9dXSoOioxdbsETEGKWrkYzTtnRgKbVkGu1UnSVY91JEa18UOslhn1YMg5gijvEFFcHzpCzUMQNwVosCInWY+Y4HeJ1nlYbP+kF8rBCfKqXbRRdvm+RWoDq9yb2P39VmIXabJ6QQbOoQwErFnRcE0hIiWXnQQOHXg/gT3HHaUKLDMK1AjzGd1anT0oM2Kcz5Cj2AbzwKE+jHXhpcA76KycB2OPBKfQpll1/eYNK9Xzfak6/gGpBqdSarBXaqCqIxsThUwwxozwRYtOWzJGymp9rlA3iC0Fv0DK2lwvpJTYJwgqJn/o1z/4xvrZWZlXJvLWqI1xHCMFliKEJ/zG5nIjIoan4pmWq4vyJL8COJFs3b/GXp0te03/p+sRv8m7omv8zDXwWi1/CWLNVP3+RjONosgNw0PNlAarwD9lM3W8A91z/Jbdc3L0QDYMSUa2h/h35jJ799nR/P3Maf6/OqdZFb6rMe3xcWyn58yD6WS+OKVUz95uTlNm+1W6Xet823uLPw==&lt;/diagram&gt;&lt;diagram name=&quot;High level canary&quot; id=&quot;FLtQ9wXyWbOBd6qBOtnU&quot;&gt;7Vhdd6IwEP01PrpHQbE+1o/adttud91zdtu3SAZIGwkbgsL++k0gCIi1eqpb93SfYG4mk2TuzGSgYQ7n8YSjwLtlGGjDaOG4YY4ahtHudlvyoZAkQ87Mfga4nGCtVABT8hs0qOe5EcEQVhQFY1SQoArazPfBFhUMcc6WVTWH0eqqAXKhBkxtROvoD4KFp0+RH0vhl0BcL1+53dIjc5QrayD0EGbLEmSOG+aQMyayt3k8BKqcl/vlGd9OJ18/X3WEc99/GkzQo/O9mRm72GfK6ggcfHFY00ZmeoFopP3VMCw0DxrmwJ+F6qEshIKwJvFdDmEo5REElCVztZnMMSLJvb30iIBpgGwlL2VESQuemFMpteXrArggkptzSlxfYoIpBYpmQO9ZSOQyCrWlZeAl9Zs1hTnBWK04QNoOBUeke93JT9qfyjrEpSjRfpsAm4PgiVTRMW/0dQgsiwgy8jjxytHT0SDSUeuubBXMyBdNzh5EmZuIourQDlM8WG7mgAwLA+RXiLF+RSxXboZpkp5LhbYVxMVgbmWd73uGc8Ny75nt6nozvo5ku9phB+1NO+CwIGHGNQYHRVSUNrDpwPUN1BTXIpWzyMeAdWC+Erd5nK0i0yGUDhllPDVmQht3oaccLzh7htJI3+qZyDpGbOpRo5vN0KFqduqh2u5uCFXrWJHaqbkasKzIWmRceMxlPqLjAh0UZLSkVOjcMFUgUgqeQIhEXy8oEqxKEMRE/FTTP3W19FAaGcXaciokWtiPkZBF3IYtepa+3BB3YZs9XXKVU7byy4EiQRbVa+zgbFmv1JUD1ZD1LJ0CXxDpzvdIVsdxDNvelKzYmlndYyZru5qsq8QsJ2vvbyZrb+/7v2kjH6Vn+jhtQF5q807wdNqCs4/aFuRReFJdwcu3/1oJGlmDs9H4mKHaece24JrejS6/XQxwwJLH5u3o+uouWF2jJ98WSCZ4UpqkxIfyWDEtld7eTmz0V2vHdqL3Xu3Etl0ft50orqAP2kYY5jv2ERt5N/9n917ZbeyY3dZJZfc/82l3uixvq5onwnL9n+A4lhVQcibRG4Zk19eS1RH5NvB6p/XlWx0b3U2zP7wOcSOO0vb9TbW5VorBeqEU9/qz1v7M7l6KN30CWIepvFIsfi6nY6Vf9Ob4Dw==&lt;/diagram&gt;&lt;/mxfile&gt;" version="1.1" viewBox="0 0 421 431" style="background-color:#fff"><g><rect width="200" height="140" x="0" y="290" fill="#fff" stroke="#000" pointer-events="all"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:297px;margin-left:2px"><div style="box-sizing:border-box;font-size:0;text-align:left"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">istio-ingress Deployment</div></div></div></foreignObject><text x="2" y="309" fill="#000" font-family="Helvetica" font-size="12">istio-ingress Deployment</text></switch></g><rect width="150" height="60" x="25" y="340" fill="#e1d5e7" stroke="#9673a6" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:370px;margin-left:26px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font><span style="font-size:16px">istio-ingress Pod</span><br/><font style="font-size:11px">revision=default</font><br/></font></div></div></div></foreignObject><text x="100" y="374" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress Pod...</text></switch></g><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 100 210 L 100 283.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 100 288.88 L 96.5 281.88 L 100 283.63 L 103.5 281.88 Z" pointer-events="all"/><rect width="170" height="60" x="15" y="150" fill="#fff2cc" stroke="#d6b656" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:168px;height:1px;padding-top:180px;margin-left:16px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">istio-ingress<br/>Service</font></div></div></div></foreignObject><text x="100" y="184" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress...</text></switch></g><rect width="200" height="140" x="220" y="290" fill="#fff" stroke="#000" pointer-events="all"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:297px;margin-left:222px"><div style="box-sizing:border-box;font-size:0;text-align:left"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">istio-ingress-canary Deployment</div></div></div></foreignObject><text x="222" y="309" fill="#000" font-family="Helvetica" font-size="12">istio-ingress-canary Deployment</text></switch></g><rect width="150" height="60" x="245" y="340" fill="#d6b8de" stroke="#9673a6" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:370px;margin-left:246px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font><span style="font-size:16px">istio-ingress Pod</span><br/><font style="font-size:11px">revision=canary</font><br/></font></div></div></div></foreignObject><text x="320" y="374" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress Pod...</text></switch></g><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 320 210 L 320 283.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 320 288.88 L 316.5 281.88 L 320 283.63 L 323.5 281.88 Z" pointer-events="all"/><rect width="170" height="60" x="235" y="150" fill="#fff2cc" stroke="#d6b656" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:168px;height:1px;padding-top:180px;margin-left:236px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">istio-ingress-canary Service</font></div></div></div></foreignObject><text x="320" y="184" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress-canary Service</text></switch></g><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 220 60 L 220 105 L 100 105 L 100 143.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 100 148.88 L 96.5 141.88 L 100 143.63 L 103.5 141.88 Z" pointer-events="all"/><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 220 60 L 220 105 L 320 105 L 320 143.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 320 148.88 L 316.5 141.88 L 320 143.63 L 323.5 141.88 Z" pointer-events="all"/><rect width="260" height="60" x="90" y="0" fill="#ffe6cc" stroke="#d79b00" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:258px;height:1px;padding-top:30px;margin-left:91px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">External Load Balancer<br/>OR<br/>DNS configuration</div></div></div></foreignObject><text x="220" y="34" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">External Load Balancer...</text></switch></g></g><switch><a target="_blank" transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems"><text x="50%" y="100%" font-size="10" text-anchor="middle">Viewer does not support full SVG 1.1</text></a></switch></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="421"
+   height="431"
+   content="&lt;mxfile host=&quot;drawio-internal.googleplex.com&quot; modified=&quot;2021-05-25T16:02:10.991Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.212 Safari/537.36&quot; etag=&quot;yed_ux-m13XPFIT1P7DT&quot; version=&quot;14.4.8&quot; type=&quot;google&quot; pages=&quot;5&quot;&gt;&lt;diagram id=&quot;P8ZkhgxdiRg3_sUfxNwi&quot; name=&quot;Page-1&quot;&gt;7VjLcpswFP0aL9Mxz5BlYqfuIm0y45m0WcpwAbUCUSEM9OsrgWTArzitXaeZrJDOfYDO0b3SMLImSTVjKIs/0wDIyBwH1ciajkzTcJyxeEikbhHPumqBiOFAOXXAHP8CBaq4qMAB5ANHTinhOBuCPk1T8PkAQ4zRcugWUjJ8a4Yi2ADmPiKb6Fcc8FitQi9L4p8AR7F+szFWlgRpZwXkMQpo2YOs25E1YZTydpRUEyCSPM1LG/dxh3X1YQxSfkhAWt/H/nXlp4/2l7CkM3Z/cX+hsiwRKdSCR6aLkmxk3aSLXD5khjRikOdilKIE8gz5oJbEa81TGWMO88ZkTUuxF0RozBMiZoYYLoFxLFi9JjhKBcapdCBoAeSB5phjKlFfLAVYz/1uzSHBQSDfeINUHgIhbz5ynQu9MJEIqh6kuJkBTYCzWriojWlcKp3KTmZbaxf3JDZtBSK1taJVro59MVACvEAM8xAxUJYZb1SJHvPmeAvzq9o6OvPWgcybb5R5ZV31qvMp4W6wCoFoyGpKGY9pRFNEbjv0htEiDUBmHYtZ53NHJcMN99+B81qdLqjgdKgMVJh/k+EfHDV76lmmlcrcTGo9ScVye0Fy+tS3dWHNTMftlCmnBfNhDzW2Ov4Qi4Dv8XNaP8nbXtEZEMTxcnjQHV1Q76yC9uTsxH1GUGMgZ6fu2QS9fFWC2tt6JZEdKKSCgb7U7s+CasNF3oh1LRwMN6s6oxhF8jlDHEpU62Ti29p8rXVjF3V7ROr1TOvVrXLVXENMyIQSyppkVuCAF9gCzzmjP6Bn8cyF5bpHbq/qymFam+3W2HblcE/VbZ0TaTmFjNA6gUa/M8iJwAv9bXK6vgeL8DRyWltOz38r5+WJ5JzIq0goLiMczqJnGIamv1XPwF24zpHK035t1WkYG7S+X4YUN1cHnp32qzo7r05UoI+Y8QKRObAl9s9Uo54P22t04Tm2s1ftF/Rcd63nnr1Gzf+lRv+81vS/uOMVkQp9oLjZ9Vpcb0cH1inaaldRa8KtPuMvtBy/l+dRj9ATVqeYdr9O2w3Q/YC2bn8D&lt;/diagram&gt;&lt;diagram id=&quot;4JeC2udJRXLg3M3sNg4T&quot; name=&quot;Page-2&quot;&gt;zVjJcqMwEP0aHzNl1uBjYmc5JFWpcc2SowwNaEYgRggD+fqRQCCwXU6cCnFOqF8vSP2abtkza5lUdwxl8SMNgMzMeVDNrNXMNA3HmYuHROoW8Ty7BSKGA2WkgTV+AQUqv6jAAeQjQ04p4Tgbgz5NU/D5CEOM0XJsFlIyfmuGItgD1j4i++gvHPBYnaI7lsTvAUdx92ZjrjQJ6owVkMcooOUAsm5m1pJRyttVUi2ByOR1edkW9g8zW31fPJb3i/XLsrbL8qINdnuKS38EBin/2NBmG3qLSKHyNTNdlGQz6zrd5PIhacgysYV5ihLIM+SDSgevuxyXMeawblTWqhR1JPxinhAhGWK5BcaxYOSK4CgVGKfSgKANkCeaY46pRH1xOGAD84cdgwQHgXzjNVJxCIS82eGbsqOyKKNDNagNla07oAlwVguTUteJ3ZEfD2rEtBWIVG1Gva/Ov1goCk6gw9pLLQSimpVIGY9pRFNEbjR6zWiRBiCjzoWkbR6oTHNDwB/gvFafJio4HdMDFea/pfs3R0nPA82qUpEboe6EVBx34CTF56FOuzVS53caVzktmA9H7BzVUBCL4Fg8t7WTyTzKPAOCON6OW8eHs2yfleUBx5rxV1g2Rhxryr8Wy5dfimXnUGslsmGFVKRlyL/7r6Cd4iJvGLwSBoabVVopVpF83iEOJaq7YGJvbbxWu1daunAkia906q6z9r04xIQsKaGsCWYFDniBLfCcM/oXBhrP3FiuO0U3Vtp+DKt7iKvEQbM2DjVrd6pe7U7E7woyQusEGk7PQDECL/QPUez6HmzCT6TYcM7N8eVEHC/lFScUlxwOZyE5DEPTP0hy4G5cZ8rv2P5in7F33ivX5fDO1Q/g1+5c5ujS1U/nzxnHizeOY+ejx3HjesWYHH69QUZxyvNB5CcJ6HozrJ2mYu/8TNqxN52j9mLR7kBXXH+U9xfhYqI+8xMzXiCyBrbF/plajefD4Vaz8RzbOb0+391qphwnQtR/BLRVof9OsW7+Aw==&lt;/diagram&gt;&lt;diagram id=&quot;acmydcBVvZ5PIrEsXtoc&quot; name=&quot;Page-3&quot;&gt;7Vddc5swEPw1fkzHgMHOY7DddDJJ6hlPG6dvMjpArUBUCBv66yuBMB+mSdOxm840T+ZWp9XpdgXyyJpH+TVHSXjHMNCROcb5yFqMTNOw7bH8UUhRIbPZpAICTrBOaoA1+QEa1POCjGBIO4mCMSpI0gU9FsfgiQ6GOGf7bprPaHfVBAVwBKw9RI/RB4JFqHdRb0vhH4AEYb2yMdYjEaqTNZCGCLN9C7KWI2vOGRPVU5TPgarm1X0p3OvQnd+we8f8slpZ093naHNRkb1/yZTDFjjE4rTUZkW9QzTT/RqZDoqSkeXG21T9KIZUEHZB4oBDmsp4AQllRaSKqRojirrb+5AIWCfIU/FeOkoyhCKiMjLk4w64IFKbK0qCWGKCqQSKtkBXLCVyGYV6khl4K/22lxARjNWKLtI8FHxR1lpuRs6CvKf+M60zDnrKgwAsAsELOU973phoC+wbB01qn4Qt95h1ItKuDQ5cjTLyQYvzAqEuh4SiatM+Uzo4QdWACksTFHeEcb5nrE6+SMtDeiUTDCfJm8Gapa/3iuGaWNZecXfX2/I+UlX1GxUYQxVw2JG00hqDjzIqWgUMbfi4gKPEnlM5y2IMWBvzGd/WPjs40yeUzhllvCSzwMA2TFXjBWffoDVy6Uwt5JzDm5rFtCua2qqXx1Y17AGrOudyqjF5s+qbVYesatR3gqL3tnw9r9r/q1c9FCPVwH/Kqr+2ZM/EC8edLZbnfKtaPavO/qJVN8j1P95xfgP4Hj88ZvApL+pLYKvXgOVFV4eMi5AFLEZ02aBuo8ZYRk3OLVP3rlKDryBEoW/tKBOsqxDkRGzU9He2jh5bI4tcM5dBoYOqTlXcHwgiN8gy7sETjdANFogH8BSfOSwwB4oE2XWLO7la42feK6d6h6yB74hs12t8SXzfNz1v6NhiZ+vY5/2S2MfHcXqa4yjD5j9dOdb6Z2wtfwI=&lt;/diagram&gt;&lt;diagram id=&quot;ZL7lzrrOx4l-0F7w-HLO&quot; name=&quot;Canary&quot;&gt;7VfbcpswEP0aP7pjIGDnMb407TTJZMadXh5ltIAawVIhbMjXVzJSANu5eCZOM9M+mT1aVqs9x6tl4M3S6lKQPLlGCnzgjmg18OYD13V8f6R+NFI3yMQ7b4BYMGqcWmDJ7sGA5r24ZBSKnqNE5JLlfTDELINQ9jAiBG76bhHy/q45iWEPWIaE76PfGZWJOYU9lsY/AYsTu7MzMispsc4GKBJCcdOBvMXAmwlE2Tyl1Qy4Lp6tS1R/+Xpz797lE7ypXHb1ufx2PWyCfTzmlYcjCMjk64Z2m9BrwktTr4EbkDQfeNNsVegfHaGQDIcsiwUUhbLnkHOsU51MUxhZ22pvEiZhmZNQ2xulKBUhkSlXlqMe1yAkU9xccBZnCpOoHThZAb/FgqltNBqqyCA67lc7DimjVO84JSYOh0huc31RnUw9dXSoOioxdbsETEGKWrkYzTtnRgKbVkGu1UnSVY91JEa18UOslhn1YMg5gijvEFFcHzpCzUMQNwVosCInWY+Y4HeJ1nlYbP+kF8rBCfKqXbRRdvm+RWoDq9yb2P39VmIXabJ6QQbOoQwErFnRcE0hIiWXnQQOHXg/gT3HHaUKLDMK1AjzGd1anT0oM2Kcz5Cj2AbzwKE+jHXhpcA76KycB2OPBKfQpll1/eYNK9Xzfak6/gGpBqdSarBXaqCqIxsThUwwxozwRYtOWzJGymp9rlA3iC0Fv0DK2lwvpJTYJwgqJn/o1z/4xvrZWZlXJvLWqI1xHCMFliKEJ/zG5nIjIoan4pmWq4vyJL8COJFs3b/GXp0te03/p+sRv8m7omv8zDXwWi1/CWLNVP3+RjONosgNw0PNlAarwD9lM3W8A91z/Jbdc3L0QDYMSUa2h/h35jJ799nR/P3Maf6/OqdZFb6rMe3xcWyn58yD6WS+OKVUz95uTlNm+1W6Xet823uLPw==&lt;/diagram&gt;&lt;diagram name=&quot;High level canary&quot; id=&quot;FLtQ9wXyWbOBd6qBOtnU&quot;&gt;7Vhdd6IwEP01PrpHQbE+1o/adttud91zdtu3SAZIGwkbgsL++k0gCIi1eqpb93SfYG4mk2TuzGSgYQ7n8YSjwLtlGGjDaOG4YY4ahtHudlvyoZAkQ87Mfga4nGCtVABT8hs0qOe5EcEQVhQFY1SQoArazPfBFhUMcc6WVTWH0eqqAXKhBkxtROvoD4KFp0+RH0vhl0BcL1+53dIjc5QrayD0EGbLEmSOG+aQMyayt3k8BKqcl/vlGd9OJ18/X3WEc99/GkzQo/O9mRm72GfK6ggcfHFY00ZmeoFopP3VMCw0DxrmwJ+F6qEshIKwJvFdDmEo5REElCVztZnMMSLJvb30iIBpgGwlL2VESQuemFMpteXrArggkptzSlxfYoIpBYpmQO9ZSOQyCrWlZeAl9Zs1hTnBWK04QNoOBUeke93JT9qfyjrEpSjRfpsAm4PgiVTRMW/0dQgsiwgy8jjxytHT0SDSUeuubBXMyBdNzh5EmZuIourQDlM8WG7mgAwLA+RXiLF+RSxXboZpkp5LhbYVxMVgbmWd73uGc8Ny75nt6nozvo5ku9phB+1NO+CwIGHGNQYHRVSUNrDpwPUN1BTXIpWzyMeAdWC+Erd5nK0i0yGUDhllPDVmQht3oaccLzh7htJI3+qZyDpGbOpRo5vN0KFqduqh2u5uCFXrWJHaqbkasKzIWmRceMxlPqLjAh0UZLSkVOjcMFUgUgqeQIhEXy8oEqxKEMRE/FTTP3W19FAaGcXaciokWtiPkZBF3IYtepa+3BB3YZs9XXKVU7byy4EiQRbVa+zgbFmv1JUD1ZD1LJ0CXxDpzvdIVsdxDNvelKzYmlndYyZru5qsq8QsJ2vvbyZrb+/7v2kjH6Vn+jhtQF5q807wdNqCs4/aFuRReFJdwcu3/1oJGlmDs9H4mKHaece24JrejS6/XQxwwJLH5u3o+uouWF2jJ98WSCZ4UpqkxIfyWDEtld7eTmz0V2vHdqL3Xu3Etl0ft50orqAP2kYY5jv2ERt5N/9n917ZbeyY3dZJZfc/82l3uixvq5onwnL9n+A4lhVQcibRG4Zk19eS1RH5NvB6p/XlWx0b3U2zP7wOcSOO0vb9TbW5VorBeqEU9/qz1v7M7l6KN30CWIepvFIsfi6nY6Vf9Ob4Dw==&lt;/diagram&gt;&lt;/mxfile&gt;"
+   version="1.1"
+   viewBox="0 0 421 431"
+   style="background-color:#fff"
+   id="svg11"
+   sodipodi:docname="high-level-canary.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <defs
+     id="defs11" />
+  <sodipodi:namedview
+     id="namedview11"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.4431555"
+     inkscape:cx="210.30305"
+     inkscape:cy="215.5"
+     inkscape:window-width="1456"
+     inkscape:window-height="837"
+     inkscape:window-x="117"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11" />
+  <g
+     id="g11">
+    <rect
+       width="200"
+       height="140"
+       x="0"
+       y="290"
+       fill="#fff"
+       stroke="#000"
+       pointer-events="all"
+       id="rect1" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g1">
+      <switch
+         id="switch1">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:297px;margin-left:2px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:left">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">istio-ingress Deployment</xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="2"
+           y="309"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           id="text1">istio-ingress Deployment</text>
+      </switch>
+    </g>
+    <rect
+       width="150"
+       height="60"
+       x="25"
+       y="340"
+       fill="#e1d5e7"
+       stroke="#9673a6"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect2" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g2">
+      <switch
+         id="switch2">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:370px;margin-left:26px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font>
+                  <xhtml:span
+                     style="font-size:16px">istio-ingress Pod</xhtml:span>
+                  <xhtml:br />
+                  <xhtml:font
+                     style="font-size:11px">revision=default</xhtml:font>
+                  <xhtml:br />
+                </xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="100"
+           y="374"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text2">istio-ingress Pod...</text>
+      </switch>
+    </g>
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 100 210 L 100 283.63"
+       pointer-events="stroke"
+       id="path2" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 100 288.88 L 96.5 281.88 L 100 283.63 L 103.5 281.88 Z"
+       pointer-events="all"
+       id="path3" />
+    <rect
+       width="170"
+       height="60"
+       x="15"
+       y="150"
+       fill="#fff2cc"
+       stroke="#d6b656"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect3" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g3">
+      <switch
+         id="switch3">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:168px;height:1px;padding-top:180px;margin-left:16px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">istio-ingress<xhtml:br />
+Service</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="100"
+           y="184"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text3">istio-ingress...</text>
+      </switch>
+    </g>
+    <rect
+       width="200"
+       height="140"
+       x="220"
+       y="290"
+       fill="#fff"
+       stroke="#000"
+       pointer-events="all"
+       id="rect4" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g4">
+      <switch
+         id="switch4">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:297px;margin-left:222px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:left">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">istio-ingress-canary Deployment</xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="222"
+           y="309"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           id="text4">istio-ingress-canary Deployment</text>
+      </switch>
+    </g>
+    <rect
+       width="150"
+       height="60"
+       x="245"
+       y="340"
+       fill="#d6b8de"
+       stroke="#9673a6"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect5" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g5">
+      <switch
+         id="switch5">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:370px;margin-left:246px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font>
+                  <xhtml:span
+                     style="font-size:16px">istio-ingress Pod</xhtml:span>
+                  <xhtml:br />
+                  <xhtml:font
+                     style="font-size:11px">revision=canary</xhtml:font>
+                  <xhtml:br />
+                </xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="320"
+           y="374"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text5">istio-ingress Pod...</text>
+      </switch>
+    </g>
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 320 210 L 320 283.63"
+       pointer-events="stroke"
+       id="path5" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 320 288.88 L 316.5 281.88 L 320 283.63 L 323.5 281.88 Z"
+       pointer-events="all"
+       id="path6" />
+    <rect
+       width="170"
+       height="60"
+       x="235"
+       y="150"
+       fill="#fff2cc"
+       stroke="#d6b656"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect6" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g6">
+      <switch
+         id="switch6">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:168px;height:1px;padding-top:180px;margin-left:236px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">istio-ingress-canary Service</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="320"
+           y="184"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text6">istio-ingress-canary Service</text>
+      </switch>
+    </g>
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 220 60 L 220 105 L 100 105 L 100 143.63"
+       pointer-events="stroke"
+       id="path7" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 100 148.88 L 96.5 141.88 L 100 143.63 L 103.5 141.88 Z"
+       pointer-events="all"
+       id="path8" />
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 220 60 L 220 105 L 320 105 L 320 143.63"
+       pointer-events="stroke"
+       id="path9" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 320 148.88 L 316.5 141.88 L 320 143.63 L 323.5 141.88 Z"
+       pointer-events="all"
+       id="path10" />
+    <rect
+       width="260"
+       height="60"
+       x="90"
+       y="0"
+       fill="#ffe6cc"
+       stroke="#d79b00"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect10" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g10">
+      <switch
+         id="switch10">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:258px;height:1px;padding-top:30px;margin-left:91px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">External Load Balancer<xhtml:br />
+OR<xhtml:br />
+DNS configuration</xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="220"
+           y="34"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text10">External Load Balancer...</text>
+      </switch>
+    </g>
+  </g>
+</svg>

--- a/content/en/docs/setup/additional-setup/gateway/inplace-upgrade.svg
+++ b/content/en/docs/setup/additional-setup/gateway/inplace-upgrade.svg
@@ -1,1 +1,286 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="401" height="381" content="&lt;mxfile host=&quot;drawio-internal.googleplex.com&quot; modified=&quot;2021-05-12T22:52:20.022Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36&quot; etag=&quot;SzER8CjIQfKzXOWCFtJb&quot; version=&quot;14.4.8&quot; type=&quot;google&quot; pages=&quot;4&quot;&gt;&lt;diagram id=&quot;P8ZkhgxdiRg3_sUfxNwi&quot; name=&quot;Page-1&quot;&gt;7VjLcpswFP0aL9Mxz5BlYqfuIm0y45m0WcpwAbUCUSEM9OsrgWTArzitXaeZrJDOfYDO0b3SMLImSTVjKIs/0wDIyBwH1ciajkzTcJyxeEikbhHPs1sgYjhQTh0wx79AgSouKnAA+cCRU0o4zoagT9MUfD7AEGO0HLqFlAzfmqEINoC5j8gm+hUHPFar0MuS+CfAUazfbIyVJUHaWQF5jAJa9iDrdmRNGKW8HSXVBIgkT/PSxn3cYV19GIOUHxKQ1vexf1356aP9JSzpjN1f3F+oLEtECrXgkemiJBtZN+kilw+ZIY0Y5LkYpSiBPEM+qCXxWvNUxpjDvDFZ01LsBREa84SImSGGS2AcC1avCY5SgXEqHQhaAHmgOeaYStQXSwHWc79bc0hwEMg33iCVh0DIm49c50IvTCSCqgcpbmZAE+CsFi5qYxqXSqeyk9nW2sU9iU1bgUhtrWiVq2NfDJQALxDDPEQMlGXGG1Wix7w53sL8qraOzrx1IPPmG2VeWVe96nxKuBusQiAasppSxmMa0RSR2w69YbRIA5BZx2LW+dxRyXDD/XfgvFanCyo4HSoDFebfZPgHR82eepZppTI3k1pPUrHcXpCcPvVtXVgz03E7ZcppwXzYQ406ODliEfA9fk7rJ3nbKzoDgjheDg+6owvqnVXQnpyduM8Iagzk7NQ9m6CXr0pQe1uvJLIDhVQw0Jfa/VlQbbjIG7GuhYPhZlVnFKNIPmeIQ4lqnUx8W5uvtW7som6PSL2eab26Va6aa4gJmVBCWZPMChzwAlvgOWf0B/QsnrmwXPfI7VVdOUxrs90a264c7qm6rXMiLaeQEVon0Oh3BjkReKG/TU7X92ARnkZOa8vp+W/lvDyRnBN5FQnFZYTDWfQMw9D0t+oZuAvXOVJ52q+tOg1jg9b3y5Di5urAs9N+VWfn1YkK9BEzXiAyB7bE/plq1PNhe40uPMd29qr9gp7rrvXcs9eo+b/U6J/Xmv4Xd7wiUqEPFDe7Xovr7ejAOkVb7SpqTbjVZ/yFluP38jzqEXrC6hTT7tdpuwG6H9DW7W8=&lt;/diagram&gt;&lt;diagram id=&quot;4JeC2udJRXLg3M3sNg4T&quot; name=&quot;Page-2&quot;&gt;zVjJcqMwEP0aHzNl1uBjYmc5JFWpcc2SowwNaEYgRggD+fqRQCCwXU6cCnFOqF8vSP2abtkza5lUdwxl8SMNgMzMeVDNrNXMNA3HmYuHROoW8Ty7BSKGA2WkgTV+AQUqv6jAAeQjQ04p4Tgbgz5NU/D5CEOM0XJsFlIyfmuGItgD1j4i++gvHPBYnaI7lsTvAUdx92ZjrjQJ6owVkMcooOUAsm5m1pJRyttVUi2ByOR1edkW9g8zW31fPJb3i/XLsrbL8qINdnuKS38EBin/2NBmG3qLSKHyNTNdlGQz6zrd5PIhacgysYV5ihLIM+SDSgevuxyXMeawblTWqhR1JPxinhAhGWK5BcaxYOSK4CgVGKfSgKANkCeaY46pRH1xOGAD84cdgwQHgXzjNVJxCIS82eGbsqOyKKNDNagNla07oAlwVguTUteJ3ZEfD2rEtBWIVG1Gva/Ov1goCk6gw9pLLQSimpVIGY9pRFNEbjR6zWiRBiCjzoWkbR6oTHNDwB/gvFafJio4HdMDFea/pfs3R0nPA82qUpEboe6EVBx34CTF56FOuzVS53caVzktmA9H7BzVUBCL4Fg8t7WTyTzKPAOCON6OW8eHs2yfleUBx5rxV1g2Rhxryr8Wy5dfimXnUGslsmGFVKRlyL/7r6Cd4iJvGLwSBoabVVopVpF83iEOJaq7YGJvbbxWu1daunAkia906q6z9r04xIQsKaGsCWYFDniBLfCcM/oXBhrP3FiuO0U3Vtp+DKt7iKvEQbM2DjVrd6pe7U7E7woyQusEGk7PQDECL/QPUez6HmzCT6TYcM7N8eVEHC/lFScUlxwOZyE5DEPTP0hy4G5cZ8rv2P5in7F33ivX5fDO1Q/g1+5c5ujS1U/nzxnHizeOY+ejx3HjesWYHH69QUZxyvNB5CcJ6HozrJ2mYu/8TNqxN52j9mLR7kBXXH+U9xfhYqI+8xMzXiCyBrbF/plajefD4Vaz8RzbOb0+391qphwnQtR/BLRVof9OsW7+Aw==&lt;/diagram&gt;&lt;diagram id=&quot;acmydcBVvZ5PIrEsXtoc&quot; name=&quot;Page-3&quot;&gt;7Vddc5swEPw1fkzHgMHOY7DddDJJ6hlPG6dvMjpArUBUCBv66yuBMB+mSdOxm840T+ZWp9XpdgXyyJpH+TVHSXjHMNCROcb5yFqMTNOw7bH8UUhRIbPZpAICTrBOaoA1+QEa1POCjGBIO4mCMSpI0gU9FsfgiQ6GOGf7bprPaHfVBAVwBKw9RI/RB4JFqHdRb0vhH4AEYb2yMdYjEaqTNZCGCLN9C7KWI2vOGRPVU5TPgarm1X0p3OvQnd+we8f8slpZ093naHNRkb1/yZTDFjjE4rTUZkW9QzTT/RqZDoqSkeXG21T9KIZUEHZB4oBDmsp4AQllRaSKqRojirrb+5AIWCfIU/FeOkoyhCKiMjLk4w64IFKbK0qCWGKCqQSKtkBXLCVyGYV6khl4K/22lxARjNWKLtI8FHxR1lpuRs6CvKf+M60zDnrKgwAsAsELOU973phoC+wbB01qn4Qt95h1ItKuDQ5cjTLyQYvzAqEuh4SiatM+Uzo4QdWACksTFHeEcb5nrE6+SMtDeiUTDCfJm8Gapa/3iuGaWNZecXfX2/I+UlX1GxUYQxVw2JG00hqDjzIqWgUMbfi4gKPEnlM5y2IMWBvzGd/WPjs40yeUzhllvCSzwMA2TFXjBWffoDVy6Uwt5JzDm5rFtCua2qqXx1Y17AGrOudyqjF5s+qbVYesatR3gqL3tnw9r9r/q1c9FCPVwH/Kqr+2ZM/EC8edLZbnfKtaPavO/qJVN8j1P95xfgP4Hj88ZvApL+pLYKvXgOVFV4eMi5AFLEZ02aBuo8ZYRk3OLVP3rlKDryBEoW/tKBOsqxDkRGzU9He2jh5bI4tcM5dBoYOqTlXcHwgiN8gy7sETjdANFogH8BSfOSwwB4oE2XWLO7la42feK6d6h6yB74hs12t8SXzfNz1v6NhiZ+vY5/2S2MfHcXqa4yjD5j9dOdb6Z2wtfwI=&lt;/diagram&gt;&lt;diagram id=&quot;ZL7lzrrOx4l-0F7w-HLO&quot; name=&quot;Page-4&quot;&gt;7VfbcpswEP0aP7pjIGDnMb70Mk0ymXGnl0cZLaBGsFQIG+frK4FkwHZz6cRJZ9In2KPVarXnsBIDb5ZWHwTJkyukwAfuiFYDbz5wXcf3R+qhkW2DTCZnDRALRo1TCyzZHRjQzItLRqHoOUpELlneB0PMMghlDyNC4KbvFiHvr5qTGA6AZUj4IfqNUZmYXdhtafwjsDixKzsjM5IS62yAIiEUNx3IWwy8mUCUzVtazYDr4tm6RNvPX67v3Nt8gteVyy4/lV+vhk2w90+ZstuCgEw+b2i3Cb0mvDT1GrgBSfOBN81WhX7oCIVkOGRZLKAolD2HnOM21ck0hZFbW+1NwiQscxJqe6MUpSIkMuXKctTrGoRkipsLzuJMYRK1Aycr4DdYMLWMRkMVGUTH/XLPIWWU6hWnxMThEMk613ozahZUe+w/UDpnx6f6EABTkGKr5hnNO2dGAptWQa7VSdJVj3UkRrXxLlbLjHox5DyBKO8YUVxvOkLNQxA3BWiwIidZj5jgV4nWeVjUH+mFcnCCvGoHbZR9vm+Q2sAq9yZ2f72V2EearB6RgXMsAwFrVjRcU4hIyWUngWMbPkzgwHFPqQLLjAI1wnxAt1ZnO2VGjPMZchR1MA8c6sNYF14KvIXOyHkw9khwCm2aKK7fhLFSPT+UquMfkWpwKqUGB6UGqjqyMVHIBGPMCF+06LQlY6Ss1ucSdYOoKfgJUm7N8UJKiX2CoGLyu57+zjfWj87IvDKRa2NrjCZPndxf8KE2iKUI4R6/sTntiIjhvnjucX4FcCLZup/cs7Nlj+n/dD2Wrslr0jV+4Bh4rpa/BLFmqlyv0UyjKHLD8FgzpcEq8E/ZTB3vSPccv2T3nDz5QjYMSUbqTbyde5k9++zV/N+5p/lv9Z5mVfhPXdP+fB3b6znzYDqZL04p1bOXu6cps/0rrcc6//be4jc=&lt;/diagram&gt;&lt;/mxfile&gt;" version="1.1" viewBox="0 0 401 381" style="background-color:#fff"><g><rect width="400" height="240" x="0" y="140" fill="#fff" stroke="#000" pointer-events="all"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:398px;height:1px;padding-top:147px;margin-left:2px"><div style="box-sizing:border-box;font-size:0;text-align:left"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">istio-ingress Deployment</div></div></div></foreignObject><text x="2" y="159" fill="#000" font-family="Helvetica" font-size="12">istio-ingress Deployment</text></switch></g><rect width="150" height="60" x="25" y="190" fill="#e1d5e7" stroke="#9673a6" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:220px;margin-left:26px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font><span style="font-size:16px">istio-ingress Pod</span><br/><font style="font-size:11px">revision=default</font><br/></font></div></div></div></foreignObject><text x="100" y="224" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress Pod...</text></switch></g><rect width="150" height="60" x="110" y="240" fill="#e1d5e7" stroke="#9673a6" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:270px;margin-left:111px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font><span style="font-size:16px">istio-ingress Pod</span><br/><font style="font-size:11px">revision=default</font><br/></font></div></div></div></foreignObject><text x="185" y="274" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress Pod...</text></switch></g><rect width="150" height="60" x="230" y="280" fill="#d6b8de" stroke="#9673a6" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:310px;margin-left:231px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font><span style="font-size:16px">istio-ingress Pod</span><br/><font style="font-size:11px">revision=canary</font><br/></font></div></div></div></foreignObject><text x="305" y="314" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress Pod...</text></switch></g><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 200 60 L 200 133.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 200 138.88 L 196.5 131.88 L 200 133.63 L 203.5 131.88 Z" pointer-events="all"/><rect width="170" height="60" x="115" y="0" fill="#fff2cc" stroke="#d6b656" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:168px;height:1px;padding-top:30px;margin-left:116px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">istio-ingress Service</font></div></div></div></foreignObject><text x="200" y="34" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">istio-ingress Service</text></switch></g></g><switch><a target="_blank" transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems"><text x="50%" y="100%" font-size="10" text-anchor="middle">Viewer does not support full SVG 1.1</text></a></switch></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="401"
+   height="381"
+   content="&lt;mxfile host=&quot;drawio-internal.googleplex.com&quot; modified=&quot;2021-05-12T22:52:20.022Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36&quot; etag=&quot;SzER8CjIQfKzXOWCFtJb&quot; version=&quot;14.4.8&quot; type=&quot;google&quot; pages=&quot;4&quot;&gt;&lt;diagram id=&quot;P8ZkhgxdiRg3_sUfxNwi&quot; name=&quot;Page-1&quot;&gt;7VjLcpswFP0aL9Mxz5BlYqfuIm0y45m0WcpwAbUCUSEM9OsrgWTArzitXaeZrJDOfYDO0b3SMLImSTVjKIs/0wDIyBwH1ciajkzTcJyxeEikbhHPs1sgYjhQTh0wx79AgSouKnAA+cCRU0o4zoagT9MUfD7AEGO0HLqFlAzfmqEINoC5j8gm+hUHPFar0MuS+CfAUazfbIyVJUHaWQF5jAJa9iDrdmRNGKW8HSXVBIgkT/PSxn3cYV19GIOUHxKQ1vexf1356aP9JSzpjN1f3F+oLEtECrXgkemiJBtZN+kilw+ZIY0Y5LkYpSiBPEM+qCXxWvNUxpjDvDFZ01LsBREa84SImSGGS2AcC1avCY5SgXEqHQhaAHmgOeaYStQXSwHWc79bc0hwEMg33iCVh0DIm49c50IvTCSCqgcpbmZAE+CsFi5qYxqXSqeyk9nW2sU9iU1bgUhtrWiVq2NfDJQALxDDPEQMlGXGG1Wix7w53sL8qraOzrx1IPPmG2VeWVe96nxKuBusQiAasppSxmMa0RSR2w69YbRIA5BZx2LW+dxRyXDD/XfgvFanCyo4HSoDFebfZPgHR82eepZppTI3k1pPUrHcXpCcPvVtXVgz03E7ZcppwXzYQ406ODliEfA9fk7rJ3nbKzoDgjheDg+6owvqnVXQnpyduM8Iagzk7NQ9m6CXr0pQe1uvJLIDhVQw0Jfa/VlQbbjIG7GuhYPhZlVnFKNIPmeIQ4lqnUx8W5uvtW7som6PSL2eab26Va6aa4gJmVBCWZPMChzwAlvgOWf0B/QsnrmwXPfI7VVdOUxrs90a264c7qm6rXMiLaeQEVon0Oh3BjkReKG/TU7X92ARnkZOa8vp+W/lvDyRnBN5FQnFZYTDWfQMw9D0t+oZuAvXOVJ52q+tOg1jg9b3y5Di5urAs9N+VWfn1YkK9BEzXiAyB7bE/plq1PNhe40uPMd29qr9gp7rrvXcs9eo+b/U6J/Xmv4Xd7wiUqEPFDe7Xovr7ejAOkVb7SpqTbjVZ/yFluP38jzqEXrC6hTT7tdpuwG6H9DW7W8=&lt;/diagram&gt;&lt;diagram id=&quot;4JeC2udJRXLg3M3sNg4T&quot; name=&quot;Page-2&quot;&gt;zVjJcqMwEP0aHzNl1uBjYmc5JFWpcc2SowwNaEYgRggD+fqRQCCwXU6cCnFOqF8vSP2abtkza5lUdwxl8SMNgMzMeVDNrNXMNA3HmYuHROoW8Ty7BSKGA2WkgTV+AQUqv6jAAeQjQ04p4Tgbgz5NU/D5CEOM0XJsFlIyfmuGItgD1j4i++gvHPBYnaI7lsTvAUdx92ZjrjQJ6owVkMcooOUAsm5m1pJRyttVUi2ByOR1edkW9g8zW31fPJb3i/XLsrbL8qINdnuKS38EBin/2NBmG3qLSKHyNTNdlGQz6zrd5PIhacgysYV5ihLIM+SDSgevuxyXMeawblTWqhR1JPxinhAhGWK5BcaxYOSK4CgVGKfSgKANkCeaY46pRH1xOGAD84cdgwQHgXzjNVJxCIS82eGbsqOyKKNDNagNla07oAlwVguTUteJ3ZEfD2rEtBWIVG1Gva/Ov1goCk6gw9pLLQSimpVIGY9pRFNEbjR6zWiRBiCjzoWkbR6oTHNDwB/gvFafJio4HdMDFea/pfs3R0nPA82qUpEboe6EVBx34CTF56FOuzVS53caVzktmA9H7BzVUBCL4Fg8t7WTyTzKPAOCON6OW8eHs2yfleUBx5rxV1g2Rhxryr8Wy5dfimXnUGslsmGFVKRlyL/7r6Cd4iJvGLwSBoabVVopVpF83iEOJaq7YGJvbbxWu1daunAkia906q6z9r04xIQsKaGsCWYFDniBLfCcM/oXBhrP3FiuO0U3Vtp+DKt7iKvEQbM2DjVrd6pe7U7E7woyQusEGk7PQDECL/QPUez6HmzCT6TYcM7N8eVEHC/lFScUlxwOZyE5DEPTP0hy4G5cZ8rv2P5in7F33ivX5fDO1Q/g1+5c5ujS1U/nzxnHizeOY+ejx3HjesWYHH69QUZxyvNB5CcJ6HozrJ2mYu/8TNqxN52j9mLR7kBXXH+U9xfhYqI+8xMzXiCyBrbF/plajefD4Vaz8RzbOb0+391qphwnQtR/BLRVof9OsW7+Aw==&lt;/diagram&gt;&lt;diagram id=&quot;acmydcBVvZ5PIrEsXtoc&quot; name=&quot;Page-3&quot;&gt;7Vddc5swEPw1fkzHgMHOY7DddDJJ6hlPG6dvMjpArUBUCBv66yuBMB+mSdOxm840T+ZWp9XpdgXyyJpH+TVHSXjHMNCROcb5yFqMTNOw7bH8UUhRIbPZpAICTrBOaoA1+QEa1POCjGBIO4mCMSpI0gU9FsfgiQ6GOGf7bprPaHfVBAVwBKw9RI/RB4JFqHdRb0vhH4AEYb2yMdYjEaqTNZCGCLN9C7KWI2vOGRPVU5TPgarm1X0p3OvQnd+we8f8slpZ093naHNRkb1/yZTDFjjE4rTUZkW9QzTT/RqZDoqSkeXG21T9KIZUEHZB4oBDmsp4AQllRaSKqRojirrb+5AIWCfIU/FeOkoyhCKiMjLk4w64IFKbK0qCWGKCqQSKtkBXLCVyGYV6khl4K/22lxARjNWKLtI8FHxR1lpuRs6CvKf+M60zDnrKgwAsAsELOU973phoC+wbB01qn4Qt95h1ItKuDQ5cjTLyQYvzAqEuh4SiatM+Uzo4QdWACksTFHeEcb5nrE6+SMtDeiUTDCfJm8Gapa/3iuGaWNZecXfX2/I+UlX1GxUYQxVw2JG00hqDjzIqWgUMbfi4gKPEnlM5y2IMWBvzGd/WPjs40yeUzhllvCSzwMA2TFXjBWffoDVy6Uwt5JzDm5rFtCua2qqXx1Y17AGrOudyqjF5s+qbVYesatR3gqL3tnw9r9r/q1c9FCPVwH/Kqr+2ZM/EC8edLZbnfKtaPavO/qJVN8j1P95xfgP4Hj88ZvApL+pLYKvXgOVFV4eMi5AFLEZ02aBuo8ZYRk3OLVP3rlKDryBEoW/tKBOsqxDkRGzU9He2jh5bI4tcM5dBoYOqTlXcHwgiN8gy7sETjdANFogH8BSfOSwwB4oE2XWLO7la42feK6d6h6yB74hs12t8SXzfNz1v6NhiZ+vY5/2S2MfHcXqa4yjD5j9dOdb6Z2wtfwI=&lt;/diagram&gt;&lt;diagram id=&quot;ZL7lzrrOx4l-0F7w-HLO&quot; name=&quot;Page-4&quot;&gt;7VfbcpswEP0aP7pjIGDnMb70Mk0ymXGnl0cZLaBGsFQIG+frK4FkwHZz6cRJZ9In2KPVarXnsBIDb5ZWHwTJkyukwAfuiFYDbz5wXcf3R+qhkW2DTCZnDRALRo1TCyzZHRjQzItLRqHoOUpELlneB0PMMghlDyNC4KbvFiHvr5qTGA6AZUj4IfqNUZmYXdhtafwjsDixKzsjM5IS62yAIiEUNx3IWwy8mUCUzVtazYDr4tm6RNvPX67v3Nt8gteVyy4/lV+vhk2w90+ZstuCgEw+b2i3Cb0mvDT1GrgBSfOBN81WhX7oCIVkOGRZLKAolD2HnOM21ck0hZFbW+1NwiQscxJqe6MUpSIkMuXKctTrGoRkipsLzuJMYRK1Aycr4DdYMLWMRkMVGUTH/XLPIWWU6hWnxMThEMk613ozahZUe+w/UDpnx6f6EABTkGKr5hnNO2dGAptWQa7VSdJVj3UkRrXxLlbLjHox5DyBKO8YUVxvOkLNQxA3BWiwIidZj5jgV4nWeVjUH+mFcnCCvGoHbZR9vm+Q2sAq9yZ2f72V2EearB6RgXMsAwFrVjRcU4hIyWUngWMbPkzgwHFPqQLLjAI1wnxAt1ZnO2VGjPMZchR1MA8c6sNYF14KvIXOyHkw9khwCm2aKK7fhLFSPT+UquMfkWpwKqUGB6UGqjqyMVHIBGPMCF+06LQlY6Ss1ucSdYOoKfgJUm7N8UJKiX2CoGLyu57+zjfWj87IvDKRa2NrjCZPndxf8KE2iKUI4R6/sTntiIjhvnjucX4FcCLZup/cs7Nlj+n/dD2Wrslr0jV+4Bh4rpa/BLFmqlyv0UyjKHLD8FgzpcEq8E/ZTB3vSPccv2T3nDz5QjYMSUbqTbyde5k9++zV/N+5p/lv9Z5mVfhPXdP+fB3b6znzYDqZL04p1bOXu6cps/0rrcc6//be4jc=&lt;/diagram&gt;&lt;/mxfile&gt;"
+   version="1.1"
+   viewBox="0 0 401 381"
+   style="background-color:#fff"
+   id="svg6"
+   sodipodi:docname="inplace-upgrade.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.2388451"
+     inkscape:cx="115.02648"
+     inkscape:cy="209.06568"
+     inkscape:window-width="1328"
+     inkscape:window-height="821"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <g
+     id="g6">
+    <rect
+       width="400"
+       height="240"
+       x="0"
+       y="140"
+       fill="#fff"
+       stroke="#000"
+       pointer-events="all"
+       id="rect1" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g1">
+      <switch
+         id="switch1">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:398px;height:1px;padding-top:147px;margin-left:2px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:left">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">istio-ingress Deployment</xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="2"
+           y="159"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           id="text1">istio-ingress Deployment</text>
+      </switch>
+    </g>
+    <rect
+       width="150"
+       height="60"
+       x="25"
+       y="190"
+       fill="#e1d5e7"
+       stroke="#9673a6"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect2" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g2">
+      <switch
+         id="switch2">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:220px;margin-left:26px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font>
+                  <xhtml:span
+                     style="font-size:16px">istio-ingress Pod</xhtml:span>
+                  <xhtml:br />
+                  <xhtml:font
+                     style="font-size:11px">revision=default</xhtml:font>
+                  <xhtml:br />
+                </xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="100"
+           y="224"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text2">istio-ingress Pod...</text>
+      </switch>
+    </g>
+    <rect
+       width="150"
+       height="60"
+       x="110"
+       y="240"
+       fill="#e1d5e7"
+       stroke="#9673a6"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect3" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g3">
+      <switch
+         id="switch3">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:270px;margin-left:111px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font>
+                  <xhtml:span
+                     style="font-size:16px">istio-ingress Pod</xhtml:span>
+                  <xhtml:br />
+                  <xhtml:font
+                     style="font-size:11px">revision=default</xhtml:font>
+                  <xhtml:br />
+                </xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="185"
+           y="274"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text3">istio-ingress Pod...</text>
+      </switch>
+    </g>
+    <rect
+       width="150"
+       height="60"
+       x="230"
+       y="280"
+       fill="#d6b8de"
+       stroke="#9673a6"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect4" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g4">
+      <switch
+         id="switch4">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:148px;height:1px;padding-top:310px;margin-left:231px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font>
+                  <xhtml:span
+                     style="font-size:16px">istio-ingress Pod</xhtml:span>
+                  <xhtml:br />
+                  <xhtml:font
+                     style="font-size:11px">revision=canary</xhtml:font>
+                  <xhtml:br />
+                </xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="305"
+           y="314"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text4">istio-ingress Pod...</text>
+      </switch>
+    </g>
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 200 60 L 200 133.63"
+       pointer-events="stroke"
+       id="path4" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 200 138.88 L 196.5 131.88 L 200 133.63 L 203.5 131.88 Z"
+       pointer-events="all"
+       id="path5" />
+    <rect
+       width="170"
+       height="60"
+       x="115"
+       y="0"
+       fill="#fff2cc"
+       stroke="#d6b656"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect5" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g5">
+      <switch
+         id="switch5">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:168px;height:1px;padding-top:30px;margin-left:116px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">istio-ingress Service</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="200"
+           y="34"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text5">istio-ingress Service</text>
+      </switch>
+    </g>
+  </g>
+</svg>

--- a/content/en/docs/setup/additional-setup/gateway/shared-gateway.svg
+++ b/content/en/docs/setup/additional-setup/gateway/shared-gateway.svg
@@ -1,1 +1,430 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="421" height="411" content="&lt;mxfile host=&quot;drawio-internal.googleplex.com&quot; modified=&quot;2021-05-10T18:16:27.333Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36&quot; etag=&quot;MGliv7xz6fTwesFNeaBR&quot; version=&quot;14.4.8&quot; type=&quot;google&quot;&gt;&lt;diagram id=&quot;P8ZkhgxdiRg3_sUfxNwi&quot; name=&quot;Page-1&quot;&gt;7VhLc5swEP41HNPhHXJM7DQ9pE1mPJM2RxkWUCsQFbKB/vpKIF4xTtypXdJMTmifsN+nXWnQrEVS3jCUxZ9pAEQz9aDUrKVmmobj6OIhNVWj8ayLRhExHCinXrHCv0ApVVy0wQHkI0dOKeE4Gyt9mqbg85EOMUaLsVtIyfitGYpgR7HyEdnVfsUBj1UVbVlS/wlwFLdvNnRlSVDrrBR5jAJaDFTWtWYtGKW8WSXlAogEr8Wlifu4x9p9GIOUHxKQVnexf1n66YP9JSzoDbs7uztTWbaIbFTBmumiJNOsq3Sdy4fMkEYM8lysUpRAniEfVEm8anEqYsxhVZusZSH2ggiNeUKEZIjlFhjHAtVLgqNU6DiVDgStgdzTHHNMpdYXpQAbuN8+cUhwEMg3XiGVh0DI64+sqxBRUO6Fx+hAF7sVaAKcVcJFbUzjXPFU9DTbLXfxgGLTVkqktlbU5erRFwtFwB+QYR5CBsoy440yMUDe1CeQ73rr6MhbByJvvlHkVUA3q+Zjwt1BFQIxkJVIGY9pRFNErnvtFaObNACZVRdS73NLJcI19t+B80qdLmjD6ZgZKDH/JsM/OEp6HFiWpcpcC1UrpKLcQZAUH4e2PqyW2rimPlnU8yQJDOiG+fAMVrY6DxGLgD/j50yTzoAgjrfj7zg6od6shA7o7Ml9gVBjRGfP7ush9HxOQu2pWUnkBAqpKHhItftzQ1vDWV6TdSkcDDcre6NYRfJ5gzgUqGqTiW9r8jXWnV3U7xHJ1wujtx2V3XANMSELSiirk1mBA15gC33OGf0BA4tnri3XPfJ4VVcO09odt8bUlcM91bR1TsTlEjJCqwRq/magE4EX+lN0ur4H6/A0dFoTp+e/pfP8RHQu5FUkFJcRDrPwGYah6U/yGbhr1zlSe9qvrTsNYwfW98vQPrAuDjw77TnPzosTNegDZnyDyArYFvsz9ajnw3SPrj3HdvTj9GjXbO3Mnb1Hzf+lR4/Ya4Y+TdLBTaRC7ymud31LrrdnArcpmuZWUU+I6z7jL7jU39vzqEfoCbtTiP2v02YD9D+grevf&lt;/diagram&gt;&lt;/mxfile&gt;" version="1.1" viewBox="0 0 421 411"><g><rect width="420" height="240" x="0" y="170" fill="#fff" stroke="#000" pointer-events="all"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:418px;height:1px;padding-top:177px;margin-left:2px"><div style="box-sizing:border-box;font-size:0;text-align:left"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">ingress namespace</div></div></div></foreignObject><text x="2" y="189" fill="#000" font-family="Helvetica" font-size="12">ingress namespace</text></switch></g><rect width="200" height="100" x="0" y="0" fill="#fff" stroke="#000" pointer-events="all"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:7px;margin-left:2px"><div style="box-sizing:border-box;font-size:0;text-align:left"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">app1 namespace</div></div></div></foreignObject><text x="2" y="19" fill="#000" font-family="Helvetica" font-size="12">app1 namespace</text></switch></g><rect width="200" height="100" x="220" y="0" fill="#fff" stroke="#000" pointer-events="all"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:7px;margin-left:222px"><div style="box-sizing:border-box;font-size:0;text-align:left"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">app2 namespace</div></div></div></foreignObject><text x="222" y="19" fill="#000" font-family="Helvetica" font-size="12">app2 namespace</text></switch></g><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 280 290 L 280 313.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 280 318.88 L 276.5 311.88 L 280 313.63 L 283.5 311.88 Z" pointer-events="all"/><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 220 260 L 166.37 260" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 161.12 260 L 168.12 256.5 L 166.37 260 L 168.12 263.5 Z" pointer-events="all"/><rect width="120" height="60" x="220" y="230" fill="#d5e8d4" stroke="#82b366" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:260px;margin-left:221px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">Gateway</font></div></div></div></foreignObject><text x="280" y="264" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">Gateway</text></switch></g><rect width="120" height="60" x="220" y="320" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:350px;margin-left:221px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">Deployment</font></div></div></div></foreignObject><text x="280" y="354" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">Deployment</text></switch></g><rect width="120" height="60" x="40" y="230" fill="#fff2cc" stroke="#d6b656" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:260px;margin-left:41px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">Certificate</font></div></div></div></foreignObject><text x="100" y="264" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">Certificate</text></switch></g><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 320 90 L 320 160 L 280 160 L 280 223.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 280 228.88 L 276.5 221.88 L 280 223.63 L 283.5 221.88 Z" pointer-events="all"/><rect width="120" height="60" x="260" y="30" fill="#f8cecc" stroke="#b85450" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:60px;margin-left:261px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">VirtualService</font></div></div></div></foreignObject><text x="320" y="64" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">VirtualService</text></switch></g><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 100 90 L 100 160 L 280 160 L 280 223.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 280 228.88 L 276.5 221.88 L 280 223.63 L 283.5 221.88 Z" pointer-events="all"/><rect width="120" height="60" x="40" y="30" fill="#f8cecc" stroke="#b85450" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:60px;margin-left:41px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">VirtualService</font></div></div></div></foreignObject><text x="100" y="64" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">VirtualService</text></switch></g></g><switch><a target="_blank" transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems"><text x="50%" y="100%" font-size="10" text-anchor="middle">Viewer does not support full SVG 1.1</text></a></switch></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="421"
+   height="411"
+   content="&lt;mxfile host=&quot;drawio-internal.googleplex.com&quot; modified=&quot;2021-05-10T18:16:27.333Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36&quot; etag=&quot;MGliv7xz6fTwesFNeaBR&quot; version=&quot;14.4.8&quot; type=&quot;google&quot;&gt;&lt;diagram id=&quot;P8ZkhgxdiRg3_sUfxNwi&quot; name=&quot;Page-1&quot;&gt;7VhLc5swEP41HNPhHXJM7DQ9pE1mPJM2RxkWUCsQFbKB/vpKIF4xTtypXdJMTmifsN+nXWnQrEVS3jCUxZ9pAEQz9aDUrKVmmobj6OIhNVWj8ayLRhExHCinXrHCv0ApVVy0wQHkI0dOKeE4Gyt9mqbg85EOMUaLsVtIyfitGYpgR7HyEdnVfsUBj1UVbVlS/wlwFLdvNnRlSVDrrBR5jAJaDFTWtWYtGKW8WSXlAogEr8Wlifu4x9p9GIOUHxKQVnexf1n66YP9JSzoDbs7uztTWbaIbFTBmumiJNOsq3Sdy4fMkEYM8lysUpRAniEfVEm8anEqYsxhVZusZSH2ggiNeUKEZIjlFhjHAtVLgqNU6DiVDgStgdzTHHNMpdYXpQAbuN8+cUhwEMg3XiGVh0DI64+sqxBRUO6Fx+hAF7sVaAKcVcJFbUzjXPFU9DTbLXfxgGLTVkqktlbU5erRFwtFwB+QYR5CBsoy440yMUDe1CeQ73rr6MhbByJvvlHkVUA3q+Zjwt1BFQIxkJVIGY9pRFNErnvtFaObNACZVRdS73NLJcI19t+B80qdLmjD6ZgZKDH/JsM/OEp6HFiWpcpcC1UrpKLcQZAUH4e2PqyW2rimPlnU8yQJDOiG+fAMVrY6DxGLgD/j50yTzoAgjrfj7zg6od6shA7o7Ml9gVBjRGfP7ush9HxOQu2pWUnkBAqpKHhItftzQ1vDWV6TdSkcDDcre6NYRfJ5gzgUqGqTiW9r8jXWnV3U7xHJ1wujtx2V3XANMSELSiirk1mBA15gC33OGf0BA4tnri3XPfJ4VVcO09odt8bUlcM91bR1TsTlEjJCqwRq/magE4EX+lN0ur4H6/A0dFoTp+e/pfP8RHQu5FUkFJcRDrPwGYah6U/yGbhr1zlSe9qvrTsNYwfW98vQPrAuDjw77TnPzosTNegDZnyDyArYFvsz9ajnw3SPrj3HdvTj9GjXbO3Mnb1Hzf+lR4/Ya4Y+TdLBTaRC7ymud31LrrdnArcpmuZWUU+I6z7jL7jU39vzqEfoCbtTiP2v02YD9D+grevf&lt;/diagram&gt;&lt;/mxfile&gt;"
+   version="1.1"
+   viewBox="0 0 421 411"
+   id="svg12"
+   sodipodi:docname="shared-gateway.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <defs
+     id="defs12" />
+  <sodipodi:namedview
+     id="namedview12"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.4744526"
+     inkscape:cx="210.58663"
+     inkscape:cy="368.27228"
+     inkscape:window-width="1328"
+     inkscape:window-height="821"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg12" />
+  <g
+     id="g12">
+    <rect
+       width="420"
+       height="240"
+       x="0"
+       y="170"
+       fill="#fff"
+       stroke="#000"
+       pointer-events="all"
+       id="rect1" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g1">
+      <switch
+         id="switch1">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:418px;height:1px;padding-top:177px;margin-left:2px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:left">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">ingress namespace</xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="2"
+           y="189"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           id="text1">ingress namespace</text>
+      </switch>
+    </g>
+    <rect
+       width="200"
+       height="100"
+       x="0"
+       y="0"
+       fill="#fff"
+       stroke="#000"
+       pointer-events="all"
+       id="rect2" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g2">
+      <switch
+         id="switch2">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:7px;margin-left:2px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:left">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">app1 namespace</xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="2"
+           y="19"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           id="text2">app1 namespace</text>
+      </switch>
+    </g>
+    <rect
+       width="200"
+       height="100"
+       x="220"
+       y="0"
+       fill="#fff"
+       stroke="#000"
+       pointer-events="all"
+       id="rect3" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g3">
+      <switch
+         id="switch3">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:198px;height:1px;padding-top:7px;margin-left:222px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:left">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">app2 namespace</xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="222"
+           y="19"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           id="text3">app2 namespace</text>
+      </switch>
+    </g>
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 280 290 L 280 313.63"
+       pointer-events="stroke"
+       id="path3" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 280 318.88 L 276.5 311.88 L 280 313.63 L 283.5 311.88 Z"
+       pointer-events="all"
+       id="path4" />
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 220 260 L 166.37 260"
+       pointer-events="stroke"
+       id="path5" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 161.12 260 L 168.12 256.5 L 166.37 260 L 168.12 263.5 Z"
+       pointer-events="all"
+       id="path6" />
+    <rect
+       width="120"
+       height="60"
+       x="220"
+       y="230"
+       fill="#d5e8d4"
+       stroke="#82b366"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect6" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g6">
+      <switch
+         id="switch6">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:260px;margin-left:221px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">Gateway</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="280"
+           y="264"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text6">Gateway</text>
+      </switch>
+    </g>
+    <rect
+       width="120"
+       height="60"
+       x="220"
+       y="320"
+       fill="#dae8fc"
+       stroke="#6c8ebf"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect7" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g7">
+      <switch
+         id="switch7">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:350px;margin-left:221px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">Deployment</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="280"
+           y="354"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text7">Deployment</text>
+      </switch>
+    </g>
+    <rect
+       width="120"
+       height="60"
+       x="40"
+       y="230"
+       fill="#fff2cc"
+       stroke="#d6b656"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect8" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g8">
+      <switch
+         id="switch8">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:260px;margin-left:41px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">Certificate</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="100"
+           y="264"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text8">Certificate</text>
+      </switch>
+    </g>
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 320 90 L 320 160 L 280 160 L 280 223.63"
+       pointer-events="stroke"
+       id="path8" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 280 228.88 L 276.5 221.88 L 280 223.63 L 283.5 221.88 Z"
+       pointer-events="all"
+       id="path9" />
+    <rect
+       width="120"
+       height="60"
+       x="260"
+       y="30"
+       fill="#f8cecc"
+       stroke="#b85450"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect9" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g9">
+      <switch
+         id="switch9">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:60px;margin-left:261px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">VirtualService</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="320"
+           y="64"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text9">VirtualService</text>
+      </switch>
+    </g>
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 100 90 L 100 160 L 280 160 L 280 223.63"
+       pointer-events="stroke"
+       id="path10" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 280 228.88 L 276.5 221.88 L 280 223.63 L 283.5 221.88 Z"
+       pointer-events="all"
+       id="path11" />
+    <rect
+       width="120"
+       height="60"
+       x="40"
+       y="30"
+       fill="#f8cecc"
+       stroke="#b85450"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect11" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g11">
+      <switch
+         id="switch11">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:60px;margin-left:41px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">VirtualService</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="100"
+           y="64"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text11">VirtualService</text>
+      </switch>
+    </g>
+  </g>
+</svg>

--- a/content/en/docs/setup/additional-setup/gateway/user-gateway.svg
+++ b/content/en/docs/setup/additional-setup/gateway/user-gateway.svg
@@ -1,1 +1,296 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="421" height="241" content="&lt;mxfile host=&quot;drawio-internal.googleplex.com&quot; modified=&quot;2021-05-10T18:33:21.494Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36&quot; etag=&quot;Z6V1qB2jDteWuHtnzFMV&quot; version=&quot;14.4.8&quot; type=&quot;google&quot; pages=&quot;2&quot;&gt;&lt;diagram id=&quot;P8ZkhgxdiRg3_sUfxNwi&quot; name=&quot;Page-1&quot;&gt;7VhLc5swEP41HNPhHXJM7DQ9pE1mPJM2RxkWUCsQFbKB/vpKIF4xTtypXdJMTmifsN+nXWnQrEVS3jCUxZ9pAEQz9aDUrKVmmobj6OIhNVWj8ayLRhExHCinXrHCv0ApVVy0wQHkI0dOKeE4Gyt9mqbg85EOMUaLsVtIyfitGYpgR7HyEdnVfsUBj1UVbVlS/wlwFLdvNnRlSVDrrBR5jAJaDFTWtWYtGKW8WSXlAogEr8Wlifu4x9p9GIOUHxKQVnexf1n66YP9JSzoDbs7uztTWbaIbFTBmumiJNOsq3Sdy4fMkEYM8lysUpRAniEfVEm8anEqYsxhVZusZSH2ggiNeUKEZIjlFhjHAtVLgqNU6DiVDgStgdzTHHNMpdYXpQAbuN8+cUhwEMg3XiGVh0DI64+sqxBRUO6Fx+hAF7sVaAKcVcJFbUzjXPFU9DTbLXfxgGLTVkqktlbU5erRFwtFwB+QYR5CBsoy440yMUDe1CeQ73rr6MhbByJvvlHkVUA3q+Zjwt1BFQIxkJVIGY9pRFNErnvtFaObNACZVRdS73NLJcI19t+B80qdLmjD6ZgZKDH/JsM/OEp6HFiWpcpcC1UrpKLcQZAUH4e2PqyW2rimPlnU8yQJDOiG+fAMVrY6DxGLgD/j50yTzoAgjrfj7zg6od6shA7o7Ml9gVBjRGfP7ush9HxOQu2pWUnkBAqpKHhItftzQ1vDWV6TdSkcDDcre6NYRfJ5gzgUqGqTiW9r8jXWnV3U7xHJ1wujtx2V3XANMSELSiirk1mBA15gC33OGf0BA4tnri3XPfJ4VVcO09odt8bUlcM91bR1TsTlEjJCqwRq/magE4EX+lN0ur4H6/A0dFoTp+e/pfP8RHQu5FUkFJcRDrPwGYah6U/yGbhr1zlSe9qvrTsNYwfW98vQPrAuDjw77TnPzosTNegDZnyDyArYFvsz9ajnw3SPrj3HdvTj9GjXbO3Mnb1Hzf+lR4/Ya4Y+TdLBTaRC7ymud31LrrdnArcpmuZWUU+I6z7jL7jU39vzqEfoCbtTiP2v02YD9D+grevf&lt;/diagram&gt;&lt;diagram id=&quot;4JeC2udJRXLg3M3sNg4T&quot; name=&quot;Page-2&quot;&gt;zVhLc5swEP41PqZjnsHHxE6TQzKTqaevowwLqBWICmEgv74SCAS2J27SEHJC+2l30e637MpeWOukumUoix9oAGRhLoNqYW0Wpmk4zlI8JFK3iGetWiBiOFBKGtjiJ1CgsosKHEA+UuSUEo6zMejTNAWfjzDEGC3HaiEl47dmKIIjYOsjcox+xwGPVRRdWBK/AxzF3ZuNpdpJUKesgDxGAS0HkHWzsNaMUt6ukmoNRCavy8u+sL+a2ebL6qG8W22f1rVdlhets88vMelDYJDyt3Vttq73iBQqXwvTRUm2sK7TXS4fkoYsE0dYpiiBPEM+qHTwustxGWMO22bL2pSijoRdzBMiJEMs98A4FoxcERylAuNUKhC0A/JIc8wxlagvggM2UL8/UEhwEMg3XiPlh0DImxM2IQgrqA44P5Mwo2dRlD/QBDirhV2p68TuyI8HNWLaCkSqNqPeVudfLBQFL6DDOkotBKKalUgZj2lEU0RuNHrNaJEGIL0uhaR17qlMc0PAL+C8Vp8mKjgd0wMV5j+k+SdHST8HO5tKeW6EuhNSEe7ASIo/h3varJE6uzY+GdQrmBKJoQXz4Rk9R3UYxCJ4zp97mnkGBHG8Hx/uzVm2Z2V5wLFm/AzLxohjTfkHZ/lyTpadU62VyIYVUpGFIf/un4J2Gxd5w+CVUDDcrNKbYhXJ5y3iUKK6cybO1vprd49KSxeOJPFMp+46a9+LQ0zImhLKGmdW4IAX2ALPOaO/YbDjmTvLdafoxspLP4bVPcRV4qBZG6eatTtVr3Yn4ncDGaF1Ag2nM1CMwAv9UxS7vge78B0pNpy5Ob6ciOO1vOKE4pLDYRaSwzA0/ZMkB+7Odab8ju0P9hl78165Lod3rn4An7tzmaNLVz+dZxrHq38cx85/juPG9IoxOfx6hYzilOcDz48S0PVmWAdNxT74mXSgbzrP6otFewJdcX0ory/C1UR95htmvEBkC2yP/ZlajefD6Vaz8xzbWb5fq5lynAhR/xHQVoX+O8W6+Qs=&lt;/diagram&gt;&lt;/mxfile&gt;" version="1.1" viewBox="0 0 421 241"><g><rect width="420" height="240" x="0" y="0" fill="#fff" stroke="#000" pointer-events="all"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:418px;height:1px;padding-top:7px;margin-left:2px"><div style="box-sizing:border-box;font-size:0;text-align:left"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">app1 namespace</div></div></div></foreignObject><text x="2" y="19" fill="#000" font-family="Helvetica" font-size="12">app1 namespace</text></switch></g><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 280 120 L 280 143.63" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 280 148.88 L 276.5 141.88 L 280 143.63 L 283.5 141.88 Z" pointer-events="all"/><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 220 90 L 166.37 90" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 161.12 90 L 168.12 86.5 L 166.37 90 L 168.12 93.5 Z" pointer-events="all"/><rect width="120" height="60" x="220" y="60" fill="#d5e8d4" stroke="#82b366" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:90px;margin-left:221px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">Gateway</font></div></div></div></foreignObject><text x="280" y="94" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">Gateway</text></switch></g><rect width="120" height="60" x="220" y="150" fill="#dae8fc" stroke="#6c8ebf" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:180px;margin-left:221px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">Deployment</font></div></div></div></foreignObject><text x="280" y="184" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">Deployment</text></switch></g><rect width="120" height="60" x="40" y="60" fill="#fff2cc" stroke="#d6b656" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:90px;margin-left:41px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">Certificate</font></div></div></div></foreignObject><text x="100" y="94" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">Certificate</text></switch></g><path fill="none" stroke="#000" stroke-miterlimit="10" d="M 130 150 L 130 140 L 250 140 L 250 126.37" pointer-events="stroke"/><path fill="#000" stroke="#000" stroke-miterlimit="10" d="M 250 121.12 L 253.5 128.12 L 250 126.37 L 246.5 128.12 Z" pointer-events="all"/><rect width="120" height="60" x="40" y="150" fill="#f8cecc" stroke="#b85450" pointer-events="all" rx="9" ry="9"/><g transform="translate(-0.5 -0.5)"><switch><foreignObject style="overflow:visible;text-align:left" width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"><div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:180px;margin-left:41px"><div style="box-sizing:border-box;font-size:0;text-align:center"><div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal"><font style="font-size:16px">VirtualService</font></div></div></div></foreignObject><text x="100" y="184" fill="#000" font-family="Helvetica" font-size="12" text-anchor="middle">VirtualService</text></switch></g></g><switch><a target="_blank" transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems"><text x="50%" y="100%" font-size="10" text-anchor="middle">Viewer does not support full SVG 1.1</text></a></switch></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="421"
+   height="241"
+   content="&lt;mxfile host=&quot;drawio-internal.googleplex.com&quot; modified=&quot;2021-05-10T18:33:21.494Z&quot; agent=&quot;5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/90.0.4430.93 Safari/537.36&quot; etag=&quot;Z6V1qB2jDteWuHtnzFMV&quot; version=&quot;14.4.8&quot; type=&quot;google&quot; pages=&quot;2&quot;&gt;&lt;diagram id=&quot;P8ZkhgxdiRg3_sUfxNwi&quot; name=&quot;Page-1&quot;&gt;7VhLc5swEP41HNPhHXJM7DQ9pE1mPJM2RxkWUCsQFbKB/vpKIF4xTtypXdJMTmifsN+nXWnQrEVS3jCUxZ9pAEQz9aDUrKVmmobj6OIhNVWj8ayLRhExHCinXrHCv0ApVVy0wQHkI0dOKeE4Gyt9mqbg85EOMUaLsVtIyfitGYpgR7HyEdnVfsUBj1UVbVlS/wlwFLdvNnRlSVDrrBR5jAJaDFTWtWYtGKW8WSXlAogEr8Wlifu4x9p9GIOUHxKQVnexf1n66YP9JSzoDbs7uztTWbaIbFTBmumiJNOsq3Sdy4fMkEYM8lysUpRAniEfVEm8anEqYsxhVZusZSH2ggiNeUKEZIjlFhjHAtVLgqNU6DiVDgStgdzTHHNMpdYXpQAbuN8+cUhwEMg3XiGVh0DI64+sqxBRUO6Fx+hAF7sVaAKcVcJFbUzjXPFU9DTbLXfxgGLTVkqktlbU5erRFwtFwB+QYR5CBsoy440yMUDe1CeQ73rr6MhbByJvvlHkVUA3q+Zjwt1BFQIxkJVIGY9pRFNErnvtFaObNACZVRdS73NLJcI19t+B80qdLmjD6ZgZKDH/JsM/OEp6HFiWpcpcC1UrpKLcQZAUH4e2PqyW2rimPlnU8yQJDOiG+fAMVrY6DxGLgD/j50yTzoAgjrfj7zg6od6shA7o7Ml9gVBjRGfP7ush9HxOQu2pWUnkBAqpKHhItftzQ1vDWV6TdSkcDDcre6NYRfJ5gzgUqGqTiW9r8jXWnV3U7xHJ1wujtx2V3XANMSELSiirk1mBA15gC33OGf0BA4tnri3XPfJ4VVcO09odt8bUlcM91bR1TsTlEjJCqwRq/magE4EX+lN0ur4H6/A0dFoTp+e/pfP8RHQu5FUkFJcRDrPwGYah6U/yGbhr1zlSe9qvrTsNYwfW98vQPrAuDjw77TnPzosTNegDZnyDyArYFvsz9ajnw3SPrj3HdvTj9GjXbO3Mnb1Hzf+lR4/Ya4Y+TdLBTaRC7ymud31LrrdnArcpmuZWUU+I6z7jL7jU39vzqEfoCbtTiP2v02YD9D+grevf&lt;/diagram&gt;&lt;diagram id=&quot;4JeC2udJRXLg3M3sNg4T&quot; name=&quot;Page-2&quot;&gt;zVhLc5swEP41PqZjnsHHxE6TQzKTqaevowwLqBWICmEgv74SCAS2J27SEHJC+2l30e637MpeWOukumUoix9oAGRhLoNqYW0Wpmk4zlI8JFK3iGetWiBiOFBKGtjiJ1CgsosKHEA+UuSUEo6zMejTNAWfjzDEGC3HaiEl47dmKIIjYOsjcox+xwGPVRRdWBK/AxzF3ZuNpdpJUKesgDxGAS0HkHWzsNaMUt6ukmoNRCavy8u+sL+a2ebL6qG8W22f1rVdlhets88vMelDYJDyt3Vttq73iBQqXwvTRUm2sK7TXS4fkoYsE0dYpiiBPEM+qHTwustxGWMO22bL2pSijoRdzBMiJEMs98A4FoxcERylAuNUKhC0A/JIc8wxlagvggM2UL8/UEhwEMg3XiPlh0DImxM2IQgrqA44P5Mwo2dRlD/QBDirhV2p68TuyI8HNWLaCkSqNqPeVudfLBQFL6DDOkotBKKalUgZj2lEU0RuNHrNaJEGIL0uhaR17qlMc0PAL+C8Vp8mKjgd0wMV5j+k+SdHST8HO5tKeW6EuhNSEe7ASIo/h3varJE6uzY+GdQrmBKJoQXz4Rk9R3UYxCJ4zp97mnkGBHG8Hx/uzVm2Z2V5wLFm/AzLxohjTfkHZ/lyTpadU62VyIYVUpGFIf/un4J2Gxd5w+CVUDDcrNKbYhXJ5y3iUKK6cybO1vprd49KSxeOJPFMp+46a9+LQ0zImhLKGmdW4IAX2ALPOaO/YbDjmTvLdafoxspLP4bVPcRV4qBZG6eatTtVr3Yn4ncDGaF1Ag2nM1CMwAv9UxS7vge78B0pNpy5Ob6ciOO1vOKE4pLDYRaSwzA0/ZMkB+7Odab8ju0P9hl78165Lod3rn4An7tzmaNLVz+dZxrHq38cx85/juPG9IoxOfx6hYzilOcDz48S0PVmWAdNxT74mXSgbzrP6otFewJdcX0ory/C1UR95htmvEBkC2yP/ZlajefD6Vaz8xzbWb5fq5lynAhR/xHQVoX+O8W6+Qs=&lt;/diagram&gt;&lt;/mxfile&gt;"
+   version="1.1"
+   viewBox="0 0 421 241"
+   id="svg8"
+   sodipodi:docname="user-gateway.svg"
+   inkscape:version="1.3 (0e150ed, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview8"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="1.7980998"
+     inkscape:cx="210.5"
+     inkscape:cy="120.68296"
+     inkscape:window-width="1328"
+     inkscape:window-height="821"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
+  <g
+     id="g8">
+    <rect
+       width="420"
+       height="240"
+       x="0"
+       y="0"
+       fill="#fff"
+       stroke="#000"
+       pointer-events="all"
+       id="rect1" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g1">
+      <switch
+         id="switch1">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe flex-start;justify-content:unsafe flex-start;width:418px;height:1px;padding-top:7px;margin-left:2px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:left">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">app1 namespace</xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="2"
+           y="19"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           id="text1">app1 namespace</text>
+      </switch>
+    </g>
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 280 120 L 280 143.63"
+       pointer-events="stroke"
+       id="path1" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 280 148.88 L 276.5 141.88 L 280 143.63 L 283.5 141.88 Z"
+       pointer-events="all"
+       id="path2" />
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 220 90 L 166.37 90"
+       pointer-events="stroke"
+       id="path3" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 161.12 90 L 168.12 86.5 L 166.37 90 L 168.12 93.5 Z"
+       pointer-events="all"
+       id="path4" />
+    <rect
+       width="120"
+       height="60"
+       x="220"
+       y="60"
+       fill="#d5e8d4"
+       stroke="#82b366"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect4" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g4">
+      <switch
+         id="switch4">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:90px;margin-left:221px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">Gateway</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="280"
+           y="94"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text4">Gateway</text>
+      </switch>
+    </g>
+    <rect
+       width="120"
+       height="60"
+       x="220"
+       y="150"
+       fill="#dae8fc"
+       stroke="#6c8ebf"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect5" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g5">
+      <switch
+         id="switch5">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:180px;margin-left:221px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">Deployment</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="280"
+           y="184"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text5">Deployment</text>
+      </switch>
+    </g>
+    <rect
+       width="120"
+       height="60"
+       x="40"
+       y="60"
+       fill="#fff2cc"
+       stroke="#d6b656"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect6" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g6">
+      <switch
+         id="switch6">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:90px;margin-left:41px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">Certificate</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="100"
+           y="94"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text6">Certificate</text>
+      </switch>
+    </g>
+    <path
+       fill="none"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 130 150 L 130 140 L 250 140 L 250 126.37"
+       pointer-events="stroke"
+       id="path6" />
+    <path
+       fill="#000"
+       stroke="#000"
+       stroke-miterlimit="10"
+       d="M 250 121.12 L 253.5 128.12 L 250 126.37 L 246.5 128.12 Z"
+       pointer-events="all"
+       id="path7" />
+    <rect
+       width="120"
+       height="60"
+       x="40"
+       y="150"
+       fill="#f8cecc"
+       stroke="#b85450"
+       pointer-events="all"
+       rx="9"
+       ry="9"
+       id="rect7" />
+    <g
+       transform="translate(-0.5 -0.5)"
+       id="g7">
+      <switch
+         id="switch7">
+        <foreignObject
+           style="overflow:visible;text-align:left"
+           width="100%"
+           height="100%"
+           pointer-events="none"
+           requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+          <xhtml:div
+             style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:118px;height:1px;padding-top:180px;margin-left:41px">
+            <xhtml:div
+               style="box-sizing:border-box;font-size:0;text-align:center">
+              <xhtml:div
+                 style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                <xhtml:font
+                   style="font-size:16px">VirtualService</xhtml:font>
+              </xhtml:div>
+            </xhtml:div>
+          </xhtml:div>
+        </foreignObject>
+        <text
+           x="100"
+           y="184"
+           fill="#000"
+           font-family="Helvetica"
+           font-size="12"
+           text-anchor="middle"
+           id="text7">VirtualService</text>
+      </switch>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
The error tip at the bottom, generated by draw.io in SVG, is unrelated to Istio, might confuse the reader, and can likely be removed:

```text
Viewer does not support full SVG 1.1
```

See discussions about this error text: https://github.com/jgraph/drawio/issues/774

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
