### PR TITLE
Update index.md

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/gateway-api/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/gateway-api/index.md
@@ -334,7 +334,7 @@ spec:
         add:
         - name: my-added-header
           value: added-value
-  - backendRefs:
+    backendRefs:
     - name: example
       port: 80
 {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/ingress/gateway-api/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/gateway-api/snips.sh
@@ -232,7 +232,7 @@ spec:
         add:
         - name: my-added-header
           value: added-value
-  - backendRefs:
+    backendRefs:
     - name: example
       port: 80
 ENDSNIP


### PR DESCRIPTION
corrects example httproute for mesh traffic in k8s gw api ingress task.  the backendRefs should be part of the one rule that applies the filters.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [x] Docs
