### PR TITLE
Fix list format of traffic-management/request-timeouts/index.md

### DIFF
--- a/content/en/docs/tasks/traffic-management/request-timeouts/index.md
+++ b/content/en/docs/tasks/traffic-management/request-timeouts/index.md
@@ -29,7 +29,7 @@ timeout to half a second.
 To see its effect, however, you also introduce an artificial 2 second delay in calls
 to the `ratings` service.
 
-1.  Route requests to v2 of the `reviews` service, i.e., a version that calls the `ratings` service:
+1)  Route requests to v2 of the `reviews` service, i.e., a version that calls the `ratings` service:
 
 {{< tabset category-name="config-api" >}}
 


### PR DESCRIPTION
Fix list format of traffic-management/request-timeouts/index.md:
```
content/en/docs/tasks/traffic-management/request-timeouts/index.md
```

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
