### PR TITLE
Replace mention of virtual service in dns proxying docs

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/dns/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns/index.md
@@ -35,7 +35,7 @@ Istio uses this information to determine the intended destination.
 [Understanding Traffic Routing](/docs/ops/configuration/traffic-management/traffic-routing/) gives a deep dive into how this behavior works.
 
 If the client was unable to resolve the DNS request, the request would terminate before Istio receives it.
-This means that if a request is sent to a hostname which is known to Istio (for example, by a `VirtualService`) but not to the DNS server, the request will fail.
+This means that if a request is sent to a hostname which is known to Istio (for example, by a `ServiceEntry`) but not to the DNS server, the request will fail.
 Istio [DNS proxying](#dns-proxying) can change this behavior.
 
 Once Istio has identified the intended destination, it must choose which address to send to.


### PR DESCRIPTION

Delete mention of virtual service in dns proxying related docs

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
