### PR TITLE
telemetry: change ALL_METRICS to REQUEST_COUNT

### DIFF
--- a/content/en/docs/tasks/observability/metrics/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/metrics/telemetry-api/index.md
@@ -75,13 +75,13 @@ You can modify the standard metric definitions using `tags_to_remove` or by re-d
       metrics:
         - overrides:
             - match:
-                metric: ALL_METRICS
+                metric: REQUEST_COUNT
                 mode: CLIENT
               tagOverrides:
                 destination_x:
                   value: upstream_peer.labels['app'].value
             - match:
-                metric: ALL_METRICS
+                metric: REQUEST_COUNT
                 mode: SERVER
               tagOverrides:
                 source_x:

--- a/content/en/docs/tasks/observability/metrics/telemetry-api/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/telemetry-api/snips.sh
@@ -60,13 +60,13 @@ spec:
   metrics:
     - overrides:
         - match:
-            metric: ALL_METRICS
+            metric: REQUEST_COUNT
             mode: CLIENT
           tagOverrides:
             destination_x:
               value: upstream_peer.labels['app'].value
         - match:
-            metric: ALL_METRICS
+            metric: REQUEST_COUNT
             mode: SERVER
           tagOverrides:
             source_x:

--- a/content/zh/docs/tasks/observability/metrics/telemetry-api/index.md
+++ b/content/zh/docs/tasks/observability/metrics/telemetry-api/index.md
@@ -72,13 +72,13 @@ spec:
       metrics:
         - overrides:
             - match:
-                metric: ALL_METRICS
+                metric: REQUEST_COUNT
                 mode: CLIENT
               tagOverrides:
                 destination_x:
                   value: upstream_peer.labels['app'].value
             - match:
-                metric: ALL_METRICS
+                metric: REQUEST_COUNT
                 mode: SERVER
               tagOverrides:
                 source_x:


### PR DESCRIPTION
change `ALL_METRICS` to `REQUEST_COUNT`.
- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
