### PR TITLE
Update Istio VM installation guide in multi-network setup

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -171,6 +171,12 @@ Install Istio and expose the control plane on cluster so that your virtual machi
     $ kubectl apply -n istio-system -f @samples/multicluster/expose-services.yaml@
     {{< /text >}}
 
+    Ensure to label the istio-system namespace with the defined cluster network:
+    
+    {{< text bash >}}
+    $ kubectl label namespace istio-system topology.istio.io/network="${CLUSTER_NETWORK}"
+    {{< /text >}}
+
     {{< /tab >}}
 
     {{< /tabset >}}

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -172,7 +172,7 @@ Install Istio and expose the control plane on cluster so that your virtual machi
     {{< /text >}}
 
     Ensure to label the istio-system namespace with the defined cluster network:
-    
+
     {{< text bash >}}
     $ kubectl label namespace istio-system topology.istio.io/network="${CLUSTER_NETWORK}"
     {{< /text >}}

--- a/content/en/docs/setup/install/virtual-machine/snips.sh
+++ b/content/en/docs/setup/install/virtual-machine/snips.sh
@@ -91,6 +91,10 @@ snip_install_the_istio_control_plane_8() {
 kubectl apply -n istio-system -f samples/multicluster/expose-services.yaml
 }
 
+snip_install_the_istio_control_plane_9() {
+kubectl label namespace istio-system topology.istio.io/network="${CLUSTER_NETWORK}"
+}
+
 snip_install_namespace() {
 kubectl create namespace "${VM_NAMESPACE}"
 }


### PR DESCRIPTION
Update Istio VM installation guide in multi-network setup

Please provide a description for what this PR is for.
Add missing instruction on Istio VM installation guide in multi-network setup

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [x] Docs
- [x] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
