### PR TITLE
Drop support for Kubernetes 1.21 and 1.22

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -6,7 +6,7 @@
   releaseDate:
   eolDate:
   k8sVersions: ["1.25", "1.26", "1.27", "1.28"]
-  testedK8sVersions: ["1.21", "1.22", "1.23", "1.24"]
+  testedK8sVersions: ["1.23", "1.24"]
 - version: "1.19"
   supported: "Yes"
   releaseDate: "Sept 5, 2023"


### PR DESCRIPTION
We stopped testing these recently