### PR TITLE
Add xt_multiport to platform prerequisites

### DIFF
--- a/content/en/docs/setup/platform-setup/prerequisites/index.md
+++ b/content/en/docs/setup/platform-setup/prerequisites/index.md
@@ -37,6 +37,7 @@ the automatic loading of some of the below mentioned kernel modules.
 | `xt_mark` | Only needed for `TPROXY` interception mode |
 | `xt_owner` |  |
 | `xt_tcpudp` |  |
+| `xt_multiport`|  |
 
 The following additional modules are used by the above listed modules and should be also loaded on the cluster node:
 


### PR DESCRIPTION
Users deploying in Openshift cluster have reported that upgrade from Istio 1.17 to Istio 1.18.3 has failed due to the lack of kernel module xt_multiport from the cluster.

This is most probably related to modifications in IPtables creation, see https://github.com/istio/istio/blame/7e7d52a2d12724e1719f679fa4fab206a70d838b/tools/istio-iptables/pkg/capture/run.go#L369


