### PR TITLE
Add note to ambient quickstart mentioning minikube workaround

### DIFF
--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -64,6 +64,12 @@ Follow these steps to get started with ambient:
     Install Istio with the `ambient` profile on your Kubernetes cluster, using
     the `istioctl` command downloaded above:
 
+{{< tip >}}
+Note that if you are using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) (or any other platform using nodes configured with a nonstandard `netns` path for containers), you may need to append `--set values.cni.cniNetnsDir="/var/run/docker/netns"` to the `istioctl install` command so that the Istio CNI DaemonSet can correctly manage and capture pods on the node.
+
+Consult your platform documentation for details.
+{{< /tip >}}
+
 {{< tabset category-name="config-api" >}}
 
 {{< tab name="Istio APIs" category-value="istio-apis" >}}


### PR DESCRIPTION
Document minikube-specific workaround config flag introduced in https://github.com/istio/istio/pull/47444

This may or may not be final, but it's current state and it's better to mention it.

- [x] Ambient
- [x] Docs
- [x] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
