### PR TITLE
Drop "distroless is alpha" warning

### DIFF
--- a/content/en/docs/ops/configuration/security/harden-docker-images/index.md
+++ b/content/en/docs/ops/configuration/security/harden-docker-images/index.md
@@ -7,10 +7,8 @@ aliases:
   - /docs/ops/security/harden-docker-images
 owner: istio/wg-security-maintainers
 test: n/a
-status: Alpha
+status: Beta
 ---
-
-{{< boilerplate alpha >}}
 
 Istio's [default images](https://hub.docker.com/r/istio/base) are based on `ubuntu` with some extra tools added.
 An alternative image based on [distroless images](https://github.com/GoogleContainerTools/distroless) is also available.


### PR DESCRIPTION
https://github.com/istio/enhancements/pull/105

Please provide a description for what this PR is for.

And to help us figure out who should review this PR, please 
put an X in all the areas that this PR affects.

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
