### PR TITLE
Fix make format-spelling difference on MacOS

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -85,7 +85,7 @@ site:
 snips:
 	@scripts/gen_snips.sh
 
-# Force locale since MacOS and Linux use differnet locales. Else MacOS users updates will
+# Force locale, since macOS and Linux use different locales. Otherwise updates from macOS users will
 # fail make gen-check with an incorrect (for the pipeline) .spelling.
 format-spelling:
 	@echo "Sorting the .spelling file..."

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -85,9 +85,11 @@ site:
 snips:
 	@scripts/gen_snips.sh
 
+# Force locale since MacOS and Linux use differnet locales. Else MacOS users updates will
+# fail make gen-check with an incorrect (for the pipeline) .spelling.
 format-spelling:
 	@echo "Sorting the .spelling file..."
-	@sort .spelling --ignore-case -o .spelling
+	@LC_ALL=C sort .spelling --ignore-case -o .spelling
 	@echo ".spelling file sorted."
 
 gen: tidy-go format-go update-gateway-version snips format-spelling


### PR DESCRIPTION
## Description

Fix make format-spelling differnce on MacOS. Running `make gen` on a Mac will result in a .spelling file update that if checked in fails the `make gen-check` in the pipeline. This is because MacOS and Linux use different locales by default, and sort uses the locale to determine its sorting. This change forces the C locale to be used on both platforms for the sort.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
