### PR TITLE
Fix typo for istioctl command pre-check to precheck

### DIFF
--- a/content/en/news/releases/1.20.x/announcing-1.20/change-notes/index.md
+++ b/content/en/news/releases/1.20.x/announcing-1.20/change-notes/index.md
@@ -187,7 +187,7 @@ environment to remove the deprecated functionality.
 - **Added** a new `istioctl dashboard proxy` command, which can be used to show the admin UI of different proxy pods,
   like Envoy, Ztunnel, Waypoint.
 
-- **Added** an output format option for the `istioctl experimental pre-check` command. Valid options are `log`, `json`
+- **Added** an output format option for the `istioctl experimental precheck` command. Valid options are `log`, `json`
   or `yaml`.
 
 - **Added** the `--output-threshold` flag in `istioctl experimental precheck` to control the message output threshold.

--- a/content/zh/news/releases/1.20.x/announcing-1.20/change-notes/index.md
+++ b/content/zh/news/releases/1.20.x/announcing-1.20/change-notes/index.md
@@ -186,7 +186,7 @@ weight: 20
 - **新增** 添加了一个新的 `istioctl dashboard proxy` 命令，
   可用于显示不同代理 Pod 的管理 UI，例如 Envoy、Ztunnel、Waypoint。
 
-- **新增** 添加了 `istioctl experimental pre-check` 命令的输出格式选项。
+- **新增** 添加了 `istioctl experimental precheck` 命令的输出格式选项。
   有效选项为 `log`、`json` 或 `yaml`。
 
 - **新增** 在 `istioctl experimental precheck` 中添加了 `--output-threshold`


### PR DESCRIPTION
## Description

Fix typo for istioctl command pre-check to precheck


- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
