### PR TITLE
Add Linux Foundation trademark link to site footer

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -91,6 +91,9 @@ other = "Privacy policy"
 [footer_terms_and_conditions]
 other = "Terms and Conditions"
 
+[footer_trademarks]
+other = "Trademarks"
+
 [page_publish_date_format]
 other = "January 2, 2006"
 

--- a/i18n/pt-br.toml
+++ b/i18n/pt-br.toml
@@ -85,6 +85,9 @@ other = "2 de janeiro de 2006"
 [footer_privacy_policy]
 other = "Política de Privacidade"
 
+[footer_trademarks]
+other = "Marcas registradas"
+
 [page_publish_date_format]
 other = "2 de janeiro de 2006"
 

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -91,6 +91,9 @@ other = "隐私政策"
 [footer_terms_and_conditions]
 other = "条款"
 
+[footer_trademarks]
+other = "商标"
+
 [page_publish_date_format]
 other = "2006年1月2日"
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -53,6 +53,9 @@
                 <a class="footer-policies-link" href="https://www.linuxfoundation.org/legal/privacy-policy">
                     {{ i18n "footer_privacy_policy" }}
                 </a> |
+                <a class="footer-policies-link" href="https://www.linuxfoundation.org/legal/trademark-usage">
+                    {{ i18n "footer_trademarks" }}
+                </a> |
                 {{ if .Params.source_repo }}
                     {{ $msg := i18n "generated_file" }}
                     {{ $title := printf $msg .Page.Params.source_repo }}


### PR DESCRIPTION
Hi all,

I filed an issue on Istio and when I do that, I like to also try to contribute something back.

This supports https://github.com/istio/istio/issues/48087. 

## Description

Adds a link to the linux foundation's trademarks page to the footer of the site. This will then pass the legal check on CLOMonitor.

## Work

* [ ] Add link to footer
* [ ] Add i18n for link

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation