### PR TITLE
Lower linkinator concurrency to solve lint flake?

### DIFF
--- a/scripts/lint_site.sh
+++ b/scripts/lint_site.sh
@@ -205,12 +205,12 @@ if [ -d ./public ]; then
         fi
         echo "Running linkinator..."
         if [[ ${CHECK_EXTERNAL_LINKS:-} == "true" ]]; then
-            if ! linkinator public/ -r -s 'github.com localhost:3000 localhost:5601 localhost:8001 localhost:9080 localhost:9081 en.wikipedia.org my-istio-logs-database.io' --silent; then
+            if ! linkinator public/ -r -s 'github.com localhost:3000 localhost:5601 localhost:8001 localhost:9080 localhost:9081 en.wikipedia.org my-istio-logs-database.io' --silent --concurrency 25; then
                 FAILED=1
             fi
         else
             #TODO: Remove .../workload-selector/ from ignored links. PRs take a long time to get through istio/api, and a link is broken from there. Once this PR is complete, remove it: https://github.com/istio/api/pull/1405
-            if ! linkinator public/ -r -s 'github.com localhost:3000 localhost:5601 localhost:8001 localhost:9080 localhost:9081 en.wikipedia.org my-istio-logs-database.io ^((?!localhost).)*$ /docs/reference/config/type/v1beta1/workload-selector/' --silent; then
+            if ! linkinator public/ -r -s 'github.com localhost:3000 localhost:5601 localhost:8001 localhost:9080 localhost:9081 en.wikipedia.org my-istio-logs-database.io ^((?!localhost).)*$ /docs/reference/config/type/v1beta1/workload-selector/' --silent --concurrency 25; then
                 FAILED=1
             fi
         fi


### PR DESCRIPTION
## Description

Attempt to fix https://github.com/istio/istio.io/issues/14155

Lower concurrency from the default of 100 to see if that helps.