### PR TITLE
Update supportStatus.yml

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -26,7 +26,7 @@
   k8sVersions: ["1.24", "1.25", "1.26", "1.27"]
   testedK8sVersions: ["1.20", "1.21", "1.22", "1.23"]
 - version: "1.17"
-  supported: "Yes"
+  supported: "No"
   releaseDate: "Feb 14, 2023"
   eolDate: "Oct 27, 2023"
   k8sVersions: ["1.23", "1.24", "1.25", "1.26"]


### PR DESCRIPTION

## Description

Mark 1.17 as no longer supported, since October 27, 2023 has passed

1.18 is noted as EOL soon ("~Dec 2023 (Expected)") and I don't know if that should also be updated.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
