### PR TITLE
Fix a date to security-2023-005 in 1.20.1 release notes for consistency

### DIFF
--- a/content/en/news/releases/1.20.x/announcing-1.20.1/index.md
+++ b/content/en/news/releases/1.20.x/announcing-1.20.1/index.md
@@ -7,7 +7,7 @@ publishdate: 2023-12-12
 release: 1.20.1
 ---
 
-This release implements the security updates described in our Dec 11th post, [`ISTIO-SECURITY-2023-005`](/news/security/istio-security-2023-005) along with bug fixes to improve robustness.
+This release implements the security updates described in our Dec 12th post, [`ISTIO-SECURITY-2023-005`](/news/security/istio-security-2023-005) along with bug fixes to improve robustness.
 
 This release note describes what’s different between Istio 1.20.0 and 1.20.1.
 


### PR DESCRIPTION
Checked [ISTIO-SECURITY-2023-005](https://github.com/istio/istio.io/blob/master/content/en/news/security/istio-security-2023-005/index.md) was released on Dec 12th.

It is also Dec 12th in release notes of [1.19.5](https://github.com/istio/istio.io/blob/master/content/en/news/releases/1.19.x/announcing-1.19.5/index.md) and [1.18.6](https://github.com/istio/istio.io/blob/master/content/en/news/releases/1.18.x/announcing-1.18.6/index.md).

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation
