### PR TITLE
Fix typo for best practices security doc

### DIFF
--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -182,7 +182,7 @@ before evaluating against the authorization policies and routing the requests:
 
 {{< tip >}}
 The configuration is specified via the [`pathNormalization`](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-ProxyPathNormalization)
-field in the the [mesh config](/docs/reference/config/istio.mesh.v1alpha1/).
+field in the [mesh config](/docs/reference/config/istio.mesh.v1alpha1/).
 {{< /tip >}}
 
 To emphasize, the normalization algorithms are conducted in the following order:


### PR DESCRIPTION
## Description

Remove dup `the`.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
