### PR TITLE
update deprecated field percent to percentage

### DIFF
--- a/content/en/docs/tasks/traffic-management/request-timeouts/index.md
+++ b/content/en/docs/tasks/traffic-management/request-timeouts/index.md
@@ -97,7 +97,8 @@ spec:
   http:
   - fault:
       delay:
-        percent: 100
+        percentage:
+          value: 100
         fixedDelay: 2s
     route:
     - destination:
@@ -125,7 +126,8 @@ spec:
   http:
   - fault:
       delay:
-        percent: 100
+        percentage:
+          value: 100
         fixedDelay: 2s
     route:
     - destination:

--- a/content/en/docs/tasks/traffic-management/request-timeouts/snips.sh
+++ b/content/en/docs/tasks/traffic-management/request-timeouts/snips.sh
@@ -69,7 +69,8 @@ spec:
   http:
   - fault:
       delay:
-        percent: 100
+        percentage:
+          value: 100
         fixedDelay: 2s
     route:
     - destination:
@@ -90,7 +91,8 @@ spec:
   http:
   - fault:
       delay:
-        percent: 100
+        percentage:
+          value: 100
         fixedDelay: 2s
     route:
     - destination:


### PR DESCRIPTION

## Description
"percent" field is deprecated.
This PR updates it to use "percentage". 
https://github.com/istio/api/blob/v1.20.1/networking/v1alpha3/virtual_service.proto#L1998

## Reviewers

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

