### PR TITLE
Clarify Helm installation chart usage

### DIFF
--- a/content/en/boilerplates/helm-preamble.md
+++ b/content/en/boilerplates/helm-preamble.md
@@ -1,6 +1,7 @@
 ---
 ---
-The Helm charts used
-in this guide are the same underlying charts used when
+The Helm charts for `base` and `istiod` used
+in this guide are the same as those used when
 installing Istio via [Istioctl](/docs/setup/install/istioctl/) or the
 [Operator](/docs/setup/install/operator/).
+However installations via Istioctl and the Operator use a different [gateway chart]({{< github_tree >}}/manifests/charts/gateways/istio-ingress) to the [chart]({{< github_tree >}}/manifests/charts/gateway) described in this guide


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->
The helm guide currently indicates that the installation is the same using helm, istioctl and the Operator. However the helm installation doc uses this [helm chart](https://github.com/istio/istio/tree/master/manifests/charts/gateway) and 
 the Operator and istioctl uses this  [helm chart](https://github.com/istio/istio/tree/master/manifests/charts/gateways/istio-ingress), which is specified in the code [here](https://github.com/istio/istio/blob/master/operator/pkg/translate/translate.go#L140).
 
<img width="945" alt="Screenshot 2023-12-27 at 4 38 37 PM" src="https://github.com/istio/istio.io/assets/11987596/4bbff19e-f77a-432b-a90a-6f81d7ff6e08">



## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
