### PR TITLE
Remove extra alpha status warning

### DIFF
--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -16,7 +16,6 @@ others specified by the
 [platform-specific setup instructions](/docs/setup/platform-setup/).
 
 {{< warning >}}
-Ambient is currently in [alpha status](/docs/releases/feature-stages/#feature-phase-definitions).
 Note that Ambient currently requires the use of [istio-cni](/docs/setup/additional-setup/cni) to configure Kubernetes nodes.
 `istio-cni` ambient mode does **not** currently support types of cluster CNI (namely, CNI implementations that do not use `veth` devices, such as [Minikube's](https://kubernetes.io/docs/tasks/tools/install-minikube/) `bridge` mode)
 {{< /warning >}}


### PR DESCRIPTION
## Description

We have a 

https://github.com/istio/istio.io/blob/d239c023c2e6649629762fd1dab05592689f1d2c/content/en/docs/ops/ambient/getting-started/index.md?plain=1#L9

at top, this is an extra alpha status warning.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
