### PR TITLE
[release-1.20] Fix egress-tls-origination test- snip renamed

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/mtls_test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/mtls_test.sh
@@ -36,7 +36,7 @@ snip_before_you_begin_3
 set +e # suppress harmless "No such file or directory:../crypto/bio/bss_file.c:72:fopen('1_root/index.txt.attr','r')" error
 snip_generate_client_and_server_certificates_and_keys_1
 snip_generate_client_and_server_certificates_and_keys_2
-snip_generate_client_and_server_certificates_and_keys_3
+snip_generate_client_and_server_certificates_and_keys_4
 set -e
 
 # Create mesh-external namespace


### PR DESCRIPTION
## Description

This contains the same fix in the `master` branch where a snip was renamed due to a doc change and the test wasn't updated (due to a problem with the test framework not running that particular test based on the snip change) (so problem is noted in post-submit where we run tests regardless).