### PR TITLE
Fix directory level of script dependencies 

### DIFF
--- a/scripts/pr_tests.py
+++ b/scripts/pr_tests.py
@@ -90,8 +90,7 @@ try:
                         if el in script_dependencies:
                             to_add = script_dependencies[el] - checked
                             to_check.update(to_add)
-                            test_paths.update(map(lambda file_path: file_path[len(doc_file_prefix):].rsplit('/', 1)[0], to_add))
-
+                            test_paths.update(map(lambda file_path: file_path[len(doc_file_prefix):], to_add))
             elif filename == istio_go_dependency or \
                     filename.startswith(test_framework_pkg) or \
                     filename.startswith(test_framework_util) or \


### PR DESCRIPTION
## Description

The script for computing dependencies is returning the dependency directories one level too high after #14443.
```
build-tools:/work$ python3 scripts/pr_tests.py 14362
tasks/traffic-management/egress,tasks/traffic-management/egress/egress-gateway-tls-origination
```
I overlooked the fact that it should have returned tasks/traffic-management/egress/egress-tls-origination instead of tasks/traffic-management/egress.

With these changes included the script is now returning the correct smallest subset of tests that need to be executed.

```
build-tools:/work$ python3 scripts/pr_tests.py 14362
tasks/traffic-management/egress/egress-gateway-tls-origination,tasks/traffic-management/egress/egress-tls-origination
```

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [x] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
