### PR TITLE
docs: fix an incorrect link on the Observability page

### DIFF
--- a/content/en/docs/concepts/observability/index.md
+++ b/content/en/docs/concepts/observability/index.md
@@ -54,7 +54,7 @@ operators can easily expand the set of collected proxy metrics when required. Th
 overall cost of monitoring across the mesh.
 
 The [Envoy documentation site](https://www.envoyproxy.io/docs/envoy/latest/) includes a detailed overview of [Envoy statistics collection](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/observability/statistics.html?highlight=statistics).
-The operations guide on [Envoy Statistics](/docs/ops/diagnostic-tools/proxy-cmd/) provides more information on controlling the generation of proxy-level metrics.
+The operations guide on [Envoy Statistics](/docs/ops/configuration/telemetry/envoy-stats/) provides more information on controlling the generation of proxy-level metrics.
 
 Example proxy-level Metrics:
 


### PR DESCRIPTION

## Description
Fixes the incorrect link to Envoy statistics.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
