### PR TITLE
Designate master and Istio 1.20 as being supported on Kubernetes 1.29

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -5,13 +5,13 @@
   supported: "No, development only"
   releaseDate:
   eolDate:
-  k8sVersions: ["1.25", "1.26", "1.27", "1.28", "1.29"]
-  testedK8sVersions: ["1.23", "1.24"]
+  k8sVersions: ["1.26", "1.27", "1.28", "1.29"]
+  testedK8sVersions: ["1.23", "1.24", "1.25"]
 - version: "1.20"
   supported: "Yes"
   releaseDate: "Nov 14, 2023"
   eolDate: "~Jul 2024 (Expected)"
-  
+
   k8sVersions: ["1.25", "1.26", "1.27", "1.28", "1.29"]
   testedK8sVersions: ["1.23", "1.24"]
 - version: "1.19"

--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -5,13 +5,14 @@
   supported: "No, development only"
   releaseDate:
   eolDate:
-  k8sVersions: ["1.25", "1.26", "1.27", "1.28"]
+  k8sVersions: ["1.25", "1.26", "1.27", "1.28", "1.29"]
   testedK8sVersions: ["1.23", "1.24"]
 - version: "1.20"
   supported: "Yes"
   releaseDate: "Nov 14, 2023"
   eolDate: "~Jul 2024 (Expected)"
-  k8sVersions: ["1.25", "1.26", "1.27", "1.28"]
+  
+  k8sVersions: ["1.25", "1.26", "1.27", "1.28", "1.29"]
   testedK8sVersions: ["1.23", "1.24"]
 - version: "1.19"
   supported: "Yes"


### PR DESCRIPTION
## Description

Designate master and Istio 1.20 as being supported on Kubernetes 1.29 after running acceptance tests (via GKE rapid channel) and configuring test infra to run against those versions as well in istio/test-infra#5139

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
