### PR TITLE
Add wait flag to istioctl waypoint apply cmd

### DIFF
--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -346,7 +346,7 @@ Using the Kubernetes Gateway API, you can deploy a {{< gloss "waypoint" >}}waypo
 Deploy a waypoint proxy for the `productpage` service:
 
 {{< text bash >}}
-$ istioctl x waypoint apply --service-account bookinfo-productpage
+$ istioctl x waypoint apply --service-account bookinfo-productpage --wait
 waypoint default/bookinfo-productpage applied
 {{< /text >}}
 
@@ -416,7 +416,7 @@ $ kubectl exec deploy/sleep -- curl -s http://productpage:9080/ | grep -o "<titl
 Deploy a waypoint proxy for the review service, using the `bookinfo-review` service account, so that any traffic going to the review service will be mediated by the waypoint proxy.
 
 {{< text bash >}}
-$ istioctl x waypoint apply --service-account bookinfo-reviews
+$ istioctl x waypoint apply --service-account bookinfo-reviews --wait
 waypoint default/bookinfo-reviews applied
 {{< /text >}}
 

--- a/content/en/docs/ops/ambient/getting-started/snips.sh
+++ b/content/en/docs/ops/ambient/getting-started/snips.sh
@@ -210,7 +210,7 @@ command terminated with exit code 56
 ENDSNIP
 
 snip_l7_authorization_policy_1() {
-istioctl x waypoint apply --service-account bookinfo-productpage
+istioctl x waypoint apply --service-account bookinfo-productpage --wait
 }
 
 ! read -r -d '' snip_l7_authorization_policy_1_out <<\ENDSNIP
@@ -286,7 +286,7 @@ kubectl exec deploy/sleep -- curl -s http://productpage:9080/ | grep -o "<title>
 ENDSNIP
 
 snip_control_traffic_1() {
-istioctl x waypoint apply --service-account bookinfo-reviews
+istioctl x waypoint apply --service-account bookinfo-reviews --wait
 }
 
 ! read -r -d '' snip_control_traffic_1_out <<\ENDSNIP

--- a/content/en/docs/ops/ambient/getting-started/test.sh
+++ b/content/en/docs/ops/ambient/getting-started/test.sh
@@ -75,6 +75,7 @@ _verify_contains snip_l4_authorization_policy_3 "$snip_l4_authorization_policy_3
 _verify_failure snip_l4_authorization_policy_4
 
 _verify_contains snip_l7_authorization_policy_1 "$snip_l7_authorization_policy_1_out"
+_verify_contains snip_l7_authorization_policy_2 "Resource programmed, assigned to service"
 snip_l7_authorization_policy_3
 _verify_contains snip_l7_authorization_policy_4 "$snip_l7_authorization_policy_4_out"
 _verify_contains snip_l7_authorization_policy_5 "$snip_l7_authorization_policy_5_out"

--- a/content/en/docs/ops/ambient/getting-started/test.sh
+++ b/content/en/docs/ops/ambient/getting-started/test.sh
@@ -75,7 +75,6 @@ _verify_contains snip_l4_authorization_policy_3 "$snip_l4_authorization_policy_3
 _verify_failure snip_l4_authorization_policy_4
 
 _verify_contains snip_l7_authorization_policy_1 "$snip_l7_authorization_policy_1_out"
-_verify_contains snip_l7_authorization_policy_2 "Resource programmed, assigned to service"
 snip_l7_authorization_policy_3
 _verify_contains snip_l7_authorization_policy_4 "$snip_l7_authorization_policy_4_out"
 _verify_contains snip_l7_authorization_policy_5 "$snip_l7_authorization_policy_5_out"

--- a/content/zh/docs/ops/ambient/getting-started/index.md
+++ b/content/zh/docs/ops/ambient/getting-started/index.md
@@ -354,7 +354,7 @@ command terminated with exit code 56
 为 `productpage` 服务部署 waypoint proxy：
 
 {{< text bash >}}
-$ istioctl x waypoint apply --service-account bookinfo-productpage
+$ istioctl x waypoint apply --service-account bookinfo-productpage --wait
 waypoint default/bookinfo-productpage applied
 {{< /text >}}
 
@@ -425,7 +425,7 @@ $ kubectl exec deploy/sleep -- curl -s http://productpage:9080/ | grep -o "<titl
 因此转到评审服务的所有流量都将通过 waypoint proxy 进行协调。
 
 {{< text bash >}}
-$ istioctl x waypoint apply --service-account bookinfo-reviews
+$ istioctl x waypoint apply --service-account bookinfo-reviews --wait
 waypoint default/bookinfo-reviews applied
 {{< /text >}}
 


### PR DESCRIPTION
## Description

The https://github.com/istio/istio/pull/48769 commit added a --wait flag to `istioctl x waypoint apply` cmd.
With that flag set, istioctl will wait until the gateway has the "Programmed" status set to `true`.

This commit updates the documentation to use that flag and removes the logic in test.sh that was checking for the "Programmed" status.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
