### PR TITLE
add additional breakpoints for blog content width

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -129,7 +129,7 @@ lint-md: clean_public build_nominify
 	@SKIP_LINK_CHECK=true scripts/lint_site.sh en
 
 serve: site
-	@hugo serve --baseURL "http://${ISTIO_SERVE_DOMAIN}:1313/latest/" --bind 0.0.0.0 --disableFastRender
+	@hugo serve --baseURL "http://${ISTIO_SERVE_DOMAIN}:1313/latest/" --bind 0.0.0.0 --watch --disableFastRender
 
 archive-version:
 	@scripts/archive_version.sh

--- a/src/sass/misc/_blog.scss
+++ b/src/sass/misc/_blog.scss
@@ -157,10 +157,27 @@
     max-width: 100%;
     margin: 0 auto;
     padding: 0 1.25em;
+
     @media (min-width: $bp-md) {
         max-width: 754px;
         padding: 0;
     }
+    
+    @media (min-width: $bp-lg) {
+        max-width: 994px;
+        padding: 0;
+    }
+
+    @media (min-width: $bp-xxl) {
+        max-width: 1354px;
+        padding: 0;
+    }
+
+    @media (min-width: $bp-xl) {
+        max-width: 1174px;
+        padding: 0;
+    }
+    
     // TODO : consider changing font size back to 1rem
 
     p, li {

--- a/src/sass/misc/_blog.scss
+++ b/src/sass/misc/_blog.scss
@@ -162,7 +162,7 @@
         max-width: 754px;
         padding: 0;
     }
-    
+
     @media (min-width: $bp-lg) {
         max-width: 994px;
         padding: 0;
@@ -177,7 +177,7 @@
         max-width: 1174px;
         padding: 0;
     }
-    
+
     // TODO : consider changing font size back to 1rem
 
     p, li {


### PR DESCRIPTION
## Description

Adds additional breakpoints to increase max-width for larger screens. They are much more common now than when originally written, which leaves a lot of whitespace to the left and right of blog posts.

Closes #14556 

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
