### PR TITLE
fix: Multi-cluster installation with revision istiod vs

### DIFF
--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -110,7 +110,7 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
 If the control-plane was installed with a revision `rev`, use the following command instead:
 
 {{< text bash >}}
-$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
+$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl@ | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
 {{< /text >}}
 
 {{< /warning >}}

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -108,9 +108,11 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
 
 {{< warning >}}
 If the control-plane was installed with a revision `rev`, run
+
 {{< text bash >}}
 $ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply -n istio-system -f -
 {{< /text >}}
+
 {{< /warning >}}
 
 ## Set the control plane cluster for `cluster2`

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -106,6 +106,13 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
     @samples/multicluster/expose-istiod.yaml@
 {{< /text >}}
 
+{{< warning >}}
+If the control-plane was installed with a revision `rev`, run
+{{< text bash >}}
+$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply -n istio-system -f -
+{{< /text >}}
+{{< /warning >}}
+
 ## Set the control plane cluster for `cluster2`
 
 We need identify the external control plane cluster that should manage `cluster2` by annotating the

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -107,10 +107,10 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
 {{< /text >}}
 
 {{< warning >}}
-If the control-plane was installed with a revision `rev`, run
+If the control-plane was installed with a revision `rev`, use the following command instead:
 
 {{< text bash >}}
-$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply -n istio-system -f -
+$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
 {{< /text >}}
 
 {{< /warning >}}

--- a/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
@@ -59,7 +59,7 @@ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
 }
 
 snip_expose_the_control_plane_in_cluster1_2() {
-sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply -n istio-system -f -
+sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
 }
 
 snip_set_the_control_plane_cluster_for_cluster2_1() {

--- a/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
@@ -59,7 +59,7 @@ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
 }
 
 snip_expose_the_control_plane_in_cluster1_2() {
-sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
+sed 's/{{.Revision}}/rev/g' samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
 }
 
 snip_set_the_control_plane_cluster_for_cluster2_1() {

--- a/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
@@ -58,6 +58,10 @@ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
     samples/multicluster/expose-istiod.yaml
 }
 
+snip_expose_the_control_plane_in_cluster1_2() {
+sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply -n istio-system -f -
+}
+
 snip_set_the_control_plane_cluster_for_cluster2_1() {
 kubectl --context="${CTX_CLUSTER2}" create namespace istio-system
 kubectl --context="${CTX_CLUSTER2}" annotate namespace istio-system topology.istio.io/controlPlaneClusters=cluster1

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -113,7 +113,7 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
 If the control-plane was installed with a revision `rev`, use the following command instead:
 
 {{< text bash >}}
-$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
+$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl@ | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
 {{< /text >}}
 
 {{< /warning >}}

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -109,6 +109,15 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
     @samples/multicluster/expose-istiod.yaml@
 {{< /text >}}
 
+{{< warning >}}
+If the control-plane was installed with a revision `rev`, use the following command instead:
+
+{{< text bash >}}
+$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
+{{< /text >}}
+
+{{< /warning >}}
+
 ## Set the control plane cluster for `cluster2`
 
 We need identify the external control plane cluster that should manage `cluster2` by annotating the

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
@@ -63,6 +63,10 @@ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
     samples/multicluster/expose-istiod.yaml
 }
 
+snip_expose_the_control_plane_in_cluster1_2() {
+sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
+}
+
 snip_set_the_control_plane_cluster_for_cluster2_1() {
 kubectl --context="${CTX_CLUSTER2}" create namespace istio-system
 kubectl --context="${CTX_CLUSTER2}" annotate namespace istio-system topology.istio.io/controlPlaneClusters=cluster1

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
@@ -64,7 +64,7 @@ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
 }
 
 snip_expose_the_control_plane_in_cluster1_2() {
-sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
+sed 's/{{.Revision}}/rev/g' samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
 }
 
 snip_set_the_control_plane_cluster_for_cluster2_1() {

--- a/content/zh/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/zh/docs/setup/install/multicluster/primary-remote/index.md
@@ -104,9 +104,11 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -f \
 
 {{< warning >}}
 如果控制面指定了版本 `rev`, 需要执行
+
 {{< text bash >}}
 $ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply -n istio-system -f -
 {{< /text >}}
+
 {{< /warning >}}
 
 ## 设置集群 `cluster2` 的控制平面 {#set-the-control-plane-cluster-for-cluster2}

--- a/content/zh/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/zh/docs/setup/install/multicluster/primary-remote/index.md
@@ -106,7 +106,7 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -f \
 如果控制面指定了版本 `rev`, 需要改为执行
 
 {{< text bash >}}
-$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
+$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl@ | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
 {{< /text >}}
 
 {{< /warning >}}

--- a/content/zh/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/zh/docs/setup/install/multicluster/primary-remote/index.md
@@ -103,10 +103,10 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -f \
 {{< /text >}}
 
 {{< warning >}}
-如果控制面指定了版本 `rev`, 需要执行
+如果控制面指定了版本 `rev`, 需要改为执行
 
 {{< text bash >}}
-$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply -n istio-system -f -
+$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
 {{< /text >}}
 
 {{< /warning >}}

--- a/content/zh/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/zh/docs/setup/install/multicluster/primary-remote/index.md
@@ -102,6 +102,13 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -f \
     @samples/multicluster/expose-istiod.yaml@
 {{< /text >}}
 
+{{< warning >}}
+如果控制面指定了版本 `rev`, 需要执行
+{{< text bash >}}
+$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply -n istio-system -f -
+{{< /text >}}
+{{< /warning >}}
+
 ## 设置集群 `cluster2` 的控制平面 {#set-the-control-plane-cluster-for-cluster2}
 
 我们需要通过为 `istio-system` 命名空间添加注解来识别应管理集群

--- a/content/zh/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/zh/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -104,6 +104,15 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
     @samples/multicluster/expose-istiod.yaml@
 {{< /text >}}
 
+{{< warning >}}
+如果控制面指定了版本 `rev`, 需要改为执行
+
+{{< text bash >}}
+$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
+{{< /text >}}
+
+{{< /warning >}}
+
 ## 为 `cluster2` 设置控制平面集群 {#set-the-control-plane-cluster-for-cluster2}
 
 命名空间 `istio-system` 创建之后，我们需要设置集群的网络：

--- a/content/zh/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/zh/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -108,7 +108,7 @@ $ kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f \
 如果控制面指定了版本 `rev`, 需要改为执行
 
 {{< text bash >}}
-$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
+$ sed 's/{{.Revision}}/rev/g' @samples/multicluster/expose-istiod-rev.yaml.tmpl@ | kubectl apply --context="${CTX_CLUSTER1}" -n istio-system -f -
 {{< /text >}}
 
 {{< /warning >}}


### PR DESCRIPTION
Multi-cluster installation should use expose-istiod-rev.yaml.tmpl when control plane is installed with revision

## Description

To align with PR https://github.com/istio/istio/pull/48942

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [X] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
