### PR TITLE
[Egress Gateway task] Remove troubleshooting section and add tip for cert verification

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -358,6 +358,17 @@ You should see a line similar to the following:
 [2019-09-03T20:57:49.103Z] "GET /politics HTTP/2" 301 - "-" "-" 0 0 90 89 "10.244.2.10" "curl/7.64.0" "ea379962-9b5c-4431-ab66-f01994f5a5a5" "edition.cnn.com" "151.101.65.67:80" outbound|80||edition.cnn.com - 10.244.1.5:80 10.244.2.10:50482 edition.cnn.com -
 {{< /text >}}
 
+{{< tip >}}
+If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/) is enabled and you have issues connecting to the Egress Gateway, run the following command to verify the if the certificate is correct:
+
+    {{< text bash >}}
+    $ istioctl pc secret -n istio-system "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
+            X509v3 Subject Alternative Name: critical
+                URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
+    {{< /text >}}
+
+{{< /tip >}}
+
 {{< /tab >}}
 
 {{< tab name="Gateway API" category-value="gateway-api" >}}
@@ -984,42 +995,6 @@ $ kubectl delete namespace test-egress
 {{< /tabset >}}
 
 2)  Follow the steps in the [Cleanup HTTPS gateway](#cleanup-https-gateway) section.
-
-## Troubleshooting
-
-1.  If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/) is enabled, verify the correct certificate of the
-    egress gateway:
-
-    {{< text bash >}}
-    $ kubectl exec -i -n istio-system "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')"  -- cat /etc/certs/cert-chain.pem | openssl x509 -text -noout  | grep 'Subject Alternative Name' -A 1
-            X509v3 Subject Alternative Name:
-                URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
-    {{< /text >}}
-
-1.  For HTTPS traffic (TLS originated by the application), test the traffic flow by using the _openssl_ command.
-    _openssl_ has an explicit option for setting the SNI, namely `-servername`.
-
-    {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- openssl s_client -connect edition.cnn.com:443 -servername edition.cnn.com
-    CONNECTED(00000003)
-    ...
-    Certificate chain
-     0 s:/C=US/ST=California/L=San Francisco/O=Fastly, Inc./CN=turner-tls.map.fastly.net
-       i:/C=BE/O=GlobalSign nv-sa/CN=GlobalSign CloudSSL CA - SHA256 - G3
-     1 s:/C=BE/O=GlobalSign nv-sa/CN=GlobalSign CloudSSL CA - SHA256 - G3
-       i:/C=BE/O=GlobalSign nv-sa/OU=Root CA/CN=GlobalSign Root CA
-     ---
-     Server certificate
-     -----BEGIN CERTIFICATE-----
-    ...
-    {{< /text >}}
-
-    If you get the certificate as in the output above, your traffic is routed correctly. Check the statistics of the egress gateway's proxy and see a counter that corresponds to your requests (sent by _openssl_ and _curl_) to _edition.cnn.com_.
-
-    {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')" -c istio-proxy -n istio-system -- pilot-agent request GET stats | grep edition.cnn.com.upstream_cx_total
-    cluster.outbound|443||edition.cnn.com.upstream_cx_total: 2
-    {{< /text >}}
 
 ## Cleanup
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -385,6 +385,17 @@ You should see a line similar to the following:
 [2024-01-09T15:35:47.283Z] "GET /politics HTTP/1.1" 301 - via_upstream - "-" 0 0 2 2 "172.30.239.55" "curl/7.87.0-DEV" "6c01d65f-a157-97cd-8782-320a40026901" "edition.cnn.com" "151.101.195.5:80" outbound|80||edition.cnn.com 172.30.239.16:55636 172.30.239.16:80 172.30.239.55:59224 - default.forward-cnn-from-egress-gateway.0
 {{< /text >}}
 
+{{< tip >}}
+If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/) is enabled, and you have issues connecting to the egress gateway, run the following command to verify the if the certificate is correct:
+
+{{< text bash >}}
+$ istioctl pc secret "$(kubectl get pod -l istio.io/gateway-name=cnn-egress-gateway  -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
+        X509v3 Subject Alternative Name: critical
+            URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
+{{< /text >}}
+
+{{< /tip >}}
+
 {{< /tab >}}
 
 {{< /tabset >}}

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -359,7 +359,7 @@ You should see a line similar to the following:
 {{< /text >}}
 
 {{< tip >}}
-If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/) is enabled, and you have issues connecting to the egress gateway, run the following command to verify the if the certificate is correct:
+If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/) is enabled, and you have issues connecting to the egress gateway, run the following command to verify the certificate is correct:
 
 {{< text bash >}}
 $ istioctl pc secret -n istio-system "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
@@ -386,10 +386,10 @@ You should see a line similar to the following:
 {{< /text >}}
 
 {{< tip >}}
-If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/) is enabled, and you have issues connecting to the egress gateway, run the following command to verify the if the certificate is correct:
+If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/) is enabled, and you have issues connecting to the egress gateway, run the following command to verify the certificate is correct:
 
 {{< text bash >}}
-$ istioctl pc secret "$(kubectl get pod -l istio.io/gateway-name=cnn-egress-gateway  -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
+$ istioctl pc secret "$(kubectl get pod -l istio.io/gateway-name=cnn-egress-gateway -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
         X509v3 Subject Alternative Name: critical
             URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
 {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -359,13 +359,13 @@ You should see a line similar to the following:
 {{< /text >}}
 
 {{< tip >}}
-If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/) is enabled and you have issues connecting to the Egress Gateway, run the following command to verify the if the certificate is correct:
+If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/) is enabled, and you have issues connecting to the egress gateway, run the following command to verify the if the certificate is correct:
 
-    {{< text bash >}}
-    $ istioctl pc secret -n istio-system "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
-            X509v3 Subject Alternative Name: critical
-                URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
-    {{< /text >}}
+{{< text bash >}}
+$ istioctl pc secret -n istio-system "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
+        X509v3 Subject Alternative Name: critical
+            URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
+{{< /text >}}
 
 {{< /tip >}}
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -391,7 +391,7 @@ If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/
 {{< text bash >}}
 $ istioctl pc secret "$(kubectl get pod -l istio.io/gateway-name=cnn-egress-gateway -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
         X509v3 Subject Alternative Name: critical
-            URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
+            URI:spiffe://cluster.local/ns/default/sa/cnn-egress-gateway-istio
 {{< /text >}}
 
 {{< /tip >}}

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -363,8 +363,8 @@ If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/
 
 {{< text bash >}}
 $ istioctl pc secret -n istio-system "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
-        X509v3 Subject Alternative Name: critical
-            URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
+            X509v3 Subject Alternative Name: critical
+                URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
 {{< /text >}}
 
 {{< /tip >}}
@@ -390,8 +390,8 @@ If [mutual TLS Authentication](/docs/tasks/security/authentication/authn-policy/
 
 {{< text bash >}}
 $ istioctl pc secret "$(kubectl get pod -l istio.io/gateway-name=cnn-egress-gateway -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
-        X509v3 Subject Alternative Name: critical
-            URI:spiffe://cluster.local/ns/default/sa/cnn-egress-gateway-istio
+            X509v3 Subject Alternative Name: critical
+                URI:spiffe://cluster.local/ns/default/sa/cnn-egress-gateway-istio
 {{< /text >}}
 
 {{< /tip >}}

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
@@ -230,8 +230,8 @@ istioctl pc secret -n istio-system "$(kubectl get pod -l istio=egressgateway -n 
 }
 
 ! read -r -d '' snip_egress_gateway_for_http_traffic_10_out <<\ENDSNIP
-        X509v3 Subject Alternative Name: critical
-            URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
+            X509v3 Subject Alternative Name: critical
+                URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
 ENDSNIP
 
 snip_egress_gateway_for_http_traffic_11() {
@@ -247,8 +247,8 @@ istioctl pc secret "$(kubectl get pod -l istio.io/gateway-name=cnn-egress-gatewa
 }
 
 ! read -r -d '' snip_egress_gateway_for_http_traffic_13_out <<\ENDSNIP
-        X509v3 Subject Alternative Name: critical
-            URI:spiffe://cluster.local/ns/default/sa/cnn-egress-gateway-istio
+            X509v3 Subject Alternative Name: critical
+                URI:spiffe://cluster.local/ns/default/sa/cnn-egress-gateway-istio
 ENDSNIP
 
 snip_cleanup_http_gateway_1() {

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
@@ -243,7 +243,7 @@ kubectl logs -l istio.io/gateway-name=cnn-egress-gateway -c istio-proxy | tail
 ENDSNIP
 
 snip_egress_gateway_for_http_traffic_13() {
-istioctl pc secret "$(kubectl get pod -l istio.io/gateway-name=cnn-egress-gateway  -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
+istioctl pc secret "$(kubectl get pod -l istio.io/gateway-name=cnn-egress-gateway -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
 }
 
 ! read -r -d '' snip_egress_gateway_for_http_traffic_13_out <<\ENDSNIP

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
@@ -248,7 +248,7 @@ istioctl pc secret "$(kubectl get pod -l istio.io/gateway-name=cnn-egress-gatewa
 
 ! read -r -d '' snip_egress_gateway_for_http_traffic_13_out <<\ENDSNIP
         X509v3 Subject Alternative Name: critical
-            URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
+            URI:spiffe://cluster.local/ns/default/sa/cnn-egress-gateway-istio
 ENDSNIP
 
 snip_cleanup_http_gateway_1() {

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
@@ -226,11 +226,29 @@ kubectl logs -l istio=egressgateway -c istio-proxy -n istio-system | tail
 ENDSNIP
 
 snip_egress_gateway_for_http_traffic_10() {
+istioctl pc secret -n istio-system "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
+}
+
+! read -r -d '' snip_egress_gateway_for_http_traffic_10_out <<\ENDSNIP
+        X509v3 Subject Alternative Name: critical
+            URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
+ENDSNIP
+
+snip_egress_gateway_for_http_traffic_11() {
 kubectl logs -l istio.io/gateway-name=cnn-egress-gateway -c istio-proxy | tail
 }
 
-! read -r -d '' snip_egress_gateway_for_http_traffic_11 <<\ENDSNIP
+! read -r -d '' snip_egress_gateway_for_http_traffic_12 <<\ENDSNIP
 [2024-01-09T15:35:47.283Z] "GET /politics HTTP/1.1" 301 - via_upstream - "-" 0 0 2 2 "172.30.239.55" "curl/7.87.0-DEV" "6c01d65f-a157-97cd-8782-320a40026901" "edition.cnn.com" "151.101.195.5:80" outbound|80||edition.cnn.com 172.30.239.16:55636 172.30.239.16:80 172.30.239.55:59224 - default.forward-cnn-from-egress-gateway.0
+ENDSNIP
+
+snip_egress_gateway_for_http_traffic_13() {
+istioctl pc secret "$(kubectl get pod -l istio.io/gateway-name=cnn-egress-gateway  -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
+}
+
+! read -r -d '' snip_egress_gateway_for_http_traffic_13_out <<\ENDSNIP
+        X509v3 Subject Alternative Name: critical
+            URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
 ENDSNIP
 
 snip_cleanup_http_gateway_1() {
@@ -624,41 +642,6 @@ kubectl label namespace istio-system istio-
 kubectl label namespace default gateway-
 kubectl delete namespace test-egress
 }
-
-snip_troubleshooting_1() {
-kubectl exec -i -n istio-system "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')"  -- cat /etc/certs/cert-chain.pem | openssl x509 -text -noout  | grep 'Subject Alternative Name' -A 1
-}
-
-! read -r -d '' snip_troubleshooting_1_out <<\ENDSNIP
-        X509v3 Subject Alternative Name:
-            URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account
-ENDSNIP
-
-snip_troubleshooting_2() {
-kubectl exec "$SOURCE_POD" -c sleep -- openssl s_client -connect edition.cnn.com:443 -servername edition.cnn.com
-}
-
-! read -r -d '' snip_troubleshooting_2_out <<\ENDSNIP
-CONNECTED(00000003)
-...
-Certificate chain
- 0 s:/C=US/ST=California/L=San Francisco/O=Fastly, Inc./CN=turner-tls.map.fastly.net
-   i:/C=BE/O=GlobalSign nv-sa/CN=GlobalSign CloudSSL CA - SHA256 - G3
- 1 s:/C=BE/O=GlobalSign nv-sa/CN=GlobalSign CloudSSL CA - SHA256 - G3
-   i:/C=BE/O=GlobalSign nv-sa/OU=Root CA/CN=GlobalSign Root CA
- ---
- Server certificate
- -----BEGIN CERTIFICATE-----
-...
-ENDSNIP
-
-snip_troubleshooting_3() {
-kubectl exec "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')" -c istio-proxy -n istio-system -- pilot-agent request GET stats | grep edition.cnn.com.upstream_cx_total
-}
-
-! read -r -d '' snip_troubleshooting_3_out <<\ENDSNIP
-cluster.outbound|443||edition.cnn.com.upstream_cx_total: 2
-ENDSNIP
 
 snip_cleanup_1() {
 kubectl delete -f samples/sleep/sleep.yaml

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
@@ -77,11 +77,9 @@ spec:
 EOF
 set -e  # Exit on failure
 if [ "$GATEWAY_API" == "true" ]; then
-    _verify_contains snip_egress_gateway_for_http_traffic_13 "X509v3 Subject Alternative Name"
-    _verify_contains snip_egress_gateway_for_http_traffic_13 "URI:spiffe://cluster.local/ns/default/sa/cnn-egress-gateway-istio"
+    _verify_contains snip_egress_gateway_for_http_traffic_13 "$snip_egress_gateway_for_http_traffic_13_out"
 else
-    _verify_contains snip_egress_gateway_for_http_traffic_10 "X509v3 Subject Alternative Name"
-    _verify_contains snip_egress_gateway_for_http_traffic_10 "URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account"
+    _verify_contains snip_egress_gateway_for_http_traffic_10 "$snip_egress_gateway_for_http_traffic_10_out"
 fi
 kubectl delete peerauthentication -n istio-system default
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
@@ -78,7 +78,7 @@ EOF
 set -e  # Exit on failure
 if [ "$GATEWAY_API" == "true" ]; then
     _verify_contains snip_egress_gateway_for_http_traffic_13 "X509v3 Subject Alternative Name"
-    _verify_contains snip_egress_gateway_for_http_traffic_13 "URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account"
+    _verify_contains snip_egress_gateway_for_http_traffic_13 "URI:spiffe://cluster.local/ns/default/sa/cnn-egress-gateway-istio"
 else
     _verify_contains snip_egress_gateway_for_http_traffic_10 "X509v3 Subject Alternative Name"
     _verify_contains snip_egress_gateway_for_http_traffic_10 "URI:spiffe://cluster.local/ns/istio-system/sa/istio-egressgateway-service-account"

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
@@ -63,25 +63,11 @@ else
     _verify_contains snip_egress_gateway_for_http_traffic_8 "outbound|80||edition.cnn.com"
 fi
 
-# Verify the certificate is correct if mTLS is enabled
-set +e  # Don't exit on failure
-kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
-kind: PeerAuthentication
-metadata:
-  name: "default"
-  namespace: "istio-system"
-spec:
-  mtls:
-    mode: STRICT
-EOF
-set -e  # Exit on failure
 if [ "$GATEWAY_API" == "true" ]; then
-    _verify_contains snip_egress_gateway_for_http_traffic_13 "$snip_egress_gateway_for_http_traffic_13_out"
+    _verify_same snip_egress_gateway_for_http_traffic_13 "$snip_egress_gateway_for_http_traffic_13_out"
 else
-    _verify_contains snip_egress_gateway_for_http_traffic_10 "$snip_egress_gateway_for_http_traffic_10_out"
+    _verify_same snip_egress_gateway_for_http_traffic_10 "$snip_egress_gateway_for_http_traffic_10_out"
 fi
-kubectl delete peerauthentication -n istio-system default
 
 # cleanup http task
 if [ "$GATEWAY_API" == "true" ]; then

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
@@ -59,14 +59,10 @@ _verify_contains snip_egress_gateway_for_http_traffic_7 "HTTP/2 200"
 # Verify routing through gateway
 if [ "$GATEWAY_API" == "true" ]; then
     _verify_contains snip_egress_gateway_for_http_traffic_11 "outbound|80||edition.cnn.com"
+    _verify_contains snip_egress_gateway_for_http_traffic_13 "$snip_egress_gateway_for_http_traffic_13_out"
 else
     _verify_contains snip_egress_gateway_for_http_traffic_8 "outbound|80||edition.cnn.com"
-fi
-
-if [ "$GATEWAY_API" == "true" ]; then
-    _verify_same snip_egress_gateway_for_http_traffic_13 "$snip_egress_gateway_for_http_traffic_13_out"
-else
-    _verify_same snip_egress_gateway_for_http_traffic_10 "$snip_egress_gateway_for_http_traffic_10_out"
+    _verify_contains snip_egress_gateway_for_http_traffic_10 "$snip_egress_gateway_for_http_traffic_10_out"
 fi
 
 # cleanup http task


### PR DESCRIPTION
## Description
[Troubleshooting section for Egress Gateways task](https://preliminary.istio.io/latest/docs/tasks/traffic-management/egress/egress-gateway/#troubleshooting) is not working as expected for 3 reasons:

1. /etc/certs/cert-chain.pem is gone - see https://github.com/istio/istio.io/issues/14521#issuecomment-1919956285 
2. openssl is not available in the sleep pod anymore (changed base image)
3. envoy stat was removed to save memory footprint https://github.com/istio/istio/issues/23166

I have removed the troubleshooting section and added a tip for cert validation

### Reference:

* relates to https://github.com/istio/istio.io/issues/14521#issuecomment-1914929161

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
