### PR TITLE
Current supported release is empty

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -7,11 +7,16 @@
   eolDate:
   k8sVersions: ["1.26", "1.27", "1.28", "1.29"]
   testedK8sVersions: ["1.23", "1.24", "1.25"]
+- version: "1.21"
+  supported: "Yes"
+  releaseDate: "~Feb 2024"
+  eolDate: "~Dec 2024 (Expected)"
+  k8sVersions: ["1.26", "1.27", "1.28", "1.29"]
+  testedK8sVersions: ["1.23", "1.24", "1.25"]
 - version: "1.20"
   supported: "Yes"
   releaseDate: "Nov 14, 2023"
   eolDate: "~Jul 2024 (Expected)"
-
   k8sVersions: ["1.25", "1.26", "1.27", "1.28", "1.29"]
   testedK8sVersions: ["1.23", "1.24"]
 - version: "1.19"


### PR DESCRIPTION
The current supported version statement is empty:
<img width="671" alt="Screenshot 2024-02-07 at 9 48 18 AM" src="https://github.com/istio/istio.io/assets/10537847/5535494f-a77c-4786-8eba-1a698395dc1c">

This should fix that. Note that I have simply copied the versions as those supported in the `master` branch from which 1.21 was cut. I leave it to the @istio/release-managers-1-21 to verify that this is still correct.