### PR TITLE
Note on DR workloadSelector

### DIFF
--- a/content/en/docs/reference/config/networking/destination-rule/index.html
+++ b/content/en/docs/reference/config/networking/destination-rule/index.html
@@ -136,6 +136,11 @@ spec:
 <p>Destination Rules can be customized to specific workloads as well.
 The following example shows how a destination rule can be applied to a
 specific workload using the workloadSelector configuration.</p>
+<p><strong>Note:</strong> The workloadSelector configuration in 
+Destination Rules reveals which workloads the traffic emanating from 
+uses this Destination Rule, unlike the workloadSelector configuration 
+in <a href="/docs/reference/config/networking/service-entry/#ServiceEntry">ServiceEntries</a>, 
+which is used to reveal which workloads the traffic is routed to.</p>
 <p>{{<tabset category-name="selector-example">}}
 {{<tab name="v1alpha3" category-value="v1alpha3">}}</p>
 <pre><code class="language-yaml">apiVersion: networking.istio.io/v1alpha3


### PR DESCRIPTION
## Description

Supplementary explanation based on https://github.com/istio/istio/issues/49111#issuecomment-1921674872.
The same field name WorkloadSelector has a different effect/behavior in DR and SE. WorkloadSelector in ServiceEntry indicates destination workloads of traffic, while in DR workloadSelector reveals which workloads the traffic emanating from uses the DR. 

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [X] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
