### PR TITLE
Egress Gateway, istioctl command wrap with dquotes

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -109,8 +109,8 @@ in the following sections.
 
     {{< text syntax=bash snip_id=none >}}
     $ istioctl install <flags-you-used-to-install-Istio> \
-                       --set components.egressGateways[0].name=istio-egressgateway \
-                       --set components.egressGateways[0].enabled=true
+                       --set "components.egressGateways[0].name=istio-egressgateway" \
+                       --set "components.egressGateways[0].enabled=true"
     {{< /text >}}
 
 ## Egress gateway for HTTP traffic

--- a/content/zh/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -104,8 +104,8 @@ Egress Gateway 节点，用它引导所有的出站流量，可以使应用节�
 
     {{< text syntax=bash snip_id=none >}}
     $ istioctl install <flags-you-used-to-install-Istio> \
-                       --set components.egressGateways[0].name=istio-egressgateway \
-                       --set components.egressGateways[0].enabled=true
+                       --set "components.egressGateways[0].name=istio-egressgateway" \
+                       --set "components.egressGateways[0].enabled=true"
     {{< /text >}}
 
 ## 定义 Egress gateway 并引导 HTTP 流量 {#egress-gateway-for-http-traffic}


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

Wrap command parameters with dquotes, because of square brackets `[0]`.  For me, it causes parsing error.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
