### PR TITLE
Remove ambient alpha banner in light of beta next week

### DIFF
--- a/content/en/events/banners/ambient-release.md
+++ b/content/en/events/banners/ambient-release.md
@@ -1,6 +1,7 @@
 ---
 title: Ambient Alpha Release
-period_start: latest_release
+period_start: 2024-01-27
+period_end: 2024-02-21
 period_duration: 30
 max_impressions: 4
 link: https://istio.io/docs/ops/ambient/getting-started/


### PR DESCRIPTION
1.21 will move (parts of) Ambient to Beta, so we should remove the "it's in Alpha" banner.

I have done this by setting its end date to yesterday.