### PR TITLE
Correct httpbin URL

### DIFF
--- a/content/en/blog/2018/traffic-mirroring/index.md
+++ b/content/en/blog/2018/traffic-mirroring/index.md
@@ -16,7 +16,7 @@ Istio can help here. With the release of [Istio 0.5](/news/releases/0.x/announci
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
 metadata:
-  name: mirror-traffic-to-httbin-v2
+  name: mirror-traffic-to-httpbin-v2
 spec:
   destination:
     name: httpbin

--- a/content/en/blog/2019/proxy/index.md
+++ b/content/en/blog/2019/proxy/index.md
@@ -209,7 +209,7 @@ The blog post shows configuring access to an HTTP and an HTTPS external service,
     [Determining the ingress IP and ports](/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-ip-and-ports)
     to define the `SECURE_INGRESS_PORT` and `INGRESS_HOST` environment variables.
 
-1.  Access the `httbin.org` service through your ingress IP and port which you stored in the
+1.  Access the `httpbin.org` service through your ingress IP and port which you stored in the
     `$INGRESS_HOST` and `$INGRESS_PORT` environment variables, respectively, during the previous step.
     Access the `/status/418` path of the `httpbin.org` service that returns the HTTP status
     [418 I'm a teapot](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418).

--- a/content/zh/blog/2018/traffic-mirroring/index.md
+++ b/content/zh/blog/2018/traffic-mirroring/index.md
@@ -16,7 +16,7 @@ Istio 可以在这里提供帮助。随着 [Istio 0.5](/zh/news/releases/0.x/ann
 apiVersion: config.istio.io/v1alpha2
 kind: RouteRule
 metadata:
-  name: mirror-traffic-to-httbin-v2
+  name: mirror-traffic-to-httpbin-v2
 spec:
   destination:
     name: httpbin

--- a/content/zh/blog/2019/proxy/index.md
+++ b/content/zh/blog/2019/proxy/index.md
@@ -193,7 +193,7 @@ keywords: [traffic-management,ingress,https,http]
 
 1. 根据[确定入口网关的 IP 和端口](/zh/docs/tasks/traffic-management/ingress/ingress-control/#determining-the-ingress-i-p-and-ports)中的命令，设置 `SECURE_INGRESS_PORT` 和 `INGRESS_HOST` 两个环境变量。
 
-1. 在上一步中分别把 IP 和端口存储到了环境变量 `$INGRESS_HOST` 和 `$INGRESS_PORT` 中，现在可以用这个 IP 和端口访问 `httbin.org` 服务。访问 `httpbin.org` 服务的 `/status/418` 路径，会返回 [418 我是一个茶壶](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418)的 HTTP 状态码。
+1. 在上一步中分别把 IP 和端口存储到了环境变量 `$INGRESS_HOST` 和 `$INGRESS_PORT` 中，现在可以用这个 IP 和端口访问 `httpbin.org` 服务。访问 `httpbin.org` 服务的 `/status/418` 路径，会返回 [418 我是一个茶壶](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418)的 HTTP 状态码。
 
     {{< text bash >}}
     $ curl $INGRESS_HOST:$INGRESS_PORT/status/418 -Hhost:httpbin.org


### PR DESCRIPTION
httbin.org is a spam site typosquatting on httpbin.org. It is referenced in our examples.

Fixes #14633, with thanks to @cdm-arm for reporting.

/cherrypick release-1.20