### PR TITLE
Update callout colours in _light_theme.scss for better contrast and aesthetic

### DIFF
--- a/src/sass/themes/_light-theme.scss
+++ b/src/sass/themes/_light-theme.scss
@@ -43,7 +43,6 @@ html {
     --warningCalloutBackgroundColor: #ffe6e6;
     --warningCalloutBorderColor: #ff9999;
 
-
     --preBlockShadowColor: #a7a7a7;
     --preBlockBorderColor: #7dc6f2;
     --preBlockBackgroundColor: #f8f9fa;

--- a/src/sass/themes/_light-theme.scss
+++ b/src/sass/themes/_light-theme.scss
@@ -34,14 +34,15 @@ html {
     --boxBorderColor: var(--tipCalloutBorderColor);
     --inputBorderColor: #566ca5;
 
-    --quoteCalloutBackgroundColor: #f8f9fa;
-    --quoteCalloutBorderColor: #f8f9fa;
-    --tipCalloutBackgroundColor: #f2fff2;
-    --tipCalloutBorderColor: #7dc6f2;
-    --ideaCalloutBackgroundColor: #ffffe0;
-    --ideaCalloutBorderColor: #f7f7d8;
-    --warningCalloutBackgroundColor: #fff2f2;
-    --warningCalloutBorderColor: #f7eaea;
+    --quoteCalloutBackgroundColor: #f2f2f2;      
+    --quoteCalloutBorderColor: #d4d4d4;          
+    --tipCalloutBackgroundColor: #e6f7ff;      
+    --tipCalloutBorderColor: #66b3ff;           
+    --ideaCalloutBackgroundColor: #ffffcc;      
+    --ideaCalloutBorderColor: #e6e600;          
+    --warningCalloutBackgroundColor: #ffe6e6;   
+    --warningCalloutBorderColor: #ff9999;     
+
 
     --preBlockShadowColor: #a7a7a7;
     --preBlockBorderColor: #7dc6f2;

--- a/src/sass/themes/_light-theme.scss
+++ b/src/sass/themes/_light-theme.scss
@@ -34,14 +34,14 @@ html {
     --boxBorderColor: var(--tipCalloutBorderColor);
     --inputBorderColor: #566ca5;
 
-    --quoteCalloutBackgroundColor: #f2f2f2;      
-    --quoteCalloutBorderColor: #d4d4d4;          
-    --tipCalloutBackgroundColor: #e6f7ff;      
-    --tipCalloutBorderColor: #66b3ff;           
-    --ideaCalloutBackgroundColor: #ffffcc;      
-    --ideaCalloutBorderColor: #e6e600;          
-    --warningCalloutBackgroundColor: #ffe6e6;   
-    --warningCalloutBorderColor: #ff9999;     
+    --quoteCalloutBackgroundColor: #f2f2f2;
+    --quoteCalloutBorderColor: #d4d4d4;
+    --tipCalloutBackgroundColor: #e6f7ff;
+    --tipCalloutBorderColor: #66b3ff;
+    --ideaCalloutBackgroundColor: #ffffcc;
+    --ideaCalloutBorderColor: #e6e600;
+    --warningCalloutBackgroundColor: #ffe6e6;
+    --warningCalloutBorderColor: #ff9999;
 
 
     --preBlockShadowColor: #a7a7a7;


### PR DESCRIPTION
The callout colours have been updated to improve contrast and better fit the aesthetic of the site. Changes include:

- Updated quote callout background and border colours
- Updated tip callout background and border colours
- Updated idea callout background and border colours
- Updated warning callout background and border colours
#14666 