### PR TITLE
Update three.js to 0.162.0

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -15,7 +15,14 @@
         </div>
     </main>
 {{ else }}
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/0.159.0/three.min.js" integrity="sha512-OviGQIoFPxWNbGybQNprasilCxjtXNGCjnaZQvDeCT0lSPwJXd5TC3usI/jsWepKW9lZLZ1ob1q/Vy4MnlTt7g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script type="importmap">
+    {
+        "imports": {
+        "three": "https://unpkg.com/three@v0.162.0/build/three.module.js",
+        "three/addons/": "https://unpkg.com/three@v0.162.0/examples/jsm/"
+        }
+    }
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/@splidejs/splide@latest/dist/js/splide.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@splidejs/splide@latest/dist/css/splide.min.css">
     <script>
@@ -31,6 +38,6 @@
 
     {{ .Content }}
     
-    <script src="/js/headerAnimation.min.js"></script>
+    <script type="module" src="/js/headerAnimation.min.js"></script>
 {{ end }}
 {{ end }}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -18,8 +18,7 @@
     <script type="importmap">
     {
         "imports": {
-        "three": "https://unpkg.com/three@v0.162.0/build/three.module.js",
-        "three/addons/": "https://unpkg.com/three@v0.162.0/examples/jsm/"
+            "three": "https://unpkg.com/three@v0.162.0/build/three.module.js"
         }
     }
     </script>

--- a/src/ts/headerAnimation.js
+++ b/src/ts/headerAnimation.js
@@ -1,3 +1,5 @@
+import * as THREE from 'three';
+
 // Vertex shader for the points animation
 const vertexShader = `
       #define PI 3.14159265359


### PR DESCRIPTION
## Description

This PR will update the three.js version.
The import mechanism has been changed to use importmap as the three.js and three.min.js build files have been deprecated since 0.160.x.
As a consequence the header animation is now imported as an ES module 

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
