### PR TITLE
Drop CNI compat warning from ambient getting started guide - no longer relevant for 1.21+

### DIFF
--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -15,10 +15,9 @@ example [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) or
 others specified by the
 [platform-specific setup instructions](/docs/setup/platform-setup/).
 
-{{< warning >}}
-Note that Ambient currently requires the use of [istio-cni](/docs/setup/additional-setup/cni) to configure Kubernetes nodes.
-`istio-cni` ambient mode does **not** currently support types of cluster CNI (namely, CNI implementations that do not use `veth` devices, such as [Minikube's](https://kubernetes.io/docs/tasks/tools/install-minikube/) `bridge` mode)
-{{< /warning >}}
+{{< tip >}}
+Note that Ambient currently requires the use of [istio-cni](/docs/setup/additional-setup/cni) to configure Kubernetes nodes, which must run as a privileged pod. Ambient is compatible with every major CNI that previously supported sidecar mode.
+{{< /tip >}}
 
 Follow these steps to get started with ambient:
 

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -16,7 +16,7 @@ others specified by the
 [platform-specific setup instructions](/docs/setup/platform-setup/).
 
 {{< tip >}}
-Note that Ambient currently requires the use of [istio-cni](/docs/setup/additional-setup/cni) to configure Kubernetes nodes, which must run as a privileged pod. Ambient is compatible with every major CNI that previously supported sidecar mode.
+Note that ambient mode currently requires the use of [istio-cni](/docs/setup/additional-setup/cni) to configure Kubernetes nodes, which must run as a privileged pod. Ambient mode is compatible with every major CNI that previously supported sidecar mode.
 {{< /tip >}}
 
 Follow these steps to get started with ambient:


### PR DESCRIPTION
## Description

Deleting the (now outdated) CNI caveat from the Ambient getting started guide.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [x] Docs
- [x] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
