### PR TITLE
Add `platform prerequisites` for ambient, and simplify `getting started` ambient guide

### DIFF
--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -9,7 +9,7 @@ test: yes
 {{< boilerplate ambient-alpha-warning >}}
 
 This guide lets you quickly evaluate Istio's {{< gloss "ambient" >}}ambient mode{{< /gloss >}}. These steps require you to have a {{< gloss >}}cluster{{< /gloss >}} running a
-[supported version](/docs/releases/supported-releases#support-status-of-istio-releases) of Kubernetes ({{< supported_kubernetes_versions >}}). You can install Istio ambient mode on [any supported Kubernetes platform](/docs/setup/platform-setup/), but this guide will assume the use of [kind](https://kind.sigs.k8s.io/) simplicity.
+[supported version](/docs/releases/supported-releases#support-status-of-istio-releases) of Kubernetes ({{< supported_kubernetes_versions >}}). You can install Istio ambient mode on [any supported Kubernetes platform](/docs/setup/platform-setup/), but this guide will assume the use of [kind](https://kind.sigs.k8s.io/) for simplicity.
 
 {{< tip >}}
 Note that ambient mode currently requires the use of [istio-cni](/docs/setup/additional-setup/cni) to configure Kubernetes nodes, which must run as a privileged pod. Ambient mode is compatible with every major CNI that previously supported sidecar mode.

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -59,12 +59,6 @@ Follow these steps to get started with Istio's ambient mode:
 1.  Install Istio with the `ambient` profile on your Kubernetes cluster, using
     the version of `istioctl` downloaded above:
 
-{{< tip >}}
-Note that if you are using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) (or any other platform using nodes configured with a nonstandard `netns` path for containers), you may need to append `--set values.cni.cniNetnsDir="/var/run/docker/netns"` to the `istioctl install` command so that the Istio CNI DaemonSet can correctly manage and capture pods on the node.
-
-Consult your platform documentation for details.
-{{< /tip >}}
-
 {{< tabset category-name="config-api" >}}
 
 {{< tab name="Istio APIs" category-value="istio-apis" >}}

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -9,7 +9,8 @@ test: yes
 {{< boilerplate ambient-alpha-warning >}}
 
 This guide lets you quickly evaluate Istio's {{< gloss "ambient" >}}ambient mode{{< /gloss >}}. These steps require you to have a {{< gloss >}}cluster{{< /gloss >}} running a
-[supported version](/docs/releases/supported-releases#support-status-of-istio-releases) of Kubernetes ({{< supported_kubernetes_versions >}}). You can install Istio ambient mode on [any supported Kubernetes platform](/docs/setup/platform-setup/), but this guide will assume the use of [kind](https://kind.sigs.k8s.io/) for simplicity.
+[supported version](/docs/releases/supported-releases#support-status-of-istio-releases) of Kubernetes ({{< supported_kubernetes_versions >}}).
+You can install Istio ambient mode on [any supported Kubernetes platform](/docs/setup/platform-setup/), but this guide will assume the use of [kind](https://kind.sigs.k8s.io/) for simplicity.
 
 {{< tip >}}
 Note that ambient mode currently requires the use of [istio-cni](/docs/setup/additional-setup/cni) to configure Kubernetes nodes, which must run as a privileged pod. Ambient mode is compatible with every major CNI that previously supported sidecar mode.

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -30,7 +30,7 @@ Follow these steps to get started with Istio's ambient mode:
 
 1.  Download the [latest version of Istio](/docs/setup/getting-started/#download) (v1.21.0 or later) with Alpha support for ambient mode.
 
-1.  For this guide, we will deploy a new local `kind` cluster with the following command:
+1.  For this guide, you will deploy a new local `kind` cluster with the following command:
 
     {{< text syntax=bash snip_id=none >}}
     $ kind create cluster --config=- <<EOF

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -9,9 +9,7 @@ test: yes
 {{< boilerplate ambient-alpha-warning >}}
 
 This guide lets you quickly evaluate Istio's {{< gloss "ambient" >}}ambient mode{{< /gloss >}}. These steps require you to have a {{< gloss >}}cluster{{< /gloss >}} running a
-[supported version](/docs/releases/supported-releases#support-status-of-istio-releases) of Kubernetes ({{< supported_kubernetes_versions >}}). You can use any supported platform, for
-example [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) or
-others specified by the [platform-specific setup instructions](/docs/setup/platform-setup/).
+[supported version](/docs/releases/supported-releases#support-status-of-istio-releases) of Kubernetes ({{< supported_kubernetes_versions >}}). You can install Istio ambient mode on [any supported Kubernetes platform](/docs/setup/platform-setup/), but this guide will assume the use of [kind](https://kind.sigs.k8s.io/) simplicity.
 
 {{< tip >}}
 Note that ambient mode currently requires the use of [istio-cni](/docs/setup/additional-setup/cni) to configure Kubernetes nodes, which must run as a privileged pod. Ambient mode is compatible with every major CNI that previously supported sidecar mode.
@@ -30,7 +28,7 @@ Follow these steps to get started with Istio's ambient mode:
 
 1.  Download the [latest version of Istio](/docs/setup/getting-started/#download) (v1.21.0 or later) with Alpha support for ambient mode.
 
-1.  If you don’t have a Kubernetes cluster, you can deploy one locally using `kind` with the following command:
+1.  For this guide, we will deploy a new local `kind` cluster with the following command:
 
     {{< text syntax=bash snip_id=none >}}
     $ kind create cluster --config=- <<EOF

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -31,7 +31,7 @@ Follow these steps to get started with Istio's ambient mode:
 
 1.  Download the [latest version of Istio](/docs/setup/getting-started/#download) (v1.21.0 or later) with Alpha support for ambient mode.
 
-1.  For this guide, you will deploy a new local `kind` cluster with the following command:
+1.  Deploy a new local `kind` cluster:
 
     {{< text syntax=bash snip_id=none >}}
     $ kind create cluster --config=- <<EOF

--- a/content/en/docs/ops/ambient/getting-started/index.md
+++ b/content/en/docs/ops/ambient/getting-started/index.md
@@ -26,6 +26,8 @@ Follow these steps to get started with Istio's ambient mode:
 
 ## Download and install {#download}
 
+1.  Install [kind](https://kind.sigs.k8s.io/)
+
 1.  Download the [latest version of Istio](/docs/setup/getting-started/#download) (v1.21.0 or later) with Alpha support for ambient mode.
 
 1.  For this guide, we will deploy a new local `kind` cluster with the following command:

--- a/content/en/docs/ops/ambient/install/helm-installation/index.md
+++ b/content/en/docs/ops/ambient/install/helm-installation/index.md
@@ -12,7 +12,7 @@ we encourage the use of Helm to install Istio for use in ambient mode. Helm help
 
 ## Prerequisites
 
-1. Perform any necessary [platform-specific setup](/docs/setup/platform-setup/).
+1. Check the [Platform-Specific Prerequisites](/docs/ops/ambient/install/platform-prerequisites).
 
 1. Check the [Requirements for Pods and Services](/docs/ops/deployment/requirements/).
 

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -16,7 +16,7 @@ This document covers any platform or environment specific prerequisites for inst
 `cni.exclusive = false` to properly support chaining. See https://docs.cilium.io/en/stable/helm-reference/ for more details.
 
 1. Due to how Cilium manages node identity and internally allow-lists node-level health probes to pods,
-applying default-DENY `NetworkPolicy` in a Cilium CNI install with Istio ambient mesh will cause `kubelet` health probes (which are by-default exempted from NetworkPolicy enforcement by Cilium) to be blocked.
+applying default-DENY `NetworkPolicy` in a Cilium CNI install underlying Istio in ambient mode, will cause `kubelet` health probes (which are by-default exempted from NetworkPolicy enforcement by Cilium) to be blocked.
 
     This can be resolved by applying the following `CiliumClusterWideNetworkPolicy`:
 

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -30,12 +30,12 @@ applying default-DENY `NetworkPolicy` in a Cilium CNI install underlying Istio i
     apiVersion: "cilium.io/v2"
     kind: CiliumClusterwideNetworkPolicy
     metadata:
-    name: "allow-ambient-hostprobes"
+      name: "allow-ambient-hostprobes"
     spec:
-    description: "Allows SNAT-ed kubelet health check probes into ambient pods"
-    endpointSelector: {}
-    ingress:
-    - fromCIDR:
+      description: "Allows SNAT-ed kubelet health check probes into ambient pods"
+      endpointSelector: {}
+      ingress:
+      - fromCIDR:
         - "169.254.7.127/32"
     {{< /text >}}
 

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -12,7 +12,9 @@ This document covers any platform or environment specific prerequisites for inst
 
 ### Minikube
 
-1. If you are using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) with the [docker driver](https://minikube.sigs.k8s.io/docs/drivers/docker/), you may need to append `--set cni.cniNetnsDir="/var/run/docker/netns"` to the `helm install` command so that the Istio `cni-agent`node agent can correctly manage and capture pods on the node.
+1. If you are using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) with the [docker driver](https://minikube.sigs.k8s.io/docs/drivers/docker/),
+you may need to append `--set cni.cniNetnsDir="/var/run/docker/netns"` to the `helm install` command so that the Istio `cni-agent` node agent can correctly manage
+and capture pods on the node.
 
 ## CNI
 

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -1,6 +1,6 @@
 ---
 title: Platform-Specific Prerequisites
-description: Platform-Specific Prerequisites for Installing Istio Ambient Mode.
+description: Platform-specific prerequisites for installing Istio in ambient mode.
 weight: 4
 owner: istio/wg-environments-maintainers
 test: no

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -13,7 +13,7 @@ This document covers any platform or environment specific prerequisites for inst
 ### Cilium
 
 1. Cilium currently defaults to proactively deleting other CNI plugins and their config, and must be configured with
-`cni.exclusive = false` to properly support chaining. See https://docs.cilium.io/en/stable/helm-reference/ for more details.
+`cni.exclusive = false` to properly support chaining. See [the Cilium documentation](https://docs.cilium.io/en/stable/helm-reference/) for more details.
 
 1. Due to how Cilium manages node identity and internally allow-lists node-level health probes to pods,
 applying default-DENY `NetworkPolicy` in a Cilium CNI install underlying Istio in ambient mode, will cause `kubelet` health probes (which are by-default exempted from NetworkPolicy enforcement by Cilium) to be blocked.

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -1,0 +1,36 @@
+---
+title: Platform-Specific Prerequisites
+description: Platform-Specific Prerequisites for Installing Istio Ambient Mode.
+weight: 4
+owner: istio/wg-environments-maintainers
+test: no
+---
+
+This document covers any platform or environment specific prerequisites for installing Istio in ambient mode.
+
+## CNI
+
+### Cilium
+
+1. Cilium currently defaults to proactively deleting other CNI plugins and their config, and must be configured with
+`cni.exclusive = false` to properly support chaining. See https://docs.cilium.io/en/stable/helm-reference/ for more details.
+
+1. Due to how Cilium manages node identity and internally allow-lists node-level health probes to pods,
+applying default-DENY `NetworkPolicy` in a Cilium CNI install with Istio ambient mesh will cause `kubelet` health probes (which are by-default exempted from NetworkPolicy enforcement by Cilium) to be blocked.
+
+    This can be resolved by applying the following `CiliumClusterWideNetworkPolicy`:
+
+    {{< text syntax=yaml snip_id=none >}}
+    apiVersion: "cilium.io/v2"
+    kind: CiliumClusterwideNetworkPolicy
+    metadata:
+    name: "allow-ambient-hostprobes"
+    spec:
+    description: "Allows SNAT-ed kubelet health check probes into ambient pods"
+    endpointSelector: {}
+    ingress:
+    - fromCIDR:
+        - "169.254.7.127/32"
+    {{< /text >}}
+
+    Please see the [#49277](https://github.com/istio/istio/issues/49277) and [CiliumClusterWideNetworkPolicy](https://docs.cilium.io/en/stable/network/kubernetes/policy/#ciliumclusterwidenetworkpolicy) for more details.

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -41,4 +41,4 @@ applying default-DENY `NetworkPolicy` in a Cilium CNI install underlying Istio i
         - "169.254.7.127/32"
     {{< /text >}}
 
-    Please see the [#49277](https://github.com/istio/istio/issues/49277) and [CiliumClusterWideNetworkPolicy](https://docs.cilium.io/en/stable/network/kubernetes/policy/#ciliumclusterwidenetworkpolicy) for more details.
+    Please see [issue #49277](https://github.com/istio/istio/issues/49277) and [CiliumClusterWideNetworkPolicy](https://docs.cilium.io/en/stable/network/kubernetes/policy/#ciliumclusterwidenetworkpolicy) for more details.

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -12,8 +12,8 @@ This document covers any platform or environment specific prerequisites for inst
 
 ### Minikube
 
-1. If you are using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) with the [docker driver](https://minikube.sigs.k8s.io/docs/drivers/docker/),
-you may need to append `--set cni.cniNetnsDir="/var/run/docker/netns"` to the `helm install` command so that the Istio `cni-agent` node agent can correctly manage
+1. If you are using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) with the [Docker driver](https://minikube.sigs.k8s.io/docs/drivers/docker/),
+you must append `--set cni.cniNetnsDir="/var/run/docker/netns"` to the `helm install` command so that the `istio-cni` node agent can correctly manage
 and capture pods on the node.
 
 ## CNI

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -8,6 +8,12 @@ test: no
 
 This document covers any platform or environment specific prerequisites for installing Istio in ambient mode.
 
+## Platform
+
+### Minikube
+
+1. If you are using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) with the [docker driver](https://minikube.sigs.k8s.io/docs/drivers/docker/), you may need to append `--set cni.cniNetnsDir="/var/run/docker/netns"` to the `helm install` command so that the Istio `cni-agent`node agent can correctly manage and capture pods on the node.
+
 ## CNI
 
 ### Cilium


### PR DESCRIPTION
## Description

1. We have "platform guides" already which are detailed/opinionated platform-specific setup guides. This starts a new convention for the ambient guides - `platform prerequisites`. These are things you _must_ take care of on your platform/CNI of choice _before_ installing Istio in ambient mode, but are not opinionated platform-specific setup guides. Think of these as documentation versions of `istioctl precheck` assertions.

2. Tweaks the ambient `getting started` guide a bit - we were suggesting `minikube` and using `kind` in the steps. The guide is a quickstart and we already have a proper/generic `helm install` guide that is separate, so simply saying "for simplicity we are assuming the use of a specific local cluster using `kind`" is better.

## Reviewers


- [x] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
