### PR TITLE
Add $DEPLOY_PRIME_URL to the Hugo baseURL.

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -152,7 +152,7 @@ netlify_install:
 
 netlify: netlify_install
 	@scripts/gen_site.sh
-	@scripts/build_site.sh "/latest"
+	@scripts/build_site.sh "${DEPLOY_PRIME_URL}/latest"
 	@scripts/include_archive_site.sh
 
 # ISTIO_API_GIT_SOURCE allows to override the default Istio API repository, https://github.com/istio/api@$(SOURCE_BRANCH_NAME)


### PR DESCRIPTION
This PR changes how Netlify will deploy istio.io and all its previews.

## What happens today

The build on netlify will run `make netlify`, which will end up running `hugo --baseURL "$1"`.

The parameter passed in is currently `/latest`.

## What I am changing

I am changing the parameter to `${DEPLOY_PRIME_URL}/latest`.

That value is populated by Netlify based on the URL of the site being deployed to.  It will be `https://istio.io/` on production, `https://preliminary.istio.io/` on staging, and `https://deploy-preview-14725--preliminary-istio.netlify.app/` on this PR.

## What will this mean

All the URLs that are generated will now become absolute URLs, i.e. include the fully qualified domain name.

## And why do you want this?

```
<meta property="og:url" content="/latest/">
```

That has to be fully qualified, so Hugo has to know the URL.  It doesn't currently.

## What's the collateral damage?

I _think_ all URLs will now be absolute.  This should already have been happening, due to `canonifyURLs` being `true` in our Hugo config, but we were never specifying the domain in the `baseURL` before.

This might increase the number of bytes we ship a little.

## How do I validate this?

Copy and paste `view-source:https://deploy-preview-14725--preliminary-istio.netlify.app/` into a new tab.

## Will it work perfectly when it lands on istio.io?

Can't tell until that happens, unfortunately.  Can hope that it looks good on preliminary.