### PR TITLE
Add GKE note for `kube-system` to Platform Prerequisites

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -955,6 +955,7 @@ repo
 repurposed
 requires_any
 Reskill
+ResourceQuota
 resources.limits.cpu
 resources.limits.memory
 resources.request.cpu

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -13,7 +13,7 @@ This document covers any platform or environment specific prerequisites for inst
 ### Google Kubernetes Engine (GKE)
 
 1. On GKE, `istio-cni` and `ztunnel` must be installed into `kube-system` (_not_ `istio-system`) to ensure the [`system-node-critical`](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/)
-`priorityClassName` is respected during scheduling. GKE does not respect the use of `node-critical` PriorityClasses on pods deployed outside of `kube-system`.
+`priorityClassName` is respected during scheduling. GKE does not respect the use of `node-critical` priority classes on pods deployed outside of `kube-system`.
 
 ### Minikube
 

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -14,8 +14,9 @@ This document covers any platform or environment specific prerequisites for inst
 
 1. On GKE, Istio components with the [system-node-critical](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/) `priorityClassName` can only be installed in namespaces that have a [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) defined. By default in GKE, only `kube-system` has a defined ResourceQuota for the `node-critical` class. `istio-cni` and `ztunnel` both require the `node-critical` class, and so in GKE, both components must either:
 
-      - Be installed into `kube-system` (_not_ `istio-system`) 
+      - Be installed into `kube-system` (_not_ `istio-system`)
       - Be installed into another namespace (such as `istio-system`) in which a ResourceQuota has been manually created, for example:
+
           {{< text syntax=yaml snip_id=none >}}
             apiVersion: v1
             kind: ResourceQuota
@@ -32,7 +33,6 @@ This document covers any platform or environment specific prerequisites for inst
                   values:
                   - system-node-critical
           {{< /text >}}
-
 
 ### Minikube
 

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -10,6 +10,11 @@ This document covers any platform or environment specific prerequisites for inst
 
 ## Platform
 
+### Google Kubernetes Engine (GKE)
+
+1. On GKE, `istio-cni` and `ztunnel` must be installed into `kube-system` (_not_ `istio-system`) to ensure the [`system-node-critical`](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/)
+`priorityClassName` is respected during scheduling. GKE does not respect the use of `node-critical` PriorityClasses on pods deployed outside of `kube-system`.
+
 ### Minikube
 
 1. If you are using [Minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) with the [Docker driver](https://minikube.sigs.k8s.io/docs/drivers/docker/),

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -12,8 +12,27 @@ This document covers any platform or environment specific prerequisites for inst
 
 ### Google Kubernetes Engine (GKE)
 
-1. On GKE, `istio-cni` and `ztunnel` must be installed into `kube-system` (_not_ `istio-system`) to ensure the [`system-node-critical`](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/)
-`priorityClassName` is respected during scheduling. GKE does not respect the use of `node-critical` priority classes on pods deployed outside of `kube-system`.
+1. On GKE, Istio components with the [system-node-critical](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/) `priorityClassName` can only be installed in namespaces that have a [ResourceQuota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) defined. By default in GKE, only `kube-system` has a defined ResourceQuota for the `node-critical` class. `istio-cni` and `ztunnel` both require the `node-critical` class, and so in GKE, both components must either:
+
+      - Be installed into `kube-system` (_not_ `istio-system`) 
+      - Be installed into another namespace (such as `istio-system`) in which a ResourceQuota has been manually created, for example:
+          {{< text syntax=yaml snip_id=none >}}
+            apiVersion: v1
+            kind: ResourceQuota
+            metadata:
+              name: gcp-critical-pods
+              namespace: istio-system
+            spec:
+              hard:
+                pods: 1000
+              scopeSelector:
+                matchExpressions:
+                - operator: In
+                  scopeName: PriorityClass
+                  values:
+                  - system-node-critical
+          {{< /text >}}
+
 
 ### Minikube
 


### PR DESCRIPTION
## Description

Add CNI note from https://github.com/istio/istio/blob/2e87d2a82f64414d287f509a67ee0a2fe59cb668/manifests/charts/istio-cni/README.md?plain=1#L23C1-L25C47 to Platform Prerequisites around use of `kube-system`

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
