### PR TITLE
Revert "Add $DEPLOY_PRIME_URL to the Hugo baseURL."

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -152,7 +152,7 @@ netlify_install:
 
 netlify: netlify_install
 	@scripts/gen_site.sh
-	@scripts/build_site.sh "${DEPLOY_PRIME_URL}/latest"
+	@scripts/build_site.sh "/latest"
 	@scripts/include_archive_site.sh
 
 # ISTIO_API_GIT_SOURCE allows to override the default Istio API repository, https://github.com/istio/api@$(SOURCE_BRANCH_NAME)


### PR DESCRIPTION
We ended up with URLs of the style `https://master--preliminary-istio.netlify.app/latest/about/service-mesh`, which will not do what we want when we get to the release-1.21 branch.

Reverts istio/istio.io#14725.