### PR TITLE
Documentation - Update broken link on Dynamic Admission Webhooks Overview page

### DIFF
--- a/content/en/docs/ops/configuration/mesh/webhook/index.md
+++ b/content/en/docs/ops/configuration/mesh/webhook/index.md
@@ -26,7 +26,7 @@ injecting the sidecar proxy into user pods.
 
 The webhook setup guides assuming general familiarity with Kubernetes
 Dynamic Admission Webhooks. Consult the Kubernetes API references for
-detailed documentation of the [Mutating Webhook Configuration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#mutatingwebhookconfiguration-v1-admissionregistration-k8s-io) and [Validating Webhook Configuration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io).
+detailed documentation of the [Mutating Webhook Configuration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#mutatingwebhookconfiguration-v1-admissionregistration-k8s-io) and [Validating Webhook Configuration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#validatingwebhookconfiguration-v1-admissionregistration-k8s-io).
 
 ## Verify dynamic admission webhook prerequisites
 
@@ -41,8 +41,8 @@ webhooks and dependent features are not functioning properly.
 
     {{< text bash >}}
     $ kubectl version --short
-    Client Version: v1.19.0
-    Server Version: v1.19.1
+    Client Version: v1.29.0
+    Server Version: v1.29.1
     {{< /text >}}
 
 1. `admissionregistration.k8s.io/v1` should be enabled


### PR DESCRIPTION
## Description

This PR changes the version of Kubernetes on the `Dynamic Admission Webhooks Overview` page from `1.19` to `1.29` - fixes broken link, and updates in the formatted text as well! 


## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
