### PR TITLE
Remove the reference to installed-state CR

### DIFF
--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -106,28 +106,6 @@ to install the `demo` profile:
 $ istioctl install --set profile=demo
 {{< /text >}}
 
-## Check what's installed
-
-The `istioctl` command saves the `IstioOperator` CR that was used to install Istio in a copy of the CR named `installed-state`.
-Instead of inspecting the deployments, pods, services and other resources that were installed by Istio, for example:
-
-{{< text bash >}}
-$ kubectl -n istio-system get deploy
-NAME                   READY   UP-TO-DATE   AVAILABLE   AGE
-istio-egressgateway    1/1     1            1           25s
-istio-ingressgateway   1/1     1            1           24s
-istiod                 1/1     1            1           20s
-{{< /text >}}
-
-You can inspect the `installed-state` CR, to see what is installed in the cluster, as well as all custom settings.
-For example, dump its content into a YAML file using the following command:
-
-{{< text bash >}}
-$ kubectl -n istio-system get IstioOperator installed-state -o yaml > installed-state.yaml
-{{< /text >}}
-
-The `installed-state` CR is also used to perform checks in some `istioctl` commands and should therefore not be removed.
-
 ## Display the list of available profiles
 
 You can display the names of Istio configuration profiles that are


### PR DESCRIPTION
## Description
Fixes #14811

This PR removes the [reference](https://istio.io/latest/docs/setup/install/istioctl/#check-whats-installed) to the `installed-state` CR in the [Install with Istioctl](https://istio.io/latest/docs/setup/install/istioctl/) docs. 

This is necessary as this CR is no longer available and the following command mentioned in the docs is failing:
`kubectl -n istio-system get IstioOperator installed-state -o yaml > installed-state.yaml `

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
