### PR TITLE
ambient/install: mention k3s CNI paths

### DIFF
--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -22,7 +22,7 @@ and capture pods on the node.
 
 ### K3S
 
-1. If you are using [K3S](https://k3s.io/) with flannel CNI (default), you must append `--set values.cni.cniConfDir=/var/lib/rancher/k3s/agent/etc/cni/net.d --set values.cni.cniBinDir=/var/lib/rancher/k3s/data/current/bin/` to the `helm install` command, as K3S uses nonstandard locations for CNI configuration and binaries. These nonstandard locations may be overriden as well [according to K3S documentation](https://docs.k3s.io/cli/server#k3s-server-cli-help).
+1. If you are using [K3S](https://k3s.io/), you must append `--set values.cni.cniConfDir=/var/lib/rancher/k3s/agent/etc/cni/net.d --set values.cni.cniBinDir=/var/lib/rancher/k3s/data/current/bin/` to the `helm install` command, as K3S uses nonstandard locations for CNI configuration and binaries. These nonstandard locations may be overriden as well [according to K3S documentation](https://docs.k3s.io/cli/server#k3s-server-cli-help).
 
 ## CNI
 

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -22,7 +22,7 @@ and capture pods on the node.
 
 ### K3S
 
-1. If you are using [K3S](https://k3s.io/), you must append `--set values.cni.cniConfDir=/var/lib/rancher/k3s/agent/etc/cni/net.d --set values.cni.cniBinDir=/var/lib/rancher/k3s/data/current/bin/` to the `helm install` command, as K3S uses nonstandard locations for CNI configuration and binaries. These nonstandard locations may be overriden as well [according to K3S documentation](https://docs.k3s.io/cli/server#k3s-server-cli-help).
+1. If you are using [K3S](https://k3s.io/), you must append `--set values.cni.cniConfDir=/var/lib/rancher/k3s/agent/etc/cni/net.d --set values.cni.cniBinDir=/var/lib/rancher/k3s/data/current/bin/` to the `helm install` command, as K3S uses nonstandard locations for CNI configuration and binaries. These nonstandard locations may be overridden as well [according to K3S documentation](https://docs.k3s.io/cli/server#k3s-server-cli-help).
 
 ## CNI
 

--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -20,6 +20,10 @@ and capture pods on the node.
 
 1. If you are using [MicroK8s](https://microk8s.io/), you must append `--set values.cni.cniConfDir=/var/snap/microk8s/current/args/cni-network --set values.cni.cniBinDir=/var/snap/microk8s/current/opt/cni/bin` to the `helm install` command, as MicroK8s [uses nonstandard locations for CNI configuration and binaries](https://microk8s.io/docs/change-cidr).
 
+### K3S
+
+1. If you are using [K3S](https://k3s.io/) with flannel CNI (default), you must append `--set values.cni.cniConfDir=/var/lib/rancher/k3s/agent/etc/cni/net.d --set values.cni.cniBinDir=/var/lib/rancher/k3s/data/current/bin/` to the `helm install` command, as K3S uses nonstandard locations for CNI configuration and binaries. These nonstandard locations may be overriden as well [according to K3S documentation](https://docs.k3s.io/cli/server#k3s-server-cli-help).
+
 ## CNI
 
 ### Cilium


### PR DESCRIPTION
## Description

This adds a hint how to install istio-cni with k3s/flannel CNI as it uses nonstandard paths. 

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
