### PR TITLE
Ambient: Document that PeerAuthentication mTLS.Mode = DISABLE is a no…

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/tls-configuration/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/tls-configuration/index.md
@@ -32,6 +32,7 @@ Sidecar traffic has a variety of associated connections. Let's break them down o
     By default, the sidecar will be configured to accept both mTLS and non-mTLS traffic, known as `PERMISSIVE` mode.
     The mode can alternatively be configured to `STRICT`, where traffic must be mTLS, or `DISABLE`, where traffic must be plaintext.
     The mTLS mode is configured using a [`PeerAuthentication` resource](/docs/reference/config/security/peer_authentication/).
+    In ambient, you can still create `PeerAuthentication` policy at the mesh or namespace level that uses DISABLE, but it will be ignored.
 
 1. **Local inbound traffic**
     This is traffic going to your application service, from the sidecar. This traffic will always be forwarded as-is.


### PR DESCRIPTION
…-op in ambient

## Description

resolve: https://github.com/istio/istio.io/issues/14789
clarify In ambient, you can still create `PeerAuthentication` policy at the mesh or namespace level that uses DISABLE, but it will be ignored.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
