### PR TITLE
Fix CVSS Vector Calculator Link Gen

### DIFF
--- a/content/en/news/security/istio-security-2019-001/index.md
+++ b/content/en/news/security/istio-security-2019-001/index.md
@@ -4,7 +4,8 @@ subtitle: Security Bulletin
 description: Incorrect access control.
 cves: [CVE-2019-12243]
 cvss: "8.9"
-vector: "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N/E:H/RL:O/RC:C"
+vector: "AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N/E:H/RL:O/RC:C"
+cvss_version: "3.0"
 releases: ["1.1 to 1.1.6"]
 publishdate: 2019-05-28
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2019-002/index.md
+++ b/content/en/news/security/istio-security-2019-002/index.md
@@ -4,7 +4,8 @@ subtitle: Security Bulletin
 description: Denial of service affecting JWT access token parsing.
 cves: [CVE-2019-12995]
 cvss: "7.5"
-vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:F/RL:O/RC:C"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:F/RL:O/RC:C"
+cvss_version: "3.0"
 releases: ["1.0 to 1.0.8", "1.1 to 1.1.9", "1.2 to 1.2.1"]
 publishdate: 2019-06-28
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2019-003/index.md
+++ b/content/en/news/security/istio-security-2019-003/index.md
@@ -4,7 +4,8 @@ subtitle: Security Bulletin
 description: Denial of service in regular expression parsing.
 cves: [CVE-2019-14993]
 cvss: "7.5"
-vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+cvss_version: "3.0"
 releases: ["1.1 to 1.1.12", "1.2 to 1.2.3"]
 publishdate: 2019-08-13
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2019-004/index.md
+++ b/content/en/news/security/istio-security-2019-004/index.md
@@ -4,7 +4,8 @@ subtitle: Security Bulletin
 description: Multiple denial of service vulnerabilities related to HTTP2 support in Envoy.
 cves: [CVE-2019-9512, CVE-2019-9513, CVE-2019-9514, CVE-2019-9515, CVE-2019-9518]
 cvss: "7.5"
-vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+cvss_version: "3.0"
 releases: ["1.1 to 1.1.12", "1.2 to 1.2.3"]
 publishdate: 2019-08-13
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2019-005/index.md
+++ b/content/en/news/security/istio-security-2019-005/index.md
@@ -4,7 +4,8 @@ subtitle: Security Bulletin
 description: Denial of service caused by the presence of numerous HTTP headers in client requests.
 cves: [CVE-2019-15226]
 cvss: "7.5"
-vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+cvss_version: "3.0"
 releases: ["1.1 to 1.1.15", "1.2 to 1.2.6", "1.3 to 1.3.1"]
 publishdate: 2019-10-08
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2019-006/index.md
+++ b/content/en/news/security/istio-security-2019-006/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: Denial of service.
 cves: [CVE-2019-18817]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:H/RL:O/RC:C"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:H/RL:O/RC:C"
 releases: ["1.3 to 1.3.4"]
 publishdate: 2019-11-07
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2019-007/index.md
+++ b/content/en/news/security/istio-security-2019-007/index.md
@@ -4,7 +4,8 @@ subtitle: Security Bulletin
 description: Heap overflow and improper input validation in Envoy.
 cves: [CVE-2019-18801,CVE-2019-18802]
 cvss: "9.0"
-vector: "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+vector: "AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+cvss_version: "3.0"
 releases: ["1.2 to 1.2.9", "1.3 to 1.3.5", "1.4 to 1.4.1"]
 publishdate: 2019-12-10
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2022-003/index.md
+++ b/content/en/news/security/istio-security-2022-003/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: Multiple CVEs related to istiod Denial of Service and Envoy.
 cves: [CVE-2022-23635, CVE-2021-43824, CVE-2021-43825, CVE-2021-43826, CVE-2022-21654, CVE-2022-21655, CVE-2022-23606]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["All releases prior to 1.11.0", "1.11.0 to 1.11.6", "1.12.0 to 1.12.3", "1.13.0"]
 publishdate: 2022-02-22
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2022-004/index.md
+++ b/content/en/news/security/istio-security-2022-004/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: Unauthenticated control plane denial of service attack due to stack exhaustion.
 cves: [CVE-2022-24726, CVE-2022-24921]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["All releases prior to 1.11.0", "1.11.0 to 1.11.7", "1.12.0 to 1.12.4", "1.13.0 to 1.13.1"]
 publishdate: 2022-03-09
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2022-005/index.md
+++ b/content/en/news/security/istio-security-2022-005/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: Ill-formed headers sent to Envoy in certain configurations can lead to unexpected memory access resulting in undefined behavior or crashing.
 cves: [CVE-2022-31045, CVE-2022-29225, CVE-2022-29224, CVE-2022-29226, CVE-2022-29228, CVE-2022-29227]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["All releases prior to 1.12.0", "1.12.0 to 1.12.7", "1.13.0 to 1.13.4", "1.14.0"]
 publishdate: 2022-06-09
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2022-006/index.md
+++ b/content/en/news/security/istio-security-2022-006/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: Ill-formed headers sent to Envoy in certain configurations can lead to unexpected memory access resulting in undefined behavior or crashing.
 cves: [CVE-2022-31045]
 cvss: "5.9"
-vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["1.13.6", "1.14.2"]
 publishdate: 2022-07-26
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2022-007/index.md
+++ b/content/en/news/security/istio-security-2022-007/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: Denial of service attack due to Go Regex Library.
 cves: [CVE-2022-39278]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["All releases prior to 1.13", "1.13.0 to 1.13.8", "1.14.0 to 1.14.4", "1.15.0 to 1.15.1"]
 publishdate: 2022-10-12
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2022-008/index.md
+++ b/content/en/news/security/istio-security-2022-008/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: Identity impersonation if user has localhost access.
 cves: [CVE-2022-39388]
 cvss: "7.6"
-vector: "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N"
+vector: "AV:A/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N"
 releases: ["1.15.2"]
 publishdate: 2022-11-09
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2023-001/index.md
+++ b/content/en/news/security/istio-security-2023-001/index.md
@@ -4,7 +4,8 @@ subtitle: Security Bulletin
 description: Multiple CVEs reported by Envoy.
 cves: [CVE-2023-27496, CVE-2023-27488, CVE-2023-27493, CVE-2023-27492, CVE-2023-27491, CVE-2023-27487]
 cvss: "8.2"
-vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"
+cvss_version: "3.0"
 releases: ["All releases prior to 1.15.0", "1.15.0 to 1.15.6", "1.16.0 to 1.16.3", "1.17.0 to 1.17.1"]
 publishdate: 2023-04-04
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2023-002/index.md
+++ b/content/en/news/security/istio-security-2023-002/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: CVE reported by Envoy.
 cves: [CVE-2023-35945]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["All releases prior to 1.16.0", "1.16.0 to 1.16.5", "1.17.0 to 1.17.3", "1.18.0"]
 publishdate: 2023-07-14
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2023-003/index.md
+++ b/content/en/news/security/istio-security-2023-003/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: CVEs reported by Envoy.
 cves: [CVE-2023-35941,CVE-2023-35942,CVE-2023-35943,CVE-2023-35944]
 cvss: "8.6"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L"
 releases: ["All releases prior to 1.16.0", "1.16.0 to 1.16.6", "1.17.0 to 1.17.4", "1.18.0 to 1.18.1"]
 publishdate: 2023-07-25
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2023-004/index.md
+++ b/content/en/news/security/istio-security-2023-004/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: CVEs reported by Envoy and Go.
 cves: [CVE-2023-44487, CVE-2023-39325]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["All releases prior to 1.17.0", "1.17.0 to 1.17.6", "1.18.0 to 1.18.3", "1.19.0 to 1.19.1"]
 publishdate: 2023-10-11
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2024-001/index.md
+++ b/content/en/news/security/istio-security-2024-001/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: CVEs reported by Envoy.
 cves: [CVE-2024-23322, CVE-2024-23323, CVE-2024-23324, CVE-2024-23325, CVE-2024-23327]
 cvss: "8.6"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+vector: "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
 releases: ["All releases prior to 1.19.0", "1.19.0 to 1.19.6", "1.20.0 to 1.20.2"]
 publishdate: 2024-02-09
 keywords: [CVE]

--- a/content/en/news/security/istio-security-2024-002/index.md
+++ b/content/en/news/security/istio-security-2024-002/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: CVEs reported by Envoy and Go.
 cves: [CVE-2024-27919, CVE-2024-30255, CVE-2023-45288]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["All releases prior to 1.19.0", "1.19.0 to 1.19.8", "1.20.0 to 1.20.4", "1.21.0"]
 publishdate: 2024-04-08
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2019-001/index.md
+++ b/content/zh/news/security/istio-security-2019-001/index.md
@@ -4,7 +4,8 @@ subtitle: 安全公告
 description: 错误的权限控制。
 cves: [CVE-2019-12243]
 cvss: "8.9"
-vector: "CVSS:3.0/AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N/E:H/RL:O/RC:C"
+vector: "AV:A/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:N/E:H/RL:O/RC:C"
+cvss_version: "3.0"
 releases: ["1.1 to 1.1.6"]
 publishdate: 2019-05-28
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2019-002/index.md
+++ b/content/zh/news/security/istio-security-2019-002/index.md
@@ -4,7 +4,8 @@ subtitle: 安全公告
 description: CVE-2019-12995 所披露的安全漏洞。
 cves: [CVE-2019-12995]
 cvss: "7.5"
-vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:F/RL:O/RC:C"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:F/RL:O/RC:C"
+cvss_version: "3.0"
 releases: ["1.0 to 1.0.8", "1.1 to 1.1.9", "1.2 to 1.2.1"]
 publishdate: 2019-06-28
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2019-003/index.md
+++ b/content/zh/news/security/istio-security-2019-003/index.md
@@ -4,7 +4,8 @@ subtitle: 安全公告
 description: 解析正则表达式导致的拒绝服务。
 cves: [CVE-2019-14993]
 cvss: "7.5"
-vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+cvss_version: "3.0"
 releases: ["1.1 to 1.1.12", "1.2 to 1.2.3"]
 publishdate: 2019-08-13
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2019-004/index.md
+++ b/content/zh/news/security/istio-security-2019-004/index.md
@@ -4,7 +4,8 @@ subtitle: 安全公告
 description: 与 Envoy 中的 HTTP2 支持相关的多个拒绝服务的漏洞。
 cve: [CVE-2019-9512, CVE-2019-9513, CVE-2019-9514, CVE-2019-9515, CVE-2019-9518]
 cvss: "7.5"
-vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+cvss_version: "3.0"
 releases: ["1.1 to 1.1.12", "1.2 to 1.2.3"]
 publishdate: 2019-08-13
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2019-005/index.md
+++ b/content/zh/news/security/istio-security-2019-005/index.md
@@ -4,7 +4,8 @@ subtitle: 安全公告
 description: 由于客户端请求中存在大量 HTTP（请求）头 而导致的拒绝服务。
 cves: [CVE-2019-15226]
 cvss: "7.5"
-vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+cvss_version: "3.0"
 releases: ["1.1 to 1.1.15", "1.2 to 1.2.6", "1.3 to 1.3.1"]
 publishdate: 2019-10-08
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2019-006/index.md
+++ b/content/zh/news/security/istio-security-2019-006/index.md
@@ -4,7 +4,7 @@ subtitle: 安全公告
 description: 拒绝服务。
 cves: [CVE-2019-18817]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:H/RL:O/RC:C"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:H/RL:O/RC:C"
 releases: ["1.3 to 1.3.4"]
 publishdate: 2019-11-07
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2019-007/index.md
+++ b/content/zh/news/security/istio-security-2019-007/index.md
@@ -4,7 +4,8 @@ subtitle: 安全公告
 description: Envoy 中的堆溢出及错误的输入验证。
 cves: [CVE-2019-18801,CVE-2019-18802]
 cvss: "9.0"
-vector: "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+vector: "AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H"
+cvss_version: "3.0"
 releases: ["1.2 to 1.2.9", "1.3 to 1.3.5", "1.4 to 1.4.1"]
 publishdate: 2019-12-10
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2022-003/index.md
+++ b/content/zh/news/security/istio-security-2022-003/index.md
@@ -4,7 +4,7 @@ subtitle: 安全公告
 description: Multiple CVEs related to istiod Denial of Service and Envoy.
 cves: [CVE-2022-23635, CVE-2021-43824, CVE-2021-43825, CVE-2021-43826, CVE-2022-21654, CVE-2022-21655, CVE-2022-23606]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["All releases prior to 1.11.0", "1.11.0 to 1.11.6", "1.12.0 to 1.12.3", "1.13.0"]
 publishdate: 2022-02-22
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2022-004/index.md
+++ b/content/zh/news/security/istio-security-2022-004/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: 由于堆栈耗尽而导致控制平面不能拒绝未经身份验证的服务攻击。
 cves: [CVE-2022-24726, CVE-2022-24921]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["All releases prior to 1.11.0", "1.11.0 to 1.11.7", "1.12.0 to 1.12.4", "1.13.0 to 1.13.1"]
 publishdate: 2022-03-09
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2022-005/index.md
+++ b/content/zh/news/security/istio-security-2022-005/index.md
@@ -4,7 +4,7 @@ subtitle: Security Bulletin
 description: 在某些配置中，发送给 Envoy 的格式错误的请求头可能会导致意外的内存访问冲突，从而产生未定义的行为或崩溃。
 cves: [CVE-2022-31045, CVE-2022-29225, CVE-2022-29224, CVE-2022-29226, CVE-2022-29228, CVE-2022-29227]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["All releases prior to 1.12.0", "1.12.0 to 1.12.7", "1.13.0 to 1.13.4", "1.14.0"]
 publishdate: 2022-06-09
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2022-006/index.md
+++ b/content/zh/news/security/istio-security-2022-006/index.md
@@ -4,7 +4,7 @@ subtitle: 安全公告
 description: 在某些配置中，发送给 Envoy 的格式错误的标头可能会导致意外的内存访问，从而导致未定义的行为或崩溃。
 cves: [CVE-2022-31045]
 cvss: "5.9"
-vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["1.13.6", "1.14.2"]
 publishdate: 2022-07-26
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2022-007/index.md
+++ b/content/zh/news/security/istio-security-2022-007/index.md
@@ -4,7 +4,7 @@ subtitle: 安全公告
 description: 由于 Go 语言正则表达式库造成拒绝服务 (DoS) 攻击。
 cves: [CVE-2022-39278]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["1.13 之前的所有版本", "1.13.0 到 1.13.8", "1.14.0 到 1.14.4", "1.15.0 到 1.15.1"]
 publishdate: 2022-10-12
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2022-008/index.md
+++ b/content/zh/news/security/istio-security-2022-008/index.md
@@ -4,7 +4,7 @@ subtitle: 安全公告
 description: 用户具有 localhost 访问权限时有身份模仿的风险。
 cves: [CVE-2022-39388]
 cvss: "7.6"
-vector: "CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N"
+vector: "AV:A/AC:L/PR:L/UI:N/S:C/C:H/I:L/A:N"
 releases: ["1.15.2"]
 publishdate: 2022-11-09
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2023-001/index.md
+++ b/content/zh/news/security/istio-security-2023-001/index.md
@@ -4,7 +4,8 @@ subtitle: 安全公告
 description: Envoy 上报的众多 CVE 漏洞。
 cves: [CVE-2023-27496, CVE-2023-27488, CVE-2023-27493, CVE-2023-27492, CVE-2023-27491, CVE-2023-27487]
 cvss: "8.2"
-vector: "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"
+cvss_version: "3.0"
 releases: ["1.15.0 之前的所有版本", "1.15.0 到 1.15.6", "1.16.0 到 1.16.3", "1.17.0 到 1.17.1"]
 publishdate: 2023-04-04
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2023-002/index.md
+++ b/content/zh/news/security/istio-security-2023-002/index.md
@@ -4,7 +4,7 @@ subtitle: 安全公告
 description: Envoy 上报的 CVE 漏洞。
 cves: [CVE-2023-35945]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["1.16.0 以及之前的所有版本", "1.16.0 到 1.16.5", "1.17.0 到 1.17.3", "1.18.0"]
 publishdate: 2023-07-14
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2023-003/index.md
+++ b/content/zh/news/security/istio-security-2023-003/index.md
@@ -4,7 +4,7 @@ subtitle: 安全公告
 description: Envoy 上报的 CVE 漏洞。
 cves: [CVE-2023-35941,CVE-2023-35942,CVE-2023-35943,CVE-2023-35944]
 cvss: "8.6"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:L"
 releases: ["1.16.0 以及之前的所有版本", "1.16.0 到 1.16.6", "1.17.0 到 1.17.4", "1.18.0 到 1.18.1"]
 publishdate: 2023-07-25
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2023-004/index.md
+++ b/content/zh/news/security/istio-security-2023-004/index.md
@@ -4,7 +4,7 @@ subtitle: 安全公告
 description: Envoy 和 Go 上报的 CVE 漏洞。
 cves: [CVE-2023-44487, CVE-2023-39325]
 cvss: "7.5"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+vector: "AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 releases: ["1.17.0 以及之前的所有版本", "1.17.0 到 1.17.6", "1.18.0 到 1.18.3", "1.19.0 到 1.19.1"]
 publishdate: 2023-10-11
 keywords: [CVE]

--- a/content/zh/news/security/istio-security-2024-001/index.md
+++ b/content/zh/news/security/istio-security-2024-001/index.md
@@ -4,7 +4,7 @@ subtitle: 安全公告
 description: Envoy 上报的 CVE 漏洞。
 cves: [CVE-2024-23322, CVE-2024-23323, CVE-2024-23324, CVE-2024-23325, CVE-2024-23327]
 cvss: "8.6"
-vector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+vector: "AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
 releases: ["1.19.0 之前的所有版本", "1.19.0 到 1.19.6", "1.20.0 到 1.20.2"]
 publishdate: 2024-02-09
 keywords: [CVE]

--- a/layouts/news/security-grid.html
+++ b/layouts/news/security-grid.html
@@ -42,7 +42,9 @@
 
                                     <td class="score">
                                         {{ if .Params.cvss }}
-                                            <a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector={{ .Params.vector }}">{{ .Params.cvss }}</a>
+                                        <a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector={{ .Params.vector }}&version={{ default "3.1" .Params.cvss_version }}">
+                                            {{ .Params.cvss }}
+                                        </a>
                                         {{ end }}
                                     </td>
 

--- a/layouts/shortcodes/security_bulletin.html
+++ b/layouts/shortcodes/security_bulletin.html
@@ -2,6 +2,7 @@
 {{ $cvss := .Page.Params.cvss }}
 {{ $vector := .Page.Params.vector }}
 {{ $releases := .Page.Params.releases }}
+{{ $cvss_version := default "3.1" .Page.Params.cvss_version }}
 
 <table>
     <thead>
@@ -20,7 +21,7 @@
         </tr>
         <tr>
             <td>{{ i18n "security_bulletin_cvss" }}</td>
-            <td>{{ $cvss }} <a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector={{ $vector }}">{{ $vector }}</a></td>
+            <td>{{ $cvss }} <a href="https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector={{ $vector }}&version={{ $cvss_version }}">{{ $vector }}</a></td>
         </tr>
         <tr>
             <td>{{ i18n "security_bulletin_affected_releases" }}</td>


### PR DESCRIPTION
## Description

The vector calculator does not support `CVSS:x.x/` as part of the vector to define the version to use. It's a seperate query parameter.

Issue found here: https://github.com/istio/istio.io/pull/14846#discussion_r1555964752

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
