### PR TITLE
Fixup K3S ambinet docs to be a bit more clear

### DIFF
--- a/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ops/ambient/install/platform-prerequisites/index.md
@@ -46,7 +46,7 @@ and capture pods on the node.
 
 ### K3S
 
-1. If you are using [K3S](https://k3s.io/), you must append `--set values.cni.cniConfDir=/var/lib/rancher/k3s/agent/etc/cni/net.d --set values.cni.cniBinDir=/var/lib/rancher/k3s/data/current/bin/` to the `helm install` command, as K3S uses nonstandard locations for CNI configuration and binaries. These nonstandard locations may be overridden as well [according to K3S documentation](https://docs.k3s.io/cli/server#k3s-server-cli-help).
+1. If you are using [K3S](https://k3s.io/) and one of its bundled CNIs, you must append `--set values.cni.cniConfDir=/var/lib/rancher/k3s/agent/etc/cni/net.d --set values.cni.cniBinDir=/var/lib/rancher/k3s/data/current/bin/` to the `helm install` command, as K3S uses nonstandard locations for CNI configuration and binaries. These nonstandard locations may be overridden as well [according to K3S documentation](https://docs.k3s.io/cli/server#k3s-server-cli-help). If you are using K3S with a custom, non-bundled CNI, you must use the correct paths for those CNIs, e.g. `/etc/cni/net.d` - [see K3S docs for details](https://docs.k3s.io/zh/networking/basic-network-options#custom-cni)
 
 ## CNI
 


### PR DESCRIPTION
## Description

With K3S it's a bit more complicated - if you are using K3S with bundled CNIs, you need the path overrides for nonstandard CNI config locations. If you disable the bundled CNIs and install your own, you need to use the path that that custom CNI prefers.

https://github.com/istio/istio/issues/50072#issuecomment-2057367083

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
