### PR TITLE
Update ambient helm install index.md to be consistent

### DIFF
--- a/content/en/docs/ops/ambient/install/helm-installation/index.md
+++ b/content/en/docs/ops/ambient/install/helm-installation/index.md
@@ -14,8 +14,6 @@ we encourage the use of Helm to install Istio for use in ambient mode. Helm help
 
 1. Check the [Platform-Specific Prerequisites](/docs/ops/ambient/install/platform-prerequisites).
 
-1. Check the [Requirements for Pods and Services](/docs/ops/deployment/requirements/).
-
 1. [Install the Helm client](https://helm.sh/docs/intro/install/), version 3.6 or above.
 
 1. Configure the Helm repository:
@@ -27,9 +25,9 @@ we encourage the use of Helm to install Istio for use in ambient mode. Helm help
 
 *See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation.*
 
-## Installing the components
+## Install the components
 
-### Installing the base component
+### Install the base component
 
 The `base` chart contains the basic CRDs and cluster roles required to set up Istio.
 This should be installed prior to any other Istio component.
@@ -38,7 +36,7 @@ This should be installed prior to any other Istio component.
 $ helm install istio-base istio/base -n istio-system --create-namespace
 {{< /text >}}
 
-### Installing the CNI Component
+### Install the CNI component
 
 The `cni` chart installs the Istio CNI plugin. It is responsible for detecting the pods that belong to the ambient mesh, and configuring the traffic redirection between pods and the ztunnel node proxy (which will be installed later).
 
@@ -46,7 +44,7 @@ The `cni` chart installs the Istio CNI plugin. It is responsible for detecting t
 $ helm install istio-cni istio/cni -n istio-system --set profile=ambient
 {{< /text >}}
 
-### Installing the discovery component
+### Install the Istiod component
 
 The `istiod` chart installs a revision of Istiod. Istiod is the control plane component that manages and
 configures the proxies to route traffic within the mesh.
@@ -55,7 +53,7 @@ configures the proxies to route traffic within the mesh.
 $ helm install istiod istio/istiod --namespace istio-system --set profile=ambient
 {{< /text >}}
 
-### Installing the ztunnel component
+### Install the ztunnel component
 
 The `ztunnel` chart installs the ztunnel DaemonSet, which is the node proxy component of Istio's ambient mode.
 
@@ -71,7 +69,7 @@ See [Controlling the injection policy](/docs/setup/additional-setup/sidecar-inje
 {{< /warning >}}
 
 {{< text syntax=bash snip_id=install_ingress >}}
-$ helm install istio-ingress istio/gateway -n istio-ingress --wait --create-namespace
+$ helm install istio-ingress istio/gateway -n istio-ingress --create-namespace
 {{< /text >}}
 
 See [Installing Gateways](/docs/setup/additional-setup/gateway/) for in-depth documentation on gateway installation.
@@ -84,9 +82,9 @@ To view supported configuration options and documentation, run:
 $ helm show values istio/istiod
 {{< /text >}}
 
-## Verifying the installation
+## Verify the installation
 
-### Verifying the workload status
+### Verify the workload status
 
 After installing all the components, you can check the Helm deployment status with:
 
@@ -109,7 +107,7 @@ istiod-5f4c75464f-gskxf          1/1     Running   0          10m
 ztunnel-c2z4s                    1/1     Running   0          10m
 {{< /text >}}
 
-### Verifying with the sample application
+### Verify with the sample application
 
 After installing ambient mode with Helm, you can follow the [Deploy the sample application](/docs/ops/ambient/getting-started/#bookinfo) guide to deploy the sample application and ingress gateways, and then you can
 [add your application to the ambient mesh](/docs/ops/ambient/getting-started/#addtoambient).

--- a/content/en/docs/ops/ambient/install/helm-installation/index.md
+++ b/content/en/docs/ops/ambient/install/helm-installation/index.md
@@ -69,7 +69,7 @@ To install an ingress gateway, run the command below:
 $ helm install istio-ingress istio/gateway -n istio-ingress --create-namespace --wait
 {{< /text >}}
 
-If your Kubernetes cluster doesn't support the LoadBalancer service type (`type: LoadBalancer`) with proper external IP assigned, run the command without the `--wait` parameter. See [Installing Gateways](/docs/setup/additional-setup/gateway/) for in-depth documentation on gateway installation.
+If your Kubernetes cluster doesn't support the `LoadBalancer` service type (`type: LoadBalancer`) with a proper external IP assigned, run the above command without the `--wait` parameter to avoid the infinite wait. See [Installing Gateways](/docs/setup/additional-setup/gateway/) for in-depth documentation on gateway installation.
 
 ## Configuration
 

--- a/content/en/docs/ops/ambient/install/helm-installation/index.md
+++ b/content/en/docs/ops/ambient/install/helm-installation/index.md
@@ -33,7 +33,7 @@ The `base` chart contains the basic CRDs and cluster roles required to set up Is
 This should be installed prior to any other Istio component.
 
 {{< text syntax=bash snip_id=install_base >}}
-$ helm install istio-base istio/base -n istio-system --create-namespace
+$ helm install istio-base istio/base -n istio-system --create-namespace --wait
 {{< /text >}}
 
 ### Install the CNI component
@@ -41,7 +41,7 @@ $ helm install istio-base istio/base -n istio-system --create-namespace
 The `cni` chart installs the Istio CNI plugin. It is responsible for detecting the pods that belong to the ambient mesh, and configuring the traffic redirection between pods and the ztunnel node proxy (which will be installed later).
 
 {{< text syntax=bash snip_id=install_cni >}}
-$ helm install istio-cni istio/cni -n istio-system --set profile=ambient
+$ helm install istio-cni istio/cni -n istio-system --set profile=ambient --wait
 {{< /text >}}
 
 ### Install the Istiod component
@@ -50,7 +50,7 @@ The `istiod` chart installs a revision of Istiod. Istiod is the control plane co
 configures the proxies to route traffic within the mesh.
 
 {{< text syntax=bash snip_id=install_discovery >}}
-$ helm install istiod istio/istiod --namespace istio-system --set profile=ambient
+$ helm install istiod istio/istiod --namespace istio-system --set profile=ambient --wait
 {{< /text >}}
 
 ### Install the ztunnel component
@@ -58,21 +58,18 @@ $ helm install istiod istio/istiod --namespace istio-system --set profile=ambien
 The `ztunnel` chart installs the ztunnel DaemonSet, which is the node proxy component of Istio's ambient mode.
 
 {{< text syntax=bash snip_id=install_ztunnel >}}
-$ helm install ztunnel istio/ztunnel -n istio-system
+$ helm install ztunnel istio/ztunnel -n istio-system --wait
 {{< /text >}}
 
 ### Install an ingress gateway (optional)
 
-{{< warning >}}
-The namespace the gateway is deployed in must not have a `istio-injection=disabled` label.
-See [Controlling the injection policy](/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy) for more info.
-{{< /warning >}}
+To install an ingress gateway, run the command below:
 
 {{< text syntax=bash snip_id=install_ingress >}}
-$ helm install istio-ingress istio/gateway -n istio-ingress --create-namespace
+$ helm install istio-ingress istio/gateway -n istio-ingress --create-namespace --wait
 {{< /text >}}
 
-See [Installing Gateways](/docs/setup/additional-setup/gateway/) for in-depth documentation on gateway installation.
+If your Kubernetes cluster doesn't support the LoadBalancer service type (`type: LoadBalancer`) with proper external IP assigned, run the command without the `--wait` parameter. See [Installing Gateways](/docs/setup/additional-setup/gateway/) for in-depth documentation on gateway installation.
 
 ## Configuration
 

--- a/content/en/docs/ops/ambient/install/helm-installation/snips.sh
+++ b/content/en/docs/ops/ambient/install/helm-installation/snips.sh
@@ -42,7 +42,7 @@ helm install ztunnel istio/ztunnel -n istio-system
 }
 
 snip_install_ingress() {
-helm install istio-ingress istio/gateway -n istio-ingress --wait --create-namespace
+helm install istio-ingress istio/gateway -n istio-ingress --create-namespace
 }
 
 snip_configuration_1() {

--- a/content/en/docs/ops/ambient/install/helm-installation/snips.sh
+++ b/content/en/docs/ops/ambient/install/helm-installation/snips.sh
@@ -26,23 +26,23 @@ helm repo update
 }
 
 snip_install_base() {
-helm install istio-base istio/base -n istio-system --create-namespace
+helm install istio-base istio/base -n istio-system --create-namespace --wait
 }
 
 snip_install_cni() {
-helm install istio-cni istio/cni -n istio-system --set profile=ambient
+helm install istio-cni istio/cni -n istio-system --set profile=ambient --wait
 }
 
 snip_install_discovery() {
-helm install istiod istio/istiod --namespace istio-system --set profile=ambient
+helm install istiod istio/istiod --namespace istio-system --set profile=ambient --wait
 }
 
 snip_install_ztunnel() {
-helm install ztunnel istio/ztunnel -n istio-system
+helm install ztunnel istio/ztunnel -n istio-system --wait
 }
 
 snip_install_ingress() {
-helm install istio-ingress istio/gateway -n istio-ingress --create-namespace
+helm install istio-ingress istio/gateway -n istio-ingress --create-namespace --wait
 }
 
 snip_configuration_1() {


### PR DESCRIPTION
## Description
1. pods and services requirement are mainly for sidecar, so no need to ask users to check it.
2. discovery component -> istiod as we don't explain discovery component here in install yet.
3. remove `--wait` to be consistent with the rest of cmds on this page.
4. Use similar words as https://istio.io/latest/docs/setup/install/istioctl/ without `ing`.