### PR TITLE
Allow / in compare like prefixes

### DIFF
--- a/tests/util/verify.sh
+++ b/tests/util/verify.sh
@@ -234,7 +234,7 @@ __cmp_like() {
                     fi
                     comm="${comm}${otok:$k:1}"
                 done
-                if ! [[ "$comm" =~ ^([a-zA-Z0-9_]+-)+ ]]; then
+                if ! [[ "$comm" =~ ^([a-zA-Z0-9_\/]+-)+ ]]; then
                     return 1
                 fi
             done


### PR DESCRIPTION
## Description

The ambient getting started test has snippets with lines in which a similar token which ends at a `-` plus something has an `/` in the line like the following failure:
```
VERIFY FAILED snip_download_and_install_7 (timeout after 120s):
received:
"NAME                                        READY   STATUS    RESTARTS   AGE
pod/istio-cni-node-nhfqn                    1/1     Running   0          2m10s
pod/istio-ingressgateway-7bb7649f89-28p26   1/1     Running   0          2m10s
pod/istiod-55b74b77bd-stb9n                 1/1     Running   0          2m13s
pod/ztunnel-q98d9                           1/1     Running   0          2m6s

NAME                            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
daemonset.apps/istio-cni-node   1         1         1       1            1           kubernetes.io/os=linux   2m10s
daemonset.apps/ztunnel          1         1         1       1            1           kubernetes.io/os=linux   2m6s"
expected:
"NAME                                    READY   STATUS    RESTARTS   AGE
pod/istio-cni-node-zq94l                    1/1     Running   0          2m7s
pod/istio-ingressgateway-56b9cb5485-ksnvc   1/1     Running   0          2m7s
pod/istiod-56d848857c-mhr5w                 1/1     Running   0          2m9s
pod/ztunnel-srrnm                           1/1     Running   0          2m5s

NAME             DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
daemonset.apps/istio-cni-node   1         1         1       1            1           kubernetes.io/os=linux   2m16s
daemonset.apps/ztunnel          1         1         1       1            1           kubernetes.io/os=linux   2m10s"
```
It fails on the first token in the line starting with `pod/istio-cni-node-nhfqn` 

This change allows the `/` within the token.

You can see in https://github.com/istio/istio.io/pull/14941 that after adding this change the test processed further failing on a different incorrect snippet (lines don't match).