### PR TITLE
updating dashboard instructions to reflect latest kubernetes dashboar…

### DIFF
--- a/content/en/docs/setup/platform-setup/k3d/index.md
+++ b/content/en/docs/setup/platform-setup/k3d/index.md
@@ -78,9 +78,8 @@ Follow these instructions to set up Dashboard for k3d.
 1.  To deploy Dashboard, run the following command:
 
     {{< text bash >}}
-    $ GITHUB_URL=https://github.com/kubernetes/dashboard/releases
-    $ VERSION_KUBE_DASHBOARD=$(curl -w '%{url_effective}' -I -L -s -S ${GITHUB_URL}/latest -o /dev/null | sed -e 's|.*/||')
-    $ kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/${VERSION_KUBE_DASHBOARD}/aio/deploy/recommended.yaml
+    $ helm repo add kubernetes-dashboard https://kubernetes.github.io/dashboard/
+    $ helm upgrade --install kubernetes-dashboard kubernetes-dashboard/kubernetes-dashboard --create-namespace --namespace kubernetes-dashboard
     {{< /text >}}
 
 1.  Verify that Dashboard is deployed and running.
@@ -118,7 +117,7 @@ Follow these instructions to set up Dashboard for k3d.
     Starting to serve on 127.0.0.1:8001
     {{< /text >}}
 
-    Click [Kubernetes Dashboard](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/) to
+    Click [Kubernetes Dashboard](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/http:kubernetes-dashboard-web:web/proxy/) to
     view your deployments and services.
 
     {{< warning >}}


### PR DESCRIPTION
## Description

https://github.com/istio/istio.io/issues/14946

Updates the instructions for installing the Dashboard UI to use helm, deployment path no longer exists in newer version of kubernetes dashboard (manifest based install no longer supported in 7.0.0). https://github.com/kubernetes/dashboard

Updates the Kubernetes Dashboard link in the Dashboard UI instructions https://istio.io/latest/docs/setup/platform-setup/k3d/

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
