### PR TITLE
fix ambient redirects

### DIFF
--- a/content/en/docs/ambient/_index.md
+++ b/content/en/docs/ambient/_index.md
@@ -4,6 +4,7 @@ description: Information for setting up and operating Istio in ambient mode.
 weight: 25
 aliases:
   - /docs/ops/ambient
+  - /latest/docs/ops/ambient
 keywords: [ambient]
 test: n/a
 ---

--- a/content/en/docs/ambient/architecture/index.md
+++ b/content/en/docs/ambient/architecture/index.md
@@ -4,6 +4,7 @@ description: A deep dive into the architecture of ambient mode.
 weight: 20
 aliases:
   - /docs/ops/ambient/architecture
+  - /latest/docs/ops/ambient/architecture
 owner: istio/wg-networking-maintainers
 test: n/a
 ---

--- a/content/en/docs/ambient/getting-started/index.md
+++ b/content/en/docs/ambient/getting-started/index.md
@@ -4,6 +4,7 @@ description: How to deploy and install Istio in ambient mode.
 weight: 1
 aliases:
   - /docs/ops/ambient/getting-started
+  - /latest/docs/ops/ambient/getting-started
 owner: istio/wg-networking-maintainers
 test: yes
 ---

--- a/content/en/docs/ambient/install/_index.md
+++ b/content/en/docs/ambient/install/_index.md
@@ -4,6 +4,7 @@ description: Installation guide for Istio ambient mode.
 weight: 5
 aliases:
   - /docs/ops/ambient/install
+  - /latest/docs/ops/ambient/install
 owner: istio/wg-environment-maintainers
 test: n/a
 ---

--- a/content/en/docs/ambient/install/helm-installation/index.md
+++ b/content/en/docs/ambient/install/helm-installation/index.md
@@ -4,6 +4,7 @@ description: Install Istio in Ambient mode with Helm.
 weight: 4
 aliases:
   - /docs/ops/ambient/install/helm-installation
+  - /latest/docs/ops/ambient/install/helm-installation
 owner: istio/wg-environments-maintainers
 test: yes
 ---

--- a/content/en/docs/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ambient/install/platform-prerequisites/index.md
@@ -4,6 +4,7 @@ description: Platform-specific prerequisites for installing Istio in ambient mod
 weight: 4
 aliases:
   - /docs/ops/ambient/install/platform-prerequisites
+  - /latest/docs/ops/ambient/install/platform-prerequisites  
 owner: istio/wg-environments-maintainers
 test: no
 ---

--- a/content/en/docs/ambient/upgrade/_index.md
+++ b/content/en/docs/ambient/upgrade/_index.md
@@ -4,6 +4,7 @@ description: Upgrade guide for Istio ambient mode.
 weight: 10
 aliases:
   - /docs/ops/ambient/upgrade
+  - /latest/docs/ops/ambient/upgrade
 owner: istio/wg-environment-maintainers
 test: n/a
 ---

--- a/content/en/docs/ambient/upgrade/helm-upgrade/index.md
+++ b/content/en/docs/ambient/upgrade/helm-upgrade/index.md
@@ -4,6 +4,7 @@ description: Upgrading an ambient mode installation with Helm.
 weight: 5
 aliases:
   - /docs/ops/ambient/upgrade/helm-upgrade
+  - /latest/docs/ops/ambient/upgrade/helm-upgrade  
 owner: istio/wg-environments-maintainers
 test: yes
 status: Experimental

--- a/content/en/docs/ambient/usage/_index.md
+++ b/content/en/docs/ambient/usage/_index.md
@@ -4,6 +4,7 @@ description: How to configure a mesh in ambient mode.
 weight: 15
 aliases:
   - /docs/ops/ambient/usage
+  - /latest/docs/ops/ambient/usage  
 owner: istio/wg-networking-maintainers
 test: n/a
 ---

--- a/content/en/docs/ambient/usage/traffic-redirection/index.md
+++ b/content/en/docs/ambient/usage/traffic-redirection/index.md
@@ -4,6 +4,7 @@ description: Understand how traffic is redirected between pods and the ztunnel n
 weight: 2
 aliases:
   - /docs/ops/ambient/usage/traffic-redirection
+  - /latest/docs/ops/ambient/usage/traffic-redirection
 owner: istio/wg-networking-maintainers
 test: no
 ---

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -4,6 +4,7 @@ description: Gain the full set of Istio feature with optional waypoint proxies.
 weight: 2
 aliases:
   - /docs/ops/ambient/usage/waypoint
+  - /latest/docs/ops/ambient/usage/waypoint
 owner: istio/wg-networking-maintainers
 test: no
 ---

--- a/content/en/docs/ambient/usage/ztunnel/index.md
+++ b/content/en/docs/ambient/usage/ztunnel/index.md
@@ -4,6 +4,7 @@ description: Understand and manage Istio's "zero-trust tunnel" proxy.
 weight: 2
 aliases:
   - /docs/ops/ambient/usage/ztunnel
+  - /latest/docs/ops/ambient/usage/ztunnel
 owner: istio/wg-networking-maintainers
 test: no
 ---


### PR DESCRIPTION
https://istio.io/latest/docs/ops/ambient/usage/waypoint/ was a page before

https://preliminary.istio.io/latest/docs/ops/ambient/usage/waypoint/ does not redirect, so the top URL won't work when this branch becomes the primary.