### PR TITLE
remove istio api from getting started guide

### DIFF
--- a/content/en/docs/ambient/getting-started/index.md
+++ b/content/en/docs/ambient/getting-started/index.md
@@ -4,7 +4,6 @@ description: How to deploy and install Istio in ambient mode.
 weight: 1
 aliases:
   - /docs/ops/ambient/getting-started
-  - /latest/docs/ops/ambient/getting-started
 owner: istio/wg-networking-maintainers
 test: yes
 ---
@@ -61,34 +60,6 @@ Follow these steps to get started with Istio's ambient mode:
 1.  Install Istio with the `ambient` profile on your Kubernetes cluster, using
     the version of `istioctl` downloaded above:
 
-{{< tabset category-name="config-api" >}}
-
-{{< tab name="Istio APIs" category-value="istio-apis" >}}
-
-{{< text bash >}}
-$ istioctl install --set profile=ambient --set "components.ingressGateways[0].enabled=true" --set "components.ingressGateways[0].name=istio-ingressgateway" --skip-confirmation
-{{< /text >}}
-
-{{< tip >}}
-Note that this command includes `--set "components.ingressGateways[0].enabled=true"` because the ambient profile does not install the ingress gateway by default.
-{{< /tip >}}
-
-After running the above command, you’ll get the following output that indicates
-five components (including {{< gloss "ztunnel" >}}ztunnel{{< /gloss >}}) have been installed successfully!
-
-{{< text syntax=plain snip_id=none >}}
-✔ Istio core installed
-✔ Istiod installed
-✔ CNI installed
-✔ Ingress gateways installed
-✔ Ztunnel installed
-✔ Installation complete
-{{< /text >}}
-
-{{< /tab >}}
-
-{{< tab name="Gateway API" category-value="gateway-api" >}}
-
 {{< text bash >}}
 $ istioctl install --set profile=ambient --skip-confirmation
 {{< /text >}}
@@ -104,32 +75,7 @@ four components (including {{< gloss "ztunnel" >}}ztunnel{{< /gloss >}}) have be
 ✔ Installation complete
 {{< /text >}}
 
-{{< /tab >}}
-
-{{< /tabset >}}
-
 6)  Verify the installed components using the following commands:
-
-{{< tabset category-name="config-api" >}}
-
-{{< tab name="Istio APIs" category-value="istio-apis" >}}
-
-{{< text bash >}}
-$ kubectl get pods,daemonset -n istio-system
-NAME                                        READY   STATUS    RESTARTS   AGE
-pod/istio-cni-node-zq94l                    1/1     Running   0          2m7s
-pod/istio-ingressgateway-56b9cb5485-ksnvc   1/1     Running   0          2m7s
-pod/istiod-56d848857c-mhr5w                 1/1     Running   0          2m9s
-pod/ztunnel-srrnm                           1/1     Running   0          2m5s
-
-NAME                            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
-daemonset.apps/istio-cni-node   1         1         1       1            1           kubernetes.io/os=linux   2m16s
-daemonset.apps/ztunnel          1         1         1       1            1           kubernetes.io/os=linux   2m10s
-{{< /text >}}
-
-{{< /tab >}}
-
-{{< tab name="Gateway API" category-value="gateway-api" >}}
 
 {{< text bash >}}
 $ kubectl get pods,daemonset -n istio-system
@@ -142,10 +88,6 @@ NAME                            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILAB
 daemonset.apps/istio-cni-node   1         1         1       1            1           kubernetes.io/os=linux   2m18s
 daemonset.apps/ztunnel          1         1         1       1            1           kubernetes.io/os=linux   2m10s
 {{< /text >}}
-
-{{< /tab >}}
-
-{{< /tabset >}}
 
 ## Deploy the sample application {#bookinfo}
 
@@ -179,28 +121,6 @@ Make sure the default namespace does not include the label `istio-injection=enab
     To get IP address assignment for `Loadbalancer` service types in `kind`, you may need to install a tool like [MetalLB](https://metallb.universe.tf/). Please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
     {{</ tip >}}
 
-{{< tabset category-name="config-api" >}}
-
-{{< tab name="Istio APIs" category-value="istio-apis" >}}
-
-Create an Istio [Gateway](/docs/reference/config/networking/gateway/) and
-[VirtualService](/docs/reference/config/networking/virtual-service/):
-
-{{< text bash >}}
-$ kubectl apply -f @samples/bookinfo/networking/bookinfo-gateway.yaml@
-{{< /text >}}
-
-Set the environment variables for the Istio ingress gateway:
-
-{{< text bash >}}
-$ export GATEWAY_HOST=istio-ingressgateway.istio-system
-$ export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/istio-ingressgateway-service-account
-{{< /text >}}
-
-{{< /tab >}}
-
-{{< tab name="Gateway API" category-value="gateway-api" >}}
-
 Create a [Kubernetes Gateway](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.Gateway)
 and [HTTPRoute](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io/v1.HTTPRoute):
 
@@ -220,10 +140,6 @@ $ kubectl wait --for=condition=programmed gtw/bookinfo-gateway -n istio-system
 $ export GATEWAY_HOST=bookinfo-gateway-istio.istio-system
 $ export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/bookinfo-gateway-istio
 {{< /text >}}
-
-{{< /tab >}}
-
-{{< /tabset >}}
 
 3) Test your bookinfo application. It should work with or without the gateway:
 
@@ -404,27 +320,10 @@ $ kubectl exec deploy/sleep -- curl -s http://productpage:9080/ | grep -o "<titl
 
 You can use the same waypoint to control traffic to `reviews`. Configure traffic routing to send 90% of requests to `reviews` v1 and 10% to `reviews` v2:
 
-{{< tabset category-name="config-api" >}}
-
-{{< tab name="Istio APIs" category-value="istio-apis" >}}
-
-{{< text bash >}}
-$ kubectl apply -f @samples/bookinfo/networking/virtual-service-reviews-90-10.yaml@
-$ kubectl apply -f @samples/bookinfo/networking/destination-rule-reviews.yaml@
-{{< /text >}}
-
-{{< /tab >}}
-
-{{< tab name="Gateway API" category-value="gateway-api" >}}
-
 {{< text bash >}}
 $ kubectl apply -f @samples/bookinfo/platform/kube/bookinfo-versions.yaml@
 $ kubectl apply -f @samples/bookinfo/gateway-api/route-reviews-90-10.yaml@
 {{< /text >}}
-
-{{< /tab >}}
-
-{{< /tabset >}}
 
 Confirm that roughly 10% of the traffic from 100 requests goes to reviews-v2:
 

--- a/content/en/docs/ambient/getting-started/snips.sh
+++ b/content/en/docs/ambient/getting-started/snips.sh
@@ -26,34 +26,14 @@ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
 }
 
 snip_download_and_install_3() {
-istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING=true --set profile=ambient --set "components.ingressGateways[0].enabled=true" --set "components.ingressGateways[0].name=istio-ingressgateway" --skip-confirmation
-}
-
-snip_download_and_install_5() {
 istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING=true --set profile=ambient --skip-confirmation
 }
 
-snip_download_and_install_7() {
+snip_download_and_install_5() {
 kubectl get pods,daemonset -n istio-system
 }
 
-! IFS=$'\n' read -r -d '' snip_download_and_install_7_out <<\ENDSNIP
-NAME                                        READY   STATUS    RESTARTS   AGE
-pod/istio-cni-node-zq94l                    1/1     Running   0          2m7s
-pod/istio-ingressgateway-56b9cb5485-ksnvc   1/1     Running   0          2m7s
-pod/istiod-56d848857c-mhr5w                 1/1     Running   0          2m9s
-pod/ztunnel-srrnm                           1/1     Running   0          2m5s
-
-NAME                            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
-daemonset.apps/istio-cni-node   1         1         1       1            1           kubernetes.io/os=linux   2m16s
-daemonset.apps/ztunnel          1         1         1       1            1           kubernetes.io/os=linux   2m10s
-ENDSNIP
-
-snip_download_and_install_8() {
-kubectl get pods,daemonset -n istio-system
-}
-
-! IFS=$'\n' read -r -d '' snip_download_and_install_8_out <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_download_and_install_5_out <<\ENDSNIP
 NAME                                        READY   STATUS    RESTARTS   AGE
 pod/istio-cni-node-btbjf                    1/1     Running   0          2m18s
 pod/istiod-55b74b77bd-xggqf                 1/1     Running   0          2m27s
@@ -74,15 +54,6 @@ kubectl apply -f samples/sleep/notsleep.yaml
 }
 
 snip_deploy_the_sample_application_3() {
-kubectl apply -f samples/bookinfo/networking/bookinfo-gateway.yaml
-}
-
-snip_deploy_the_sample_application_4() {
-export GATEWAY_HOST=istio-ingressgateway.istio-system
-export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/istio-ingressgateway-service-account
-}
-
-snip_deploy_the_sample_application_5() {
 sed -e 's/from: Same/from: All/'\
       -e '/^  name: bookinfo-gateway/a\
   namespace: istio-system\
@@ -91,7 +62,7 @@ sed -e 's/from: Same/from: All/'\
 ' samples/bookinfo/gateway-api/bookinfo-gateway.yaml | kubectl apply -f -
 }
 
-snip_deploy_the_sample_application_6() {
+snip_deploy_the_sample_application_4() {
 kubectl wait --for=condition=programmed gtw/bookinfo-gateway -n istio-system
 export GATEWAY_HOST=bookinfo-gateway-istio.istio-system
 export GATEWAY_SERVICE_ACCOUNT=ns/istio-system/sa/bookinfo-gateway-istio
@@ -278,16 +249,11 @@ kubectl exec deploy/sleep -- curl -s http://productpage:9080/ | grep -o "<title>
 ENDSNIP
 
 snip_control_traffic_1() {
-kubectl apply -f samples/bookinfo/networking/virtual-service-reviews-90-10.yaml
-kubectl apply -f samples/bookinfo/networking/destination-rule-reviews.yaml
-}
-
-snip_control_traffic_2() {
 kubectl apply -f samples/bookinfo/platform/kube/bookinfo-versions.yaml
 kubectl apply -f samples/bookinfo/gateway-api/route-reviews-90-10.yaml
 }
 
-snip_control_traffic_3() {
+snip_control_traffic_2() {
 kubectl exec deploy/sleep -- sh -c "for i in \$(seq 1 100); do curl -s http://productpage:9080/productpage | grep reviews-v.-; done"
 }
 

--- a/content/en/docs/ambient/getting-started/test.sh
+++ b/content/en/docs/ambient/getting-started/test.sh
@@ -27,33 +27,20 @@ set -o pipefail
 snip_download_and_install_2
 
 # install istio with ambient profile
-if [ "$GATEWAY_API" == "true" ]; then
-  snip_download_and_install_5
-else
-  snip_download_and_install_3
-fi
+snip_download_and_install_3
 
 _wait_for_deployment istio-system istiod
 _wait_for_daemonset istio-system ztunnel
 _wait_for_daemonset istio-system istio-cni-node
 
-if [ "$GATEWAY_API" == "true" ]; then
-  _verify_like snip_download_and_install_8 "$snip_download_and_install_8_out"
-else
-  _verify_like snip_download_and_install_7 "$snip_download_and_install_7_out"
-fi
+_verify_like snip_download_and_install_5 "$snip_download_and_install_5_out"
 
 # deploy test application
 snip_deploy_the_sample_application_1
 snip_deploy_the_sample_application_2
 
-if [ "$GATEWAY_API" == "true" ]; then
-  snip_deploy_the_sample_application_5
-  snip_deploy_the_sample_application_6
-else
-  snip_deploy_the_sample_application_3
-  snip_deploy_the_sample_application_4
-fi
+snip_deploy_the_sample_application_3
+snip_deploy_the_sample_application_4
 
 # test traffic before ambient mode is enabled
 _verify_contains snip_verify_traffic_sleep_to_ingress "$snip_verify_traffic_sleep_to_ingress_out"
@@ -79,23 +66,10 @@ _verify_contains snip_layer_7_authorization_policy_4 "$snip_layer_7_authorizatio
 _verify_contains snip_layer_7_authorization_policy_5 "$snip_layer_7_authorization_policy_5_out"
 _verify_contains snip_layer_7_authorization_policy_6 "$snip_layer_7_authorization_policy_6_out"
 
-if [ "$GATEWAY_API" == "true" ]; then
-  snip_control_traffic_2
-else
-  snip_control_traffic_1
-fi
+snip_control_traffic_1
 
-_verify_lines snip_control_traffic_3 "
+_verify_lines snip_control_traffic_2 "
 + reviews-v1
 + reviews-v2
 - reviews-v3
 "
-
-# @cleanup
-if [ "$GATEWAY_API" != "true" ]; then
-    snip_uninstall_1
-    snip_uninstall_2
-    snip_uninstall_3
-    samples/bookinfo/platform/kube/cleanup.sh
-    snip_uninstall_4
-fi


### PR DESCRIPTION
## Description

Removes legacy API types from the Ambient getting started guide in favor of Kubernetes Gateway API.

fixes #14956 

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [X] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
