### PR TITLE
Update test to use profile=none since it now installs Istio

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-dry-run/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-dry-run/test.sh
@@ -22,7 +22,7 @@ set -o pipefail
 source "tests/util/addons.sh"
 source "content/en/docs/tasks/observability/distributed-tracing/telemetry-api/snips.sh"
 
-# @setup profile=default
+# @setup profile=none
 snip_installation_1
 
 # Install Prometheus and Zipkin

--- a/content/en/docs/tasks/security/authorization/authz-dry-run/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-dry-run/test.sh
@@ -83,3 +83,5 @@ pgrep istioctl | xargs kill
 # @cleanup
 _undeploy_addons prometheus zipkin
 snip_clean_up_1
+istioctl uninstall --purge -y
+kubectl delete ns istio-system


### PR DESCRIPTION
## Description

Although the test was updated to enable tracing (that was removed as part of the default install), and the post-submits all continued to pass, it's probably best to not change the default install across tests. Fixing the  test case to use the none profile as it is installing Istio, and then needing to add cleanup to pass tests.

Since the doc is already pointing to the Zipkin install page, no additional doc changes should be needed, unless we specifically want to call out uninstalling Istio.