### PR TITLE
Tweak the LHS moving ambient and slight rename for legacy

### DIFF
--- a/content/en/docs/ambient/_index.md
+++ b/content/en/docs/ambient/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Ambient Mode
 description: Information for setting up and operating Istio in ambient mode.
-weight: 25
+weight: 17
 aliases:
   - /docs/ops/ambient
   - /latest/docs/ops/ambient

--- a/content/en/docs/ambient/_index.md
+++ b/content/en/docs/ambient/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Ambient Mode (Sidecar-less)
+title: Ambient Mode
 description: Information for setting up and operating Istio in ambient mode.
 weight: 17
 aliases:

--- a/content/en/docs/ambient/_index.md
+++ b/content/en/docs/ambient/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Ambient Mode
+title: Ambient Mode (Sidecar-less)
 description: Information for setting up and operating Istio in ambient mode.
 weight: 17
 aliases:

--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Setup
-description: Instructions for installing the Istio control plane on Kubernetes.
+title: Legacy Setup
+description: Instructions for installing the Istio control plane using sidecars.
 weight: 15
 aliases:
     - /docs/tasks/installing-istio.html

--- a/content/en/docs/setup/_index.md
+++ b/content/en/docs/setup/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Legacy Setup
-description: Instructions for installing the Istio control plane using sidecars.
+title: Sidecar Mode
+description: Information for setting up and operating Istio in sidecar mode.
 weight: 15
 aliases:
     - /docs/tasks/installing-istio.html


### PR DESCRIPTION
## Description

From the discussion in yesterday's ambient call, here is a slight tweak to the LHS naming/organization for discussion.

I moved the Ambient Mode item up.
I wanted to rename Setup to something else so went with `Legacy`. Maybe there is a better word.
I removed Kubernetes from the description as we have VM under that topic.

Look at the left hand column as well as text for items on the right:
https://deploy-preview-14968--preliminary-istio.netlify.app/latest/docs/

I believe @linsun and @justinpettit had some thoughts on this during the call.
