### PR TITLE
[zh] Sync #15001 use targetrefs instead in get started doc into Chinese

### DIFF
--- a/content/zh/docs/ambient/getting-started/index.md
+++ b/content/zh/docs/ambient/getting-started/index.md
@@ -283,8 +283,8 @@ Ambient 模式与之前支持 Sidecar 模式的所有主流 CNI 兼容。
       name: productpage-viewer
       namespace: default
     spec:
-      targetRef:
-        kind: Service
+      targetRefs:
+      - kind: Service
         group: ""
         name: productpage
       action: ALLOW


### PR DESCRIPTION
## Description

Sync #15001 use targetrefs instead in get started doc into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
