### PR TITLE
Correct the indentation in the cleanup section of the egress-tls-origination task

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -198,10 +198,10 @@ topics and articles but does not prevent attackers from learning that `edition.c
 
 Remove the Istio configuration items you created:
 
-    {{< text bash >}}
-    $ kubectl delete serviceentry edition-cnn-com
-    $ kubectl delete destinationrule edition-cnn-com
-    {{< /text >}}
+{{< text bash >}}
+$ kubectl delete serviceentry edition-cnn-com
+$ kubectl delete destinationrule edition-cnn-com
+{{< /text >}}
 
 ## Mutual TLS origination for egress traffic
 


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->
On using the shortcut to copy the code block for the commands in the [Cleanup the TLS origination configuration](https://istio.io/latest/docs/tasks/traffic-management/egress/egress-tls-origination/#cleanup-the-tls-origination-configuration) section of the [Egress TLS Origination](https://istio.io/latest/docs/tasks/traffic-management/egress/egress-tls-origination/) page, the commands get copied along with the $ sign denoting the prompt. When pasting this in a terminal, the execution fails which hampers the reader's experience.

This PR makes the necessary alignment change in the source code, so that the commands are rendered correctly on the webpage and the shortcut to copy the code block does not copy the $ sign of the prompt.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
