### PR TITLE
[zh] improve `egress` translation for egress docs

### DIFF
--- a/content/zh/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -91,7 +91,7 @@ Istio 代理允许调用未知的服务。如果这个选项设置为 `REGISTRY_
     HTTP/2 200
     {{< /text >}}
 
-恭喜！您已经成功地从网格中发送了 Egress 流量。
+恭喜！您已经成功地从网格中发送了出口流量。
 
 这种访问外部服务的简单方法有一个缺点，即丢失了对外部服务流量的 Istio 监控和控制；
 比如，外部服务的调用没有记录到 Mixer 的日志中。下一节将介绍如何监控和控制网格对外部服务的访问。
@@ -564,7 +564,7 @@ $ istioctl install <flags-you-used-to-install-Istio>
 恶意程序可以绕过 Istio Sidecar 代理并在没有 Istio 控制的情况下访问任何外部服务。
 {{< /warning >}}
 
-为了以更安全的方式实施出口流量控制，您必须[通过 Egress Gateway 引导出口流量](/zh/docs/tasks/traffic-management/egress/egress-gateway/)，
+为了以更安全的方式实施出口流量控制，您必须[通过 Egress 网关引导出口流量](/zh/docs/tasks/traffic-management/egress/egress-gateway/)，
 并查看[其他安全注意事项](/zh/docs/tasks/traffic-management/egress/egress-gateway/#additional-security-considerations)部分中描述的安全问题。
 
 ## 清理 {#cleanup}

--- a/content/zh/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -11,11 +11,11 @@ owner: istio/wg-networking-maintainers
 test: yes
 ---
 
-[为 Egress 流量发起 TLS 连接](/zh/docs/tasks/traffic-management/egress/egress-tls-origination/)
+[为出口流量发起 TLS 连接](/zh/docs/tasks/traffic-management/egress/egress-tls-origination/)
 示例中演示了如何配置 Istio 以对外部服务流量实施 {{< gloss >}}TLS origination{{< /gloss >}}。
-[配置 Egress Gateway](/zh/docs/tasks/traffic-management/egress/egress-gateway/)
-示例中演示了如何配置 Istio 来通过专门的 egress 网关服务引导 egress 流量。
-本示例兼容以上两者，描述如何配置 egress 网关，为外部服务流量发起 TLS 连接。
+[配置 Egress 网关](/zh/docs/tasks/traffic-management/egress/egress-gateway/)示例中演示了如何配置
+Istio 来通过专门的 Egress 网关服务引导出口流量。
+本示例兼容以上两者，描述如何配置 Egress 网关，为外部服务流量发起 TLS 连接。
 
 {{< boilerplate gateway-api-gamma-support >}}
 
@@ -65,12 +65,12 @@ test: yes
     {{< /text >}}
 
 *   如果您不使用 `Gateway API` 指令，
-    请确保[部署 Istio egress 网关](/zh/docs/tasks/traffic-management/egress/egress-gateway/#deploy-istio-egress-gateway)。
+    请确保[部署 Istio Egress 网关](/zh/docs/tasks/traffic-management/egress/egress-gateway/#deploy-istio-egress-gateway)。
 
-## 通过 egress 网关发起 TLS 连接 {#perform-TLS-origination-with-an-egress-gateway}
+## 通过 Egress 网关发起 TLS 连接 {#perform-TLS-origination-with-an-egress-gateway}
 
-本节描述如何使用 egress 网关发起与示例[为 Egress 流量发起 TLS 连接](/zh/docs/tasks/traffic-management/egress/egress-tls-origination/)中一样的
-TLS。注意，这种情况下，TLS 的发起过程由 egress 网关完成，而不是像之前示例演示的那样由
+本节描述如何使用 Egress 网关发起与示例[为出口流量发起 TLS 连接](/zh/docs/tasks/traffic-management/egress/egress-tls-origination/)中一样的
+TLS。注意，这种情况下，TLS 的发起过程由 Egress 网关完成，而不是像之前示例演示的那样由
 Sidecar 完成。
 
 1. 为 `edition.cnn.com` 定义一个 `ServiceEntry`：
@@ -110,8 +110,8 @@ Sidecar 完成。
 
     如果在输出中看到 `301 Moved Permanently`，说明 `ServiceEntry` 配置正确。
 
-1. 为 `edition.cnn.com` 创建一个 egress `Gateway`，端口 443，以及一个 Sidecar
-   请求的目标规则，Sidecar 请求被直接导向 egress 网关。
+1. 为 `edition.cnn.com` 创建一个 Egress `Gateway`，端口 443，以及一个 Sidecar
+   请求的目标规则，Sidecar 请求被直接导向 Egress 网关。
 
 {{< tabset category-name="config-api" >}}
 
@@ -205,7 +205,7 @@ EOF
 
 {{< /tabset >}}
 
-4) Configure route rules to direct traffic through the egress gateway:
+4) 配置路由规则以引导流量通过 Egress 网关：
 
 {{< tabset category-name="config-api" >}}
 
@@ -290,7 +290,6 @@ EOF
 
 {{< /tabset >}}
 
-5)  Define a `DestinationRule` to perform TLS origination for requests to `edition.cnn.com`:
 5)  定义一个 `DestinationRule` 来为 `edition.cnn.com` 的请求执行 TLS 发起：
 
     {{< text bash >}}
@@ -320,9 +319,9 @@ EOF
     ...
     {{< /text >}}
 
-    输出将与在示例[为 Egress 流量发起 TLS 连接](/zh/docs/tasks/traffic-management/egress/egress-tls-origination/)中显示的一样，发起 TLS 连接后，不再显示 _301 Moved Permanently_ 消息。
+    输出将与在示例[为出口流量发起 TLS 连接](/zh/docs/tasks/traffic-management/egress/egress-tls-origination/)中显示的一样，发起 TLS 连接后，不再显示 _301 Moved Permanently_ 消息。
 
-7)  检查 egress 网关代理的日志。
+7)  检查 Egress 网关代理的日志。
 
 {{< tabset category-name="config-api" >}}
 
@@ -344,7 +343,7 @@ $ kubectl logs -l istio=egressgateway -c istio-proxy -n istio-system | tail
 
 {{< tab name="Gateway API" category-value="gateway-api" >}}
 
-使用 Istio 生成的 Pod 标签访问 egress 网关对应的日志：
+使用 Istio 生成的 Pod 标签访问 Egress 网关对应的日志：
 
 {{< text bash >}}
 $ kubectl logs -l gateway.networking.k8s.io/gateway-name=cnn-egress-gateway -c istio-proxy | tail
@@ -393,18 +392,18 @@ $ kubectl delete destinationrule originate-tls-for-edition-cnn-com
 
 {{< /tabset >}}
 
-## 通过 egress 网关发起双向 TLS 连接 {#perform-mutual-TLS-origination-with-an-egress-gateway}
+## 通过 Egress 网关发起双向 TLS 连接 {#perform-mutual-TLS-origination-with-an-egress-gateway}
 
-与前一章节类似，本章节描述如何配置一个 egress 网关，为外部服务发起 TLS 连接，
+与前一章节类似，本章节描述如何配置一个 Egress 网关，为外部服务发起 TLS 连接，
 只是这次服务要求双向 TLS。
 
 本示例要求更高的参与性，首先需要：
 
 1. 生成客户端和服务器证书
 1. 部署一个支持双向 TLS 的外部服务
-1. 使用所需的证书重新部署 egress 网关
+1. 使用所需的证书重新部署 Egress 网关
 
-然后才可以配置出口流量流经 egress 网关，egress 网关将发起 TLS 连接。
+然后才可以配置出口流量流经 Egress 网关，Egress 网关将发起 TLS 连接。
 
 ### 生成客户端和服务器的证书与密钥 {#generate-client-and-server-certificates-and-keys}
 
@@ -464,7 +463,7 @@ $ kubectl delete destinationrule originate-tls-for-edition-cnn-com
 
 1. 创建一个命名空间，表示 Istio 网格之外的服务，`mesh-external`。
    注意在这个命名空间中，Sidecar 自动注入是没有[开启](/zh/docs/setup/additional-setup/sidecar-injection/#deploying-an-app)的，
-   不会在 Pod 中自动注入 Sidecar proxy。
+   不会在 Pod 中自动注入 Sidecar 代理。
 
     {{< text bash >}}
     $ kubectl create namespace mesh-external
@@ -622,9 +621,9 @@ $ kubectl delete destinationrule originate-tls-for-edition-cnn-com
     EOF
     {{< /text >}}
 
-### 为 egress 流量配置双向 TLS {#configure-mutual-TLS-origination-for-egress-traffic}
+### 为出口流量配置双向 TLS {#configure-mutual-TLS-origination-for-egress-traffic}
 
-1)  在部署 egress 网关的**同一命名空间**中创建一个
+1)  在部署 Egress 网关的**同一命名空间**中创建一个
     Kubernetes [Secret](https://kubernetes.io/zh-cn/docs/concepts/configuration/secret/)，
     以保存客户端的证书：
 
@@ -664,8 +663,8 @@ $ kubectl create secret -n default generic client-credential --from-file=tls.key
 
 {{< /tabset >}}
 
-2)  为 `my-nginx.mesh-external.svc.cluster.local`、端口 443 创建 egress `Gateway`，
-    并为将定向到 egress 网关的 Sidecar 请求创建目标规则：
+2)  为 `my-nginx.mesh-external.svc.cluster.local`、端口 443 创建 Egress `Gateway`，
+    并为将定向到 Egress 网关的 Sidecar 请求创建目标规则：
 
 {{< tabset category-name="config-api" >}}
 
@@ -785,7 +784,7 @@ EOF
 
 {{< /tabset >}}
 
-3)  配置路由规则以引导流量通过 egress 网关：
+3)  配置路由规则以引导流量通过 Egress 网关：
 
 {{< tabset category-name="config-api" >}}
 
@@ -953,7 +952,7 @@ EOF
 
 {{< /tabset >}}
 
-5)  验证凭证是否已提供给 egress 网关并且处于活动状态：
+5)  验证凭证是否已提供给 Egress 网关并且处于活动状态：
 
 {{< tabset category-name="config-api" >}}
 
@@ -990,7 +989,7 @@ kubernetes://client-credential-cacert     Cert Chain     ACTIVE     true        
     ...
     {{< /text >}}
 
-7)  检查 egress 网关代理的日志：
+7)  检查 Egress 网关代理的日志：
 
 {{< tabset category-name="config-api" >}}
 
@@ -1012,7 +1011,7 @@ You should see a line similar to the following:
 
 {{< tab name="Gateway API" category-value="gateway-api" >}}
 
-使用 Istio 生成的 Pod 标签访问 egress 网关对应的日志：
+使用 Istio 生成的 Pod 标签访问 Egress 网关对应的日志：
 
 {{< text bash >}}
 $ kubectl logs -l gateway.networking.k8s.io/gateway-name=nginx-egressgateway | grep 'my-nginx.mesh-external.svc.cluster.local' | grep HTTP

--- a/content/zh/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -1,5 +1,5 @@
 ---
-title: 出口网关
+title: Egress 网关
 description: 描述如何配置 Istio 通过专用网关服务将流量定向到外部服务。
 weight: 30
 keywords: [traffic-management,egress]
@@ -13,25 +13,24 @@ test: yes
 此例子对 Minikube 无效。
 {{</warning>}}
 
-[控制 Egress 流量](/zh/docs/tasks/traffic-management/egress/egress-control)任务展示了如何配置
+[控制出口流量](/zh/docs/tasks/traffic-management/egress/egress-control)任务展示了如何配置
 Istio 以允许网格内部的应用程序访问外部 HTTP 和 HTTPS 服务，但那个任务实际上是通过
-Sidecar 直接调用的外部服务。而这个示例会展示如何配置 Istio 以通过专用的 **Egress Gateway**
-服务间接调用外部服务。
+Sidecar 直接调用的外部服务。而这个示例会展示如何配置 Istio 以通过专用的 **Egress 网关**服务间接调用外部服务。
 
-Istio 使用 [Ingress 和 Egress Gateway](/zh/docs/reference/config/networking/gateway/)
-配置运行在服务网格边缘的负载均衡。Ingress Gateway 允许您定义网格所有入站流量的入口。
-Egress Gateway 是一个与 Ingress Gateway 对称的概念，它定义了网格的出口。
-Egress Gateway 允许您将 Istio 的功能（例如，监视和路由规则）应用于网格的出站流量。
+Istio 使用 [Ingress 和 Egress 网关](/zh/docs/reference/config/networking/gateway/)
+配置运行在服务网格边缘的负载均衡。Ingress 网关允许您定义网格所有入站流量的入口。
+Egress 网关是一个与 Ingress 网关对称的概念，它定义了网格的出口。
+Egress 网关允许您将 Istio 的功能（例如，监视和路由规则）应用于网格的出站流量。
 
 ## 使用场景 {#use-case}
 
 设想一个对安全有严格要求的组织，要求服务网格所有的出站流量必须经过一组专用节点。
 专用节点运行在专门的机器上，与集群中运行应用程序的其他节点隔离。
-这些专用节点用于实施 Egress 流量的策略，并且受到比其余节点更严密地监控。
+这些专用节点用于实施出口流量的策略，并且受到比其余节点更严密地监控。
 
 另一个使用场景是集群中的应用节点没有公有 IP，所以在该节点上运行的网格
-Service 无法访问互联网。通过定义 Egress gateway，将公有 IP 分配给
-Egress Gateway 节点，用它引导所有的出站流量，可以使应用节点以受控的方式访问外部服务。
+Service 无法访问互联网。通过定义 Egress 网关，将公有 IP 分配给
+Egress 网关节点，用它引导所有的出站流量，可以使应用节点以受控的方式访问外部服务。
 
 {{< boilerplate gateway-api-gamma-support >}}
 
@@ -41,7 +40,7 @@ Egress Gateway 节点，用它引导所有的出站流量，可以使应用节�
 
     {{< tip >}}
     如果您安装 `demo` [配置文件](/zh/docs/setup/additional-setup/config-profiles/)，
-    则会启用 Egress Gateway 和访问日志。
+    则会启用 Egress 网关和访问日志。
     {{< /tip >}}
 
 *   部署 [sleep]({{< github_tree >}}/samples/sleep) 示例应用，用作发送请求的测试源。
@@ -61,7 +60,7 @@ Egress Gateway 节点，用它引导所有的出站流量，可以使应用节�
     {{< /text >}}
 
     {{< warning >}}
-    此任务中的指令在 `default` 命名空间中为 Egress Gateway 创建目标规则。
+    此任务中的指令在 `default` 命名空间中为 Egress 网关创建目标规则。
     并假设客户端 `SOURCE_POD` 也在 `default` 命名空间中运行。如果没有，
     目标规则将不会在[目标规则查找路径](/zh/docs/ops/best-practices/traffic-management/#cross-namespace-configuration)上找到，
     并且客户端请求将失败。
@@ -74,21 +73,21 @@ Egress Gateway 节点，用它引导所有的出站流量，可以使应用节�
     $ istioctl install <flags-you-used-to-install-Istio> --set meshConfig.accessLogFile=/dev/stdout
     {{< /text >}}
 
-## 部署 Istio Egress Gateway {#deploy-Istio-egress-gateway}
+## 部署 Istio Egress 网关 {#deploy-Istio-egress-gateway}
 
 {{< tip >}}
-当使用 Gateway API 配置 Egress Gateway 时，这些 Egress Gateway
-会被[自动部署](/zh/docs/tasks/traffic-management/ingress/gateway-api/#deployment-methods)。
+当使用 Gateway API 配置 Egress 网关时，
+这些 Egress 网关会被[自动部署](/zh/docs/tasks/traffic-management/ingress/gateway-api/#deployment-methods)。
 如果您在下文中使用 `Gateway API` 指令，则可以跳过这部分。
 {{< /tip >}}
 
-1. 检查 Istio Egress Gateway 是否已部署：
+1. 检查 Istio Egress 网关是否已部署：
 
     {{< text bash >}}
     $ kubectl get pod -l istio=egressgateway -n istio-system
     {{< /text >}}
 
-    如果没有 Pod 返回，通过接下来的步骤来部署 Istio Egress Gateway。
+    如果没有 Pod 返回，通过接下来的步骤来部署 Istio Egress 网关。
 
 1. 如果您使用 `IstioOperator` CR 安装 Istio，请在配置中添加以下字段：
 
@@ -108,7 +107,7 @@ Egress Gateway 节点，用它引导所有的出站流量，可以使应用节�
                        --set "components.egressGateways[0].enabled=true"
     {{< /text >}}
 
-## 定义 Egress gateway 并引导 HTTP 流量 {#egress-gateway-for-http-traffic}
+## 定义 Egress 网关并引导 HTTP 流量 {#egress-gateway-for-http-traffic}
 
 首先创建一个 `ServiceEntry`，允许流量直接访问一个外部服务。
 
@@ -158,7 +157,7 @@ Egress Gateway 节点，用它引导所有的出站流量，可以使应用节�
     ...
     {{< /text >}}
 
-    输出结果应该与[发起 TLS 的 Egress 流量](/zh/docs/tasks/traffic-management/egress/egress-tls-origination/)中示例中的输出结果相同，
+    输出结果应该与[发起 TLS 的出口流量](/zh/docs/tasks/traffic-management/egress/egress-tls-origination/)中示例中的输出结果相同，
     都还没有发起 TLS。
 
 1. 为 `edition.cnn.com` 端口 80 的出口流量创建一个 `Gateway`。
@@ -168,7 +167,7 @@ Egress Gateway 节点，用它引导所有的出站流量，可以使应用节�
 {{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< tip >}}
-要通过 Egress Gateway 引导多个主机，您可以在 `Gateway` 中包含主机列表，
+要通过 Egress 网关引导多个主机，您可以在 `Gateway` 中包含主机列表，
 或使用 `*` 匹配所有主机。应该将 `DestinationRule` 中的 `subset` 字段重用于其他主机。
 {{< /tip >}}
 
@@ -229,7 +228,7 @@ EOF
 
 {{< /tabset >}}
 
-4)  配置路由规则，将流量从边车导向到 Egress Gateway，再从 Egress Gateway 导向到外部服务：
+4)  配置路由规则，将流量从边车导向到 Egress 网关，再从 Egress 网关导向到外部服务：
 
 {{< tabset category-name="config-api" >}}
 
@@ -331,7 +330,7 @@ EOF
 
     输出应与第 2 步中的输出相同。
 
-6)  检查 Egress Gateway Pod 的日志，找到与请求对应的那一行。
+6)  检查 Egress 网关 Pod 的日志，找到与请求对应的那一行。
 
 {{< tabset category-name="config-api" >}}
 
@@ -351,7 +350,7 @@ $ kubectl logs -l istio=egressgateway -c istio-proxy -n istio-system | tail
 
 {{< tip >}}
 如果启用了[双向 TLS 身份验证](/zh/docs/tasks/security/authentication/authn-policy/)，
-并且当您在连接到出口网关时遇到问题，请运行以下命令来验证证书是否正确：
+并且当您在连接到 Egress 网关时遇到问题，请运行以下命令来验证证书是否正确：
 
 {{< text bash >}}
 $ istioctl pc secret -n istio-system "$(kubectl get pod -l istio=egressgateway -n istio-system -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
@@ -365,7 +364,7 @@ $ istioctl pc secret -n istio-system "$(kubectl get pod -l istio=egressgateway -
 
 {{< tab name="Gateway API" category-value="gateway-api" >}}
 
-使用 Istio 生成的 Pod 标签访问与 Egress Gateway 对应的日志：
+使用 Istio 生成的 Pod 标签访问与 Egress 网关对应的日志：
 
 {{< text bash >}}
 $ kubectl logs -l gateway.networking.k8s.io/gateway-name=cnn-egress-gateway -c istio-proxy | tail
@@ -379,7 +378,7 @@ $ kubectl logs -l gateway.networking.k8s.io/gateway-name=cnn-egress-gateway -c i
 
 {{< tip >}}
 如果启用了[双向 TLS 身份验证](/zh/docs/tasks/security/authentication/authn-policy/)，
-并且当您在连接到出口网关时遇到问题，请运行以下命令来验证证书是否正确：
+并且当您在连接到 Egress 网关时遇到问题，请运行以下命令来验证证书是否正确：
 
 {{< text bash >}}
 $ istioctl pc secret "$(kubectl get pod -l gateway.networking.k8s.io/gateway-name=cnn-egress-gateway -o jsonpath='{.items[0].metadata.name}')" -ojson | jq '[.dynamicActiveSecrets[] | select(.name == "default")][0].secret.tlsCertificate.certificateChain.inlineBytes' -r | base64 -d | openssl x509 -text -noout | grep 'Subject Alternative Name' -A 1
@@ -393,10 +392,10 @@ $ istioctl pc secret "$(kubectl get pod -l gateway.networking.k8s.io/gateway-nam
 
 {{< /tabset >}}
 
-请注意，您只是将流量从 80 端口重定向到 Egress Gateway。到端口 443 的 HTTPS
+请注意，您只是将流量从 80 端口重定向到 Egress 网关。到端口 443 的 HTTPS
 流量直接进入 **edition.cnn.com**。
 
-### 清理 HTTP Gateway {#cleanup-http-gateway}
+### 清理 HTTP 网关 {#cleanup-http-gateway}
 
 在继续下一步之前删除先前的定义：
 
@@ -426,9 +425,9 @@ $ kubectl delete httproute forward-cnn-from-egress-gateway
 
 {{< /tabset >}}
 
-## 用 Egress Gateway 发起 HTTPS 请求 {#egress-gateway-for-https-traffic}
+## 用 Egress 网关发起 HTTPS 请求 {#egress-gateway-for-https-traffic}
 
-接下来尝试使用 Egress Gateway 发起 HTTPS 请求（TLS 由应用程序发起）。
+接下来尝试使用 Egress 网关发起 HTTPS 请求（TLS 由应用程序发起）。
 您需要在相应的 `ServiceEntry` 和 Egress `Gateway` 中指定 `TLS` 协议的端口 443。
 
 1. 为 `edition.cnn.com` 定义 `ServiceEntry`：
@@ -462,14 +461,14 @@ $ kubectl delete httproute forward-cnn-from-egress-gateway
     {{< /text >}}
 
 1. 为 `edition.cnn.com` 创建 Egress `Gateway` 以及路由规则，
-   用来引导流量通过 Egress Gateway，并通过 Egress Gateway 与外部服务通信。
+   用来引导流量通过 Egress 网关，并通过 Egress 网关与外部服务通信。
 
 {{< tabset category-name="config-api" >}}
 
 {{< tab name="Istio APIs" category-value="istio-apis" >}}
 
 {{< tip >}}
-要通过 Egress Gateway 引导多个主机，您可以在 `Gateway` 中包含主机列表，
+要通过 Egress 网关引导多个主机，您可以在 `Gateway` 中包含主机列表，
 或使用 `*` 匹配所有主机。应该将 `DestinationRule` 中的 `subset` 字段用于其他主机。
 {{< /tip >}}
 
@@ -611,7 +610,7 @@ EOF
     ...
     {{< /text >}}
 
-5)  检查 Egress Gateway 代理的日志。
+5)  检查 Egress 网关代理的日志。
 
 {{< tabset category-name="config-api" >}}
 
@@ -633,7 +632,7 @@ $ kubectl logs -l istio=egressgateway -n istio-system
 
 {{< tab name="Gateway API" category-value="gateway-api" >}}
 
-使用 Istio 生成的 Pod 标签访问与 Egress Gateway 对应的日志：
+使用 Istio 生成的 Pod 标签访问与 Egress 网关对应的日志：
 
 {{< text bash >}}
 $ kubectl logs -l gateway.networking.k8s.io/gateway-name=cnn-egress-gateway -c istio-proxy | tail
@@ -649,7 +648,7 @@ $ kubectl logs -l gateway.networking.k8s.io/gateway-name=cnn-egress-gateway -c i
 
 {{< /tabset >}}
 
-### 清理 HTTPS Gateway {#cleanup-https-gateway}
+### 清理 HTTPS 网关 {#cleanup-https-gateway}
 
 {{< tabset category-name="config-api" >}}
 
@@ -679,26 +678,26 @@ $ kubectl delete tlsroute forward-cnn-from-egress-gateway
 
 ## 其他安全注意事项 {#additional-security-considerations}
 
-注意，Istio 中定义的 egress `Gateway` 本身并没有为其所在的节点提供任何特殊处理。
-集群管理员或云提供商可以在专用节点上部署 Egress Gateway，并引入额外的安全措施，
+注意，Istio 中定义的 Egress `Gateway` 本身并没有为其所在的节点提供任何特殊处理。
+集群管理员或云提供商可以在专用节点上部署 Egress 网关，并引入额外的安全措施，
 从而使这些节点比网格中的其他节点更安全。
 
-另外要注意的是，Istio **无法强制**让所有出站流量都经过 Egress Gateway，
+另外要注意的是，Istio **无法强制**让所有出站流量都经过 Egress 网关，
 Istio 只是通过 Sidecar 代理实现了这种流向。攻击者只要绕过 Sidecar 代理，
-就可以不经 Egress Gateway 直接与网格外的服务进行通信，从而避开了 Istio 的控制和监控。
-出于安全考虑，集群管理员和云供应商必须确保网格所有的出站流量都要经过 Egress Gateway。
+就可以不经 Egress 网关直接与网格外的服务进行通信，从而避开了 Istio 的控制和监控。
+出于安全考虑，集群管理员和云供应商必须确保网格所有的出站流量都要经过 Egress 网关。
 这需要通过 Istio 之外的机制来满足这一要求。例如，集群管理员可以配置防火墙，
-拒绝 Egress Gateway 以外的所有流量。
+拒绝 Egress 网关以外的所有流量。
 [Kubernetes 网络策略](https://kubernetes.io/zh-cn/docs/concepts/services-networking/network-policies/)也能禁止所有不是从
-Egress Gateway 发起的出站流量（[下一节](#apply-Kubernetes-network-policies)有一个这样的例子）。
+Egress 网关发起的出站流量（[下一节](#apply-Kubernetes-network-policies)有一个这样的例子）。
 此外，集群管理员和云供应商还可以对网络进行限制，让运行应用的节点只能通过 gateway 来访问外部网络。
-要实现这一限制，可以只给 gateway Pod 分配公网 IP，并且可以配置 NAT 设备，
-丢弃来自 Egress Gateway Pod 之外的所有流量。
+要实现这一限制，可以只给网关 Pod 分配公网 IP，并且可以配置 NAT 设备，
+丢弃来自 Egress 网关 Pod 之外的所有流量。
 
 ## 应用 Kubernetes 网络策略 {#apply-Kubernetes-network-policies}
 
 本节中展示了如何创建 [Kubernetes 网络策略](https://kubernetes.io/zh-cn/docs/concepts/services-networking/network-policies/)来阻止绕过
-Egress Gateway 的出站流量。为了测试网络策略，首先创建一个 `test-egress` 命名空间，
+Egress 网关的出站流量。为了测试网络策略，首先创建一个 `test-egress` 命名空间，
 并在其中部署 [sleep]({{< github_tree >}}/samples/sleep) 示例应用，
 然后尝试发送一个会通过安全网关的外部服务请求。
 
@@ -888,7 +887,7 @@ sleep istio-proxy
 {{< /text >}}
 
 在 `default` 命名空间中创建一个与 `sleep` Pod 类似的目标规则，用来引导
-`test-egress` 命名空间内的流量经过 Egress Gateway：
+`test-egress` 命名空间内的流量经过 Egress 网关：
 
 {{< text bash >}}
 $ kubectl apply -n test-egress -f - <<EOF
@@ -917,7 +916,7 @@ sleep istio-proxy
 {{< /tabset >}}
 
 13) 向 [https://edition.cnn.com/politics](https://edition.cnn.com/politics)
-    发送 HTTP 请求，这次会成功，原因是网络策略允许流量流向 Egress Gateway。
+    发送 HTTP 请求，这次会成功，原因是网络策略允许流量流向 Egress 网关。
     Gateway 最终把流量转发到 `edition.cnn.com`。
 
     {{< text bash >}}
@@ -925,7 +924,7 @@ sleep istio-proxy
     200
     {{< /text >}}
 
-14) 检查 Egress Gateway 代理的日志。
+14) 检查 Egress 网关代理的日志。
 
 {{< tabset category-name="config-api" >}}
 
@@ -947,7 +946,7 @@ $ kubectl logs -l istio=egressgateway -n istio-system
 
 {{< tab name="Gateway API" category-value="gateway-api" >}}
 
-使用 Istio 生成的 Pod 标签访问与 Egress Gateway 对应的日志：
+使用 Istio 生成的 Pod 标签访问与 Egress 网关对应的日志：
 
 {{< text bash >}}
 $ kubectl logs -l gateway.networking.k8s.io/gateway-name=cnn-egress-gateway -c istio-proxy | tail
@@ -997,7 +996,7 @@ $ kubectl delete namespace test-egress
 
 {{< /tabset >}}
 
-2) 请参考[清理 HTTPS Gateway](#cleanup-https-gateway) 一节的内容。
+2) 请参考[清理 HTTPS 网关](#cleanup-https-gateway) 一节的内容。
 
 ## 清理 {#cleanup}
 

--- a/content/zh/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
@@ -1,5 +1,5 @@
 ---
-title: Kubernetes Egress 流量服务
+title: Kubernetes 出口流量服务
 description: 展示如何配置 Istio Kubernetes 外部服务。
 keywords: [traffic-management,egress]
 weight: 60
@@ -23,10 +23,10 @@ Kubernetes [ExternalName](https://kubernetes.io/zh-cn/docs/concepts/services-net
 
 {{< warning >}}
 本页介绍 Istio 如何与现有 Kubernetes 配置集成。对于新部署，
-我们建议遵循[访问 Egress 服务](/zh/docs/tasks/traffic-management/egress/egress-control/)。
+我们建议遵循[访问出口服务](/zh/docs/tasks/traffic-management/egress/egress-control/)。
 {{< /warning >}}
 
-虽然本页的示例使用 HTTP 协议，但是用于引导 Egress 流量的 Kubernetes 服务也可以与其他协议一起使用。
+虽然本页的示例使用 HTTP 协议，但是用于引导出口流量的 Kubernetes 服务也可以与其他协议一起使用。
 
 {{< boilerplate before-you-begin-egress >}}
 
@@ -101,7 +101,7 @@ Kubernetes [ExternalName](https://kubernetes.io/zh-cn/docs/concepts/services-net
 
 1. 在这个例子中，未加密的 HTTP 请求被发送到 `httpbin.org`。
    仅出于示例目的，您禁用 TLS 模式，并允许外部服务的未加密流量。在现实生活中，我们建议
-   由 Istio 执行 [Egress TLS Origination](/zh/docs/tasks/traffic-management/egress/egress-tls-origination)。
+   由 Istio 执行 [Egress TLS 源](/zh/docs/tasks/traffic-management/egress/egress-tls-origination)。
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF

--- a/content/zh/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -1,5 +1,5 @@
 ---
-title: Egress TLS Origination
+title: Egress TLS 源
 description: 描述如何配置 Istio 对来自外部服务的流量执行 TLS 发起。
 keywords: [traffic-management,egress]
 weight: 20
@@ -9,14 +9,14 @@ owner: istio/wg-networking-maintainers
 test: yes
 ---
 
-[控制 Egress 流量](/zh/docs/tasks/traffic-management/egress/)的任务向我们展示了位于服务网格内部的应用应如何访问外部
+[控制出口流量](/zh/docs/tasks/traffic-management/egress/)的任务向我们展示了位于服务网格内部的应用应如何访问外部
 （即服务网格之外）的 HTTP 和 HTTPS 服务。
 正如该任务所述，[`ServiceEntry`](/zh/docs/reference/config/networking/service-entry/)
 用于配置 Istio 以受控的方式访问外部服务。
 本示例将演示如何通过配置 Istio 去实现对发往外部服务的流量的 {{< gloss >}}TLS origination{{< /gloss >}}。
 若此时原始的流量为 HTTP，则 Istio 会将其转换为 HTTPS 连接。
 
-## 使用场景   {#use-case}
+## 使用场景  {#use-case}
 
 假设有一个传统应用正在使用 HTTP 和外部服务进行通信。
 而运行该应用的组织却收到了一个新的需求，该需求要求必须对所有外部的流量进行加密。
@@ -111,7 +111,7 @@ test: yes
 
 通过配置 `Istio` 执行 `TLS` 发起，则可以解决这两个问题。
 
-## 用于 egress 流量的 TLS 发起   {#TLS-origination-for-egress-traffic}
+## 用于出口流量的 TLS 源   {#TLS-origination-for-egress-traffic}
 
 1. 重新定义上一节的 `ServiceEntry` 和 `VirtualService` 以重写 HTTP 请求端口，
    并添加一个 `DestinationRule` 以执行 TLS 发起。
@@ -199,7 +199,7 @@ $ kubectl delete serviceentry edition-cnn-com
 $ kubectl delete destinationrule edition-cnn-com
 {{< /text >}}
 
-## 出口流量的双向 TLS 发起   {#mutual-tls-origination-for-egress-traffic}
+## 出口流量的双向 TLS 源   {#mutual-tls-origination-for-egress-traffic}
 
 本节介绍如何配置 Sidecar 为外部服务执行 TLS 发起，这次使用需要双向 TLS 的服务。
 此示例涉及许多内容，需要先执行以下前置操作：
@@ -403,7 +403,7 @@ $ kubectl delete destinationrule edition-cnn-com
     $ kubectl create rolebinding client-credential-role-binding --role=client-credential-role --serviceaccount=default:sleep
     {{< /text >}}
 
-### 为 Sidecar 上的出口流量配置双向 TLS 发起   {#configure-mutual-tls-origination-for-egress-traffic-at-sidecar}
+### 为 Sidecar 上的出口流量配置双向 TLS 源   {#configure-mutual-tls-origination-for-egress-traffic-at-sidecar}
 
 1. 添加 `ServiceEntry` 将 HTTP 请求重定向到 443 端口，并且添加 `DestinationRule`
    以执行发起双向 TLS：

--- a/content/zh/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -9,8 +9,8 @@ owner: istio/wg-networking-maintainers
 test: yes
 ---
 
-[配置 Egress Gateway](/zh/docs/tasks/traffic-management/egress/egress-gateway/)
-示例展示如何通过名为 Egress Gateway 的 Istio 组件将流量从网格引导到外部服务。但是，
+[配置 Egress 网关](/zh/docs/tasks/traffic-management/egress/egress-gateway/)
+示例展示如何通过名为 Egress 网关的 Istio 组件将流量从网格引导到外部服务。但是，
 有些情况下需要一个外部的传统（非 Istio）HTTPS 代理来访问外部服务。例如，您的公司可能已经有了这样的代理，
 并且可能需要所有应用程序通过代理来引导其流量。
 

--- a/content/zh/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
@@ -9,16 +9,16 @@ owner: istio/wg-networking-maintainers
 test: yes
 ---
 
-[控制 Egress 流量](/zh/docs/tasks/traffic-management/egress/)任务和
-[配置一个 Egress 网关](/zh/docs/tasks/traffic-management/egress/egress-gateway/)示例描述如何配置特定主机的
-Egress 流量，如：`edition.cnn.com`。本示例描述如何为通用域中的一组特定主机开启 Egress 流量，
+[控制出口流量](/zh/docs/tasks/traffic-management/egress/)任务和
+[配置一个 Egress 网关](/zh/docs/tasks/traffic-management/egress/egress-gateway/)示例描述如何配置特定主机的出口流量，
+如：`edition.cnn.com`。本示例描述如何为通用域中的一组特定主机开启出口流量，
 譬如 `*.wikipedia.org`，无需单独配置每一台主机。
 
 ## 背景  {#background}
 
-假定您想要为 Istio 中所有语种的 `wikipedia.org` 站点开启 Egress 流量。每个语种的
+假定您想要为 Istio 中所有语种的 `wikipedia.org` 站点开启出口流量。每个语种的
 `wikipedia.org` 站点均有自己的主机名，譬如：英语和德语对应的主机分别为 `en.wikipedia.org`
-和 `de.rikipedia.org`。您希望通过通用配置项开启所有 Wikipedia 站点的 Egress 流量，无需单独配置每个语种的站点。
+和 `de.rikipedia.org`。您希望通过通用配置项开启所有 Wikipedia 站点的出口流量，无需单独配置每个语种的站点。
 
 {{< boilerplate gateway-api-gamma-support >}}
 


### PR DESCRIPTION
## Description

Make translation of `egress` follow standard:
The `Egress Gateway` translate to `Egress 网关`
The `egress traffic` translate to `出口流量`

And with some translation corrections.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
