### PR TITLE
move bookinfo version earlier & change tcp/tlsroute to alpha

### DIFF
--- a/content/en/docs/ambient/getting-started/index.md
+++ b/content/en/docs/ambient/getting-started/index.md
@@ -102,6 +102,7 @@ Make sure the default namespace does not include the label `istio-injection=enab
 
     {{< text bash >}}
     $ kubectl apply -f @samples/bookinfo/platform/kube/bookinfo.yaml@
+    $ kubectl apply -f @samples/bookinfo/platform/kube/bookinfo-versions.yaml@
     {{< /text >}}
 
     {{< text bash >}}
@@ -312,7 +313,6 @@ identities, but not at the Layer 7 level, such as HTTP methods like `GET` and `P
 1. You can use the same waypoint to control traffic to `reviews`. Configure traffic routing to send 90% of requests to `reviews` v1 and 10% to `reviews` v2:
 
     {{< text bash >}}
-    $ kubectl apply -f @samples/bookinfo/platform/kube/bookinfo-versions.yaml@
     $ kubectl apply -f @samples/bookinfo/gateway-api/route-reviews-90-10.yaml@
     {{< /text >}}
 

--- a/content/en/docs/ambient/getting-started/snips.sh
+++ b/content/en/docs/ambient/getting-started/snips.sh
@@ -46,6 +46,7 @@ ENDSNIP
 
 snip_deploy_the_sample_application_1() {
 kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
+kubectl apply -f samples/bookinfo/platform/kube/bookinfo-versions.yaml
 }
 
 snip_deploy_the_sample_application_2() {
@@ -244,7 +245,6 @@ kubectl exec deploy/sleep -- curl -s http://productpage:9080/ | grep -o "<title>
 ENDSNIP
 
 snip_control_traffic_1() {
-kubectl apply -f samples/bookinfo/platform/kube/bookinfo-versions.yaml
 kubectl apply -f samples/bookinfo/gateway-api/route-reviews-90-10.yaml
 }
 

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -189,8 +189,8 @@ The following L7 policies are supported for waypoint proxy:
 |  Name  | Feature Status | Policy Attachment |
 | --- | --- | --- |
 | `HTTPRoute` | Beta | `parentRefs` |
-| `TCPRoute` | Beta | `parentRefs` |
-| `TLSRoute` | Beta | `parentRefs` |
+| `TCPRoute` | Alpha | `parentRefs` |
+| `TLSRoute` | Alpha | `parentRefs` |
 | `AuthorizationPolicy` | Beta | `targetRefs` |
 | `RequestAuthentication` | Beta | `targetRefs` |
 | `Telemetry` | Alpha | `targetRefs` |


### PR DESCRIPTION
## Description

Based on some of the discussion in https://github.com/istio/istio.io/issues/15043

Move installing bookinfo versions earlier because it flows better with the waypoint usage guide. There are discussions of combing versions and bookinfo to bookinfo-all in https://github.com/istio/istio/issues/50871

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x ] Ambient
- [ x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
