### PR TITLE
Fix links in ambient usage and architecture docs

### DIFF
--- a/content/en/docs/ambient/architecture/data-plane/index.md
+++ b/content/en/docs/ambient/architecture/data-plane/index.md
@@ -8,8 +8,8 @@ test: no
 
 In {{< gloss "ambient" >}}ambient mode{{< /gloss >}}, workloads can fall into 3 categories:
 1. **Out of Mesh**: a standard pod without any mesh features enabled. Istio and the ambient {{< gloss >}}data plane{{< /gloss >}} are not enabled.
-1. **In Mesh**: a pod that is included in the ambient {{< gloss >}}data plane{{< /gloss >}}, and has traffic intercepted at the Layer 4 level by {{< gloss >}}ztunnel{{< /gloss >}}. In this mode, L4 policies can be enforced for pod traffic. This mode can be enabled by setting the `istio.io/dataplane-mode=ambient` label. See [labels](docs/ambient/architecture#ambient-labels) for more details.
-1. **In Mesh, Waypoint enabled**: a pod that is _in mesh_ *and* has a {{< gloss "waypoint" >}}waypoint proxy{{< /gloss >}} deployed. In this mode, L7 policies can be enforced for pod traffic. This mode can be enabled by setting the `istio.io/use-waypoint` label. See [labels](docs/ambient/architecture#ambient-labels) for more details.
+1. **In Mesh**: a pod that is included in the ambient {{< gloss >}}data plane{{< /gloss >}}, and has traffic intercepted at the Layer 4 level by {{< gloss >}}ztunnel{{< /gloss >}}. In this mode, L4 policies can be enforced for pod traffic. This mode can be enabled by setting the `istio.io/dataplane-mode=ambient` label. See [labels](/docs/ambient/architecture#ambient-labels) for more details.
+1. **In Mesh, Waypoint enabled**: a pod that is _in mesh_ *and* has a {{< gloss "waypoint" >}}waypoint proxy{{< /gloss >}} deployed. In this mode, L7 policies can be enforced for pod traffic. This mode can be enabled by setting the `istio.io/use-waypoint` label. See [labels](/docs/ambient/architecture#ambient-labels) for more details.
 
 Depending on which category a workload is in, the traffic path will be different.
 
@@ -17,7 +17,7 @@ Depending on which category a workload is in, the traffic path will be different
 
 ### Outbound
 
-When a pod in an ambient mesh makes an outbound request, it will be [transparently redirected](docs/ambient/architecture/traffic-redirection) to the node-local ztunnel which will determine where and how to forward the request.
+When a pod in an ambient mesh makes an outbound request, it will be [transparently redirected](/docs/ambient/architecture/traffic-redirection) to the node-local ztunnel which will determine where and how to forward the request.
 In general, the traffic routing behaves just like Kubernetes default traffic routing;
 requests to a `Service` will be sent to an endpoint within the `Service` while requests directly to a `Pod` IP will go directly to that IP.
 
@@ -32,7 +32,7 @@ some pods to use a waypoint while others do not. Users are generally recommended
 
 ### Inbound
 
-When a pod in an ambient mesh receives an inbound request, it will be [transparently redirected](docs/ambient/architecture/traffic-redirection) to the node-local ztunnel.
+When a pod in an ambient mesh receives an inbound request, it will be [transparently redirected](/docs/ambient/architecture/traffic-redirection) to the node-local ztunnel.
 When ztunnel receives the request, it will apply Authorization Policies and forward the request only if the request passes these checks.
 
 A pod can receive HBONE traffic or plaintext traffic.
@@ -66,7 +66,7 @@ Ztunnel additionally will handle the rotation of these certificates as they appr
 
 ##### Telemetry
 
-Ztunnel emits the full set of [Istio Standard TCP Metrics](docs/reference/config/metrics/).
+Ztunnel emits the full set of [Istio Standard TCP Metrics](/docs/reference/config/metrics/).
 
 ##### Dataplane example for Layer 4 traffic
 

--- a/content/en/docs/ambient/architecture/data-plane/index.md
+++ b/content/en/docs/ambient/architecture/data-plane/index.md
@@ -8,8 +8,8 @@ test: no
 
 In {{< gloss "ambient" >}}ambient mode{{< /gloss >}}, workloads can fall into 3 categories:
 1. **Out of Mesh**: a standard pod without any mesh features enabled. Istio and the ambient {{< gloss >}}data plane{{< /gloss >}} are not enabled.
-1. **In Mesh**: a pod that is included in the ambient {{< gloss >}}data plane{{< /gloss >}}, and has traffic intercepted at the Layer 4 level by {{< gloss >}}ztunnel{{< /gloss >}}. In this mode, L4 policies can be enforced for pod traffic. This mode can be enabled by setting the `istio.io/dataplane-mode=ambient` label. See [labels](/docs/ambient/architecture#ambient-labels) for more details.
-1. **In Mesh, Waypoint enabled**: a pod that is _in mesh_ *and* has a {{< gloss "waypoint" >}}waypoint proxy{{< /gloss >}} deployed. In this mode, L7 policies can be enforced for pod traffic. This mode can be enabled by setting the `istio.io/use-waypoint` label. See [labels](/docs/ambient/architecture#ambient-labels) for more details.
+1. **In Mesh**: a pod that is included in the ambient {{< gloss >}}data plane{{< /gloss >}}, and has traffic intercepted at the Layer 4 level by {{< gloss >}}ztunnel{{< /gloss >}}. In this mode, L4 policies can be enforced for pod traffic. This mode can be enabled by setting the `istio.io/dataplane-mode=ambient` label. See [labels](/docs/ambient/usage/add-workloads/#ambient-labels) for more details.
+1. **In Mesh, Waypoint enabled**: a pod that is _in mesh_ *and* has a {{< gloss "waypoint" >}}waypoint proxy{{< /gloss >}} deployed. In this mode, L7 policies can be enforced for pod traffic. This mode can be enabled by setting the `istio.io/use-waypoint` label. See [labels](/docs/ambient/usage/add-workloads/#ambient-labels) for more details.
 
 Depending on which category a workload is in, the traffic path will be different.
 

--- a/content/en/docs/ambient/usage/extend-waypoint-wasm/index.md
+++ b/content/en/docs/ambient/usage/extend-waypoint-wasm/index.md
@@ -15,7 +15,7 @@ One of the key advantages of Wasm extensibility is that extensions can be loaded
 
 ## Install Ambient Mode and deploy test applications
 
-Follow the [Ambient Getting Started Guide](docs/ambient/getting-started/#download) to install Istio in ambient mode. Deploy the [sample applications](docs/ambient/getting-started/#bookinfo) required for exploring waypoint proxy extensibility via Wasm. Make sure to [add the sample applications](docs/ambient/getting-started/#addtoambient) to the mesh before proceeding further.
+Follow the [Ambient Getting Started Guide](/docs/ambient/getting-started/#download) to install Istio in ambient mode. Deploy the [sample applications](/docs/ambient/getting-started/#bookinfo) required for exploring waypoint proxy extensibility via Wasm. Make sure to [add the sample applications](/docs/ambient/getting-started/#addtoambient) to the mesh before proceeding further.
 
 ## Apply Wasm configuration at the Gateway
 
@@ -23,7 +23,7 @@ With Kubernetes Gateway API, Istio provides a centralized entry point for managi
 
 ### Configure WasmPlugin for Gateway
 
-In this example, you will add a HTTP [Basic auth module](https://github.com/istio-ecosystem/wasm-extensions/tree/master/extensions/basic_auth) to your mesh. You will configure Istio to pull the Basic auth module from a remote image registry and load it. It will be configured to run on calls to `/productpage`. Steps are more or less similar as [Istio / Distributing WebAssembly Modules](docs/tasks/extensibility/wasm-module-distribution/), only difference being the recommended usage of `targetRefs` instead of `labelSelectors` in WasmPlugin.
+In this example, you will add a HTTP [Basic auth module](https://github.com/istio-ecosystem/wasm-extensions/tree/master/extensions/basic_auth) to your mesh. You will configure Istio to pull the Basic auth module from a remote image registry and load it. It will be configured to run on calls to `/productpage`. Steps are more or less similar as [Istio / Distributing WebAssembly Modules](/docs/tasks/extensibility/wasm-module-distribution/), only difference being the recommended usage of `targetRefs` instead of `labelSelectors` in WasmPlugin.
 
 To configure a WebAssembly filter with a remote Wasm module, create a `WasmPlugin` resource targeting the `bookinfo-gateway`:
 
@@ -83,7 +83,7 @@ Waypoint proxies play a crucial role in Istio's ambient mode, facilitating secur
 
 ### Deploy a waypoint proxy
 
-Follow the [waypoint deployment instructions](docs/ambient/getting-started/#layer-7-authorization-policy) to deploy a waypoint proxy in the bookinfo namespace.
+Follow the [waypoint deployment instructions](/docs/ambient/getting-started/#layer-7-authorization-policy) to deploy a waypoint proxy in the bookinfo namespace.
 
 {{< text bash >}}
 $ istioctl x waypoint apply --enroll-namespace --wait
@@ -243,4 +243,4 @@ When executing the provided command without credentials, it verifies that access
     $ kubectl delete wasmplugin basic-auth-at-gateway basic-auth-at-waypoint basic-auth-for-service
     {{< /text >}}
 
-1. Follow [the ambient mode uninstall guide](docs/ambient/getting-started/#uninstall) to remove Istio and sample test applications.
+1. Follow [the ambient mode uninstall guide](/docs/ambient/getting-started/#uninstall) to remove Istio and sample test applications.


### PR DESCRIPTION
Search and replace

```
](docs/
```
with
```
](/docs/
```

- [x] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
