### PR TITLE
Add link to extend waypoints with Wasm plugins documentation

### DIFF
--- a/content/en/docs/ambient/usage/l7-features/index.md
+++ b/content/en/docs/ambient/usage/l7-features/index.md
@@ -109,3 +109,5 @@ spec:
       weight: 10
 EOF
 {{< /text >}}
+
+Read more on how to extend waypoints with Wasm plugins [here](/docs/ambient/usage/extend-waypoint-wasm/).


### PR DESCRIPTION
This PR adds a reference link to the documentation on extending waypoints with Wasm plugins in the Istio documentation. The link directs readers to additional information on how to leverage Wasm plugins for extending waypoint functionality. This enhancement aims to provide users with comprehensive guidance on leveraging Istio's capabilities effectively. 
