### PR TITLE
Wasm Configuration for Ambient Mode - Fixes

### DIFF
--- a/content/en/docs/ambient/usage/extend-waypoint-wasm/index.md
+++ b/content/en/docs/ambient/usage/extend-waypoint-wasm/index.md
@@ -226,7 +226,7 @@ EOF
     200
     {{< /text >}}
 
-1. Test internal `/productpage` without credentials
+1. Test internal `/reviews` without credentials
 
     {{< text bash >}}
     $ kubectl exec deploy/sleep -- curl -s -w "%{http_code}" -o /dev/null http://reviews:9080/reviews/1


### PR DESCRIPTION
This PR corrects the heading in the Wasm documentation for ambient mode(PR #15041) to accurately reference the `/reviews` endpoint instead of the previously incorrect `/productpage`.

Adds documentation as per : https://github.com/istio/istio/issues/42337



