### PR TITLE
Updates Ambient Getting Started Guide

### DIFF
--- a/content/en/docs/ambient/getting-started/snips.sh
+++ b/content/en/docs/ambient/getting-started/snips.sh
@@ -59,6 +59,10 @@ kubectl apply -f samples/bookinfo/gateway-api/bookinfo-gateway.yaml
 }
 
 snip_deploy_the_sample_application_4() {
+kubectl annotate gateway bookinfo-gateway networking.istio.io/service-type=ClusterIP --namespace=default
+}
+
+snip_deploy_the_sample_application_5() {
 kubectl wait --for=condition=programmed gtw/bookinfo-gateway
 export GATEWAY_HOST=bookinfo-gateway-istio.default
 export GATEWAY_SERVICE_ACCOUNT=ns/default/sa/bookinfo-gateway-istio
@@ -178,19 +182,12 @@ namespace default labeled with "istio.io/use-waypoint: waypoint"
 ENDSNIP
 
 snip_layer_7_authorization_policy_2() {
-kubectl get gtw waypoint -o yaml
+kubectl get gtw waypoint
 }
 
 ! IFS=$'\n' read -r -d '' snip_layer_7_authorization_policy_2_out <<\ENDSNIP
-...
-status:
-  conditions:
-  - lastTransitionTime: "2024-04-18T14:25:56Z"
-    message: Resource programmed, assigned to service(s) waypoint.default.svc.cluster.local:15008
-    observedGeneration: 1
-    reason: Programmed
-    status: "True"
-    type: Programmed
+NAME       CLASS            ADDRESS       PROGRAMMED   AGE
+waypoint   istio-waypoint   10.96.58.95   True         61s
 ENDSNIP
 
 snip_layer_7_authorization_policy_3() {

--- a/content/en/docs/ambient/getting-started/test.sh
+++ b/content/en/docs/ambient/getting-started/test.sh
@@ -39,6 +39,7 @@ snip_deploy_the_sample_application_2
 
 snip_deploy_the_sample_application_3
 snip_deploy_the_sample_application_4
+snip_deploy_the_sample_application_5
 
 # test traffic before ambient mode is enabled
 _verify_contains snip_verify_traffic_sleep_to_ingress "$snip_verify_traffic_sleep_to_ingress_out"
@@ -58,7 +59,7 @@ _verify_contains snip_layer_4_authorization_policy_3 "$snip_layer_4_authorizatio
 _verify_failure snip_layer_4_authorization_policy_4
 
 _verify_contains snip_layer_7_authorization_policy_1 "$snip_layer_7_authorization_policy_1_out"
-_verify_contains snip_layer_7_authorization_policy_2 "Resource programmed, assigned to service"
+_verify_contains snip_layer_7_authorization_policy_2 "True"
 snip_layer_7_authorization_policy_3
 _verify_contains snip_layer_7_authorization_policy_4 "$snip_layer_7_authorization_policy_4_out"
 _verify_contains snip_layer_7_authorization_policy_5 "$snip_layer_7_authorization_policy_5_out"

--- a/content/en/docs/ambient/usage/extend-waypoint-wasm/test.sh
+++ b/content/en/docs/ambient/usage/extend-waypoint-wasm/test.sh
@@ -40,7 +40,7 @@ snip_deploy_the_sample_application_1
 snip_deploy_the_sample_application_2
 
 snip_deploy_the_sample_application_3
-snip_deploy_the_sample_application_4
+snip_deploy_the_sample_application_5
 
 # adding applications to ambient mesh
 _verify_same snip_adding_your_application_to_the_ambient_mesh_1 "$snip_adding_your_application_to_the_ambient_mesh_1_out"


### PR DESCRIPTION
## Description

- Adds a step to annotate the ingress gateway to use a ClusterIP service.
- Removes the reference to external tooling for managing a LoadBalancer service type.

Fixes #15119

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [X] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
