### PR TITLE
ztunnel-config command has been promoted; no longer experimental

### DIFF
--- a/content/en/docs/ambient/usage/troubleshoot-ztunnel/index.md
+++ b/content/en/docs/ambient/usage/troubleshoot-ztunnel/index.md
@@ -12,12 +12,12 @@ This guide describes some options for monitoring the ztunnel proxy configuration
 
 The ztunnel proxy gets configuration and discovery information from the istiod {{< gloss >}}control plane{{< /gloss >}} via xDS APIs.
 
-The `istioctl x ztunnel-config` command allows you to view discovered workloads as seen by a ztunnel proxy.
+The `istioctl ztunnel-config` command allows you to view discovered workloads as seen by a ztunnel proxy.
 
 In the first example, you see all the workloads and control plane components that ztunnel is currently tracking, including information about the IP address and protocol to use when connecting to that component and whether there is a waypoint proxy associated with that workload.
 
 {{< text bash >}}
-$ istioctl x ztunnel-config workloads
+$ istioctl ztunnel-config workloads
 NAMESPACE          POD NAME                                IP          NODE                  WAYPOINT PROTOCOL
 default            bookinfo-gateway-istio-59dd7c96db-q9k6v 10.244.1.11 ambient-worker        None     TCP
 default            details-v1-cf74bb974-5sqkp              10.244.1.5  ambient-worker        None     HBONE
@@ -41,7 +41,7 @@ local-path-storage local-path-provisioner-7577fdbbfb-pslg6 10.244.0.4  ambient-c
 The `ztunnel-config` command can be used to view the secrets holding the TLS certificates that the ztunnel proxy has received from the istiod control plane to use for mTLS.
 
 {{< text bash >}}
-$ istioctl x ztunnel-config certificates "$ZTUNNEL".istio-system
+$ istioctl ztunnel-config certificates "$ZTUNNEL".istio-system
 CERTIFICATE NAME                                              TYPE     STATUS        VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
 spiffe://cluster.local/ns/default/sa/bookinfo-details         Leaf     Available     true           c198d859ee51556d0eae13b331b0c259     2024-05-05T09:17:47Z     2024-05-04T09:15:47Z
 spiffe://cluster.local/ns/default/sa/bookinfo-details         Root     Available     true           bad086c516cce777645363cb8d731277     2034-04-24T03:31:05Z     2024-04-26T03:31:05Z
@@ -60,7 +60,7 @@ Using these commands, you can check that ztunnel proxies are  configured with al
 You may use the `all` option to view all parts of the ztunnel-config with a single CLI command:
 
 {{< text bash >}}
-$ istioctl x ztunnel-config all -o json
+$ istioctl ztunnel-config all -o json
 {{< /text >}}
 
 You can also view the raw configuration dump of a ztunnel proxy via a `curl` to an endpoint inside its pod:

--- a/content/zh/docs/ambient/usage/troubleshoot-ztunnel/index.md
+++ b/content/zh/docs/ambient/usage/troubleshoot-ztunnel/index.md
@@ -13,13 +13,13 @@ test: no
 
 ztunnel 代理通过 xDS API 从 istiod {{< gloss "control plane" >}}控制平面{{< /gloss >}}获取配置和发现信息。
 
-`istioctl x ztunnel-config` 命令允许您查看 ztunnel 代理所看到的和发现的工作负载。
+`istioctl ztunnel-config` 命令允许您查看 ztunnel 代理所看到的和发现的工作负载。
 
 在第一个示例中，您会看到 ztunnel 当前正在跟踪的所有工作负载和控制平面组件，
 包括有关连接到该组件时要使用的 IP 地址和协议的信息，以及是否存在与该工作负载关联的 waypoint 代理。
 
 {{< text bash >}}
-$ istioctl x ztunnel-config workloads
+$ istioctl ztunnel-config workloads
 NAMESPACE          POD NAME                                IP          NODE                  WAYPOINT PROTOCOL
 default            bookinfo-gateway-istio-59dd7c96db-q9k6v 10.244.1.11 ambient-worker        None     TCP
 default            details-v1-cf74bb974-5sqkp              10.244.1.5  ambient-worker        None     HBONE
@@ -44,7 +44,7 @@ local-path-storage local-path-provisioner-7577fdbbfb-pslg6 10.244.0.4  ambient-c
 ztunnel 代理已从 istiod 控制平面接收到用于 mTLS 的证书。
 
 {{< text bash >}}
-$ istioctl x ztunnel-config certificates "$ZTUNNEL".istio-system
+$ istioctl ztunnel-config certificates "$ZTUNNEL".istio-system
 CERTIFICATE NAME                                              TYPE     STATUS        VALID CERT     SERIAL NUMBER                        NOT AFTER                NOT BEFORE
 spiffe://cluster.local/ns/default/sa/bookinfo-details         Leaf     Available     true           c198d859ee51556d0eae13b331b0c259     2024-05-05T09:17:47Z     2024-05-04T09:15:47Z
 spiffe://cluster.local/ns/default/sa/bookinfo-details         Root     Available     true           bad086c516cce777645363cb8d731277     2034-04-24T03:31:05Z     2024-04-26T03:31:05Z
@@ -64,7 +64,7 @@ spiffe://cluster.local/ns/default/sa/sleep                    Root     Available
 您可以使用 `all` 选项通过单个 CLI 命令查看 ztunnel-config 的所有部分：
 
 {{< text bash >}}
-$ istioctl x ztunnel-config all -o json
+$ istioctl ztunnel-config all -o json
 {{< /text >}}
 
 您还可以通过 `curl` 查看 ztunnel 代理的原始配置转储到其 Pod 内的端点：


### PR DESCRIPTION
## Description
The istioctl ztunnel-config command has been promoted. We no longer need to do `istioctl x....`. For context, here is the [PR ](https://github.com/istio/istio/commit/6463a1ff36a3b1edbdbf732b21fb7205d0ee66c4)that made that change.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
