### PR TITLE
updating statement about peer authn in l4-policy usage doc

### DIFF
--- a/content/en/docs/ambient/usage/l4-policy/index.md
+++ b/content/en/docs/ambient/usage/l4-policy/index.md
@@ -108,10 +108,6 @@ This means that when you have a waypoint installed, **the ideal place to enforce
 
 Istio's [peer authentication policies](/docs/concepts/security/#peer-authentication), which configure mutual TLS (mTLS) modes, are supported by ztunnel.
 
+The default policy for ambient mode is `PERMISSIVE`, which allows pods to accept both mTLS-encrypted traffic (from within the mesh) and plain text traffic (from without). Enabling `STRICT` mode means that pods will only accept mTLS-encrypted traffic.
+
 As ztunnel and {{< gloss >}}HBONE{{< /gloss >}} implies the use of mTLS, it is not possible to use the `DISABLE` mode in a policy. Such policies will be ignored.
-
-If you need to accept traffic from clients which are not part of the mesh you may do so with a `PERMISSIVE` peer authentication policy. Permissive is the default mTLS mode Istio ambient operates in which means you may enable this mode explicitly in a peer authentication or simply not create a `STRICT` policy.
-
-{{< text bash >}}
-$ kubectl label namespace default istio.io/dataplane-mode-
-{{< /text >}}

--- a/content/en/docs/ambient/usage/l4-policy/index.md
+++ b/content/en/docs/ambient/usage/l4-policy/index.md
@@ -110,7 +110,7 @@ Istio's [peer authentication policies](/docs/concepts/security/#peer-authenticat
 
 As ztunnel and {{< gloss >}}HBONE{{< /gloss >}} implies the use of mTLS, it is not possible to use the `DISABLE` mode in a policy. Such policies will be ignored.
 
-If you need to disable mTLS for an entire namespace, you will have to disable ambient mode:
+If you need to accept traffic from clients which are not part of the mesh you may do so with a `PERMISSIVE` peer authentication policy. Permissive is the default mTLS mode Istio ambient operates in which means you may enable this mode explicitly in a peer authentication or simply not create a `STRICT` policy.
 
 {{< text bash >}}
 $ kubectl label namespace default istio.io/dataplane-mode-


### PR DESCRIPTION
## Description

Removes mention of disabling ambient and substitues using a PERMISSIVE peer authn mode when not everything may support mTLS/HBONE.

fixes #15203

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [X] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
