### PR TITLE
Add ambient profile for docs test

### DIFF
--- a/tests/setup/profile-ambient/doc_test.go
+++ b/tests/setup/profile-ambient/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Istio Authors
+// Copyright 2024 Istio Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/setup/profile-ambient/doc_test.go
+++ b/tests/setup/profile-ambient/doc_test.go
@@ -1,0 +1,56 @@
+// Copyright 2020 Istio Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package setupconfig
+
+import (
+	"testing"
+
+	"istio.io/istio.io/pkg/test/istioio"
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/istio"
+	"istio.io/istio/pkg/test/framework/resource"
+)
+
+func TestMain(m *testing.M) {
+	// nolint: staticcheck
+	framework.
+		NewSuite(m).
+		Setup(istio.Setup(nil, setupConfig)).
+		Run()
+}
+
+func TestDocs(t *testing.T) {
+	framework.
+		NewTest(t).
+		Run(istioio.NewTestDocsFunc("profile=ambient"))
+}
+
+func setupConfig(ctx resource.Context, cfg *istio.Config) {
+	cfg.ControlPlaneValues = `
+profile: ambient
+values:
+  pilot:
+    env:
+      PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING: true
+      PILOT_ENABLE_ALPHA_GATEWAY_API: false
+components:
+  egressGateways:
+  - enabled: false
+    name: istio-egressgateway
+  ingressGateways:
+  - enabled: false
+    name: istio-ingressgateway
+`
+	cfg.DeployEastWestGW = false
+}


### PR DESCRIPTION
## Description

Now that we have more documentation and document tests coming with ambient profile, I think it makes better sense to have an ambient profile created separately?

Wait on https://github.com/istio/test-infra/pull/5374

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
