### PR TITLE
Fixed link to the https://github.com/google/re2/wiki/Syntax

### DIFF
--- a/content/en/docs/reference/config/networking/virtual-service/index.html
+++ b/content/en/docs/reference/config/networking/virtual-service/index.html
@@ -999,7 +999,7 @@ values are case-sensitive and formatted as follows:</p>
 <p><code>prefix: &quot;value&quot;</code> for prefix-based match</p>
 </li>
 <li>
-<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax">https://github.com/google/re2/wiki/Syntax)</a>.</p>
 </li>
 </ul>
 <p><strong>Note:</strong> Case-insensitive matching could be enabled via the
@@ -1024,7 +1024,7 @@ values are case-sensitive and formatted as follows:</p>
 <p><code>prefix: &quot;value&quot;</code> for prefix-based match</p>
 </li>
 <li>
-<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax">https://github.com/google/re2/wiki/Syntax)</a>.</p>
 </li>
 </ul>
 
@@ -1047,7 +1047,7 @@ values are case-sensitive and formatted as follows:</p>
 <p><code>prefix: &quot;value&quot;</code> for prefix-based match</p>
 </li>
 <li>
-<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax">https://github.com/google/re2/wiki/Syntax)</a>.</p>
 </li>
 </ul>
 
@@ -1070,7 +1070,7 @@ values are case-sensitive and formatted as follows:</p>
 <p><code>prefix: &quot;value&quot;</code> for prefix-based match</p>
 </li>
 <li>
-<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax">https://github.com/google/re2/wiki/Syntax)</a>.</p>
 </li>
 </ul>
 
@@ -1094,7 +1094,7 @@ e.g. <em>x-request-id</em>.</p>
 <p><code>prefix: &quot;value&quot;</code> for prefix-based match</p>
 </li>
 <li>
-<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+<p><code>regex: &quot;value&quot;</code> for RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax">https://github.com/google/re2/wiki/Syntax)</a>.</p>
 </li>
 </ul>
 <p>If the value is empty and only the name of header is specified, presence of the header is checked.
@@ -1913,7 +1913,7 @@ No
 <td><code>match</code></td>
 <td><code>string</code></td>
 <td>
-<p>RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+<p>RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax">https://github.com/google/re2/wiki/Syntax)</a>.</p>
 
 </td>
 <td>
@@ -1983,7 +1983,7 @@ No
 <td><code>regex</code></td>
 <td><code>string (oneof)</code></td>
 <td>
-<p>RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax)">https://github.com/google/re2/wiki/Syntax)</a>.</p>
+<p>RE2 style regex-based match (<a href="https://github.com/google/re2/wiki/Syntax">https://github.com/google/re2/wiki/Syntax)</a>.</p>
 
 </td>
 <td>


### PR DESCRIPTION
## Description

Removed `)` in the end of the link https://github.com/google/re2/wiki/Syntax

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
