### PR TITLE
add link to how-to-add-company wiki from the ecosystem page

### DIFF
--- a/data/companies.yml
+++ b/data/companies.yml
@@ -353,7 +353,7 @@ pro_services:
       - "CloudRaft specializes in full-stack cloud-native solutions, including expert support for Istio service mesh integration. With extensive experience in cloud consulting, Kubernetes deployment, and Istio implementation, we ensure seamless operation within your environment. From consulting to training and production support, our comprehensive services maximize efficiency and scalability. With proven expertise and a client-centric approach, CloudRaft is your trusted partner for unlocking Istio's full potential in Kubernetes."
   - name: "Your Name Here"
     logo: "/logos/istio.svg"
-    url: "https://istio.io/"
+    url: "https://github.com/istio/community/blob/master/CONTRIBUTING.md#promote-your-company-on-istioio"
     description: "Submit a PR to add your company here!"
     details:
       - "Add information about your how your company supports Istio."


### PR DESCRIPTION
## Description

@craigbox does it make better sense to point to the wiki from the ecosystem page to help people better understand how they can add their company to the same page? Currently when we click on the link it simply goes to istio.io home page.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
