### PR TITLE
Fix the Envoy commit line in WORKSPACE

### DIFF
--- a/content/en/docs/releases/supported-releases/index.md
+++ b/content/en/docs/releases/supported-releases/index.md
@@ -86,4 +86,4 @@ The relationship between the two project's versions:
 | 1.21.x        | release/v1.29        |
 | 1.20.x        | release/v1.28        |
 
-You can find the precise Envoy commit used by Istio [in the `istio/proxy` repository](https://github.com/istio/proxy/blob/master/WORKSPACE#L26): look for the `ENVOY_SHA` variable.
+You can find the precise Envoy commit used by Istio [in the `istio/proxy` repository](https://github.com/istio/proxy/blob/{{< source_branch_name >}}/WORKSPACE#L26): look for the `ENVOY_SHA` variable.

--- a/content/en/docs/releases/supported-releases/index.md
+++ b/content/en/docs/releases/supported-releases/index.md
@@ -86,4 +86,4 @@ The relationship between the two project's versions:
 | 1.21.x        | release/v1.29        |
 | 1.20.x        | release/v1.28        |
 
-You can find the precise Envoy commit used by Istio in [`istio/proxy`](https://github.com/istio/proxy/blob/master/WORKSPACE#L38).
+You can find the precise Envoy commit used by Istio in [`istio/proxy`](https://github.com/istio/proxy/blob/master/WORKSPACE#L26) repository. Look for the `ENVOY_SHA` variable.

--- a/content/en/docs/releases/supported-releases/index.md
+++ b/content/en/docs/releases/supported-releases/index.md
@@ -86,4 +86,4 @@ The relationship between the two project's versions:
 | 1.21.x        | release/v1.29        |
 | 1.20.x        | release/v1.28        |
 
-You can find the precise Envoy commit used by Istio in [`istio/proxy`](https://github.com/istio/proxy/blob/master/WORKSPACE#L26) repository. Look for the `ENVOY_SHA` variable.
+You can find the precise Envoy commit used by Istio [in the `istio/proxy` repository](https://github.com/istio/proxy/blob/master/WORKSPACE#L26): look for the `ENVOY_SHA` variable.


### PR DESCRIPTION
Ideally we could point directly to the 1.22 branch, but that'd mean more manual maintenance.