### PR TITLE
Update HUGO_VERSION to 0.127.0

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
     publish = "public"
 
 [build.environment]
-    HUGO_VERSION = "0.126.3"
+    HUGO_VERSION = "0.127.0"
     NODE_VERSION = "18.18.2"
     BUILD_WITH_CONTAINER = "0"
     GO_VERSION = "1.21.3"


### PR DESCRIPTION
## Description

chore: update HUGO_VERSION to 0.127.0

## Reviewers

[gohugoio/hugo: v0.127.0](https://github.com/gohugoio/hugo/releases/tag/v0.127.0)

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [x] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
