### PR TITLE
Document use of ambient wrapper chart in 1.23 install/upgrade guides

### DIFF
--- a/content/en/docs/ambient/getting-started/_index.md
+++ b/content/en/docs/ambient/getting-started/_index.md
@@ -10,62 +10,123 @@ skip_list: true
 test: yes
 ---
 
-This guide lets you quickly evaluate Istio's {{< gloss "ambient" >}}ambient mode{{< /gloss >}}. You'll need a Kubernetes cluster to proceed. If you don't have a cluster, you can use [kind](/docs/setup/platform-setup/kind) or any other [supported Kubernetes platform](/docs/setup/platform-setup).
+This guide shows you how to install Istio in ambient mode with Helm, in a non-production quick-start context.
 
-These steps require you to have a {{< gloss >}}cluster{{< /gloss >}} running a
-[supported version](/docs/releases/supported-releases#support-status-of-istio-releases) of Kubernetes ({{< supported_kubernetes_versions >}}).
+If you are looking to install Istio's ambient mode in a production context, we recommend following the more [advanced Helm install guide](/docs/ambient/install/helm-installation/).
 
-## Download the Istio CLI
+We generally encourage the use of Helm to install Istio when using ambient mode. Helm helps you manage components separately, is widely compatible with other tooling, and allows you to independently install and upgrade individual Istio components if desired.
 
-Istio is configured using a command line tool called `istioctl`.  Download it, and the Istio sample applications:
+## Prerequisites
 
-{{< text syntax=bash snip_id=none >}}
-$ curl -L https://istio.io/downloadIstio | sh -
-$ cd istio-{{< istio_full_version >}}
-$ export PATH=$PWD/bin:$PATH
-{{< /text >}}
+1. Check the [Platform-Specific Prerequisites](/docs/ambient/install/platform-prerequisites).
 
-Check that you are able to run `istioctl` by printing the version of the command. At this point, Istio is not installed in your cluster, so you will see that there are no pods ready.
+1. [Install the Helm client](https://helm.sh/docs/intro/install/), version 3.6 or above.
 
-{{< text syntax=bash snip_id=none >}}
-$ istioctl version
-no ready Istio pods in "istio-system"
-{{< istio_full_version >}}
-{{< /text >}}
+1. Configure your Helm client to pull from the Istio Helm repository:
 
-## Install Istio on to your cluster
+    {{< text syntax=bash snip_id=configure_helm >}}
+    $ helm repo add istio https://istio-release.storage.googleapis.com/charts
+    $ helm repo update
+    {{< /text >}}
 
-`istioctl` supports a number of [configuration profiles](/docs/setup/additional-setup/config-profiles/) that include different default options, and can be customized for your production needs. Support for ambient mode is included in the `ambient` profile. Install Istio with the following command:
+*See [the helm repo documentation](https://helm.sh/docs/helm/helm_repo/) for command documentation.*
 
-{{< text syntax=bash snip_id=install_ambient >}}
-$ istioctl install --set profile=ambient --skip-confirmation
-{{< /text >}}
+Istio is made up of multiple components which belong to either the {{< gloss >}}data plane{{< /gloss >}} or the {{< gloss >}}control plane{{< /gloss >}}. Different components may have different effects on your applications and cluster networking when upgraded.
 
-It might take a minute for the Istio components to be installed. Once the installation completes, you’ll get the following output that indicates all components have been installed successfully.
-
-{{< text syntax=plain snip_id=none >}}
-✔ Istio core installed
-✔ Istiod installed
-✔ CNI installed
-✔ Ztunnel installed
-✔ Installation complete
-{{< /text >}}
+For installing Istio with support for the {{< gloss >}}ambient{{< /gloss >}} data plane mode quickly in a non-production cluster, we provide a simple Helm chart which bundles all the required Istio component Helm charts.
 
 {{< tip >}}
-You can verify the installed components using the command `istioctl verify-install`.
+For production deployments, it is strongly recommended to install the components separately via Helm to allow for more control during Istio upgrades. Consult the [full Helm install guide](/docs/ambient/install/helm-installation/) as well as the [operations guidelines](/docs/ops/best-practices/deployment/) for production deployment considerations.
 {{< /tip >}}
 
-## Install the Kubernetes Gateway API CRDs
+## Install
 
-You need to install the Kubernetes Gateway API CRDs, which don’t come installed by default on most Kubernetes clusters:
+The `ambient` Helm chart composes all the components that enable the use of Istio's ambient data plane mode:
 
-{{< text syntax=bash snip_id=install_k8s_gateway_api >}}
-$ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.1.0" | kubectl apply -f -; }
+{{< text syntax=bash snip_id=install_ambient_chart >}}
+$ helm install istio-ambient istio/ambient -n istio-system --create-namespace --wait
 {{< /text >}}
 
-You will use the Kubernetes Gateway API to configure traffic routing.
+Proceed to [verifying the installation](#verify-the-installation) or [installing an ingress gateway (optional)](#install-an-ingress-gateway-optional)
 
-## Next steps
+## Install an ingress gateway (optional)
 
-Congratulations! You've successfully installed Istio with support for ambient mode. Continue to the next step to [install the demo application and add it to the ambient mesh](/docs/ambient/getting-started/deploy-sample-app/).
+To install an ingress gateway, run the command below:
+
+{{< text syntax=bash snip_id=install_ingress >}}
+$ helm install istio-ingress istio/gateway -n istio-ingress --create-namespace --wait
+{{< /text >}}
+
+If your Kubernetes cluster doesn't support the `LoadBalancer` service type (`type: LoadBalancer`) with a proper external IP assigned, run the above command without the `--wait` parameter to avoid the infinite wait. See [Installing Gateways](/docs/setup/additional-setup/gateway/) for in-depth documentation on gateway installation.
+
+## Verify the installation
+
+### Verify the workload status
+
+After installing all the components, you can check the Helm deployment status with:
+
+{{< text syntax=bash snip_id=show_components >}}
+$ helm ls -n istio-system
+NAME            NAMESPACE       REVISION    UPDATED                                 STATUS      CHART           APP VERSION
+istio-base      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    base-{{< istio_full_version >}}     {{< istio_full_version >}}
+istio-cni       istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    cni-{{< istio_full_version >}}      {{< istio_full_version >}}
+istiod          istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    istiod-{{< istio_full_version >}}   {{< istio_full_version >}}
+ztunnel         istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ztunnel-{{< istio_full_version >}}  {{< istio_full_version >}}
+{{< /text >}}
+
+You can check the status of the deployed pods with:
+
+{{< text syntax=bash snip_id=check_pods >}}
+$ kubectl get pods -n istio-system
+NAME                             READY   STATUS    RESTARTS   AGE
+istio-cni-node-g97z5             1/1     Running   0          10m
+istiod-5f4c75464f-gskxf          1/1     Running   0          10m
+ztunnel-c2z4s                    1/1     Running   0          10m
+{{< /text >}}
+
+### Verify with the sample application
+
+Congratulations! You've successfully installed Istio with support for ambient mode. Continue to the next step to [install the demo application and add it to the ambient mesh](/docs/ambient/getting-started/deploy-sample-app/), or [add your own applications to the ambient mesh](/docs/ambient/usage/add-workloads/)
+
+## Uninstall
+
+### Uninstall an ingress gateway (optional)
+
+If you previously installed an ingress gateway, uninstall it by running the command below:
+
+{{< text syntax=bash snip_id=delete_ingress >}}
+$ helm delete istio-ingress -n istio-ingress --wait
+$ kubectl delete namespace istio-ingress
+{{< /text >}}
+
+If your Kubernetes cluster doesn't support the `LoadBalancer` service type (`type: LoadBalancer`) with a proper external IP assigned, run the above command without the `--wait` parameter to avoid the infinite wait. See [Installing Gateways](/docs/setup/additional-setup/gateway/) for in-depth documentation on gateway installation.
+
+### Uninstall Istio
+
+1. Remove the Istio ambient Helm installation:
+
+    {{< tip >}}
+    [By design](https://github.com/helm/community/blob/main/hips/hip-0011.md#deleting-crds),
+    deleting a chart via Helm doesn't delete the installed Custom
+    Resource Definitions (CRDs) installed via the chart.
+    {{< /tip >}}
+
+    {{< text syntax=bash snip_id=delete_ambient_chart >}}
+    $ helm delete istio-ambient -n istio-system --wait
+    {{< /text >}}
+
+1. Delete CRDs installed by Istio (optional)
+
+    {{< warning >}}
+    This will delete all created Istio resources.
+    {{< /warning >}}
+
+    {{< text syntax=bash snip_id=delete_crds_chart >}}
+    $ kubectl get crd -oname | grep --color=never 'istio.io' | xargs kubectl delete
+    {{< /text >}}
+
+1. Delete the `istio-system` namespace:
+
+    {{< text syntax=bash snip_id=delete_system_namespace_chart >}}
+    $ kubectl delete namespace istio-system
+    {{< /text >}}

--- a/content/en/docs/ambient/getting-started/_index.md
+++ b/content/en/docs/ambient/getting-started/_index.md
@@ -44,7 +44,7 @@ For production deployments, it is strongly recommended to install the components
 The `ambient` Helm chart composes all the components that enable the use of Istio's ambient data plane mode:
 
 {{< text syntax=bash snip_id=install_ambient_chart >}}
-$ helm install istio-ambient istio/ambient -n istio-system --create-namespace --wait
+$ helm install istio-ambient istio/samples/ambient -n istio-system --create-namespace --wait
 {{< /text >}}
 
 Proceed to [verifying the installation](#verify-the-installation) or [installing an ingress gateway (optional)](#install-an-ingress-gateway-optional)

--- a/content/en/docs/ambient/getting-started/snips.sh
+++ b/content/en/docs/ambient/getting-started/snips.sh
@@ -26,7 +26,7 @@ helm repo update
 }
 
 snip_install_ambient_chart() {
-helm install istio-ambient istio/ambient -n istio-system --create-namespace --wait
+helm install istio-ambient istio/samples/ambient -n istio-system --create-namespace --wait
 }
 
 snip_install_ingress() {

--- a/content/en/docs/ambient/getting-started/test.sh
+++ b/content/en/docs/ambient/getting-started/test.sh
@@ -27,8 +27,6 @@ source "content/en/docs/ambient/getting-started/enforce-auth-policies/snips.sh"
 source "content/en/docs/ambient/getting-started/manage-traffic/snips.sh"
 source "content/en/docs/ambient/getting-started/cleanup/snips.sh"
 
-snip_install_k8s_gateway_api
-
 _wait_for_deployment istio-system istiod
 _wait_for_daemonset istio-system ztunnel
 _wait_for_daemonset istio-system istio-cni-node

--- a/content/en/docs/ambient/install/helm-installation/index.md
+++ b/content/en/docs/ambient/install/helm-installation/index.md
@@ -47,14 +47,6 @@ This should be installed prior to any other Istio component.
 $ helm install istio-base istio/base -n istio-system --create-namespace --wait
 {{< /text >}}
 
-### Install the CNI component
-
-The `cni` chart installs the Istio CNI plugin. It is responsible for detecting the pods that belong to the ambient mesh, and configuring the traffic redirection between pods and the ztunnel node proxy (which will be installed later).
-
-{{< text syntax=bash snip_id=install_cni >}}
-$ helm install istio-cni istio/cni -n istio-system --set profile=ambient --wait
-{{< /text >}}
-
 ### Install the Istiod component
 
 The `istiod` chart installs a revision of Istiod. Istiod is the control plane component that manages and
@@ -62,6 +54,14 @@ configures the proxies to route traffic within the mesh.
 
 {{< text syntax=bash snip_id=install_discovery >}}
 $ helm install istiod istio/istiod --namespace istio-system --set profile=ambient --wait
+{{< /text >}}
+
+### Install the CNI component
+
+The `cni` chart installs the Istio CNI plugin. It is responsible for detecting the pods that belong to the ambient mesh, and configuring the traffic redirection between pods and the ztunnel node proxy (which will be installed later).
+
+{{< text syntax=bash snip_id=install_cni >}}
+$ helm install istio-cni istio/cni -n istio-system --set profile=ambient --wait
 {{< /text >}}
 
 ### Install the ztunnel component
@@ -167,12 +167,6 @@ If you installed the Istio component charts individually above, you can uninstal
 
     {{< text syntax=bash snip_id=delete_cni >}}
     $ helm delete istio-cni -n istio-system
-    {{< /text >}}
-
-1. Delete the Istio ztunnel chart:
-
-    {{< text syntax=bash snip_id=delete_ztunnel >}}
-    $ helm delete ztunnel -n istio-system
     {{< /text >}}
 
 1. Delete the Istio discovery chart:

--- a/content/en/docs/ambient/install/helm-installation/index.md
+++ b/content/en/docs/ambient/install/helm-installation/index.md
@@ -9,9 +9,11 @@ owner: istio/wg-environments-maintainers
 test: yes
 ---
 
-This guide shows you how to install Istio in ambient mode with Helm.
-Aside from following the demo in [Getting Started with Ambient Mode](/docs/ambient/getting-started/),
-we encourage the use of Helm to install Istio for use in ambient mode. Helm helps you manage components separately, and you can easily upgrade the components to the latest version.
+This guide shows you how to install Istio's {{< gloss "ambient" >}}ambient mode{{< /gloss >}} in a production cluster in ambient mode with Helm, as a series of separately-installed, independently-upgradable components. Doing so gives you the most control over Istio upgrades, and is strongly recommended in a production context.
+
+If you are looking to quickly evaluate Istio's ambient mode in a non-production context, we recommend following the quick-start demo in [Getting Started with Ambient Mode](/docs/ambient/getting-started/) instead.
+
+We generally encourage the use of Helm to install Istio when using ambient mode. Helm helps you manage components separately, is widely compatible with other tooling, and allows you to independently install and upgrade Istio components if desired.
 
 ## Prerequisites
 
@@ -28,21 +30,13 @@ we encourage the use of Helm to install Istio for use in ambient mode. Helm help
 
 *See [helm repo](https://helm.sh/docs/helm/helm_repo/) for command documentation.*
 
-Istio is made up of multiple components which belong to either the {{< gloss >}}data plane{{< /gloss >}} or {{< gloss >}}control plane{{< /gloss >}}, and different components may have different effects on your applications when upgraded - for production deployments, it is strongly recommended to install the components separately to allow for more control during upgrades. Consult the [operations guidelines](/docs/ops/best-practices/deployment/) for production deployment considerations.
+Istio is made up of multiple components which belong to either the {{< gloss >}}data plane{{< /gloss >}} or the {{< gloss >}}control plane{{< /gloss >}}. Different components may have different effects on your applications and cluster networking when upgraded.
 
-For installing Istio with support for the {{< gloss >}}ambient{{< /gloss >}} data plane mode in a non-production cluster, we provide a simple Helm chart which bundles all the required Helm charts.
+{{< tip >}}
+For production deployments, it is strongly recommended to install the components separately via Helm to allow for more control during Istio upgrades. Consult the [operations guidelines](/docs/ops/best-practices/deployment/) for production deployment considerations and more details.
+{{< /tip >}}
 
-## Simple install
-
-The `ambient` Helm chart composes all the components that enable the use of Istio's ambient data plane mode:
-
-{{< text syntax=bash snip_id=install_ambient_chart >}}
-$ helm install istio-ambient istio/ambient -n istio-system --create-namespace --wait
-{{< /text >}}
-
-Proceed to [verifying the installation](#verify-the-installation) or [installing an ingress gateway (optional)](#install-an-ingress-gateway-optional)
-
-## Install the components individually
+## Install
 
 ### Install the base component
 
@@ -133,8 +127,7 @@ ztunnel-c2z4s                    1/1     Running   0          10m
 
 ### Verify with the sample application
 
-After installing ambient mode with Helm, you can follow the [Deploy the sample application](/docs/ambient/getting-started/#bookinfo) guide to deploy the sample application and ingress gateways, and then you can
-[add your application to the ambient mesh](/docs/ambient/getting-started/#addtoambient).
+Congratulations! You've successfully installed Istio with support for ambient mode. Continue to the next step to [install the demo application and add it to the ambient mesh](/docs/ambient/getting-started/deploy-sample-app/), or [add your own applications to the ambient mesh](/docs/ambient/usage/add-workloads/)
 
 ## Uninstall
 
@@ -149,39 +142,9 @@ $ kubectl delete namespace istio-ingress
 
 If your Kubernetes cluster doesn't support the `LoadBalancer` service type (`type: LoadBalancer`) with a proper external IP assigned, run the above command without the `--wait` parameter to avoid the infinite wait. See [Installing Gateways](/docs/setup/additional-setup/gateway/) for in-depth documentation on gateway installation.
 
-### Simple uninstall
+### Uninstall Istio
 
-1. Delete the Istio ambient chart:
-
-    {{< tip >}}
-    [By design](https://github.com/helm/community/blob/main/hips/hip-0011.md#deleting-crds),
-    deleting a chart via Helm doesn't delete the installed Custom
-    Resource Definitions (CRDs) installed via the chart.
-    {{< /tip >}}
-
-    {{< text syntax=bash snip_id=delete_ambient_chart >}}
-    $ helm delete istio-ambient -n istio-system --wait
-    {{< /text >}}
-
-1. Delete CRDs installed by Istio (optional)
-
-    {{< warning >}}
-    This will delete all created Istio resources.
-    {{< /warning >}}
-
-    {{< text syntax=bash snip_id=delete_crds_chart >}}
-    $ kubectl get crd -oname | grep --color=never 'istio.io' | xargs kubectl delete
-    {{< /text >}}
-
-1. Delete the `istio-system` namespace:
-
-    {{< text syntax=bash snip_id=delete_system_namespace_chart >}}
-    $ kubectl delete namespace istio-system
-    {{< /text >}}
-
-### Uninstall the components individually
-
-If you installed the charts individually above, you can uninstall Istio and its components by uninstalling those charts individually:
+If you installed the Istio component charts individually above, you can uninstall Istio by uninstalling those charts individually, in reverse order:
 
 1. List all the Istio charts installed in `istio-system` namespace:
 
@@ -192,6 +155,12 @@ If you installed the charts individually above, you can uninstall Istio and its 
     istio-cni       istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    cni-{{< istio_full_version >}}      {{< istio_full_version >}}
     istiod          istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    istiod-{{< istio_full_version >}}   {{< istio_full_version >}}
     ztunnel         istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ztunnel-{{< istio_full_version >}}  {{< istio_full_version >}}
+    {{< /text >}}
+
+1. Delete the Istio ztunnel chart:
+
+    {{< text syntax=bash snip_id=delete_ztunnel >}}
+    $ helm delete ztunnel -n istio-system
     {{< /text >}}
 
 1. Delete the Istio CNI chart:

--- a/content/en/docs/ambient/install/helm-installation/snips.sh
+++ b/content/en/docs/ambient/install/helm-installation/snips.sh
@@ -101,6 +101,10 @@ snip_delete_cni() {
 helm delete istio-cni -n istio-system
 }
 
+snip_delete_ztunnel() {
+helm delete ztunnel -n istio-system
+}
+
 snip_delete_discovery() {
 helm delete istiod -n istio-system
 }

--- a/content/en/docs/ambient/install/helm-installation/snips.sh
+++ b/content/en/docs/ambient/install/helm-installation/snips.sh
@@ -101,10 +101,6 @@ snip_delete_cni() {
 helm delete istio-cni -n istio-system
 }
 
-snip_delete_ztunnel() {
-helm delete ztunnel -n istio-system
-}
-
 snip_delete_discovery() {
 helm delete istiod -n istio-system
 }

--- a/content/en/docs/ambient/install/helm-installation/snips.sh
+++ b/content/en/docs/ambient/install/helm-installation/snips.sh
@@ -25,10 +25,6 @@ helm repo add istio https://istio-release.storage.googleapis.com/charts
 helm repo update
 }
 
-snip_install_ambient_chart() {
-helm install istio-ambient istio/ambient -n istio-system --create-namespace --wait
-}
-
 snip_install_base() {
 helm install istio-base istio/base -n istio-system --create-namespace --wait
 }
@@ -85,29 +81,21 @@ helm delete istio-ingress -n istio-ingress --wait
 kubectl delete namespace istio-ingress
 }
 
-snip_delete_ambient_chart() {
-helm delete istio-ambient -n istio-system --wait
-}
-
-snip_delete_crds_chart() {
-kubectl get crd -oname | grep --color=never 'istio.io' | xargs kubectl delete
-}
-
-snip_delete_system_namespace_chart() {
-kubectl delete namespace istio-system
-}
-
-snip_uninstall_the_components_individually_1() {
+snip_uninstall_istio_1() {
 helm ls -n istio-system
 }
 
-! IFS=$'\n' read -r -d '' snip_uninstall_the_components_individually_1_out <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_uninstall_istio_1_out <<\ENDSNIP
 NAME            NAMESPACE       REVISION    UPDATED                                 STATUS      CHART           APP VERSION
 istio-base      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    base-1.23.0     1.23.0
 istio-cni       istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    cni-1.23.0      1.23.0
 istiod          istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    istiod-1.23.0   1.23.0
 ztunnel         istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ztunnel-1.23.0  1.23.0
 ENDSNIP
+
+snip_delete_ztunnel() {
+helm delete ztunnel -n istio-system
+}
 
 snip_delete_cni() {
 helm delete istio-cni -n istio-system

--- a/content/en/docs/ambient/install/helm-installation/snips.sh
+++ b/content/en/docs/ambient/install/helm-installation/snips.sh
@@ -25,6 +25,10 @@ helm repo add istio https://istio-release.storage.googleapis.com/charts
 helm repo update
 }
 
+snip_install_ambient_chart() {
+helm install istio-ambient istio/ambient -n istio-system --create-namespace --wait
+}
+
 snip_install_base() {
 helm install istio-base istio/base -n istio-system --create-namespace --wait
 }
@@ -41,12 +45,16 @@ snip_install_ztunnel() {
 helm install ztunnel istio/ztunnel -n istio-system --wait
 }
 
-snip_install_ingress() {
-helm install istio-ingress istio/gateway -n istio-ingress --create-namespace --wait
+snip_inspecting_available_chart_configuration_values_1() {
+helm show values istio/istiod
 }
 
-snip_configuration_1() {
-helm show values istio/istiod
+snip_inspecting_available_chart_configuration_values_2() {
+helm show values istio/cni
+}
+
+snip_install_ingress() {
+helm install istio-ingress istio/gateway -n istio-ingress --create-namespace --wait
 }
 
 snip_show_components() {
@@ -72,22 +80,34 @@ istiod-5f4c75464f-gskxf          1/1     Running   0          10m
 ztunnel-c2z4s                    1/1     Running   0          10m
 ENDSNIP
 
-snip_uninstall_1() {
+snip_delete_ingress() {
+helm delete istio-ingress -n istio-ingress --wait
+kubectl delete namespace istio-ingress
+}
+
+snip_delete_ambient_chart() {
+helm delete istio-ambient -n istio-system --wait
+}
+
+snip_delete_crds_chart() {
+kubectl get crd -oname | grep --color=never 'istio.io' | xargs kubectl delete
+}
+
+snip_delete_system_namespace_chart() {
+kubectl delete namespace istio-system
+}
+
+snip_uninstall_the_components_individually_1() {
 helm ls -n istio-system
 }
 
-! IFS=$'\n' read -r -d '' snip_uninstall_1_out <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_uninstall_the_components_individually_1_out <<\ENDSNIP
 NAME            NAMESPACE       REVISION    UPDATED                                 STATUS      CHART           APP VERSION
 istio-base      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    base-1.23.0     1.23.0
 istio-cni       istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    cni-1.23.0      1.23.0
 istiod          istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    istiod-1.23.0   1.23.0
 ztunnel         istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ztunnel-1.23.0  1.23.0
 ENDSNIP
-
-snip_delete_ingress() {
-helm delete istio-ingress -n istio-ingress
-kubectl delete namespace istio-ingress
-}
 
 snip_delete_cni() {
 helm delete istio-cni -n istio-system

--- a/content/en/docs/ambient/install/helm-installation/snips.sh
+++ b/content/en/docs/ambient/install/helm-installation/snips.sh
@@ -29,12 +29,12 @@ snip_install_base() {
 helm install istio-base istio/base -n istio-system --create-namespace --wait
 }
 
-snip_install_cni() {
-helm install istio-cni istio/cni -n istio-system --set profile=ambient --wait
-}
-
 snip_install_discovery() {
 helm install istiod istio/istiod --namespace istio-system --set profile=ambient --wait
+}
+
+snip_install_cni() {
+helm install istio-cni istio/cni -n istio-system --set profile=ambient --wait
 }
 
 snip_install_ztunnel() {
@@ -99,10 +99,6 @@ helm delete ztunnel -n istio-system
 
 snip_delete_cni() {
 helm delete istio-cni -n istio-system
-}
-
-snip_delete_ztunnel() {
-helm delete ztunnel -n istio-system
 }
 
 snip_delete_discovery() {

--- a/content/en/docs/ambient/upgrade/helm-upgrade/snips.sh
+++ b/content/en/docs/ambient/upgrade/helm-upgrade/snips.sh
@@ -37,6 +37,10 @@ snip_manual_crd_upgrade() {
 kubectl apply -f manifests/charts/base/crds
 }
 
+snip_upgrade_ambient_wrapper() {
+helm upgrade istio-ambient istio/ambient -n istio-system --skip-crds
+}
+
 snip_upgrade_base() {
 helm upgrade istio-base manifests/charts/base -n istio-system --skip-crds
 }
@@ -55,10 +59,6 @@ helm upgrade istio-cni istio/cni -n istio-system
 
 snip_upgrade_gateway() {
 helm upgrade istio-ingress istio/gateway -n istio-ingress
-}
-
-snip_show_istiod_values() {
-helm show values istio/istiod
 }
 
 snip_show_components() {

--- a/content/en/docs/ambient/usage/extend-waypoint-wasm/test.sh
+++ b/content/en/docs/ambient/usage/extend-waypoint-wasm/test.sh
@@ -59,7 +59,7 @@ _verify_same snip_verify_the_traffic_via_the_gateway_1 "$snip_verify_the_traffic
 _verify_same snip_verify_the_traffic_via_the_gateway_2 "$snip_verify_the_traffic_via_the_gateway_2_out"
 
 # Deploy a waypoint proxy
-snip_deploy_a_waypoint_proxy_1
+snip_deploy_waypoint_proxy
 
 # verify traffic_without wasmplugin at the waypoint
 _verify_same snip_verify_traffic_without_wasmplugin_at_the_waypoint_1 "$snip_verify_traffic_without_wasmplugin_at_the_waypoint_1_out"


### PR DESCRIPTION
## Description
Fixes https://github.com/istio/istio.io/issues/15167

Note that until at least a 1.23 prerelease build is published, the `ambient` chart will not show up in the documented repo, see https://github.com/istio/release-builder/pull/1849

To test locally in the meantime, you can use the local copies of the chart, so instead of doing:

```
helm install istio-ambient istio/ambient -n istio-system --create-namespace --wait
```
like the doc says, do 

```
helm install ambient ./manifests/charts/ambient -n istio-system --create-namespace --wait
```
(you may need to run `helm dep update ./manifests/charts/ambient` first to populate the depcache)

I left both the individual and wrapper modes in both docs.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
