### PR TITLE
Redo + refresh + update the CNI doc

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -933,6 +933,7 @@ preload
 prepend
 prepending
 prepends
+PriorityClass
 prober
 programmatically
 Prometheus

--- a/content/en/docs/reference/glossary/cni.md
+++ b/content/en/docs/reference/glossary/cni.md
@@ -12,4 +12,4 @@ Istio works with all CNI implementations that follow the CNI standard, in both s
 
 In order to configure mesh traffic redirection, the Istio CNI node agent installs [a chained CNI plugin](/docs/setup/additional-setup/cni/), which runs after all configured CNI interface plugins.
 
-The CNI plugin is optional for {{< gloss >}}sidecar{{< /gloss >}} mode and required for {{< gloss >}}ambient{{< /gloss >}} mode.
+The CNI node agent is optional for {{< gloss >}}sidecar{{< /gloss >}} mode and required for {{< gloss >}}ambient{{< /gloss >}} mode.

--- a/content/en/docs/reference/glossary/cni.md
+++ b/content/en/docs/reference/glossary/cni.md
@@ -10,6 +10,6 @@ The [Container Network Interface (CNI)](https://www.cni.dev/) is the standard us
 
 Istio works with all CNI implementations that follow the CNI standard, in both sidecar and ambient mode.
 
-In order to configure mesh traffic redirection, the Istio CNI node agent installs [a chained CNI plugin](/docs/setup/additional-setup/cni/), which runs after all configured CNI interface plugins.
+In order to configure mesh traffic redirection, Istio includes a [CNI node agent](/docs/setup/additional-setup/cni/). This agent installs a chained CNI plugin, which runs after all configured CNI interface plugins.
 
 The CNI node agent is optional for {{< gloss >}}sidecar{{< /gloss >}} mode and required for {{< gloss >}}ambient{{< /gloss >}} mode.

--- a/content/en/docs/reference/glossary/cni.md
+++ b/content/en/docs/reference/glossary/cni.md
@@ -10,6 +10,6 @@ The [Container Network Interface (CNI)](https://www.cni.dev/) is the standard us
 
 Istio works with all CNI implementations that follow the CNI standard, in both sidecar and ambient mode.
 
-In order to configure mesh traffic redirection, Istio includes [a chained CNI plugin](/docs/setup/additional-setup/cni/), which runs after all configured CNI interface plugins.
+In order to configure mesh traffic redirection, the Istio CNI node agent installs [a chained CNI plugin](/docs/setup/additional-setup/cni/), which runs after all configured CNI interface plugins.
 
 The CNI plugin is optional for {{< gloss >}}sidecar{{< /gloss >}} mode and required for {{< gloss >}}ambient{{< /gloss >}} mode.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -17,7 +17,7 @@ for pods in the Istio mesh.
 
 For the {{< gloss >}}sidecar{{< /gloss >}} data plane mode, it is optional, and removes the requirement of running privileged init containers in every pod in the mesh, replacing that model with a single privileged node agent pod on each Kubernetes node.
 
-For the {{< gloss >}}ambient{{< /gloss >}} data plane mode, it is the only supported mechanism, and must be installed.
+The `istio-cni` agent is **required** in the {{< gloss >}}ambient{{< /gloss >}} data plane mode.
 
 This guide is focused on using the `istio-cni` component as an optional part of the sidecar data plane mode. Consult [the ambient docs](/docs/ambient/) for information on using the ambient data plane mode.
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -155,6 +155,7 @@ The CNI plugin at version `1.x` is compatible with control plane at version `1.x
 which means CNI and control plane can be upgraded in any order, as long as their version difference is within one minor version.
 
 ## Operating clusters with the CNI agent installed
+
 ### Upgrading
 
 When upgrading Istio with [in-place upgrade](/docs/setup/upgrade/in-place/), the

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -113,7 +113,7 @@ Note that if installing `istiod` with the Helm chart according to the [Install w
 $ helm install istiod istio/istiod -n istio-system --set pilot.cni.enabled=true --wait
 {{< /text >}}
 
-#### Additional configuration for the `istio-cni` component
+#### Additional configuration
 
 In addition to the above basic configuration there are additional configuration flags that can be set:
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -73,7 +73,7 @@ In most environments, a basic Istio cluster with the `istio-cni` component enabl
 
 {{< tab name="IstioOperator" category-value="iop" >}}
 
-{{< text bash snip_id=cni_agent_operator_install >}}
+{{< text syntax=bash snip_id=cni_agent_operator_install >}}
 $ cat <<EOF > istio-cni.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -90,7 +90,7 @@ $ istioctl install -f istio-cni.yaml -y
 
 {{< tab name="Helm" category-value="helm" >}}
 
-{{< text bash snip_id=cni_agent_helm_install >}}
+{{< text syntax=bash snip_id=cni_agent_helm_install >}}
 $ helm install istio-cni istio/cni -n istio-system --wait
 {{< /text >}}
 
@@ -109,7 +109,7 @@ You may either install `istio-cni` into `kube-system`, or (recommended) define a
 
 Note that if installing `istiod` with the Helm chart according to the [Install with Helm](/docs/setup/install/helm/#installation-steps) guide, you must install `istiod` with the following extra override value, in order to disable the privileged init container injection:
 
-{{< text bash snip_id=cni_agent_helm_istiod_install >}}
+{{< text syntax=bash snip_id=cni_agent_helm_istiod_install >}}
 $ helm install istiod istio/istiod -n istio-system --set pilot.cni.enabled=true --wait
 {{< /text >}}
 
@@ -178,7 +178,7 @@ spec:
 
 This is not a problem for Helm as the istio-cni is installed separately, and can be upgraded via Helm:
 
-{{< text bash snip_id=cni_agent_helm_upgrade >}}
+{{< text syntax=bash snip_id=cni_agent_helm_upgrade >}}
 $ helm upgrade istio-cni istio/cni -n istio-system --wait
 {{< /text >}}
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -10,10 +10,7 @@ owner: istio/wg-networking-maintainers
 test: yes
 ---
 
-`istio-cni` is a Istio node agent DaemonSet that runs in your cluster. It is used by both Istio {{< gloss >}}data plane{{< /gloss >}} modes.
-
-`istio-cni` runs in your cluster with elevated privileges, and is used to configure traffic redirection
-for pods in the Istio mesh.
+`istio-cni` is an agent which is used to configure traffic redirection for pods in the mesh. It runs as a DaemonSet, on every node, with elevated privileges. `istio-cni` is used by both Istio {{< gloss >}}data plane{{< /gloss >}} modes.
 
 For the {{< gloss >}}sidecar{{< /gloss >}} data plane mode, `istio-cni` is optional. It removes the requirement of running privileged init containers in every pod in the mesh, replacing that model with a single privileged node agent pod on each Kubernetes node.
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -50,7 +50,7 @@ for users and pod deployments.
 
 {{< image width="60%" link="./cni.svg" caption="Istio CNI" >}}
 
-## Prerequisites for using the Istio CNI node agent
+## Prerequisites for use
 
 1. Install Kubernetes with a correctly-configured primary interface CNI plugin. As [supporting CNI plugins is required to implement the Kubernetes network model](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/), you probably already have this if you have a reasonably recent Kubernetes cluster with functional pod networking.
     * AWS EKS, Azure AKS, and IBM Cloud IKS clusters have this capability.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -13,7 +13,7 @@ test: yes
 `istio-cni` is a Istio node agent DaemonSet that runs in your cluster. It is used by both Istio {{< gloss >}}data plane{{< /gloss >}} modes.
 
 `istio-cni` runs in your cluster with elevated privileges, and is used to configure traffic redirection
-for pods in the Istio mesh. 
+for pods in the Istio mesh.
 
 For the {{< gloss >}}sidecar{{< /gloss >}} data plane mode, it is optional, and removes the requirement of running privileged init containers in every pod in the mesh, replacing that model with a single privileged node agent pod on each Kubernetes node.
 
@@ -44,12 +44,12 @@ Requiring Istio users to have elevated Kubernetes RBAC permissions is
 problematic for some organizations' security compliance, as is the requirement to deploy privileged init containers with every workload.
 
 The `istio-cni` node agent is effectively a replacement for the `istio-init` container that enables the same
-networking functionality, but without requiring the use or deployment of privileged init containers in every workload. 
+networking functionality, but without requiring the use or deployment of privileged init containers in every workload.
 
-Instead, `istio-cni` itself runs as a single privileged pod on the node. It uses this privilege to install a [chained CNI plugin](https://www.cni.dev/docs/spec/#section-2-execution-protocol) on the node, which is invoked after your "primary" interface CNI plugin. CNI plugins are invoked dynamically by Kubernetes as a privileged process on the host node whenever a new pod is created, and are able to configure pod networking. 
+Instead, `istio-cni` itself runs as a single privileged pod on the node. It uses this privilege to install a [chained CNI plugin](https://www.cni.dev/docs/spec/#section-2-execution-protocol) on the node, which is invoked after your "primary" interface CNI plugin. CNI plugins are invoked dynamically by Kubernetes as a privileged process on the host node whenever a new pod is created, and are able to configure pod networking.
 
 The Istio chained CNI plugin always runs after the primary interface plugins, identifies user application pods with sidecars requiring traffic redirection, and sets up redirection in the Kubernetes pod lifecycle's network setup phase, thereby removing the need for privileged init containers, as well as the [requirement for `NET_ADMIN` and `NET_RAW` capabilities](/docs/ops/deployment/application-requirements/)
-for users and pod deployments. 
+for users and pod deployments.
 
 {{< image width="60%" link="./cni.svg" caption="Istio CNI" >}}
 
@@ -259,7 +259,7 @@ or other plugin that also follows the spec.
 The Istio CNI plugin operates as a chained CNI plugin. This means its configuration is appended to the list of existing CNI plugins configurations.
 See the [CNI specification reference](https://www.cni.dev/docs/spec/#section-1-network-configuration-format) for further details.
 
-When a pod is created or deleted, the container runtime invokes each plugin in the list in order. 
+When a pod is created or deleted, the container runtime invokes each plugin in the list in order.
 
 The Istio CNI plugin performs actions to set up the application pod's traffic redirection - in the sidecar dataplane mode, this means applying `iptables` rules in the pod's network namespace
 to redirect in-pod traffic to the injected Istio proxy sidecar.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -65,7 +65,7 @@ for users and pod deployments.
     * The Kubernetes documentation highly recommends this for all Kubernetes installations
       where `ServiceAccounts` are utilized.
 
-## Installing the node agent
+## Installing the CNI node agent
 
 ### Install Istio with the `istio-cni` component
 
@@ -115,7 +115,7 @@ Note that if installing `istiod` with the Helm chart according to the [Install w
 $ helm install istiod istio/istiod -n istio-system --set pilot.cni.enabled=true --wait
 {{< /text >}}
 
-#### Additional configuration
+### Additional configuration
 
 In addition to the above basic configuration there are additional configuration flags that can be set:
 
@@ -133,7 +133,7 @@ This race condition is mitigated for the sidecar data plane mode by a "detect an
 Please take a look at [race condition & mitigation](#race-condition--mitigation) section to understand the implication of this mitigation, and for configuration instructions
 {{< /tip >}}
 
-#### Handling init container injection for revisions
+### Handling init container injection for revisions
 
 When installing revisioned control planes with the CNI component enabled,
 `values.pilot.cni.enabled=true` needs to be set for each installed revision, so that the sidecar injector does not attempt inject the `istio-init` init container for that revision.
@@ -154,7 +154,7 @@ spec:
 The CNI plugin at version `1.x` is compatible with control plane at version `1.x-1`, `1.x`, and `1.x+1`,
 which means CNI and control plane can be upgraded in any order, as long as their version difference is within one minor version.
 
-## Operating clusters with the CNI agent installed
+## Operating clusters with the CNI node agent installed
 
 ### Upgrading
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -73,7 +73,7 @@ In most environments, a basic Istio cluster with the `istio-cni` component enabl
 
 {{< tab name="IstioOperator" category-value="iop" >}}
 
-{{< text bash >}}
+{{< text bash snip_id=cni_agent_operator_install >}}
 $ cat <<EOF > istio-cni.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -90,7 +90,7 @@ $ istioctl install -f istio-cni.yaml -y
 
 {{< tab name="Helm" category-value="helm" >}}
 
-{{< text bash >}}
+{{< text bash snip_id=cni_agent_helm_install >}}
 $ helm install istio-cni istio/cni -n istio-system --wait
 {{< /text >}}
 
@@ -109,7 +109,7 @@ You may either install `istio-cni` into `kube-system`, or (recommended) define a
 
 Note that if installing `istiod` with the Helm chart according to the [Install with Helm](/docs/setup/install/helm/#installation-steps) guide, you must install `istiod` with the following extra override value, in order to disable the privileged init container injection:
 
-{{< text bash >}}
+{{< text bash snip_id=cni_agent_helm_istiod_install >}}
 $ helm install istiod istio/istiod -n istio-system --set pilot.cni.enabled=true --wait
 {{< /text >}}
 
@@ -178,7 +178,7 @@ spec:
 
 This is not a problem for Helm as the istio-cni is installed separately, and can be upgraded via Helm:
 
-{{< text bash >}}
+{{< text bash snip_id=cni_agent_helm_upgrade >}}
 $ helm upgrade istio-cni istio/cni -n istio-system --wait
 {{< /text >}}
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -25,7 +25,9 @@ See [compatibility with CNIs](#compatibility-with-other-cni-plugins) for details
 
 Follow this guide to install, configure, and use the Istio CNI node agent with the sidecar data plane mode.
 
-## Sidecar traffic redirection without the Istio CNI node agent
+## How sidecar traffic redirection works
+
+## Using the init container (without the Istio CNI node agent)
 
 By default Istio injects an init container, `istio-init`, in pods deployed in
 the mesh. The `istio-init` container sets up the pod network traffic

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -15,7 +15,7 @@ test: yes
 `istio-cni` runs in your cluster with elevated privileges, and is used to configure traffic redirection
 for pods in the Istio mesh.
 
-For the {{< gloss >}}sidecar{{< /gloss >}} data plane mode, it is optional, and removes the requirement of running privileged init containers in every pod in the mesh, replacing that model with a single privileged node agent pod on each Kubernetes node.
+For the {{< gloss >}}sidecar{{< /gloss >}} data plane mode, `istio-cni` is optional. It removes the requirement of running privileged init containers in every pod in the mesh, replacing that model with a single privileged node agent pod on each Kubernetes node.
 
 The `istio-cni` agent is **required** in the {{< gloss >}}ambient{{< /gloss >}} data plane mode.
 

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -35,7 +35,7 @@ redirection to/from the Istio sidecar proxy. This requires the user or
 service-account deploying pods to the mesh to have sufficient Kubernetes RBAC
 permissions to deploy [containers with the `NET_ADMIN` and `NET_RAW` capabilities](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container).
 
-## Sidecar traffic redirection with the Istio CNI node agent
+### Using the Istio CNI node agent
 
 Requiring Istio users to have elevated Kubernetes RBAC permissions is
 problematic for some organizations' security compliance, as is the requirement to deploy privileged init containers with every workload.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -27,7 +27,7 @@ Follow this guide to install, configure, and use the Istio CNI node agent with t
 
 ## How sidecar traffic redirection works
 
-## Using the init container (without the Istio CNI node agent)
+### Using the init container (without the Istio CNI node agent)
 
 By default Istio injects an init container, `istio-init`, in pods deployed in
 the mesh. The `istio-init` container sets up the pod network traffic
@@ -41,9 +41,7 @@ Requiring Istio users to have elevated Kubernetes RBAC permissions is
 problematic for some organizations' security compliance, as is the requirement to deploy privileged init containers with every workload.
 
 The `istio-cni` node agent is effectively a replacement for the `istio-init` container that enables the same
-networking functionality, but without requiring the use or deployment of privileged init containers in every workload.
-
-Instead, `istio-cni` itself runs as a single privileged pod on the node. It uses this privilege to install a [chained CNI plugin](https://www.cni.dev/docs/spec/#section-2-execution-protocol) on the node, which is invoked after your "primary" interface CNI plugin. CNI plugins are invoked dynamically by Kubernetes as a privileged process on the host node whenever a new pod is created, and are able to configure pod networking.
+networking functionality, but without requiring the use or deployment of privileged init containers in every workload. Instead, `istio-cni` itself runs as a single privileged pod on the node. It uses this privilege to install a [chained CNI plugin](https://www.cni.dev/docs/spec/#section-2-execution-protocol) on the node, which is invoked after your "primary" interface CNI plugin. CNI plugins are invoked dynamically by Kubernetes as a privileged process on the host node whenever a new pod is created, and are able to configure pod networking.
 
 The Istio chained CNI plugin always runs after the primary interface plugins, identifies user application pods with sidecars requiring traffic redirection, and sets up redirection in the Kubernetes pod lifecycle's network setup phase, thereby removing the need for privileged init containers, as well as the [requirement for `NET_ADMIN` and `NET_RAW` capabilities](/docs/ops/deployment/application-requirements/)
 for users and pod deployments.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -16,7 +16,7 @@ For the {{< gloss >}}sidecar{{< /gloss >}} data plane mode, the Istio CNI node a
 
 The Istio CNI node agent is **required** in the {{< gloss >}}ambient{{< /gloss >}} data plane mode.
 
-This guide is focused on using the Istio CNI node agent as an optional part of the sidecar data plane mode. Consult [the ambient docs](/docs/ambient/) for information on using the ambient data plane mode.
+This guide is focused on using the Istio CNI node agent as an optional part of the sidecar data plane mode. Consult [the ambient mode documentation](/docs/ambient/) for information on using the ambient data plane mode.
 
 {{< tip >}}
 Note: The Istio CNI node agent _does not_ replace your cluster's existing {{< gloss="cni" >}}CNI{{< /gloss >}}. Among other things, it installs a _chained_ CNI plugin, which is designed to be layered on top of another, previously-installed primary interface CNI, such as [Calico](https://docs.projectcalico.org), or the cluster CNI used by your cloud provider.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -65,6 +65,8 @@ for users and pod deployments.
     * The Kubernetes documentation highly recommends this for all Kubernetes installations
       where `ServiceAccounts` are utilized.
 
+## Installing the node agent
+
 ### Install Istio with the `istio-cni` component
 
 In most environments, a basic Istio cluster with the `istio-cni` component enabled can be installed using the following commands:

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -156,7 +156,8 @@ spec:
 The CNI plugin at version `1.x` is compatible with control plane at version `1.x-1`, `1.x`, and `1.x+1`,
 which means CNI and control plane can be upgraded in any order, as long as their version difference is within one minor version.
 
-### Upgrading the `istio-cni` component
+## Operating clusters with the CNI agent installed
+### Upgrading
 
 When upgrading Istio with [in-place upgrade](/docs/setup/upgrade/in-place/), the
 CNI component can be upgraded together with the control plane using one `IstioOperator` resource.

--- a/content/en/docs/setup/additional-setup/cni/snips.sh
+++ b/content/en/docs/setup/additional-setup/cni/snips.sh
@@ -20,7 +20,7 @@
 #          docs/setup/additional-setup/cni/index.md
 ####################################################################################################
 
-snip_install_istio_with_the_istiocni_component_1() {
+snip_cni_agent_operator_install() {
 cat <<EOF > istio-cni.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -33,11 +33,11 @@ EOF
 istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING=true -f istio-cni.yaml -y
 }
 
-snip_install_istio_with_the_istiocni_component_2() {
+snip_cni_agent_helm_install() {
 helm install istio-cni istio/cni -n istio-system --wait
 }
 
-snip_install_istio_with_the_istiocni_component_3() {
+snip_cni_agent_helm_istiod_install() {
 helm install istiod istio/istiod -n istio-system --set pilot.cni.enabled=true --wait
 }
 
@@ -68,6 +68,6 @@ spec:
         - istio-system
 ENDSNIP
 
-snip_upgrading_the_istiocni_component_2() {
+snip_cni_agent_helm_upgrade() {
 helm upgrade istio-cni istio/cni -n istio-system --wait
 }

--- a/content/en/docs/setup/additional-setup/cni/snips.sh
+++ b/content/en/docs/setup/additional-setup/cni/snips.sh
@@ -54,7 +54,7 @@ spec:
   ...
 ENDSNIP
 
-! IFS=$'\n' read -r -d '' snip_upgrading_the_istiocni_component_1 <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_upgrading_1 <<\ENDSNIP
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:

--- a/content/en/docs/setup/additional-setup/cni/snips.sh
+++ b/content/en/docs/setup/additional-setup/cni/snips.sh
@@ -20,44 +20,41 @@
 #          docs/setup/additional-setup/cni/index.md
 ####################################################################################################
 
-snip_install_istio_with_cni_plugin_1() {
+snip_install_istio_with_the_istiocni_component_1() {
 cat <<EOF > istio-cni.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
   components:
     cni:
+      namespace: istio-system
       enabled: true
 EOF
 istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING=true -f istio-cni.yaml -y
 }
 
-snip_install_istio_with_cni_plugin_2() {
-helm install istio-cni istio/cni -n kube-system --wait
+snip_install_istio_with_the_istiocni_component_2() {
+helm install istio-cni istio/cni -n istio-system --wait
 }
 
-snip_installing_with_helm_1() {
-helm install istiod istio/istiod -n istio-system --set istio_cni.enabled=true --wait
+snip_install_istio_with_the_istiocni_component_3() {
+helm install istiod istio/istiod -n istio-system --set pilot.cni.enabled=true --wait
 }
 
-! IFS=$'\n' read -r -d '' snip_hosted_kubernetes_settings_1 <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_handling_init_container_injection_for_revisions_1 <<\ENDSNIP
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
-  components:
-    cni:
-      enabled: true
-      namespace: kube-system
+  revision: REVISION_NAME
+  ...
   values:
-    cni:
-      cniBinDir: /home/kubernetes/bin
+    pilot:
+      cni:
+        enabled: true
+  ...
 ENDSNIP
 
-snip_hosted_kubernetes_settings_2() {
-istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING=true --set profile=openshift
-}
-
-! IFS=$'\n' read -r -d '' snip_upgrade_1 <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_upgrading_the_istiocni_component_1 <<\ENDSNIP
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
@@ -69,17 +66,8 @@ spec:
     cni:
       excludeNamespaces:
         - istio-system
-        - kube-system
 ENDSNIP
 
-! IFS=$'\n' read -r -d '' snip_upgrade_2 <<\ENDSNIP
-apiVersion: install.istio.io/v1alpha1
-kind: IstioOperator
-spec:
-  revision: REVISION_NAME
-  ...
-  values:
-    istio_cni:
-      enabled: true
-  ...
-ENDSNIP
+snip_upgrading_the_istiocni_component_2() {
+helm upgrade istio-cni istio/cni -n istio-system --wait
+}

--- a/content/en/docs/setup/additional-setup/cni/test.sh
+++ b/content/en/docs/setup/additional-setup/cni/test.sh
@@ -32,8 +32,8 @@ get_productpage() {
 # Test helm install snip
 kubectl create namespace istio-system
 helm --set global.tag="${ISTIO_IMAGE_VERSION=SHOULD_BE_SET}"."${ISTIO_LONG_SHA=latest}" install istio-base manifests/charts/base -n istio-system --set defaultRevision=default
-_rewrite_helm_repo snip_installing_with_helm_1
-_rewrite_helm_repo snip_install_istio_with_cni_plugin_2
+_rewrite_helm_repo snip_cni_agent_helm_install
+_rewrite_helm_repo snip_cni_agent_helm_istiod_install
 _wait_for_deployment istio-system istiod
 _wait_for_daemonset kube-system istio-cni-node
 helm delete istio-cni -n kube-system
@@ -42,7 +42,7 @@ helm delete istio-base -n istio-system
 kubectl delete ns istio-system
 
 # Test istioctl install snip
-snip_install_istio_with_cni_plugin_1
+cni_agent_operator_install
 _wait_for_deployment istio-system istiod
 _wait_for_daemonset istio-system istio-cni-node
 

--- a/content/en/docs/setup/additional-setup/cni/test.sh
+++ b/content/en/docs/setup/additional-setup/cni/test.sh
@@ -42,7 +42,7 @@ helm delete istio-base -n istio-system
 kubectl delete ns istio-system
 
 # Test istioctl install snip
-cni_agent_operator_install
+snip_cni_agent_operator_install
 _wait_for_deployment istio-system istiod
 _wait_for_daemonset istio-system istio-cni-node
 

--- a/content/en/docs/setup/additional-setup/cni/test.sh
+++ b/content/en/docs/setup/additional-setup/cni/test.sh
@@ -35,8 +35,8 @@ helm --set global.tag="${ISTIO_IMAGE_VERSION=SHOULD_BE_SET}"."${ISTIO_LONG_SHA=l
 _rewrite_helm_repo snip_cni_agent_helm_install
 _rewrite_helm_repo snip_cni_agent_helm_istiod_install
 _wait_for_deployment istio-system istiod
-_wait_for_daemonset kube-system istio-cni-node
-helm delete istio-cni -n kube-system
+_wait_for_daemonset istio-system istio-cni-node
+helm delete istio-cni -n istio-system
 helm delete istiod -n istio-system
 helm delete istio-base -n istio-system
 kubectl delete ns istio-system


### PR DESCRIPTION
A good chunk of the information in this doc is outdated, no longer relevant, or otherwise needs some TLC.

Additionally, I've tried to more clearly address some of the actual things people get stuck on, and recontextualize some of the content as sidecar-specific (in light of ambient)

(also gets https://github.com/istio/istio.io/issues/15270 in passing, which I didn't notice until now)

There's still too much a mixture of "architectural explainer" and "instructional guide" imo, and figuring out how to share some or all of the former between ambient and sidecar docs is TBD.

Signed-off-by: Benjamin Leggett <benjamin.leggett@solo.io>