### PR TITLE
Fix some typos and format problem docs

### DIFF
--- a/content/en/docs/ambient/getting-started/cleanup/index.md
+++ b/content/en/docs/ambient/getting-started/cleanup/index.md
@@ -1,4 +1,3 @@
-
 ---
 title: Cleanup
 description: Delete Istio and associated resources.

--- a/content/en/docs/overview/what-is-istio/index.md
+++ b/content/en/docs/overview/what-is-istio/index.md
@@ -17,7 +17,7 @@ Istio is an open source service mesh that layers transparently onto existing dis
 
 Istio is designed for extensibility and can handle a diverse range of deployment needs. Istio’s {{< gloss >}}control plane{{< /gloss >}} runs on Kubernetes, and you can add applications deployed in that cluster to your mesh, [extend the mesh to other clusters](/docs/ops/deployment/deployment-models/), or even [connect VMs or other endpoints](/docs/ops/deployment/vm-architecture/) running outside of Kubernetes.
 
-A large ecosystem of contributors, partners, integrations, and distributors extend and leverage Istio for a wide variety of scenarios. You can install Istio yourself, or a [large number of vendors](/about/ecosystem)) have products that integrate Istio and manage it for you.
+A large ecosystem of contributors, partners, integrations, and distributors extend and leverage Istio for a wide variety of scenarios. You can install Istio yourself, or a [large number of vendors](/about/ecosystem) have products that integrate Istio and manage it for you.
 
 ## How it works
 

--- a/content/en/docs/overview/why-choose-istio/index.md
+++ b/content/en/docs/overview/why-choose-istio/index.md
@@ -27,9 +27,9 @@ Istio inherits all the power and flexibility of Envoy, including world-class ext
 
 ## Community
 
- Istio is a true community project. In 2023, there were 10 companies who made over 1,000 contributions each to Istio, with no single company exceeding 25%. ([See the numbers here](https://istio.devstats.cncf.io/d/5/companies-table?var-period_name=Last%20year&var-metric=contributions&orgId=1)).
+Istio is a true community project. In 2023, there were 10 companies who made over 1,000 contributions each to Istio, with no single company exceeding 25%. ([See the numbers here](https://istio.devstats.cncf.io/d/5/companies-table?var-period_name=Last%20year&var-metric=contributions&orgId=1)).
 
- No other service mesh project has the breadth of support from the industry as Istio.
+No other service mesh project has the breadth of support from the industry as Istio.
 
 ## Packages
 
@@ -45,7 +45,7 @@ We do - where it's appropriate! Istio can be configured to use {{< gloss >}}eBPF
 
 Why not use it for everything? No-one does, because no-one actually can.
 
- eBPF is a virtual machine that runs inside the Linux kernel. It was designed for functions guaranteed to complete in a limited compute envelope to avoid destabilizing kernel behavior, such as those that perform simple L3 traffic routing or application observability. It was not designed for long running or complex functions like those found in Envoy: that's why operating systems have [user space](https://en.wikipedia.org/wiki/User_space_and_kernel_space)! eBPF maintainers have theorized that it could eventually be extended to support running a program as complex as Envoy, but this is a science project and unlikely to have real world practicality.
+eBPF is a virtual machine that runs inside the Linux kernel. It was designed for functions guaranteed to complete in a limited compute envelope to avoid destabilizing kernel behavior, such as those that perform simple L3 traffic routing or application observability. It was not designed for long running or complex functions like those found in Envoy: that's why operating systems have [user space](https://en.wikipedia.org/wiki/User_space_and_kernel_space)! eBPF maintainers have theorized that it could eventually be extended to support running a program as complex as Envoy, but this is a science project and unlikely to have real world practicality.
 
 Other meshes that claim to "use eBPF" actually use a per-node Envoy proxy, or other user space tools, for much of their functionality.
 


### PR DESCRIPTION
## Description

Fix some typo and format problem for ambient cleanup doc and overview doc:
- remove the new line on top of ambient cleanup doc
- remove some typo spaces for overview doc
- remove dup `)` in what is istio overview doc

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
