### PR TITLE
wasm: update link

### DIFF
--- a/content/en/docs/concepts/wasm/index.md
+++ b/content/en/docs/concepts/wasm/index.md
@@ -45,5 +45,5 @@ You can follow [this guide](https://github.com/istio-ecosystem/wasm-extensions/b
 - [Proxy-Wasm C++ SDK](https://github.com/proxy-wasm/proxy-wasm-cpp-sdk)
 - [Proxy-Wasm Rust SDK](https://github.com/proxy-wasm/proxy-wasm-rust-sdk)
 - [Proxy-Wasm AssemblyScript SDK](https://github.com/solo-io/proxy-runtime)
-- [WebAssembly Hub](https://docs.solo.io/web-assembly-hub/latest/tutorial_code/)
+- [WebAssembly Hub](https://webassemblyhub.io/)
 - [WebAssembly Extensions For Network Proxies (video)](https://www.youtube.com/watch?v=OIUPf8m7CGA)


### PR DESCRIPTION
## Description

The old [link](https://docs.solo.io/web-assembly-hub/latest/tutorial_code/)) is 404

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
