### PR TITLE
Fix docs on customTags

### DIFF
--- a/content/en/docs/tasks/observability/distributed-tracing/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/telemetry-api/index.md
@@ -153,7 +153,7 @@ You can customize the tags using any of the three supported options below.
         - providers:
             - name: "zipkin"
           randomSamplingPercentage: 100.00
-          custom_tags:
+          customTags:
             my_tag_header:
               header:
                 name: <CLIENT-HEADER>

--- a/content/en/docs/tasks/observability/distributed-tracing/telemetry-api/snips.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/telemetry-api/snips.sh
@@ -114,7 +114,7 @@ spec:
     - providers:
         - name: "zipkin"
       randomSamplingPercentage: 100.00
-      custom_tags:
+      customTags:
         my_tag_header:
           header:
             name: <CLIENT-HEADER>


### PR DESCRIPTION
it has a typo and that was the one example I used to copy/pasta

Just fixes the docs on custom-tags.