### PR TITLE
[zh] Sync #15392 WASM Hub link fix into Chinese

### DIFF
--- a/content/zh/docs/concepts/wasm/index.md
+++ b/content/zh/docs/concepts/wasm/index.md
@@ -47,5 +47,5 @@ C++ 实现 Wasm 扩展。
 - [Proxy-Wasm C++ SDK](https://github.com/proxy-wasm/proxy-wasm-cpp-sdk)
 - [Proxy-Wasm Rust SDK](https://github.com/proxy-wasm/proxy-wasm-rust-sdk)
 - [Proxy-Wasm AssemblyScript SDK](https://github.com/solo-io/proxy-runtime)
-- [WebAssembly Hub](https://docs.solo.io/web-assembly-hub/latest/tutorial_code/)
+- [WebAssembly Hub](https://webassemblyhub.io/)
 - [网络代理的 WebAssembly 扩展（视频）](https://www.youtube.com/watch?v=OIUPf8m7CGA)


### PR DESCRIPTION
## Description

Sync #15392 WASM Hub link fix into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
