### PR TITLE
[zh] Sync #15394 customTags fix for otel doc into Chinese

### DIFF
--- a/content/zh/docs/tasks/observability/distributed-tracing/telemetry-api/index.md
+++ b/content/zh/docs/tasks/observability/distributed-tracing/telemetry-api/index.md
@@ -148,7 +148,7 @@ EOF
         - providers:
             - name: "zipkin"
           randomSamplingPercentage: 100.00
-          custom_tags:
+          customTags:
             my_tag_header:
               header:
                 name: <CLIENT-HEADER>


### PR DESCRIPTION
## Description

Sync #15394 customTags fix for otel doc into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
