### PR TITLE
New Google Analytics property IDs

### DIFF
--- a/data/args.yml
+++ b/data/args.yml
@@ -37,9 +37,9 @@ archive_search_engine_id: "002184991200833970123:iwwf17ikgf4"
 docs_search_engine_id: "59d95045a95d16a68"
 
 # we use different site analytics ids for each incarnation of the site
-main_analytics_id: "UA-98480406-1"
-preliminary_analytics_id: "UA-98480406-3"
-archive_analytics_id: "UA-98480406-2"
+main_analytics_id: "G-RNS1643NL0"
+preliminary_analytics_id: "G-EQ3WMYC8TX"
+archive_analytics_id: "G-5XBWY4YJ1E"
 
 # The list of supported languages. Not every content available is translated
 supported_languages:


### PR DESCRIPTION
This PR replaces the Universal Analytics accounts that were restricted to only be accessed by users at google.com, and adds new accounts for Google Analytics 4 that are owned by admin@istio.io.

- [x] Docs