### PR TITLE
Fixup some waypoint docs issues

### DIFF
--- a/content/en/docs/ambient/usage/extend-waypoint-wasm/index.md
+++ b/content/en/docs/ambient/usage/extend-waypoint-wasm/index.md
@@ -83,7 +83,7 @@ Waypoint proxies play a crucial role in Istio's ambient mode, facilitating secur
 
 ### Deploy a waypoint proxy
 
-Follow the [waypoint deployment instructions](/docs/ambient/getting-started/#layer-7-authorization-policy) to deploy a waypoint proxy in the bookinfo namespace.
+Follow the [waypoint deployment instructions](docs/ambient/usage/waypoint/#deploy-a-waypoint-proxy) to deploy a waypoint proxy in the bookinfo namespace.
 
 {{< text bash >}}
 $ istioctl x waypoint apply --enroll-namespace --wait

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -46,7 +46,7 @@ After the waypoint is deployed, the entire namespace (or whichever services or p
 
 Before you deploy a waypoint proxy for a specific namespace, confirm the namespace is labeled with `istio.io/dataplane-mode: ambient`:
 
-{{< text bash snip_id=check_ns_label >}}
+{{< text syntax=bash snip_id=check_ns_label >}}
 $ kubectl get ns -L istio.io/dataplane-mode
 NAME              STATUS   AGE   DATAPLANE-MODE
 istio-system      Active   24h
@@ -55,7 +55,7 @@ default           Active   24h   ambient
 
 `istioctl` can generate a Kubernetes Gateway resource for a waypoint proxy. For example, to generate a waypoint proxy named `waypoint` for the `default` namespace that can process traffic for services in the namespace:
 
-{{< text bash snip_id=gen_waypoint_resource >}}
+{{< text syntax=bash snip_id=gen_waypoint_resource >}}
 $ istioctl waypoint generate --for service -n default
 kind: Gateway
 metadata:
@@ -75,14 +75,14 @@ Note the Gateway resource has the `istio-waypoint` label set to `gatewayClassNam
 
 To deploy a waypoint proxy directly, use `apply` instead of `generate`:
 
-{{< text bash snip_id=apply_waypoint >}}
+{{< text syntax=bash snip_id=apply_waypoint >}}
 $ istioctl waypoint apply -n default
 waypoint default/namespace applied
 {{< /text >}}
 
 Or, you can deploy the generated Gateway resource:
 
-{{< text bash >}}
+{{< text syntax=bash >}}
 $ kubectl apply -f - <<EOF
 kind: Gateway
 metadata:
@@ -128,7 +128,7 @@ Most users will want to apply a waypoint to an entire namespace, and we recommen
 
 If you use `istioctl` to deploy your namespace waypoint, you can use the `--enroll-namespace` parameter to automatically label a namespace:
 
-{{< text bash snip_id=enroll_ns_waypoint >}}
+{{< text syntax=bash snip_id=enroll_ns_waypoint >}}
 $ istioctl waypoint apply -n default --enroll-namespace
 waypoint default/waypoint applied
 namespace default labeled with "istio.io/use-waypoint: waypoint"
@@ -136,7 +136,7 @@ namespace default labeled with "istio.io/use-waypoint: waypoint"
 
 Alternatively, you may add the `istio.io/use-waypoint: waypoint` label to the `default` namespace using `kubectl`:
 
-{{< text bash >}}
+{{< text syntax=bash >}}
 $ kubectl label ns default istio.io/use-waypoint=waypoint
 namespace/default labeled
 {{< /text >}}
@@ -154,14 +154,14 @@ If the `istio.io/use-waypoint` label exists on both a namespace and a service, t
 
 Using the services from the sample [bookinfo application](/docs/examples/bookinfo/), we can deploy a waypoint called `reviews-svc-waypoint` for the `reviews` service:
 
-{{< text bash >}}
+{{< text syntax=bash >}}
 $ istioctl waypoint apply -n default --name reviews-svc-waypoint
 waypoint default/reviews-svc-waypoint applied
 {{< /text >}}
 
 Label the `reviews` service to use the `reviews-svc-waypoint` waypoint:
 
-{{< text bash >}}
+{{< text syntax=bash >}}
 $ kubectl label service reviews istio.io/use-waypoint=reviews-svc-waypoint
 service/reviews labeled
 {{< /text >}}
@@ -176,14 +176,14 @@ Deploy a waypoint called `reviews-v2-pod-waypoint` for the `reviews-v2` pod.
 Recall the default for waypoints is to target services; as we explicitly want to target a pod, we need to use the `istio.io/waypoint-for: workload` label, which we can generate by using the `--for workload` parameter to istioctl.
 {{< /tip >}}
 
-{{< text bash >}}
+{{< text syntax=bash >}}
 $ istioctl waypoint apply -n default --name reviews-v2-pod-waypoint --for workload
 waypoint default/reviews-v2-pod-waypoint applied
 {{< /text >}}
 
 Label the `reviews-v2` pod to use the `reviews-v2-pod-waypoint` waypoint:
 
-{{< text bash >}}
+{{< text syntax=bash >}}
 $ kubectl label pod -l version=v2,app=reviews istio.io/use-waypoint=reviews-v2-pod-waypoint
 pod/reviews-v2-5b667bcbf8-spnnh labeled
 {{< /text >}}

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -6,7 +6,7 @@ aliases:
   - /docs/ops/ambient/usage/waypoint
   - /latest/docs/ops/ambient/usage/waypoint
 owner: istio/wg-networking-maintainers
-test: no
+test: yes
 ---
 
 A **waypoint proxy** is an optional deployment of the Envoy-based proxy to add Layer 7 (L7) processing to a defined set of workloads.
@@ -31,13 +31,22 @@ When you configure redirection to a waypoint, traffic will be forwarded by ztunn
 
 ## Deploy a waypoint proxy
 
-Waypoint proxies are deployed declaratively using Kubernetes Gateway resources. You can use istioctl experimental subcommands to generate, apply or list these resources.
+Waypoint proxies are deployed using standard Kubernetes Gateway resources. 
+
+You need to install the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) CRDs, which don’t come installed by default on most Kubernetes clusters:
+
+{{< text syntax=bash snip_id=install_k8s_gateway_api >}}
+$ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
+  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.1.0" | kubectl apply -f -; }
+{{< /text >}}
+
+You can use istioctl waypoint subcommands to generate, apply or list these resources.
 
 After the waypoint is deployed, the entire namespace (or whichever services or pods you choose) must be [enrolled](#useawaypoint) to use it.
 
 Before you deploy a waypoint proxy for a specific namespace, confirm the namespace is labeled with `istio.io/dataplane-mode: ambient`:
 
-{{< text bash >}}
+{{< text bash snip_id=check_ns_label >}}
 $ kubectl get ns -L istio.io/dataplane-mode
 NAME              STATUS   AGE   DATAPLANE-MODE
 istio-system      Active   24h
@@ -46,8 +55,8 @@ default           Active   24h   ambient
 
 `istioctl` can generate a Kubernetes Gateway resource for a waypoint proxy. For example, to generate a waypoint proxy named `waypoint` for the `default` namespace that can process traffic for services in the namespace:
 
-{{< text bash >}}
-$ istioctl experimental waypoint generate --for service -n default
+{{< text bash snip_id=gen_waypoint_resource >}}
+$ istioctl waypoint generate --for service -n default
 kind: Gateway
 metadata:
   labels:
@@ -66,8 +75,8 @@ Note the Gateway resource has the `istio-waypoint` label set to `gatewayClassNam
 
 To deploy a waypoint proxy directly, use `apply` instead of `generate`:
 
-{{< text bash >}}
-$ istioctl experimental waypoint apply -n default
+{{< text bash snip_id=apply_waypoint >}}
+$ istioctl waypoint apply -n default
 waypoint default/namespace applied
 {{< /text >}}
 
@@ -98,7 +107,7 @@ By default, a waypoint will only handle traffic destined for **services** in its
 
 It is also possible for the waypoint to handle all traffic, only handle traffic sent directly to **workloads** (pods or VMs) in the cluster, or no traffic at all. The types of traffic that will be redirected to the waypoint are determined by the `istio.io/waypoint-for` label on the `Gateway` object.
 
-The `--for` parameter to `istioctl experimental waypoint apply` can be used to change the [traffic type](#waypoint-traffic-types) redirected to the waypoint:
+The `--for` parameter to `istioctl waypoint apply` can be used to change the [traffic type](#waypoint-traffic-types) redirected to the waypoint:
 
 | `waypoint-for` value | Traffic type |
 | -------------------- | ------------ |
@@ -119,8 +128,8 @@ Most users will want to apply a waypoint to an entire namespace, and we recommen
 
 If you use `istioctl` to deploy your namespace waypoint, you can use the `--enroll-namespace` parameter to automatically label a namespace:
 
-{{< text bash >}}
-$ istioctl experimental waypoint apply -n default --enroll-namespace
+{{< text bash snip_id=enroll_ns_waypoint >}}
+$ istioctl waypoint apply -n default --enroll-namespace
 waypoint default/waypoint applied
 namespace default labeled with "istio.io/use-waypoint: waypoint"
 {{< /text >}}
@@ -146,7 +155,7 @@ If the `istio.io/use-waypoint` label exists on both a namespace and a service, t
 Using the services from the sample [bookinfo application](/docs/examples/bookinfo/), we can deploy a waypoint called `reviews-svc-waypoint` for the `reviews` service:
 
 {{< text bash >}}
-$ istioctl experimental waypoint apply -n default --name reviews-svc-waypoint
+$ istioctl waypoint apply -n default --name reviews-svc-waypoint
 waypoint default/reviews-svc-waypoint applied
 {{< /text >}}
 
@@ -168,7 +177,7 @@ Recall the default for waypoints is to target services; as we explicitly want to
 {{< /tip >}}
 
 {{< text bash >}}
-$ istioctl experimental waypoint apply -n default --name reviews-v2-pod-waypoint --for workload
+$ istioctl waypoint apply -n default --name reviews-v2-pod-waypoint --for workload
 waypoint default/reviews-v2-pod-waypoint applied
 {{< /text >}}
 

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -189,3 +189,11 @@ pod/reviews-v2-5b667bcbf8-spnnh labeled
 {{< /text >}}
 
 Any requests from pods in the ambient mesh to the `reviews-v2` pod IP will now be routed through the `reviews-v2-pod-waypoint` waypoint for L7 processing and policy enforcement.
+
+### Cleaning up
+
+You can remove all waypoints from a namespace by doing the following:
+
+{{< text syntax=bash snip_id=delete_waypoint >}}
+$ istioctl waypoint delete --all -n default
+{{< /text >}}

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -77,7 +77,7 @@ To deploy a waypoint proxy directly, use `apply` instead of `generate`:
 
 {{< text syntax=bash snip_id=apply_waypoint >}}
 $ istioctl waypoint apply -n default
-waypoint default/namespace applied
+waypoint default/waypoint applied
 {{< /text >}}
 
 Or, you can deploy the generated Gateway resource:
@@ -196,4 +196,5 @@ You can remove all waypoints from a namespace by doing the following:
 
 {{< text syntax=bash snip_id=delete_waypoint >}}
 $ istioctl waypoint delete --all -n default
+$ kubectl label ns default istio.io/use-waypoint-
 {{< /text >}}

--- a/content/en/docs/ambient/usage/waypoint/snips.sh
+++ b/content/en/docs/ambient/usage/waypoint/snips.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2153,SC2155,SC2164
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          docs/ambient/usage/waypoint/index.md
+####################################################################################################
+
+snip_install_k8s_gateway_api() {
+kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
+  { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v1.1.0" | kubectl apply -f -; }
+}
+
+snip_check_ns_label() {
+kubectl get ns -L istio.io/dataplane-mode
+}
+
+! IFS=$'\n' read -r -d '' snip_check_ns_label_out <<\ENDSNIP
+NAME              STATUS   AGE   DATAPLANE-MODE
+istio-system      Active   24h
+default           Active   24h   ambient
+ENDSNIP
+
+snip_gen_waypoint_resource() {
+istioctl waypoint generate --for service -n default
+}
+
+! IFS=$'\n' read -r -d '' snip_gen_waypoint_resource_out <<\ENDSNIP
+kind: Gateway
+metadata:
+  labels:
+    istio.io/waypoint-for: service
+  name: waypoint
+  namespace: default
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE
+ENDSNIP
+
+snip_apply_waypoint() {
+istioctl waypoint apply -n default
+}
+
+! IFS=$'\n' read -r -d '' snip_apply_waypoint_out <<\ENDSNIP
+waypoint default/namespace applied
+ENDSNIP
+
+snip_deploy_a_waypoint_proxy_5() {
+kubectl apply -f - <<EOF
+kind: Gateway
+metadata:
+  labels:
+    istio.io/waypoint-for: service
+  name: waypoint
+  namespace: default
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE
+EOF
+}
+
+snip_enroll_ns_waypoint() {
+istioctl waypoint apply -n default --enroll-namespace
+}
+
+! IFS=$'\n' read -r -d '' snip_enroll_ns_waypoint_out <<\ENDSNIP
+waypoint default/waypoint applied
+namespace default labeled with "istio.io/use-waypoint: waypoint"
+ENDSNIP
+
+snip_use_a_waypoint_proxy_2() {
+kubectl label ns default istio.io/use-waypoint=waypoint
+}
+
+! IFS=$'\n' read -r -d '' snip_use_a_waypoint_proxy_2_out <<\ENDSNIP
+namespace/default labeled
+ENDSNIP
+
+snip_configure_a_service_to_use_a_specific_waypoint_1() {
+istioctl waypoint apply -n default --name reviews-svc-waypoint
+}
+
+! IFS=$'\n' read -r -d '' snip_configure_a_service_to_use_a_specific_waypoint_1_out <<\ENDSNIP
+waypoint default/reviews-svc-waypoint applied
+ENDSNIP
+
+snip_configure_a_service_to_use_a_specific_waypoint_2() {
+kubectl label service reviews istio.io/use-waypoint=reviews-svc-waypoint
+}
+
+! IFS=$'\n' read -r -d '' snip_configure_a_service_to_use_a_specific_waypoint_2_out <<\ENDSNIP
+service/reviews labeled
+ENDSNIP
+
+snip_configure_a_pod_to_use_a_specific_waypoint_1() {
+istioctl waypoint apply -n default --name reviews-v2-pod-waypoint --for workload
+}
+
+! IFS=$'\n' read -r -d '' snip_configure_a_pod_to_use_a_specific_waypoint_1_out <<\ENDSNIP
+waypoint default/reviews-v2-pod-waypoint applied
+ENDSNIP
+
+snip_configure_a_pod_to_use_a_specific_waypoint_2() {
+kubectl label pod -l version=v2,app=reviews istio.io/use-waypoint=reviews-v2-pod-waypoint
+}
+
+! IFS=$'\n' read -r -d '' snip_configure_a_pod_to_use_a_specific_waypoint_2_out <<\ENDSNIP
+pod/reviews-v2-5b667bcbf8-spnnh labeled
+ENDSNIP

--- a/content/en/docs/ambient/usage/waypoint/snips.sh
+++ b/content/en/docs/ambient/usage/waypoint/snips.sh
@@ -127,3 +127,7 @@ kubectl label pod -l version=v2,app=reviews istio.io/use-waypoint=reviews-v2-pod
 ! IFS=$'\n' read -r -d '' snip_configure_a_pod_to_use_a_specific_waypoint_2_out <<\ENDSNIP
 pod/reviews-v2-5b667bcbf8-spnnh labeled
 ENDSNIP
+
+snip_delete_waypoint() {
+istioctl waypoint delete --all -n default
+}

--- a/content/en/docs/ambient/usage/waypoint/snips.sh
+++ b/content/en/docs/ambient/usage/waypoint/snips.sh
@@ -59,7 +59,7 @@ istioctl waypoint apply -n default
 }
 
 ! IFS=$'\n' read -r -d '' snip_apply_waypoint_out <<\ENDSNIP
-waypoint default/namespace applied
+waypoint default/waypoint applied
 ENDSNIP
 
 snip_deploy_a_waypoint_proxy_5() {
@@ -130,4 +130,5 @@ ENDSNIP
 
 snip_delete_waypoint() {
 istioctl waypoint delete --all -n default
+kubectl label ns default istio.io/use-waypoint-
 }

--- a/content/en/docs/ambient/usage/waypoint/test.sh
+++ b/content/en/docs/ambient/usage/waypoint/test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154
+
+# Copyright 2024 Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# @setup profile=ambient
+
+set -e
+set -u
+set -o pipefail
+
+source "content/en/docs/ambient/usage/waypoint/snips.sh"
+
+snip_install_k8s_gateway_api
+
+ _wait_for_deployment istio-system istiod
+ _wait_for_daemonset istio-system ztunnel
+ _wait_for_daemonset istio-system istio-cni-node
+
+snip_check_ns_label
+snip_gen_waypoint_resource
+snip_apply_waypoint
+snip_enroll_ns_waypoint
+
+# snip_deploy_the_bookinfo_application_1
+# snip_deploy_bookinfo_gateway
+# _wait_for_deployment default bookinfo-gateway-istio
+# snip_annotate_bookinfo_gateway
+# _wait_for_deployment default bookinfo-gateway-istio
+# _verify_like snip_deploy_and_configure_the_ingress_gateway_3 "$snip_deploy_and_configure_the_ingress_gateway_3_out"
+
+# _verify_contains snip_add_bookinfo_to_the_mesh_1 "$snip_add_bookinfo_to_the_mesh_1_out"
+
+# snip_deploy_l4_policy
+# snip_deploy_sleep
+# _wait_for_deployment default sleep
+# _verify_contains snip_enforce_layer_4_authorization_policy_3 "$snip_enforce_layer_4_authorization_policy_3_out"
+
+# snip_deploy_waypoint
+# _wait_for_deployment default waypoint
+# _verify_contains snip_deploy_waypoint "$snip_deploy_waypoint_out"
+
+# _verify_like snip_enforce_layer_7_authorization_policy_2 "$snip_enforce_layer_7_authorization_policy_2_out"
+
+# snip_deploy_l7_policy
+
+# _verify_contains snip_enforce_layer_7_authorization_policy_4 "$snip_enforce_layer_7_authorization_policy_4_out"
+# _verify_contains snip_enforce_layer_7_authorization_policy_5 "$snip_enforce_layer_7_authorization_policy_5_out"
+# _verify_contains snip_enforce_layer_7_authorization_policy_6 "$snip_enforce_layer_7_authorization_policy_6_out"
+
+# snip_deploy_httproute
+# snip_test_traffic_split
+
+# _verify_lines snip_test_traffic_split "
+# + reviews-v1
+# + reviews-v2
+# - reviews-v3
+# "
+
+# # @cleanup
+# snip_remove_the_ambient_and_waypoint_labels_1
+# snip_remove_waypoint_proxies_1
+# snip_remove_the_sample_application_1
+# samples/bookinfo/platform/kube/cleanup.sh
+# snip_remove_the_kubernetes_gateway_api_crds_1

--- a/content/en/docs/ambient/usage/waypoint/test.sh
+++ b/content/en/docs/ambient/usage/waypoint/test.sh
@@ -30,48 +30,12 @@ snip_install_k8s_gateway_api
  _wait_for_daemonset istio-system istio-cni-node
 
 snip_check_ns_label
+
 snip_gen_waypoint_resource
+_verify_contains snip_gen_waypoint_resource "$snip_gen_waypoint_resource_out"
+
 snip_apply_waypoint
 snip_enroll_ns_waypoint
 
-# snip_deploy_the_bookinfo_application_1
-# snip_deploy_bookinfo_gateway
-# _wait_for_deployment default bookinfo-gateway-istio
-# snip_annotate_bookinfo_gateway
-# _wait_for_deployment default bookinfo-gateway-istio
-# _verify_like snip_deploy_and_configure_the_ingress_gateway_3 "$snip_deploy_and_configure_the_ingress_gateway_3_out"
-
-# _verify_contains snip_add_bookinfo_to_the_mesh_1 "$snip_add_bookinfo_to_the_mesh_1_out"
-
-# snip_deploy_l4_policy
-# snip_deploy_sleep
-# _wait_for_deployment default sleep
-# _verify_contains snip_enforce_layer_4_authorization_policy_3 "$snip_enforce_layer_4_authorization_policy_3_out"
-
-# snip_deploy_waypoint
-# _wait_for_deployment default waypoint
-# _verify_contains snip_deploy_waypoint "$snip_deploy_waypoint_out"
-
-# _verify_like snip_enforce_layer_7_authorization_policy_2 "$snip_enforce_layer_7_authorization_policy_2_out"
-
-# snip_deploy_l7_policy
-
-# _verify_contains snip_enforce_layer_7_authorization_policy_4 "$snip_enforce_layer_7_authorization_policy_4_out"
-# _verify_contains snip_enforce_layer_7_authorization_policy_5 "$snip_enforce_layer_7_authorization_policy_5_out"
-# _verify_contains snip_enforce_layer_7_authorization_policy_6 "$snip_enforce_layer_7_authorization_policy_6_out"
-
-# snip_deploy_httproute
-# snip_test_traffic_split
-
-# _verify_lines snip_test_traffic_split "
-# + reviews-v1
-# + reviews-v2
-# - reviews-v3
-# "
-
-# # @cleanup
-# snip_remove_the_ambient_and_waypoint_labels_1
-# snip_remove_waypoint_proxies_1
-# snip_remove_the_sample_application_1
-# samples/bookinfo/platform/kube/cleanup.sh
-# snip_remove_the_kubernetes_gateway_api_crds_1
+# @cleanup
+snip_delete_waypoint


### PR DESCRIPTION
## Description

https://github.com/istio/istio.io/pull/15443 should go in first.

This fixes a few issues I found redoing the ambient getting started guide in https://github.com/istio/istio.io/pull/15279.


This:

1. Fixes a bad ref in the `waypoint wasm` doc that points back to a "how to configure waypoints" ref that no longer exists.
2. Actually puts the "install the K8S gateway CRDS" step where it belongs in the waypoint guide
3. Starts to add a few basic tests to the waypoint guide.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
