### PR TITLE
docs: show the page title above the TOC for generated pages.

### DIFF
--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -33,48 +33,53 @@
 
     {{ if or (gt $len 0) ($page.Scratch.Get "seeAlso") }}
         {{ $page.Scratch.Set "needTOC" true }}
-        <ol>
-            {{ $page.Scratch.Set "level" 50 }}
-            {{ range $h := $headers }}
-                {{ $level := index (index (findRE "<h[23456].*?" $h) 0) 2 | int }}
-                {{ $id := replaceRE (printf "<h[%s].*?id=\"(.*?)\".*?>.*?</h[%s]>" $hdr_types $hdr_types) "$1" $h }}
-                {{ $title := replaceRE (printf "<h[%s].*?>(.*?)</h[%s]>" $hdr_types $hdr_types) "$1" $h }}
-                {{ $current := $page.Scratch.Get "level" | int }}
+        <div>
+            {{ if eq $page.Params.generator "pkg-collateral-docs" }}
+            <h5>{{ $page.Params.title }}</h5>
+            {{ end }}
+            <ol>
+                {{ $page.Scratch.Set "level" 50 }}
+                {{ range $h := $headers }}
+                    {{ $level := index (index (findRE "<h[23456].*?" $h) 0) 2 | int }}
+                    {{ $id := replaceRE (printf "<h[%s].*?id=\"(.*?)\".*?>.*?</h[%s]>" $hdr_types $hdr_types) "$1" $h }}
+                    {{ $title := replaceRE (printf "<h[%s].*?>(.*?)</h[%s]>" $hdr_types $hdr_types) "$1" $h }}
+                    {{ $current := $page.Scratch.Get "level" | int }}
 
-                {{ if gt $level $current }}
-                    {{ $delta := sub $level $current }}
-                    {{ range $index, $num := (seq $delta) }}
-                        <ol>
+                    {{ if gt $level $current }}
+                        {{ $delta := sub $level $current }}
+                        {{ range $index, $num := (seq $delta) }}
+                            <ol>
+                        {{ end }}
+                    {{ else if lt $level $current }}
+                        {{ $delta := sub $current $level }}
+                        {{ range $index, $num := (seq $delta) }}
+                            </ol>
+                            </li>
+                        {{ end }}
                     {{ end }}
-                {{ else if lt $level $current }}
-                    {{ $delta := sub $current $level }}
-                    {{ range $index, $num := (seq $delta) }}
-                        </ol>
-                        </li>
+
+                    {{ $short_title := $title }}
+                    {{ if $page.Params.remove_toc_prefix }}
+                        {{ $short_title = strings.TrimPrefix $page.Params.remove_toc_prefix $title }}
+                    {{ end }}
+
+                    <li role="none" aria-label="{{ $title | safeHTML }}"><a href="#{{ $id }}">{{ $short_title | safeHTML }}</a>
+
+                    {{ $page.Scratch.Set "level" $level }}
+                {{ end }}
+
+                {{ $delta := sub ($page.Scratch.Get "level") 50 }}
+                {{ range $index, $num := (seq $delta) }}
+                    </ol>
+                    </li>
+                {{ end }}
+
+                {{ if $page.Scratch.Get "seeAlso" }}
+                    {{ with $related }}
+                        <li role="none" aria-label="{{ i18n "see_also" }}"><a href="#see-also">{{ i18n "see_also" }}</a></li>
                     {{ end }}
                 {{ end }}
-
-                {{ $short_title := $title }}
-                {{ if $page.Params.remove_toc_prefix }}
-                    {{ $short_title = strings.TrimPrefix $page.Params.remove_toc_prefix $title }}
-                {{ end }}
-
-                <li role="none" aria-label="{{ $title | safeHTML }}"><a href="#{{ $id }}">{{ $short_title | safeHTML }}</a>
-
-                {{ $page.Scratch.Set "level" $level }}
-            {{ end }}
-
-            {{ $delta := sub ($page.Scratch.Get "level") 50 }}
-            {{ range $index, $num := (seq $delta) }}
-                </ol>
-                </li>
-            {{ end }}
-
-            {{ if $page.Scratch.Get "seeAlso" }}
-                {{ with $related }}
-                    <li role="none" aria-label="{{ i18n "see_also" }}"><a href="#see-also">{{ i18n "see_also" }}</a></li>
-                {{ end }}
-            {{ end }}
-        </ol>
+            </ol>
+        </div>
     {{ end }}
 {{ end }}

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -27,59 +27,62 @@
     {{ $hdr_types = "2345" }}
 {{ end }}
 
+{{ if eq $page.Params.generator "pkg-collateral-docs" }}
+    {{ $hdr_types = "23"}}
+{{ end }}
+
 {{ if not $page.Params.skip_toc }}
     {{ $headers := or ($custom_headers) (findRE (printf "<h[%s].*?id=\".*?\".*?>.*?</h[%s]>" $hdr_types $hdr_types) $page.Content) }}
     {{ $len := len $headers }}
 
     {{ if or (gt $len 0) ($page.Scratch.Get "seeAlso") }}
         {{ $page.Scratch.Set "needTOC" true }}
-        <div>
-            {{ if eq $page.Params.generator "pkg-collateral-docs" }}
-            <h5>{{ $page.Params.title }}</h5>
+        <ol>
+            {{ $page.Scratch.Set "level" 50 }}
+            {{ range $h := $headers }}
+                {{ $level := index (index (findRE "<h[23456].*?" $h) 0) 2 | int }}
+                {{ $id := replaceRE (printf "<h[%s].*?id=\"(.*?)\".*?>.*?</h[%s]>" $hdr_types $hdr_types) "$1" $h }}
+                {{ $title := replaceRE (printf "<h[%s].*?>(.*?)</h[%s]>" $hdr_types $hdr_types) "$1" $h }}
+                {{ $current := $page.Scratch.Get "level" | int }}
+
+                {{ if gt $level $current }}
+                    {{ $delta := sub $level $current }}
+                    {{ range $index, $num := (seq $delta) }}
+                        <!-- Add Parameters for generated docs *and* if it's the top-level -->
+                        {{ if and (eq $page.Params.generator "pkg-collateral-docs") (eq $current 50) }}
+                            <li role="none" aria-label="Parameters"><a href="#title">Parameters</a>
+                        {{ end }}
+                        <ol>
+                    {{ end }}
+                {{ else if lt $level $current }}
+                    {{ $delta := sub $current $level }}
+                    {{ range $index, $num := (seq $delta) }}
+                        </ol>
+                        </li>
+                    {{ end }}
+                {{ end }}
+
+                {{ $short_title := $title }}
+                {{ if $page.Params.remove_toc_prefix }}
+                    {{ $short_title = strings.TrimPrefix $page.Params.remove_toc_prefix $title }}
+                {{ end }}
+
+                <li role="none" aria-label="{{ $title | safeHTML }}"><a href="#{{ $id }}">{{ $short_title | safeHTML }}</a>
+
+                {{ $page.Scratch.Set "level" $level }}
             {{ end }}
-            <ol>
-                {{ $page.Scratch.Set "level" 50 }}
-                {{ range $h := $headers }}
-                    {{ $level := index (index (findRE "<h[23456].*?" $h) 0) 2 | int }}
-                    {{ $id := replaceRE (printf "<h[%s].*?id=\"(.*?)\".*?>.*?</h[%s]>" $hdr_types $hdr_types) "$1" $h }}
-                    {{ $title := replaceRE (printf "<h[%s].*?>(.*?)</h[%s]>" $hdr_types $hdr_types) "$1" $h }}
-                    {{ $current := $page.Scratch.Get "level" | int }}
 
-                    {{ if gt $level $current }}
-                        {{ $delta := sub $level $current }}
-                        {{ range $index, $num := (seq $delta) }}
-                            <ol>
-                        {{ end }}
-                    {{ else if lt $level $current }}
-                        {{ $delta := sub $current $level }}
-                        {{ range $index, $num := (seq $delta) }}
-                            </ol>
-                            </li>
-                        {{ end }}
-                    {{ end }}
+            {{ $delta := sub ($page.Scratch.Get "level") 50 }}
+            {{ range $index, $num := (seq $delta) }}
+                </ol>
+                </li>
+            {{ end }}
 
-                    {{ $short_title := $title }}
-                    {{ if $page.Params.remove_toc_prefix }}
-                        {{ $short_title = strings.TrimPrefix $page.Params.remove_toc_prefix $title }}
-                    {{ end }}
-
-                    <li role="none" aria-label="{{ $title | safeHTML }}"><a href="#{{ $id }}">{{ $short_title | safeHTML }}</a>
-
-                    {{ $page.Scratch.Set "level" $level }}
+            {{ if $page.Scratch.Get "seeAlso" }}
+                {{ with $related }}
+                    <li role="none" aria-label="{{ i18n "see_also" }}"><a href="#see-also">{{ i18n "see_also" }}</a></li>
                 {{ end }}
-
-                {{ $delta := sub ($page.Scratch.Get "level") 50 }}
-                {{ range $index, $num := (seq $delta) }}
-                    </ol>
-                    </li>
-                {{ end }}
-
-                {{ if $page.Scratch.Get "seeAlso" }}
-                    {{ with $related }}
-                        <li role="none" aria-label="{{ i18n "see_also" }}"><a href="#see-also">{{ i18n "see_also" }}</a></li>
-                    {{ end }}
-                {{ end }}
-            </ol>
-        </div>
+            {{ end }}
+        </ol>
     {{ end }}
 {{ end }}

--- a/src/sass/misc/_toc.scss
+++ b/src/sass/misc/_toc.scss
@@ -25,19 +25,6 @@
             display: block !important;
         }
 
-        h5 {
-            padding-bottom: .5rem;
-            display: none;
-
-            @media (min-width: $bp-md) {
-                display: block;
-            }
-        }
-
-        h5 + ol {
-            padding-left: 1rem;
-        }
-
         ol {
             list-style-type: none !important;
             padding-left: 0;

--- a/src/sass/misc/_toc.scss
+++ b/src/sass/misc/_toc.scss
@@ -26,7 +26,7 @@
         }
 
         h5 {
-            padding-bottom: 0.5rem;
+            padding-bottom: .5rem;
             display: none;
 
             @media (min-width: $bp-md) {

--- a/src/sass/misc/_toc.scss
+++ b/src/sass/misc/_toc.scss
@@ -25,6 +25,19 @@
             display: block !important;
         }
 
+        h5 {
+            padding-bottom: 0.5rem;
+            display: none;
+
+            @media (min-width: $bp-md) {
+                display: block;
+            }
+        }
+
+        h5 + ol {
+            padding-left: 1rem;
+        }
+
         ol {
             list-style-type: none !important;
             padding-left: 0;


### PR DESCRIPTION
## Description

Display the page title (command name) above the TOC for reference pages.

ref: https://github.com/istio/istio.io/issues/15417 
 
## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
