### PR TITLE
Declare Istio 1.20 support is dropped

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -20,7 +20,7 @@
   k8sVersions: ["1.26", "1.27", "1.28", "1.29"]
   testedK8sVersions: ["1.23", "1.24", "1.25"]
 - version: "1.20"
-  supported: "Yes"
+  supported: "No"
   releaseDate: "Nov 14, 2023"
   eolDate: "Jun 25, 2024"
   k8sVersions: ["1.25", "1.26", "1.27", "1.28", "1.29"]


### PR DESCRIPTION
This aligns the table with the other column and announcement
(https://preliminary.istio.io/latest/news/support/announcing-1.20-eol-final/)
