### PR TITLE
[zh] Fix the step for creating a 'helloworld-credential' secret

### DIFF
--- a/content/zh/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -324,7 +324,9 @@ $ export SECURE_INGRESS_PORT=$(kubectl get gtw mygateway -n istio-system -o json
 1.  创建 `helloworld-credential` Secret：
 
     {{< text bash >}}
-    $ kubectl create -n istio-system secret tls helloworld-credential --key=helloworld-v1.example.com.key --cert=helloworld-v1.example.com.crt
+    $ kubectl create -n istio-system secret tls helloworld-credential \
+      --key=example_certs1/helloworld.example.com.key \
+      --cert=example_certs1/helloworld.example.com.crt
     {{< /text >}}
 
 1.  使用 `httpbin.example.com` 和 `helloworld.example.com` 主机配置入口网关：


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->
For the Chinese document, the instructions for step 3 "**创建 `helloworld-credential` Secret**" in section [为多个主机配置 TLS 入口网关](https://istio.io/latest/zh/docs/tasks/traffic-management/ingress/secure-ingress/#configure-a-TLS-ingress-gateway-for-multiple-hosts) are incorrect. It is

```bash
$ kubectl create -n istio-system secret tls helloworld-credential --key=helloworld-v1.example.com.key --cert=helloworld-v1.example.com.crt
```

It should be the same as the English document [Configure a TLS ingress gateway for multiple hosts](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/#configure-a-tls-ingress-gateway-for-multiple-hosts), which is

```bash
$ kubectl create -n istio-system secret tls helloworld-credential \
  --key=example_certs1/helloworld.example.com.key \
  --cert=example_certs1/helloworld.example.com.crt
```

So I create a PR to fix this problem.
Please take a look at this, Thanks.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

Step 3 in [Configure a TLS ingress gateway for multiple hosts](https://istio.io/latest/docs/tasks/traffic-management/ingress/secure-ingress/#configure-a-tls-ingress-gateway-for-multiple-hosts)
