### PR TITLE
[zh] Fix the indentation issue in the command for the task 'Ingress Sidecar TLS Termination'

### DIFF
--- a/content/zh/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/index.md
@@ -113,7 +113,6 @@ $ kubectl -n test apply -f - <<EOF
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-
   name: httpbin
 ---
 apiVersion: v1
@@ -160,8 +159,8 @@ spec:
         name: httpbin
         ports:
         - containerPort: 80
-        EOF
-        {{< /text >}}
+EOF
+{{< /text >}}
 
 ## 配置 httpbin 以启用外部 mTLS {#configure-httpbin-to-enable-external-mtls}
 
@@ -196,8 +195,8 @@ spec:
       protocol: HTTP
       name: internal
     defaultEndpoint: 0.0.0.0:80
-      EOF
-      {{< /text >}}
+EOF
+{{< /text >}}
 
 ## 验证 {#verification}
 

--- a/content/zh/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/index.md
@@ -203,7 +203,7 @@ EOF
 现在已经部署和配置了 httpbin 服务器，启动两个客户端来测试网格内部和外部的端到端连接：
 
 1. 在与 httpbin 服务相同的命名空间（test）中的内部客户端（sleep），已注入 Sidecar。
-2. 在 default 命名空间（即服务网格外部）中的外部客户端（sleep）。
+1. 在 default 命名空间（即服务网格外部）中的外部客户端（sleep）。
 
 {{< text bash >}}
 $ kubectl apply -f samples/sleep/sleep.yaml


### PR DESCRIPTION
Fix the indentation issue in the command for the task 'Ingress Sidecar TLS Termination'

## Description

<!-- Please replace this line with a description of the PR. -->
For the Chinese document, the commands in steps [部署测试服务 httpbin](https://istio.io/latest/zh/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/#deploy-the-httpbin-test-service) and step [配置 httpbin 以启用外部 mTLS](https://istio.io/latest/zh/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/#configure-httpbin-to-enable-external-mtls) are not executable due to incorrect heredoc indentation.

So I create this PR to fix this issue.
Please take a look at this, Thanks.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
1. [Deploy the httpbin test service](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/#deploy-the-httpbin-test-service)
2. [Configure httpbin to enable external mTLS](https://istio.io/latest/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/#configure-httpbin-to-enable-external-mtls)

