### PR TITLE
Fix EOL dates for 21 and 22

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -10,13 +10,13 @@
 - version: "1.22"
   supported: "Yes"
   releaseDate: "May 13, 2024"
-  eolDate: "~Mar 2025 (Expected)"
+  eolDate: "~Jan 2025 (Expected)"
   k8sVersions: ["1.27", "1.28", "1.29", "1.30"]
   testedK8sVersions: ["1.23", "1.24", "1.25", "1.26"]
 - version: "1.21"
   supported: "Yes"
   releaseDate: "Mar 13, 2024"
-  eolDate: "~Dec 2024 (Expected)"
+  eolDate: "~Sept 2024 (Expected)"
   k8sVersions: ["1.26", "1.27", "1.28", "1.29"]
   testedK8sVersions: ["1.23", "1.24", "1.25"]
 - version: "1.20"


### PR DESCRIPTION
## Description

The support table had been reporting EOL dates for 1.21 and 1.22 that were far beyond our N+2 + 6 weeks policy.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
