### PR TITLE
Remove manual injection step from Bookinfo etc

### DIFF
--- a/content/en/docs/examples/bookinfo/index.md
+++ b/content/en/docs/examples/bookinfo/index.md
@@ -92,17 +92,6 @@ If you use GKE, please ensure your cluster has at least 4 standard GKE nodes. If
     $ kubectl apply -f @samples/bookinfo/platform/kube/bookinfo.yaml@
     {{< /text >}}
 
-    {{< warning >}}
-    If you disabled automatic sidecar injection during installation and rely on [manual sidecar injection](/docs/setup/additional-setup/sidecar-injection/#manual-sidecar-injection),
-    use the [`istioctl kube-inject`](/docs/reference/commands/istioctl/#istioctl-kube-inject) command to modify the `bookinfo.yaml`
-    file before deploying your application.
-
-    {{< text bash >}}
-    $ kubectl apply -f <(istioctl kube-inject -f @samples/bookinfo/platform/kube/bookinfo.yaml@)
-    {{< /text >}}
-
-    {{< /warning >}}
-
     The command launches all four services shown in the `bookinfo` application architecture diagram.
     All 3 versions of the reviews service, v1, v2, and v3, are started.
 

--- a/content/en/docs/examples/bookinfo/snips.sh
+++ b/content/en/docs/examples/bookinfo/snips.sh
@@ -30,14 +30,10 @@ kubectl apply -f samples/bookinfo/platform/kube/bookinfo.yaml
 }
 
 snip_start_the_application_services_3() {
-kubectl apply -f <(istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo.yaml)
-}
-
-snip_start_the_application_services_4() {
 kubectl get services
 }
 
-! IFS=$'\n' read -r -d '' snip_start_the_application_services_4_out <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_start_the_application_services_3_out <<\ENDSNIP
 NAME          TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)    AGE
 details       ClusterIP   10.0.0.31    <none>        9080/TCP   6m
 kubernetes    ClusterIP   10.0.0.1     <none>        443/TCP    7d
@@ -46,11 +42,11 @@ ratings       ClusterIP   10.0.0.15    <none>        9080/TCP   6m
 reviews       ClusterIP   10.0.0.170   <none>        9080/TCP   6m
 ENDSNIP
 
-snip_start_the_application_services_5() {
+snip_start_the_application_services_4() {
 kubectl get pods
 }
 
-! IFS=$'\n' read -r -d '' snip_start_the_application_services_5_out <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_start_the_application_services_4_out <<\ENDSNIP
 NAME                             READY     STATUS    RESTARTS   AGE
 details-v1-1520924117-48z17      2/2       Running   0          6m
 productpage-v1-560495357-jk1lz   2/2       Running   0          6m
@@ -60,11 +56,11 @@ reviews-v2-1343845940-b34q5      2/2       Running   0          6m
 reviews-v3-1813607990-8ch52      2/2       Running   0          6m
 ENDSNIP
 
-snip_start_the_application_services_6() {
+snip_start_the_application_services_5() {
 kubectl exec "$(kubectl get pod -l app=ratings -o jsonpath='{.items[0].metadata.name}')" -c ratings -- curl -sS productpage:9080/productpage | grep -o "<title>.*</title>"
 }
 
-! IFS=$'\n' read -r -d '' snip_start_the_application_services_6_out <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_start_the_application_services_5_out <<\ENDSNIP
 <title>Simple Bookstore App</title>
 ENDSNIP
 

--- a/content/en/docs/examples/bookinfo/test.sh
+++ b/content/en/docs/examples/bookinfo/test.sh
@@ -32,15 +32,15 @@ snip_start_the_application_services_1
 
 snip_start_the_application_services_2
 
-_verify_like snip_start_the_application_services_4 "$snip_start_the_application_services_4_out"
+_verify_like snip_start_the_application_services_3 "$snip_start_the_application_services_3_out"
 
 for deploy in "productpage-v1" "details-v1" "ratings-v1" "reviews-v1" "reviews-v2" "reviews-v3"; do
     _wait_for_deployment default "$deploy"
 done
 
-_verify_like snip_start_the_application_services_5 "$snip_start_the_application_services_5_out"
+_verify_like snip_start_the_application_services_4 "$snip_start_the_application_services_4_out"
 
-_verify_contains snip_start_the_application_services_6 "$snip_start_the_application_services_6_out"
+_verify_contains snip_start_the_application_services_5 "$snip_start_the_application_services_5_out"
 
 if [ "$GATEWAY_API" == "true" ]; then
     _verify_like snip_determine_the_ingress_ip_and_port_3 "$snip_determine_the_ingress_ip_and_port_3_out"

--- a/content/en/docs/examples/microservices-istio/add-istio/index.md
+++ b/content/en/docs/examples/microservices-istio/add-istio/index.md
@@ -1,9 +1,7 @@
 ---
 title: Enable Istio on productpage
 overview: Deploy the Istio control plane and enable Istio on a single microservice.
-
 weight: 60
-
 owner: istio/wg-docs-maintainers
 test: no
 ---
@@ -26,8 +24,8 @@ disrupt your application, it continues to run and serve user requests.
 1.  Redeploy the `productpage` microservice, Istio-enabled:
 
     {{< tip >}}
-    This tutorial step demonstrates manual sidecar injection to enable Istio for instructional purposes,
-    however [Automatic sidecar injection](/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection) is more convenient.
+    This tutorial step demonstrates manual sidecar injection to demonstrate enabling Istio service-by-service for instructional purposes.
+    [Automatic sidecar injection](/docs/setup/additional-setup/sidecar-injection/#automatic-sidecar-injection) is the recommended method for production use.
     {{< /tip >}}
 
     {{< text bash >}}

--- a/content/en/docs/tasks/observability/metrics/tcp-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/tcp-metrics/index.md
@@ -31,39 +31,18 @@ example configuration and commands.
 
     1.  Install `v2` of the `ratings` service.
 
-        If you are using a cluster with automatic sidecar injection enabled,
-        deploy the services using `kubectl`:
-
         {{< text bash >}}
         $ kubectl apply -f @samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml@
         serviceaccount/bookinfo-ratings-v2 created
         deployment.apps/ratings-v2 created
         {{< /text >}}
 
-        If you are using manual sidecar injection, run the following command instead:
-
-        {{< text bash >}}
-        $ kubectl apply -f <(istioctl kube-inject -f @samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml@)
-        deployment "ratings-v2" configured
-        {{< /text >}}
-
     1.  Install the `mongodb` service:
-
-        If you are using a cluster with automatic sidecar injection enabled,
-        deploy the services using `kubectl`:
 
         {{< text bash >}}
         $ kubectl apply -f @samples/bookinfo/platform/kube/bookinfo-db.yaml@
         service/mongodb created
         deployment.apps/mongodb-v1 created
-        {{< /text >}}
-
-        If you are using manual sidecar injection, run the following command instead:
-
-        {{< text bash >}}
-        $ kubectl apply -f <(istioctl kube-inject -f @samples/bookinfo/platform/kube/bookinfo-db.yaml@)
-        service "mongodb" configured
-        deployment "mongodb-v1" configured
         {{< /text >}}
 
     1.  The Bookinfo sample deploys multiple versions of each microservice, so begin by creating destination rules

--- a/content/en/docs/tasks/observability/metrics/tcp-metrics/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/tcp-metrics/snips.sh
@@ -30,61 +30,44 @@ deployment.apps/ratings-v2 created
 ENDSNIP
 
 snip_collecting_new_telemetry_data_2() {
-kubectl apply -f <(istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo-ratings-v2.yaml)
-}
-
-! IFS=$'\n' read -r -d '' snip_collecting_new_telemetry_data_2_out <<\ENDSNIP
-deployment "ratings-v2" configured
-ENDSNIP
-
-snip_collecting_new_telemetry_data_3() {
 kubectl apply -f samples/bookinfo/platform/kube/bookinfo-db.yaml
 }
 
-! IFS=$'\n' read -r -d '' snip_collecting_new_telemetry_data_3_out <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_collecting_new_telemetry_data_2_out <<\ENDSNIP
 service/mongodb created
 deployment.apps/mongodb-v1 created
 ENDSNIP
 
-snip_collecting_new_telemetry_data_4() {
-kubectl apply -f <(istioctl kube-inject -f samples/bookinfo/platform/kube/bookinfo-db.yaml)
-}
-
-! IFS=$'\n' read -r -d '' snip_collecting_new_telemetry_data_4_out <<\ENDSNIP
-service "mongodb" configured
-deployment "mongodb-v1" configured
-ENDSNIP
-
-snip_collecting_new_telemetry_data_5() {
+snip_collecting_new_telemetry_data_3() {
 kubectl apply -f samples/bookinfo/networking/destination-rule-all.yaml
 }
 
-snip_collecting_new_telemetry_data_6() {
+snip_collecting_new_telemetry_data_4() {
 kubectl apply -f samples/bookinfo/networking/destination-rule-all-mtls.yaml
 }
 
-snip_collecting_new_telemetry_data_7() {
+snip_collecting_new_telemetry_data_5() {
 kubectl get destinationrules -o yaml
 }
 
-snip_collecting_new_telemetry_data_8() {
+snip_collecting_new_telemetry_data_6() {
 kubectl apply -f samples/bookinfo/networking/virtual-service-ratings-db.yaml
 }
 
-! IFS=$'\n' read -r -d '' snip_collecting_new_telemetry_data_8_out <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_collecting_new_telemetry_data_6_out <<\ENDSNIP
 virtualservice.networking.istio.io/reviews created
 virtualservice.networking.istio.io/ratings created
 ENDSNIP
 
-snip_collecting_new_telemetry_data_9() {
+snip_collecting_new_telemetry_data_7() {
 curl http://"$GATEWAY_URL/productpage"
 }
 
-snip_collecting_new_telemetry_data_10() {
+snip_collecting_new_telemetry_data_8() {
 istioctl dashboard prometheus
 }
 
-! IFS=$'\n' read -r -d '' snip_collecting_new_telemetry_data_11 <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_collecting_new_telemetry_data_9 <<\ENDSNIP
 istio_tcp_connections_opened_total{
 destination_version="v1",
 instance="172.17.0.18:42422",
@@ -93,7 +76,7 @@ canonical_service_name="ratings-v2",
 canonical_service_revision="v2"}
 ENDSNIP
 
-! IFS=$'\n' read -r -d '' snip_collecting_new_telemetry_data_12 <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_collecting_new_telemetry_data_10 <<\ENDSNIP
 istio_tcp_connections_closed_total{
 destination_version="v1",
 instance="172.17.0.18:42422",

--- a/content/en/docs/tasks/observability/metrics/tcp-metrics/test.sh
+++ b/content/en/docs/tasks/observability/metrics/tcp-metrics/test.sh
@@ -38,15 +38,15 @@ _wait_for_deployment istio-system prometheus
 _verify_same snip_collecting_new_telemetry_data_1 "$snip_collecting_new_telemetry_data_1_out"
 
 # Install the MongoDB service
-_verify_same snip_collecting_new_telemetry_data_3 "$snip_collecting_new_telemetry_data_3_out"
+_verify_same snip_collecting_new_telemetry_data_2 "$snip_collecting_new_telemetry_data_2_out"
 
 # Apply the destination rules
-snip_collecting_new_telemetry_data_5
+snip_collecting_new_telemetry_data_3
 _wait_for_istio destinationrule default ratings
 _wait_for_istio destinationrule default reviews
 
 # Create the virtual services
-_verify_same snip_collecting_new_telemetry_data_8 "$snip_collecting_new_telemetry_data_8_out"
+_verify_same snip_collecting_new_telemetry_data_6 "$snip_collecting_new_telemetry_data_6_out"
 _wait_for_istio virtualservice default reviews
 _wait_for_istio virtualservice default ratings
 


### PR DESCRIPTION
Per discussion on Slack, approximately no-one should be using manual sidecar injection.  Remove it from the bookinfo sample & a task that used it.