### PR TITLE
Update to v1 in all API examples

### DIFF
--- a/content/en/about/faq/traffic-management/cors.md
+++ b/content/en/about/faq/traffic-management/cors.md
@@ -14,7 +14,7 @@ In order to allow this request, `bank.example.com` must allow `attack.example.co
 This is where CORS comes in. If we were serving `bank.example.com` in an Istio enabled cluster, we could configure a `corsPolicy` to allow this:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: bank

--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -315,7 +315,7 @@ authentication for the workloads with the `app:reviews` label must use mutual
 TLS:
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "example-peer-policy"
@@ -409,7 +409,7 @@ The following peer authentication policy requires all workloads in namespace
 `foo` to use mutual TLS:
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "example-policy"
@@ -426,7 +426,7 @@ mutual TLS on port `80` for the `app:example-app` workload, and uses the mutual 
 settings of the namespace-wide peer authentication policy for all other ports:
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "example-workload-policy"

--- a/content/en/docs/concepts/traffic-management/index.md
+++ b/content/en/docs/concepts/traffic-management/index.md
@@ -155,7 +155,7 @@ requests to different versions of a service depending on whether the request
 comes from a particular user.
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews
@@ -287,7 +287,7 @@ virtual service rules match traffic based on request URIs and direct requests to
 the appropriate service.
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: bookinfo
@@ -392,7 +392,7 @@ The following example destination rule configures three different subsets for
 the `my-svc` destination service, with different load balancing policies:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: my-destination-rule
@@ -468,7 +468,7 @@ The following example shows a possible gateway configuration for external HTTPS
 ingress traffic:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: ext-host-gwy
@@ -495,7 +495,7 @@ the gateway to a virtual service. You do this using the virtual service’s
 `gateways` field, as shown in the following example:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: virtual-svc
@@ -536,7 +536,7 @@ The following example mesh-external service entry adds the `ext-svc.example.com`
 external dependency to Istio’s service registry:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: svc-entry
@@ -561,7 +561,7 @@ adjusts the TCP connection timeout for requests to the `ext-svc.example.com`
 external service that we configured using the service entry:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: ext-res-dr
@@ -598,7 +598,7 @@ same namespace and the Istio control plane (needed by Istio’s
 egress and telemetry features):
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: default
@@ -639,7 +639,7 @@ service code. Here’s a virtual service that specifies a 10 second timeout for
 calls to the v1 subset of the ratings service:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings
@@ -676,7 +676,7 @@ configures a maximum of 3 retries to connect to this service subset after an
 initial call failure, each with a 2 second timeout.
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings
@@ -711,7 +711,7 @@ concurrent connections for the `reviews` service workloads of the v1 subset to
 100:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: reviews
@@ -764,7 +764,7 @@ For example, this virtual service introduces a 5 second delay for 1 out of every
 requests to the `ratings` service.
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings

--- a/content/en/docs/examples/microservices-istio/istio-ingress-gateway/index.md
+++ b/content/en/docs/examples/microservices-istio/istio-ingress-gateway/index.md
@@ -32,7 +32,7 @@ ingress gateway, in order to apply Istio control on traffic to your microservice
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: Gateway
     metadata:
       name: bookinfo-gateway
@@ -47,7 +47,7 @@ ingress gateway, in order to apply Istio control on traffic to your microservice
         hosts:
         - $MY_INGRESS_GATEWAY_HOST
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: bookinfo

--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -443,7 +443,7 @@ If no CA certificate is being used, `subjectAltNames` will not be used regardles
 For example:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: google-tls
@@ -548,7 +548,7 @@ spec:
 If the above is necessary, it's highly recommended to explicitly disable the http host `admin.example.com` in the `VirtualService` that attaches to `*.example.com`. The reason is that currently the underlying [envoy proxy does not require](https://github.com/envoyproxy/envoy/issues/6767) the http 1 header `Host` or the http 2 pseudo header `:authority` following the SNI constraints, an attacker can reuse the guest-SNI TLS connection to access admin `VirtualService`. The http response code 421 is designed for this `Host` SNI mismatch and can be used to fulfill the disable.
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: disable-sensitive

--- a/content/en/docs/ops/common-problems/network-issues/index.md
+++ b/content/en/docs/ops/common-problems/network-issues/index.md
@@ -85,7 +85,7 @@ Let's assume you are using an ingress `Gateway` and corresponding `VirtualServic
 For example, your `VirtualService` looks something like this:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: myapp
@@ -108,7 +108,7 @@ spec:
 You also have a `VirtualService` which routes traffic for the helloworld service to a particular subset:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: helloworld
@@ -133,7 +133,7 @@ helloworld `VirtualService` which directs traffic exclusively to subset v1.
 To control the traffic from the gateway, you need to also include the subset rule in the myapp `VirtualService`:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: myapp
@@ -157,7 +157,7 @@ spec:
 Alternatively, you can combine both `VirtualServices` into one unit if possible:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: myapp
@@ -341,7 +341,7 @@ the Envoy sidecar will attempt to parse the request as HTTP while forwarding the
 which will fail because the HTTP is unexpectedly encrypted.
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: httpbin
@@ -382,7 +382,7 @@ There are two common TLS mismatches that can occur when binding a virtual servic
 #### Gateway with TLS termination
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -401,7 +401,7 @@ spec:
       mode: SIMPLE
       credentialName: sds-credential
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin
@@ -443,7 +443,7 @@ spec:
 #### Gateway with TLS passthrough
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -460,7 +460,7 @@ spec:
     tls:
       mode: PASSTHROUGH
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: virtual-service
@@ -510,7 +510,7 @@ The following `DestinationRule` originates TLS for requests to the `httpbin.org`
 but the corresponding `ServiceEntry` defines the protocol as HTTPS on port 443.
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: httpbin
@@ -523,7 +523,7 @@ spec:
     protocol: HTTPS
   resolution: DNS
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: originate-tls
@@ -669,7 +669,7 @@ Currently, Istio does not support configuring fault injections and retry or time
 same `VirtualService`. Consider the following configuration:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: helloworld

--- a/content/en/docs/ops/common-problems/security-issues/index.md
+++ b/content/en/docs/ops/common-problems/security-issues/index.md
@@ -19,7 +19,7 @@ With Istio, you can enable authentication for end users through [request authent
 1. If `jwksUri` isn’t set, make sure the JWT issuer is of url format and `url + /.well-known/openid-configuration` can be opened in browser; for example, if the JWT issuer is `https://accounts.google.com`, make sure `https://accounts.google.com/.well-known/openid-configuration` is a valid url and can be opened in a browser.
 
     {{< text yaml >}}
-    apiVersion: security.istio.io/v1beta1
+    apiVersion: security.istio.io/v1
     kind: RequestAuthentication
     metadata:
       name: "example-3"
@@ -86,7 +86,7 @@ With Istio, you can enable authentication for end users through [request authent
 One common mistake is specifying multiple items unintentionally in the YAML. Take the following policy as an example:
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: example

--- a/content/en/docs/ops/common-problems/upgrade-issues/index.md
+++ b/content/en/docs/ops/common-problems/upgrade-issues/index.md
@@ -44,7 +44,7 @@ spec:
 The following `Telemetry` configuration replaces the above:
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: namespace-metrics

--- a/content/en/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/index.md
@@ -118,7 +118,7 @@ To configure strict mutual TLS, run:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "default"

--- a/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
+++ b/content/en/docs/ops/configuration/mesh/app-health-check/snips.sh
@@ -86,7 +86,7 @@ kubectl create ns istio-io-health
 
 snip_liveness_and_readiness_probes_using_the_command_approach_2() {
 kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "default"

--- a/content/en/docs/ops/configuration/mesh/configuration-scoping/index.md
+++ b/content/en/docs/ops/configuration/mesh/configuration-scoping/index.md
@@ -37,7 +37,7 @@ Only configurations matching the specified criteria will be seen by sidecars imp
 For example:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: default

--- a/content/en/docs/ops/configuration/security/security-policy-examples/index.md
+++ b/content/en/docs/ops/configuration/security/security-policy-examples/index.md
@@ -28,7 +28,7 @@ Use the following policy if you want to allow access to the given hosts if JWT p
 will always be denied.
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: jwt-per-host
@@ -60,7 +60,7 @@ spec:
 The following two policies enable strict mTLS on namespace `foo`, and allow traffic from the same namespace.
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -69,7 +69,7 @@ spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: foo-isolation
@@ -88,7 +88,7 @@ The following two policies enable strict mTLS on namespace `foo`, and allow traf
 from the ingress gateway.
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -97,7 +97,7 @@ spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: ns-isolation-except-ingress
@@ -122,7 +122,7 @@ In other words, the policy allows requests if the principal is non-empty.
 `"*"` means non-empty match and using with `notPrincipals` means matching on empty principal.
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: require-mtls
@@ -147,7 +147,7 @@ In other words, the policy allows requests if the request principal is non-empty
 `"*"` means non-empty match and using with `notRequestPrincipals` means matching on empty request principal.
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: require-jwt
@@ -168,7 +168,7 @@ The policy denies the request if the namespace is not `foo` and the principal is
 In other words, the policy allows the request only if the namespace is `foo` or the principal is `cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account`.
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: ns-isolation-except-ingress

--- a/content/en/docs/ops/configuration/security/security-policy-examples/snips.sh
+++ b/content/en/docs/ops/configuration/security/security-policy-examples/snips.sh
@@ -21,7 +21,7 @@
 ####################################################################################################
 
 ! IFS=$'\n' read -r -d '' snip_require_different_jwt_issuer_per_host_1 <<\ENDSNIP
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: jwt-per-host
@@ -49,7 +49,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_namespace_isolation_1 <<\ENDSNIP
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -58,7 +58,7 @@ spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: foo-isolation
@@ -72,7 +72,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_namespace_isolation_with_ingress_exception_1 <<\ENDSNIP
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -81,7 +81,7 @@ spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: ns-isolation-except-ingress
@@ -97,7 +97,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_require_mtls_in_authorization_layer_defense_in_depth_1 <<\ENDSNIP
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: require-mtls
@@ -111,7 +111,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_require_mandatory_authorization_check_with_deny_policy_1 <<\ENDSNIP
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: require-jwt
@@ -128,7 +128,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_require_mandatory_authorization_check_with_deny_policy_2 <<\ENDSNIP
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: ns-isolation-except-ingress

--- a/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -61,7 +61,7 @@ To try out the DNS capture, first setup a `ServiceEntry` for some external servi
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-address
@@ -110,7 +110,7 @@ To try this out, configure another `ServiceEntry`:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-auto
@@ -183,8 +183,8 @@ A virtual IP address will be assigned to every service entry so that client side
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1beta1
-    kind: ServiceEntry
+    apiVersion: networking.istio.io/v1
+.   kind: ServiceEntry
     metadata:
       name: external-svc-1
     spec:
@@ -196,8 +196,8 @@ A virtual IP address will be assigned to every service entry so that client side
         protocol: TCP
       resolution: DNS
     ---
-    apiVersion: networking.istio.io/v1beta1
-    kind: ServiceEntry
+    apiVersion: networking.istio.io/v1
+.   kind: ServiceEntry
     metadata:
       name: external-svc-2
     spec:

--- a/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -184,7 +184,7 @@ A virtual IP address will be assigned to every service entry so that client side
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1
-.   kind: ServiceEntry
+    kind: ServiceEntry
     metadata:
       name: external-svc-1
     spec:
@@ -197,7 +197,7 @@ A virtual IP address will be assigned to every service entry so that client side
       resolution: DNS
     ---
     apiVersion: networking.istio.io/v1
-.   kind: ServiceEntry
+    kind: ServiceEntry
     metadata:
       name: external-svc-2
     spec:

--- a/content/en/docs/ops/configuration/traffic-management/dns-proxy/snips.sh
+++ b/content/en/docs/ops/configuration/traffic-management/dns-proxy/snips.sh
@@ -124,7 +124,7 @@ kubectl -n external-2 apply -f samples/tcp-echo/tcp-echo.yaml
 snip_external_tcp_services_without_vips_4() {
 kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1
-.   kind: ServiceEntry
+kind: ServiceEntry
 metadata:
   name: external-svc-1
 spec:
@@ -137,7 +137,7 @@ spec:
   resolution: DNS
 ---
 apiVersion: networking.istio.io/v1
-.   kind: ServiceEntry
+kind: ServiceEntry
 metadata:
   name: external-svc-2
 spec:

--- a/content/en/docs/ops/configuration/traffic-management/dns-proxy/snips.sh
+++ b/content/en/docs/ops/configuration/traffic-management/dns-proxy/snips.sh
@@ -37,7 +37,7 @@ EOF
 
 snip_dns_capture_in_action_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-address
@@ -68,7 +68,7 @@ ENDSNIP
 
 snip_address_auto_allocation_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-auto
@@ -123,8 +123,8 @@ kubectl -n external-2 apply -f samples/tcp-echo/tcp-echo.yaml
 
 snip_external_tcp_services_without_vips_4() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
-kind: ServiceEntry
+apiVersion: networking.istio.io/v1
+.   kind: ServiceEntry
 metadata:
   name: external-svc-1
 spec:
@@ -136,8 +136,8 @@ spec:
     protocol: TCP
   resolution: DNS
 ---
-apiVersion: networking.istio.io/v1beta1
-kind: ServiceEntry
+apiVersion: networking.istio.io/v1
+.   kind: ServiceEntry
 metadata:
   name: external-svc-2
 spec:

--- a/content/en/docs/ops/configuration/traffic-management/multicluster/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/multicluster/index.md
@@ -69,7 +69,7 @@ One of these built-in labels, `topology.istio.io/cluster`, in the subset selecto
 creating per-cluster subsets.
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: mysvc-per-cluster-dr
@@ -90,7 +90,7 @@ or [shifting](/docs/tasks/traffic-management/traffic-shifting/).
 This provides another option to create cluster-local traffic rules by restricting the destination subset in a `VirtualService`:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: mysvc-cluster-local-vs

--- a/content/en/docs/ops/configuration/traffic-management/tls-configuration/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/tls-configuration/index.md
@@ -120,7 +120,7 @@ For TLS connections, there are a few more options:
 
     {{< text yaml >}}
     apiVersion: networking.istio.io/v1
-.   kind: Gateway
+    kind: Gateway
     ...
       servers:
       - port:
@@ -139,7 +139,7 @@ For TLS connections, there are a few more options:
 
     {{< text yaml >}}
     apiVersion: networking.istio.io/v1
-.   kind: Gateway
+    kind: Gateway
     ...
       servers:
       - port:

--- a/content/en/docs/ops/configuration/traffic-management/tls-configuration/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/tls-configuration/index.md
@@ -97,7 +97,7 @@ This is done based on the server configuration in a [`Gateway` resource](/docs/r
 For example, if an inbound connection is plaintext HTTP, the port protocol is configured as `HTTP`:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 ...
   servers:
@@ -119,8 +119,8 @@ For TLS connections, there are a few more options:
     For passthrough traffic, configure the TLS mode field to `PASSTHROUGH`:
 
     {{< text yaml >}}
-    apiVersion: networking.istio.io/v1beta1
-    kind: Gateway
+    apiVersion: networking.istio.io/v1
+.   kind: Gateway
     ...
       servers:
       - port:
@@ -138,8 +138,8 @@ For TLS connections, there are a few more options:
     requested and verified against the configured `caCertificates` or `credentialName`:
 
     {{< text yaml >}}
-    apiVersion: networking.istio.io/v1beta1
-    kind: Gateway
+    apiVersion: networking.istio.io/v1
+.   kind: Gateway
     ...
       servers:
       - port:

--- a/content/en/docs/ops/deployment/vm-architecture/index.md
+++ b/content/en/docs/ops/deployment/vm-architecture/index.md
@@ -68,7 +68,7 @@ Rather, these resources just reference these workloads and inform Istio how to c
 When adding a virtual machine workload to the mesh, you will need to create a `WorkloadGroup` that acts as template for each `WorkloadEntry` instance:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: product-vm
@@ -87,7 +87,7 @@ Once a virtual machine has been [configured and added to the mesh](/docs/setup/i
 For example:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   annotations:

--- a/content/en/docs/ops/diagnostic-tools/istioctl-describe/index.md
+++ b/content/en/docs/ops/diagnostic-tools/istioctl-describe/index.md
@@ -240,7 +240,7 @@ instructions, you can enable strict mutual TLS for the `ratings` service:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: ratings-strict

--- a/content/en/docs/ops/integrations/certmanager/index.md
+++ b/content/en/docs/ops/integrations/certmanager/index.md
@@ -64,7 +64,7 @@ For example, a `Certificate` may look like:
   This can then be referenced in the `tls` config for a Gateway under `credentialName`:
 
     {{< text yaml >}}
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: Gateway
     metadata:
       name: gateway
@@ -94,7 +94,7 @@ Alternatively, a `Certificate` can be created as described in [Istio Gateway](#i
 then referenced in the `Ingress` object:
 
 {{< text yaml >}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress

--- a/content/en/docs/reference/config/analysis/ist0101/index.md
+++ b/content/en/docs/reference/config/analysis/ist0101/index.md
@@ -18,7 +18,7 @@ Error [IST0101] (VirtualService httpbin.default) Referenced gateway not found: "
 In this example, the `VirtualService` refers to a gateway that does not exist:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: httpbin-gateway
@@ -33,7 +33,7 @@ spec:
     hosts:
     - "*"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin

--- a/content/en/docs/reference/config/analysis/ist0106/index.md
+++ b/content/en/docs/reference/config/analysis/ist0106/index.md
@@ -17,7 +17,7 @@ Error [IST0106] (VirtualService ratings-bogus-weight-default.default) Schema val
 and your Istio configuration contains these values:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-bogus-weight-default

--- a/content/en/docs/reference/config/analysis/ist0109/index.md
+++ b/content/en/docs/reference/config/analysis/ist0109/index.md
@@ -31,7 +31,7 @@ specified.
 * They both define the same host `productpage.default.svc.cluster.local`.
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: productpage
@@ -44,7 +44,7 @@ spec:
     - destination:
         host: productpage
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: custom
@@ -63,7 +63,7 @@ You can resolve this issue by setting the `exportTo` field to `.` so
 that each virtual service is scoped only to its own namespace:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: productpage
@@ -78,7 +78,7 @@ spec:
     - destination:
         host: productpage
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: custom

--- a/content/en/docs/reference/config/analysis/ist0127/index.md
+++ b/content/en/docs/reference/config/analysis/ist0127/index.md
@@ -18,7 +18,7 @@ Warning [IST0127] (AuthorizationPolicy httpbin-nopods.httpbin) No matching workl
 when your cluster has the following authorization policy:
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin-nopods

--- a/content/en/docs/reference/config/analysis/ist0128/index.md
+++ b/content/en/docs/reference/config/analysis/ist0128/index.md
@@ -19,7 +19,7 @@ Error [IST0128] (DestinationRule db-tls.default) DestinationRule default/db-tls 
 when your cluster has the following destination rule:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: db-tls

--- a/content/en/docs/reference/config/analysis/ist0129/index.md
+++ b/content/en/docs/reference/config/analysis/ist0129/index.md
@@ -19,7 +19,7 @@ Error [IST0129] (DestinationRule db-tls.default) DestinationRule default/db-tls 
 when your cluster has the following destination rule:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: db-tls

--- a/content/en/docs/reference/config/analysis/ist0130/index.md
+++ b/content/en/docs/reference/config/analysis/ist0130/index.md
@@ -19,7 +19,7 @@ Warning [IST0130] (VirtualService sample-foo-cluster01.default) VirtualService r
 when your cluster has the following virtual service:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: sample-foo-cluster01

--- a/content/en/docs/reference/config/analysis/ist0131/index.md
+++ b/content/en/docs/reference/config/analysis/ist0131/index.md
@@ -18,7 +18,7 @@ Info [IST0131] (VirtualService tls-routing.default) VirtualService rule #1 match
 when your cluster has the following virtual service:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: tls-routing

--- a/content/en/docs/reference/config/analysis/ist0132/index.md
+++ b/content/en/docs/reference/config/analysis/ist0132/index.md
@@ -18,7 +18,7 @@ Warning [IST0132] (VirtualService testing-service.default testing.yaml:8) one or
 when your cluster has the following virtual service:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: testing-service
@@ -40,7 +40,7 @@ spec:
 and the following Gateway:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: testing-gateway

--- a/content/en/docs/reference/config/analysis/ist0134/index.md
+++ b/content/en/docs/reference/config/analysis/ist0134/index.md
@@ -18,7 +18,7 @@ Warning [IST0134] (ServiceEntry service-entry.default serviceentry.yaml:13) Serv
 When your cluster has the following `ServiceEntry` with unset `protocol` and missing `addresses`:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: service-entry
@@ -38,7 +38,7 @@ spec:
 Another example of this analyzer is when you have a `ServiceEntry` with `protocol: TCP` and missing `addresses`:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: service-entry

--- a/content/en/docs/reference/config/analysis/ist0143/index.md
+++ b/content/en/docs/reference/config/analysis/ist0143/index.md
@@ -52,7 +52,7 @@ If you do want to expose the application to other pods, there are two options:
   For example, with the above application:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: ratings

--- a/content/en/docs/reference/config/analysis/ist0162/index.md
+++ b/content/en/docs/reference/config/analysis/ist0162/index.md
@@ -13,7 +13,7 @@ For example, your Istio configuration contains these values:
 {{< text yaml >}}
 # Gateway with bogus ports
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-ingressgateway
@@ -71,7 +71,7 @@ Here's a corrected example:
 {{< text yaml >}}
 # Gateway with correct ports
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-ingressgateway

--- a/content/en/docs/reference/config/analysis/ist0166/index.md
+++ b/content/en/docs/reference/config/analysis/ist0166/index.md
@@ -63,7 +63,7 @@ spec:
 If you have both `targetRef` and `selector` in the policy, this message will not occur. For example:
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: telemetry-example
@@ -88,7 +88,7 @@ Kubernetes Gateway pods. Otherwise, the policy will not be applied.
 Here is an example:
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: telemetry-example

--- a/content/en/docs/setup/additional-setup/gateway/index.md
+++ b/content/en/docs/setup/additional-setup/gateway/index.md
@@ -235,7 +235,7 @@ For example, in the above deployments, the `istio=ingressgateway` label is set o
 To apply a `Gateway` to these deployments, you need to select the same label:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/content/en/docs/setup/additional-setup/gateway/snips.sh
+++ b/content/en/docs/setup/additional-setup/gateway/snips.sh
@@ -140,7 +140,7 @@ kubectl apply -f ingress.yaml
 }
 
 ! IFS=$'\n' read -r -d '' snip_gateway_selectors_1 <<\ENDSNIP
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/content/en/docs/setup/install/external-controlplane/index.md
+++ b/content/en/docs/setup/install/external-controlplane/index.md
@@ -375,8 +375,8 @@ and installing the sidecar injector webhook configuration on the remote cluster 
 
     {{< text syntax=bash snip_id=get_external_istiod_gateway_config >}}
     $ cat <<EOF > external-istiod-gw.yaml
-    apiVersion: networking.istio.io/v1beta1
-    kind: Gateway
+    apiVersion: networking.istio.io/v1
+.   kind: Gateway
     metadata:
       name: external-istiod-gw
       namespace: external-istiod
@@ -403,8 +403,8 @@ and installing the sidecar injector webhook configuration on the remote cluster 
           hosts:
           - $EXTERNAL_ISTIOD_ADDR
     ---
-    apiVersion: networking.istio.io/v1beta1
-    kind: VirtualService
+    apiVersion: networking.istio.io/v1
+.   kind: VirtualService
     metadata:
        name: external-istiod-vs
        namespace: external-istiod
@@ -429,7 +429,7 @@ and installing the sidecar injector webhook configuration on the remote cluster 
               port:
                 number: 443
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: external-istiod-dr

--- a/content/en/docs/setup/install/external-controlplane/index.md
+++ b/content/en/docs/setup/install/external-controlplane/index.md
@@ -376,7 +376,7 @@ and installing the sidecar injector webhook configuration on the remote cluster 
     {{< text syntax=bash snip_id=get_external_istiod_gateway_config >}}
     $ cat <<EOF > external-istiod-gw.yaml
     apiVersion: networking.istio.io/v1
-.   kind: Gateway
+    kind: Gateway
     metadata:
       name: external-istiod-gw
       namespace: external-istiod
@@ -404,7 +404,7 @@ and installing the sidecar injector webhook configuration on the remote cluster 
           - $EXTERNAL_ISTIOD_ADDR
     ---
     apiVersion: networking.istio.io/v1
-.   kind: VirtualService
+    kind: VirtualService
     metadata:
        name: external-istiod-vs
        namespace: external-istiod

--- a/content/en/docs/setup/install/external-controlplane/snips.sh
+++ b/content/en/docs/setup/install/external-controlplane/snips.sh
@@ -232,8 +232,8 @@ ENDSNIP
 
 snip_get_external_istiod_gateway_config() {
 cat <<EOF > external-istiod-gw.yaml
-apiVersion: networking.istio.io/v1beta1
-kind: Gateway
+apiVersion: networking.istio.io/v1
+.   kind: Gateway
 metadata:
   name: external-istiod-gw
   namespace: external-istiod
@@ -260,8 +260,8 @@ spec:
       hosts:
       - $EXTERNAL_ISTIOD_ADDR
 ---
-apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
+apiVersion: networking.istio.io/v1
+.   kind: VirtualService
 metadata:
    name: external-istiod-vs
    namespace: external-istiod
@@ -286,7 +286,7 @@ spec:
           port:
             number: 443
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: external-istiod-dr

--- a/content/en/docs/setup/install/external-controlplane/snips.sh
+++ b/content/en/docs/setup/install/external-controlplane/snips.sh
@@ -233,7 +233,7 @@ ENDSNIP
 snip_get_external_istiod_gateway_config() {
 cat <<EOF > external-istiod-gw.yaml
 apiVersion: networking.istio.io/v1
-.   kind: Gateway
+kind: Gateway
 metadata:
   name: external-istiod-gw
   namespace: external-istiod
@@ -261,7 +261,7 @@ spec:
       - $EXTERNAL_ISTIOD_ADDR
 ---
 apiVersion: networking.istio.io/v1
-.   kind: VirtualService
+kind: VirtualService
 metadata:
    name: external-istiod-vs
    namespace: external-istiod

--- a/content/en/docs/setup/install/multiple-controlplanes/index.md
+++ b/content/en/docs/setup/install/multiple-controlplanes/index.md
@@ -91,7 +91,7 @@ By default, Istio only uses `discoverySelectors` to scope workload endpoints. To
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: security.istio.io/v1beta1
+    apiVersion: security.istio.io/v1
     kind: PeerAuthentication
     metadata:
       name: "usergroup-1-peerauth"
@@ -106,7 +106,7 @@ By default, Istio only uses `discoverySelectors` to scope workload endpoints. To
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: security.istio.io/v1beta1
+    apiVersion: security.istio.io/v1
     kind: PeerAuthentication
     metadata:
       name: "usergroup-2-peerauth"

--- a/content/en/docs/setup/install/multiple-controlplanes/snips.sh
+++ b/content/en/docs/setup/install/multiple-controlplanes/snips.sh
@@ -70,7 +70,7 @@ EOF
 
 snip_deploying_multiple_control_planes_3() {
 kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "usergroup-1-peerauth"
@@ -83,7 +83,7 @@ EOF
 
 snip_deploying_multiple_control_planes_4() {
 kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "usergroup-2-peerauth"

--- a/content/en/docs/setup/install/virtual-machine/index.md
+++ b/content/en/docs/setup/install/virtual-machine/index.md
@@ -205,7 +205,7 @@ First, create a template `WorkloadGroup` for the VM(s):
 
 {{< text bash >}}
 $ cat <<EOF > workloadgroup.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: "${VM_APP}"
@@ -230,7 +230,7 @@ First, create a template `WorkloadGroup` for the VM(s):
 
 {{< text syntax=bash snip_id=create_wg >}}
 $ cat <<EOF > workloadgroup.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: "${VM_APP}"
@@ -257,7 +257,7 @@ For example, to configure a probe on the `/ready` endpoint of your application:
 
 {{< text bash >}}
 $ cat <<EOF > workloadgroup.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: "${VM_APP}"

--- a/content/en/docs/setup/install/virtual-machine/snips.sh
+++ b/content/en/docs/setup/install/virtual-machine/snips.sh
@@ -105,7 +105,7 @@ kubectl create serviceaccount "${SERVICE_ACCOUNT}" -n "${VM_NAMESPACE}"
 
 snip_create_files_to_transfer_to_the_virtual_machine_1() {
 cat <<EOF > workloadgroup.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: "${VM_APP}"
@@ -122,7 +122,7 @@ EOF
 
 snip_create_wg() {
 cat <<EOF > workloadgroup.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: "${VM_APP}"
@@ -143,7 +143,7 @@ kubectl --namespace "${VM_NAMESPACE}" apply -f workloadgroup.yaml
 
 snip_create_files_to_transfer_to_the_virtual_machine_4() {
 cat <<EOF > workloadgroup.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: "${VM_APP}"

--- a/content/en/docs/tasks/observability/distributed-tracing/opentelemetry/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/opentelemetry/index.md
@@ -89,7 +89,7 @@ Enable tracing by applying the following configuration:
 
 {{< text syntax=bash snip_id=enable_telemetry >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: otel-demo

--- a/content/en/docs/tasks/observability/distributed-tracing/opentelemetry/snips.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/opentelemetry/snips.sh
@@ -47,7 +47,7 @@ EOF
 
 snip_enable_telemetry() {
 kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: otel-demo

--- a/content/en/docs/tasks/observability/distributed-tracing/sampling/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/sampling/index.md
@@ -64,7 +64,7 @@ Then enable the tracing provider via Telemetry API. Note we don't set `randomSam
 
 {{< text syntax=bash snip_id=enable_telemetry_no_sampling >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -131,7 +131,7 @@ Then enable the tracing provider via Telemetry API and set the `randomSamplingPe
 
 {{< text syntax=bash snip_id=enable_telemetry_with_sampling >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
    name: otel-demo

--- a/content/en/docs/tasks/observability/distributed-tracing/sampling/snips.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/sampling/snips.sh
@@ -44,7 +44,7 @@ EOF
 
 snip_enable_telemetry_no_sampling() {
 kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -75,7 +75,7 @@ EOF
 
 snip_enable_telemetry_with_sampling() {
 kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
    name: otel-demo

--- a/content/en/docs/tasks/observability/distributed-tracing/skywalking/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/skywalking/index.md
@@ -40,7 +40,7 @@ In the default profile, the sampling rate is 1%. Increase it to 100% using the [
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default

--- a/content/en/docs/tasks/observability/distributed-tracing/skywalking/snips.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/skywalking/snips.sh
@@ -39,7 +39,7 @@ ENDSNIP
 
 snip_configure_tracing_2() {
 kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default

--- a/content/en/docs/tasks/observability/distributed-tracing/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/telemetry-api/index.md
@@ -48,7 +48,7 @@ Enable tracing by applying the following configuration:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -69,7 +69,7 @@ The default rate is 1%.
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -97,7 +97,7 @@ You can customize the tags using any of the three supported options below.
 1.  Literal represents a static value that gets added to each span.
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
     name: mesh-default
@@ -117,7 +117,7 @@ You can customize the tags using any of the three supported options below.
     populated from a workload proxy environment variable.
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: mesh-default
@@ -143,7 +143,7 @@ You can customize the tags using any of the three supported options below.
     incoming client request header.
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: mesh-default

--- a/content/en/docs/tasks/observability/distributed-tracing/telemetry-api/snips.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/telemetry-api/snips.sh
@@ -41,7 +41,7 @@ istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKIN
 
 snip_enable_tracing_for_mesh_1() {
 kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -55,7 +55,7 @@ EOF
 
 snip_customizing_trace_sampling_1() {
 kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -69,7 +69,7 @@ EOF
 }
 
 ! IFS=$'\n' read -r -d '' snip_customizing_tracing_tags_1 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
 name: mesh-default
@@ -86,7 +86,7 @@ tracing:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_customizing_tracing_tags_2 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -104,7 +104,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_customizing_tracing_tags_3 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default

--- a/content/en/docs/tasks/observability/gateways/index.md
+++ b/content/en/docs/tasks/observability/gateways/index.md
@@ -69,7 +69,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: grafana-gateway
@@ -88,7 +88,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
             hosts:
             - "grafana.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: grafana-vs
@@ -105,7 +105,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
                 port:
                   number: 3000
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: grafana
@@ -126,7 +126,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: kiali-gateway
@@ -145,7 +145,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
             hosts:
             - "kiali.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: kiali-vs
@@ -162,7 +162,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
                 port:
                   number: 20001
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: kiali
@@ -183,7 +183,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: prometheus-gateway
@@ -202,7 +202,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
             hosts:
             - "prometheus.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: prometheus-vs
@@ -219,7 +219,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
                 port:
                   number: 9090
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: prometheus
@@ -240,7 +240,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: tracing-gateway
@@ -259,7 +259,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
             hosts:
             - "tracing.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: tracing-vs
@@ -276,7 +276,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
                 port:
                   number: 80
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: tracing
@@ -312,7 +312,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: grafana-gateway
@@ -328,7 +328,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
             hosts:
             - "grafana.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: grafana-vs
@@ -345,7 +345,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
                 port:
                   number: 3000
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: grafana
@@ -366,7 +366,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: kiali-gateway
@@ -382,7 +382,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
             hosts:
             - "kiali.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: kiali-vs
@@ -399,7 +399,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
                 port:
                   number: 20001
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: kiali
@@ -420,7 +420,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: prometheus-gateway
@@ -436,7 +436,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
             hosts:
             - "prometheus.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: prometheus-vs
@@ -453,7 +453,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
                 port:
                   number: 9090
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: prometheus
@@ -474,7 +474,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: tracing-gateway
@@ -490,7 +490,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
             hosts:
             - "tracing.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: tracing-vs
@@ -507,7 +507,7 @@ This example uses self-signed certificates, which may not be appropriate for pro
                 port:
                   number: 80
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: tracing

--- a/content/en/docs/tasks/observability/gateways/snips.sh
+++ b/content/en/docs/tasks/observability/gateways/snips.sh
@@ -40,7 +40,7 @@ kubectl create -n istio-system secret tls telemetry-gw-cert --key=${CERT_DIR}/tl
 
 snip_option_1_secure_access_https_2() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: grafana-gateway
@@ -59,7 +59,7 @@ spec:
     hosts:
     - "grafana.${INGRESS_DOMAIN}"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: grafana-vs
@@ -76,7 +76,7 @@ spec:
         port:
           number: 3000
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: grafana
@@ -98,7 +98,7 @@ ENDSNIP
 
 snip_option_1_secure_access_https_3() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: kiali-gateway
@@ -117,7 +117,7 @@ spec:
     hosts:
     - "kiali.${INGRESS_DOMAIN}"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: kiali-vs
@@ -134,7 +134,7 @@ spec:
         port:
           number: 20001
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: kiali
@@ -156,7 +156,7 @@ ENDSNIP
 
 snip_option_1_secure_access_https_4() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: prometheus-gateway
@@ -175,7 +175,7 @@ spec:
     hosts:
     - "prometheus.${INGRESS_DOMAIN}"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: prometheus-vs
@@ -192,7 +192,7 @@ spec:
         port:
           number: 9090
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: prometheus
@@ -214,7 +214,7 @@ ENDSNIP
 
 snip_option_1_secure_access_https_5() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: tracing-gateway
@@ -233,7 +233,7 @@ spec:
     hosts:
     - "tracing.${INGRESS_DOMAIN}"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: tracing-vs
@@ -250,7 +250,7 @@ spec:
         port:
           number: 80
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: tracing
@@ -272,7 +272,7 @@ ENDSNIP
 
 snip_option_2_insecure_access_http_1() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: grafana-gateway
@@ -288,7 +288,7 @@ spec:
     hosts:
     - "grafana.${INGRESS_DOMAIN}"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: grafana-vs
@@ -305,7 +305,7 @@ spec:
         port:
           number: 3000
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: grafana
@@ -327,7 +327,7 @@ ENDSNIP
 
 snip_option_2_insecure_access_http_2() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: kiali-gateway
@@ -343,7 +343,7 @@ spec:
     hosts:
     - "kiali.${INGRESS_DOMAIN}"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: kiali-vs
@@ -360,7 +360,7 @@ spec:
         port:
           number: 20001
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: kiali
@@ -382,7 +382,7 @@ ENDSNIP
 
 snip_option_2_insecure_access_http_3() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: prometheus-gateway
@@ -398,7 +398,7 @@ spec:
     hosts:
     - "prometheus.${INGRESS_DOMAIN}"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: prometheus-vs
@@ -415,7 +415,7 @@ spec:
         port:
           number: 9090
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: prometheus
@@ -437,7 +437,7 @@ ENDSNIP
 
 snip_option_2_insecure_access_http_4() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: tracing-gateway
@@ -453,7 +453,7 @@ spec:
     hosts:
     - "tracing.${INGRESS_DOMAIN}"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: tracing-vs
@@ -470,7 +470,7 @@ spec:
         port:
           number: 80
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: tracing

--- a/content/en/docs/tasks/observability/logs/access-log/index.md
+++ b/content/en/docs/tasks/observability/logs/access-log/index.md
@@ -28,7 +28,7 @@ Istio offers a few ways to enable access logs. Use of the Telemetry API is recom
 The Telemetry API can be used to enable or disable access logs:
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default

--- a/content/en/docs/tasks/observability/logs/access-log/snips.sh
+++ b/content/en/docs/tasks/observability/logs/access-log/snips.sh
@@ -23,7 +23,7 @@ source "content/en/boilerplates/snips/before-you-begin-egress.sh"
 source "content/en/boilerplates/snips/start-httpbin-service.sh"
 
 ! IFS=$'\n' read -r -d '' snip_using_telemetry_api_1 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default

--- a/content/en/docs/tasks/observability/logs/otel-provider/index.md
+++ b/content/en/docs/tasks/observability/logs/otel-provider/index.md
@@ -63,7 +63,7 @@ Next, add a Telemetry resource that tells Istio to send access logs to the OpenT
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n default -f -
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: sleep-logging

--- a/content/en/docs/tasks/observability/logs/otel-provider/snips.sh
+++ b/content/en/docs/tasks/observability/logs/otel-provider/snips.sh
@@ -59,7 +59,7 @@ ENDSNIP
 
 snip_enable_envoys_access_logging_3() {
 cat <<EOF | kubectl apply -n default -f -
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: sleep-logging

--- a/content/en/docs/tasks/observability/logs/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/logs/telemetry-api/index.md
@@ -30,7 +30,7 @@ $ kubectl apply -f @samples/open-telemetry/loki/otel.yaml@ -n istio-system
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -n istio-system -f -
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: mesh-logging-default
@@ -49,7 +49,7 @@ $ kubectl apply -f @samples/open-telemetry/loki/otel.yaml@ -n istio-system
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -n default -f -
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: disable-sleep-logging
@@ -71,7 +71,7 @@ $ kubectl apply -f @samples/open-telemetry/loki/otel.yaml@ -n istio-system
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -n default -f -
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: disable-httpbin-logging

--- a/content/en/docs/tasks/observability/logs/telemetry-api/snips.sh
+++ b/content/en/docs/tasks/observability/logs/telemetry-api/snips.sh
@@ -30,7 +30,7 @@ kubectl apply -f samples/open-telemetry/loki/otel.yaml -n istio-system
 
 snip_get_started_with_telemetry_api_1() {
 cat <<EOF | kubectl apply -n istio-system -f -
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-logging-default
@@ -43,7 +43,7 @@ EOF
 
 snip_get_started_with_telemetry_api_2() {
 cat <<EOF | kubectl apply -n default -f -
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: disable-sleep-logging
@@ -61,7 +61,7 @@ EOF
 
 snip_get_started_with_telemetry_api_3() {
 cat <<EOF | kubectl apply -n default -f -
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: disable-httpbin-logging

--- a/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
@@ -66,7 +66,7 @@ spec:
         - value: "CreateReview"
           condition: "request.url_path == '/reviews/' && request.method == 'POST'"
 ---
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: custom-tags
@@ -135,7 +135,7 @@ spec:
           - value: 4xx
             condition: response.code >= 400 && response.code <= 499
 ---
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: custom-tags

--- a/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/customize-metrics/index.md
@@ -37,7 +37,7 @@ gateways and sidecars in the inbound and outbound direction, use the following:
 
 {{< text bash >}}
 $ cat <<EOF > ./custom_metrics.yaml
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: namespace-metrics

--- a/content/en/docs/tasks/observability/metrics/customize-metrics/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/customize-metrics/snips.sh
@@ -22,7 +22,7 @@
 
 snip_enable_custom_metrics_1() {
 cat <<EOF > ./custom_metrics.yaml
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: namespace-metrics

--- a/content/en/docs/tasks/observability/metrics/telemetry-api/index.md
+++ b/content/en/docs/tasks/observability/metrics/telemetry-api/index.md
@@ -45,7 +45,7 @@ You can modify the standard metric definitions using `tags_to_remove` or by re-d
 1. Remove `grpc_response_status` tags from `REQUEST_COUNT` metric
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: remove-tags
@@ -66,7 +66,7 @@ You can modify the standard metric definitions using `tags_to_remove` or by re-d
 1. Add custom tags for `REQUEST_COUNT` metric
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: custom-tags
@@ -95,7 +95,7 @@ You can modify the standard metric definitions using `tags_to_remove` or by re-d
 1. Disable all metrics by following configuration:
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: remove-all-metrics
@@ -114,7 +114,7 @@ You can modify the standard metric definitions using `tags_to_remove` or by re-d
 1. Disable `REQUEST_COUNT` metrics by following configuration:
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: remove-request-count
@@ -133,7 +133,7 @@ You can modify the standard metric definitions using `tags_to_remove` or by re-d
 1. Disable `REQUEST_COUNT` metrics for client by following configuration:
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: remove-client
@@ -152,7 +152,7 @@ You can modify the standard metric definitions using `tags_to_remove` or by re-d
 1. Disable `REQUEST_COUNT` metrics for server by following configuration:
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: remove-server

--- a/content/en/docs/tasks/observability/metrics/telemetry-api/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/telemetry-api/snips.sh
@@ -32,7 +32,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_override_metrics_1 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: remove-tags
@@ -51,7 +51,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_override_metrics_2 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: custom-tags
@@ -76,7 +76,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_disable_metrics_1 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: remove-all-metrics
@@ -93,7 +93,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_disable_metrics_2 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: remove-request-count
@@ -110,7 +110,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_disable_metrics_3 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: remove-client
@@ -127,7 +127,7 @@ spec:
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_disable_metrics_4 <<\ENDSNIP
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: remove-server

--- a/content/en/docs/tasks/observability/telemetry/index.md
+++ b/content/en/docs/tasks/observability/telemetry/index.md
@@ -88,7 +88,7 @@ mesh-wide behavior, add a new (or edit the existing) `Telemetry` resource in the
 Here is an example configuration that uses the provider configuration from the prior section:
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -115,7 +115,7 @@ Any fields specified in the namespace resource will completely override the inhe
 For example:
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: namespace-override
@@ -149,7 +149,7 @@ field configuration from the configuration hierarchy.
 For example:
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: workload-override

--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -173,7 +173,7 @@ using the VirtualService http name. The PATH value `api` inserted in the prior e
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1
-.   kind: VirtualService
+    kind: VirtualService
     metadata:
       name: bookinfo
     spec:

--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -172,8 +172,8 @@ using the VirtualService http name. The PATH value `api` inserted in the prior e
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1beta1
-    kind: VirtualService
+    apiVersion: networking.istio.io/v1
+.   kind: VirtualService
     metadata:
       name: bookinfo
     spec:

--- a/content/en/docs/tasks/policy-enforcement/rate-limit/snips.sh
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/snips.sh
@@ -128,8 +128,8 @@ EOF
 
 snip_global_rate_limit_advanced_case_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
-kind: VirtualService
+apiVersion: networking.istio.io/v1
+.   kind: VirtualService
 metadata:
   name: bookinfo
 spec:

--- a/content/en/docs/tasks/policy-enforcement/rate-limit/snips.sh
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/snips.sh
@@ -129,7 +129,7 @@ EOF
 snip_global_rate_limit_advanced_case_1() {
 kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1
-.   kind: VirtualService
+kind: VirtualService
 metadata:
   name: bookinfo
 spec:

--- a/content/en/docs/tasks/security/authentication/authn-policy/index.md
+++ b/content/en/docs/tasks/security/authentication/authn-policy/index.md
@@ -119,7 +119,7 @@ The mesh-wide peer authentication policy should not have a `selector` and must b
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "default"
@@ -172,7 +172,7 @@ To change mutual TLS for all workloads within a particular namespace, use a name
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "default"
@@ -205,7 +205,7 @@ To set a peer authentication policy for a specific workload, you must configure 
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n bar -f -
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "httpbin"
@@ -246,7 +246,7 @@ To refine the mutual TLS settings per port, you must configure the `portLevelMtl
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n bar -f -
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "httpbin"
@@ -288,7 +288,7 @@ Note that you've already created a namespace-wide policy that enables mutual TLS
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n foo -f -
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "overwrite-example"

--- a/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
+++ b/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
@@ -95,7 +95,7 @@ ENDSNIP
 
 snip_globally_enabling_istio_mutual_tls_in_strict_mode_1() {
 kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "default"
@@ -130,7 +130,7 @@ kubectl delete peerauthentication -n istio-system default
 
 snip_namespacewide_policy_1() {
 kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "default"
@@ -160,7 +160,7 @@ ENDSNIP
 
 snip_enable_mutual_tls_per_workload_1() {
 cat <<EOF | kubectl apply -n bar -f -
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "httpbin"
@@ -200,7 +200,7 @@ ENDSNIP
 
 snip_enable_mutual_tls_per_workload_4() {
 cat <<EOF | kubectl apply -n bar -f -
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "httpbin"
@@ -236,7 +236,7 @@ ENDSNIP
 
 snip_policy_precedence_1() {
 cat <<EOF | kubectl apply -n foo -f -
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "overwrite-example"

--- a/content/en/docs/tasks/security/authentication/claim-to-header/index.md
+++ b/content/en/docs/tasks/security/authentication/claim-to-header/index.md
@@ -57,7 +57,7 @@ Before you begin this task, do the following:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: security.istio.io/v1beta1
+    apiVersion: security.istio.io/v1
     kind: RequestAuthentication
     metadata:
       name: "jwt-example"

--- a/content/en/docs/tasks/security/authentication/claim-to-header/snips.sh
+++ b/content/en/docs/tasks/security/authentication/claim-to-header/snips.sh
@@ -37,7 +37,7 @@ ENDSNIP
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_1() {
 kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: RequestAuthentication
 metadata:
   name: "jwt-example"

--- a/content/en/docs/tasks/security/authentication/jwt-route/index.md
+++ b/content/en/docs/tasks/security/authentication/jwt-route/index.md
@@ -82,7 +82,7 @@ identity and more secure compared using the unauthenticated HTTP attributes (e.g
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: httpbin

--- a/content/en/docs/tasks/security/authentication/jwt-route/snips.sh
+++ b/content/en/docs/tasks/security/authentication/jwt-route/snips.sh
@@ -53,7 +53,7 @@ EOF
 
 snip_configuring_ingress_routing_based_on_jwt_claims_2() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin

--- a/content/en/docs/tasks/security/authentication/mtls-migration/index.md
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/index.md
@@ -90,7 +90,7 @@ to only accept mutual TLS traffic.
 
 {{< text bash >}}
 $ kubectl apply -n foo -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -135,7 +135,7 @@ You can lock down workloads in all namespaces to only accept mutual TLS traffic 
 
 {{< text bash >}}
 $ kubectl apply -n istio-system -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default

--- a/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
+++ b/content/en/docs/tasks/security/authentication/mtls-migration/snips.sh
@@ -65,7 +65,7 @@ ENDSNIP
 
 snip_lock_down_to_mutual_tls_by_namespace_1() {
 kubectl apply -n foo -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -100,7 +100,7 @@ ENDSNIP
 
 snip_lock_down_mutual_tls_for_the_entire_mesh_1() {
 kubectl apply -n istio-system -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default

--- a/content/en/docs/tasks/security/authorization/authz-custom/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-custom/index.md
@@ -72,7 +72,7 @@ The following is an example service entry for an external authorizer deployed in
 of the application that needs the external authorization.
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-authz-grpc-local

--- a/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
@@ -54,7 +54,7 @@ kubectl logs "$(kubectl get pod -l app=ext-authz -n foo -o jsonpath={.items..met
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_deploy_the_external_authorizer_3 <<\ENDSNIP
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-authz-grpc-local

--- a/content/en/docs/tasks/security/cert-management/plugin-ca-cert/index.md
+++ b/content/en/docs/tasks/security/cert-management/plugin-ca-cert/index.md
@@ -124,7 +124,7 @@ Support for SHA-1 signatures is [disabled by default in Go 1.18](https://github.
 
     {{< text bash >}}
     $ kubectl apply -n foo -f - <<EOF
-    apiVersion: security.istio.io/v1beta1
+    apiVersion: security.istio.io/v1
     kind: PeerAuthentication
     metadata:
       name: "default"

--- a/content/en/docs/tasks/security/cert-management/plugin-ca-cert/snips.sh
+++ b/content/en/docs/tasks/security/cert-management/plugin-ca-cert/snips.sh
@@ -58,7 +58,7 @@ kubectl apply -f <(istioctl kube-inject -f samples/sleep/sleep.yaml) -n foo
 
 snip_deploying_example_services_2() {
 kubectl apply -n foo -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "default"

--- a/content/en/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/en/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -37,7 +37,7 @@ when calling the `httpbin` service:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: httpbin

--- a/content/en/docs/tasks/traffic-management/circuit-breaking/snips.sh
+++ b/content/en/docs/tasks/traffic-management/circuit-breaking/snips.sh
@@ -23,7 +23,7 @@ source "content/en/boilerplates/snips/start-httpbin-service.sh"
 
 snip_configuring_the_circuit_breaker_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: httpbin

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -171,7 +171,7 @@ any other unintentional accesses.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: httpbin-ext
@@ -219,7 +219,7 @@ any other unintentional accesses.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: google
@@ -280,7 +280,7 @@ In this example, you set a timeout rule on calls to the `httpbin.org` service.
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin-ext

--- a/content/en/docs/tasks/traffic-management/egress/egress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-control/snips.sh
@@ -64,7 +64,7 @@ ENDSNIP
 
 snip_access_an_external_http_service_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: httpbin-ext
@@ -106,7 +106,7 @@ ENDSNIP
 
 snip_access_an_external_https_service_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: google
@@ -151,7 +151,7 @@ ENDSNIP
 
 snip_manage_traffic_to_external_services_2() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin-ext

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -81,7 +81,7 @@ be done by the egress gateway, as opposed to by the sidecar in the previous exam
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: cnn
@@ -120,7 +120,7 @@ be done by the egress gateway, as opposed to by the sidecar in the previous exam
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -137,7 +137,7 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -184,7 +184,7 @@ spec:
       namespaces:
         from: Same
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -214,7 +214,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-cnn-through-egress-gateway
@@ -295,7 +295,7 @@ EOF
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: originate-tls-for-edition-cnn-com
@@ -627,7 +627,7 @@ In this example, a single generic Secret with keys `tls.key`, `tls.crt`, and `ca
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -644,7 +644,7 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-nginx
@@ -717,7 +717,7 @@ subjects:
 - kind: ServiceAccount
   name: nginx-egressgateway-istio
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-nginx
@@ -747,7 +747,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-nginx-through-egress-gateway
@@ -788,7 +788,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-nginx-to-egress-gateway
@@ -852,7 +852,7 @@ TODO: figure out why using an `HTTPRoute`, instead of the above `VirtualService`
 
 {{< text bash >}}
 $ kubectl apply -n istio-system -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: originate-mtls-for-nginx
@@ -879,7 +879,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: originate-mtls-for-nginx

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/snips.sh
@@ -47,7 +47,7 @@ ENDSNIP
 
 snip_perform_tls_origination_with_an_egress_gateway_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: cnn
@@ -78,7 +78,7 @@ ENDSNIP
 
 snip_perform_tls_origination_with_an_egress_gateway_3() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -95,7 +95,7 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -138,7 +138,7 @@ spec:
       namespaces:
         from: Same
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -158,7 +158,7 @@ EOF
 
 snip_perform_tls_origination_with_an_egress_gateway_5() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-cnn-through-egress-gateway
@@ -229,7 +229,7 @@ EOF
 
 snip_perform_tls_origination_with_an_egress_gateway_7() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: originate-tls-for-edition-cnn-com
@@ -410,7 +410,7 @@ kubectl create secret -n default generic client-credential --from-file=tls.key=c
 
 snip_configure_mutual_tls_origination_for_egress_traffic_3() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -427,7 +427,7 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-nginx
@@ -496,7 +496,7 @@ subjects:
 - kind: ServiceAccount
   name: nginx-egressgateway-istio
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-nginx
@@ -516,7 +516,7 @@ EOF
 
 snip_configure_mutual_tls_origination_for_egress_traffic_5() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-nginx-through-egress-gateway
@@ -553,7 +553,7 @@ EOF
 
 snip_configure_mutual_tls_origination_for_egress_traffic_6() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-nginx-to-egress-gateway
@@ -605,7 +605,7 @@ EOF
 
 snip_configure_mutual_tls_origination_for_egress_traffic_7() {
 kubectl apply -n istio-system -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: originate-mtls-for-nginx
@@ -628,7 +628,7 @@ EOF
 
 snip_configure_mutual_tls_origination_for_egress_traffic_8() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: originate-mtls-for-nginx

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -131,7 +131,7 @@ First create a `ServiceEntry` to allow direct traffic to an external service.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: cnn
@@ -181,7 +181,7 @@ The `subset` field in the `DestinationRule` should be reused for the additional 
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -196,7 +196,7 @@ spec:
     hosts:
     - edition.cnn.com
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -245,7 +245,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-cnn-through-egress-gateway
@@ -441,7 +441,7 @@ You need to specify port 443 with protocol `TLS` in a corresponding `ServiceEntr
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: cnn
@@ -480,7 +480,7 @@ The `subset` field in the `DestinationRule` should be reused for the additional 
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -497,7 +497,7 @@ spec:
     tls:
       mode: PASSTHROUGH
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -506,7 +506,7 @@ spec:
   subsets:
   - name: cnn
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-cnn-through-egress-gateway
@@ -899,7 +899,7 @@ to direct the `test-egress` namespace traffic through the egress gateway:
 
 {{< text bash >}}
 $ kubectl apply -n test-egress -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/snips.sh
@@ -47,7 +47,7 @@ ENDSNIP
 
 snip_egress_gateway_for_http_traffic_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: cnn
@@ -83,7 +83,7 @@ ENDSNIP
 
 snip_egress_gateway_for_http_traffic_3() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -98,7 +98,7 @@ spec:
     hosts:
     - edition.cnn.com
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -132,7 +132,7 @@ EOF
 
 snip_egress_gateway_for_http_traffic_5() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-cnn-through-egress-gateway
@@ -267,7 +267,7 @@ kubectl delete httproute forward-cnn-from-egress-gateway
 
 snip_egress_gateway_for_https_traffic_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: cnn
@@ -295,7 +295,7 @@ ENDSNIP
 
 snip_egress_gateway_for_https_traffic_3() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -312,7 +312,7 @@ spec:
     tls:
       mode: PASSTHROUGH
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -321,7 +321,7 @@ spec:
   subsets:
   - name: cnn
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-cnn-through-egress-gateway
@@ -582,7 +582,7 @@ ENDSNIP
 
 snip_apply_kubernetes_network_policies_14() {
 kubectl apply -n test-egress -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn

--- a/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
@@ -111,7 +111,7 @@ Kubernetes Services for egress traffic work with other protocols as well.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: my-httpbin
@@ -210,7 +210,7 @@ $ kubectl delete service my-httpbin
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: my-wikipedia

--- a/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-kubernetes-services/snips.sh
@@ -83,7 +83,7 @@ ENDSNIP
 
 snip_kubernetes_externalname_service_to_access_an_external_service_4() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: my-httpbin
@@ -170,7 +170,7 @@ ENDSNIP
 
 snip_use_a_kubernetes_service_with_endpoints_to_access_an_external_service_5() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: my-wikipedia

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -64,7 +64,7 @@ This time, however, use a single `ServiceEntry` to enable both HTTP and HTTPS ac
 
     {{< text syntax=bash snip_id=apply_simple >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: edition-cnn-com
@@ -119,7 +119,7 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
 
     {{< text syntax=bash snip_id=apply_origination >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: edition-cnn-com
@@ -136,7 +136,7 @@ Both of these issues can be resolved by configuring Istio to perform TLS origina
         protocol: HTTPS
       resolution: DNS
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: edition-cnn-com
@@ -414,7 +414,7 @@ to hold the configuration of the NGINX server:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: originate-mtls-for-nginx
@@ -431,7 +431,7 @@ to hold the configuration of the NGINX server:
         protocol: HTTPS
       resolution: DNS
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: originate-mtls-for-nginx

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
@@ -34,7 +34,7 @@ export SOURCE_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.n
 
 snip_apply_simple() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: edition-cnn-com
@@ -68,7 +68,7 @@ ENDSNIP
 
 snip_apply_origination() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: edition-cnn-com
@@ -85,7 +85,7 @@ spec:
     protocol: HTTPS
   resolution: DNS
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: edition-cnn-com
@@ -251,7 +251,7 @@ kubectl create rolebinding client-credential-role-binding --role=client-credenti
 
 snip_configure_mutual_tls_origination_for_egress_traffic_at_sidecar_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: originate-mtls-for-nginx
@@ -268,7 +268,7 @@ spec:
     protocol: HTTPS
   resolution: DNS
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: originate-mtls-for-nginx

--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -145,8 +145,8 @@ Next, you must configure the traffic from the Istio-enabled pods to use the HTTP
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1beta1
-    kind: ServiceEntry
+    apiVersion: networking.istio.io/v1
+.   kind: ServiceEntry
     metadata:
       name: proxy
     spec:

--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -146,7 +146,7 @@ Next, you must configure the traffic from the Istio-enabled pods to use the HTTP
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1
-.   kind: ServiceEntry
+    kind: ServiceEntry
     metadata:
       name: proxy
     spec:

--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/snips.sh
@@ -108,7 +108,7 @@ ENDSNIP
 snip_configure_traffic_to_external_https_proxy_1() {
 kubectl apply -f - <<EOF
 apiVersion: networking.istio.io/v1
-.   kind: ServiceEntry
+kind: ServiceEntry
 metadata:
   name: proxy
 spec:

--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/snips.sh
@@ -107,8 +107,8 @@ ENDSNIP
 
 snip_configure_traffic_to_external_https_proxy_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
-kind: ServiceEntry
+apiVersion: networking.istio.io/v1
+.   kind: ServiceEntry
 metadata:
   name: proxy
 spec:

--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
@@ -107,7 +107,7 @@ the default) is used in the service entry below.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: wikipedia
@@ -153,7 +153,7 @@ the set of domains.
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -170,7 +170,7 @@ spec:
     tls:
       mode: PASSTHROUGH
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-wikipedia
@@ -179,7 +179,7 @@ spec:
   subsets:
     - name: wikipedia
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-wikipedia-through-egress-gateway
@@ -273,7 +273,7 @@ spec:
       name: www.wikipedia.org
       port: 443
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: wikipedia
@@ -295,7 +295,7 @@ EOF
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: www-wikipedia

--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/snips.sh
@@ -46,7 +46,7 @@ export SOURCE_POD=$(kubectl get pod -l app=sleep -o jsonpath={.items..metadata.n
 
 snip_configure_direct_traffic_to_a_wildcard_host_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: wikipedia
@@ -75,7 +75,7 @@ kubectl delete serviceentry wikipedia
 
 snip_configure_egress_gateway_traffic_to_a_wildcard_host_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -92,7 +92,7 @@ spec:
     tls:
       mode: PASSTHROUGH
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-wikipedia
@@ -101,7 +101,7 @@ spec:
   subsets:
     - name: wikipedia
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-wikipedia-through-egress-gateway
@@ -191,7 +191,7 @@ spec:
       name: www.wikipedia.org
       port: 443
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: wikipedia
@@ -207,7 +207,7 @@ EOF
 
 snip_configure_egress_gateway_traffic_to_a_wildcard_host_3() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: www-wikipedia

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -62,7 +62,7 @@ Create an [Istio Gateway](/docs/reference/config/networking/gateway/):
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: httpbin-gateway
@@ -85,7 +85,7 @@ Configure routes for traffic entering via the `Gateway`:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin
@@ -342,7 +342,7 @@ and `VirtualService` configurations. For example, change your ingress configurat
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: httpbin-gateway
@@ -359,7 +359,7 @@ spec:
     hosts:
     - "*"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -31,7 +31,7 @@ kubectl apply -f samples/httpbin/httpbin.yaml
 
 snip_configuring_ingress_using_a_gateway_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: httpbin-gateway
@@ -52,7 +52,7 @@ EOF
 
 snip_configuring_ingress_using_a_gateway_2() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin
@@ -187,7 +187,7 @@ ENDSNIP
 
 snip_accessing_ingress_services_using_a_browser_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: httpbin-gateway
@@ -204,7 +204,7 @@ spec:
     hosts:
     - "*"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/index.md
@@ -38,7 +38,7 @@ Apply the following `PeerAuthentication` policy to require mTLS traffic for all 
 
 {{< text bash >}}
 $ kubectl -n test apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -54,7 +54,7 @@ Disable `PeerAuthentication` for the port of the httpbin service which will perf
 
 {{< text bash >}}
 $ kubectl -n test apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: disable-peer-auth-for-external-mtls-port
@@ -167,7 +167,7 @@ The TLS mode can be `SIMPLE` or `MUTUAL`. This example uses `MUTUAL`.
 
 {{< text bash >}}
 $ kubectl -n test apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: ingress-sidecar

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/snips.sh
@@ -31,7 +31,7 @@ kubectl label namespace test istio-injection=enabled
 
 snip_enable_global_mtls_1() {
 kubectl -n test apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -43,7 +43,7 @@ EOF
 
 snip_disable_peerauthentication_for_the_externally_exposed_httpbin_port_1() {
 kubectl -n test apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: disable-peer-auth-for-external-mtls-port
@@ -137,7 +137,7 @@ EOF
 
 snip_configure_httpbin_to_enable_external_mtls_1() {
 kubectl -n test apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: ingress-sidecar

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
@@ -184,7 +184,7 @@ to hold the configuration of the NGINX server:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway
@@ -240,7 +240,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: nginx

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/snips.sh
@@ -151,7 +151,7 @@ ENDSNIP
 
 snip_configure_an_ingress_gateway_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway
@@ -193,7 +193,7 @@ EOF
 
 snip_configure_an_ingress_gateway_3() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: nginx

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -120,7 +120,7 @@ secret's name. The TLS mode should have the value of `SIMPLE`.
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway
@@ -145,7 +145,7 @@ virtual service:
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin
@@ -349,7 +349,7 @@ respectively. Set TLS mode to `SIMPLE`.
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway
@@ -382,7 +382,7 @@ Configure the gateway's traffic routes by defining a corresponding virtual servi
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: helloworld
@@ -538,7 +538,7 @@ Change the gateway's definition to set the TLS mode to `MUTUAL`.
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/snips.sh
@@ -84,7 +84,7 @@ kubectl create -n istio-system secret tls httpbin-credential \
 
 snip_configure_a_tls_ingress_gateway_for_a_single_host_2() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway
@@ -106,7 +106,7 @@ EOF
 
 snip_configure_a_tls_ingress_gateway_for_a_single_host_3() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin
@@ -268,7 +268,7 @@ kubectl create -n istio-system secret tls helloworld-credential \
 
 snip_configure_a_tls_ingress_gateway_for_multiple_hosts_4() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway
@@ -299,7 +299,7 @@ EOF
 
 snip_configure_a_tls_ingress_gateway_for_multiple_hosts_5() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: helloworld
@@ -422,7 +422,7 @@ kubectl create -n istio-system secret generic httpbin-credential \
 
 snip_configure_a_mutual_tls_ingress_gateway_2() {
 cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/distribute/index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/distribute/index.md
@@ -36,7 +36,7 @@ Apply a `DestinationRule` that configures the following:
 
 {{< text bash >}}
 $ kubectl --context="${CTX_PRIMARY}" apply -n sample -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: helloworld

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/distribute/snips.sh
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/distribute/snips.sh
@@ -22,7 +22,7 @@
 
 snip_configure_weighted_distribution_1() {
 kubectl --context="${CTX_PRIMARY}" apply -n sample -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: helloworld

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/index.md
@@ -55,7 +55,7 @@ Apply a `DestinationRule` that configures the following:
 
 {{< text bash >}}
 $ kubectl --context="${CTX_PRIMARY}" apply -n sample -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: helloworld

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/snips.sh
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/snips.sh
@@ -22,7 +22,7 @@
 
 snip_configure_locality_failover_1() {
 kubectl --context="${CTX_PRIMARY}" apply -n sample -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: helloworld

--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -143,7 +143,7 @@ In this step, you will change that behavior so that all traffic goes to `v1`.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: httpbin
@@ -157,7 +157,7 @@ In this step, you will change that behavior so that all traffic goes to `v1`.
             subset: v1
           weight: 100
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: httpbin
@@ -266,7 +266,7 @@ In this step, you will change that behavior so that all traffic goes to `v1`.
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: httpbin

--- a/content/en/docs/tasks/traffic-management/mirroring/snips.sh
+++ b/content/en/docs/tasks/traffic-management/mirroring/snips.sh
@@ -121,7 +121,7 @@ EOF
 
 snip_creating_a_default_routing_policy_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin
@@ -135,7 +135,7 @@ spec:
         subset: v1
       weight: 100
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: httpbin
@@ -233,7 +233,7 @@ ENDSNIP
 
 snip_mirroring_traffic_to_httpbinv2_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin

--- a/content/en/docs/tasks/traffic-management/request-timeouts/index.md
+++ b/content/en/docs/tasks/traffic-management/request-timeouts/index.md
@@ -37,7 +37,7 @@ to the `ratings` service.
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews
@@ -87,7 +87,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings
@@ -116,7 +116,7 @@ add the delay for now:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings
@@ -153,7 +153,7 @@ the [Bookinfo](/docs/examples/bookinfo/#determine-the-ingress-ip-and-port) doc.
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews

--- a/content/en/docs/tasks/traffic-management/request-timeouts/snips.sh
+++ b/content/en/docs/tasks/traffic-management/request-timeouts/snips.sh
@@ -23,7 +23,7 @@ source "content/en/boilerplates/snips/gateway-api-support.sh"
 
 snip_request_timeouts_1() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews
@@ -59,7 +59,7 @@ EOF
 
 snip_request_timeouts_3() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings
@@ -81,7 +81,7 @@ EOF
 
 snip_request_timeouts_4() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings
@@ -102,7 +102,7 @@ EOF
 
 snip_request_timeouts_5() {
 kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews

--- a/content/en/test/tb/index.md
+++ b/content/en/test/tb/index.md
@@ -26,7 +26,7 @@ Bash text block with redirection
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 {{< /text >}}
 

--- a/content/zh/about/faq/traffic-management/cors.md
+++ b/content/zh/about/faq/traffic-management/cors.md
@@ -18,7 +18,7 @@ CORS 是一个经常被误解的 HTTP 概念，在配置时经常会导致混淆
 服务，我们可以通过配置一个 `corsPolicy` 来允许这样做：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: bank

--- a/content/zh/docs/concepts/security/index.md
+++ b/content/zh/docs/concepts/security/index.md
@@ -254,7 +254,7 @@ Istio 将这两种认证类型以及凭证中的其他声明（如果适用）�
 必须使用双向 TLS：
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "example-peer-policy"
@@ -331,7 +331,7 @@ Istio 可以将所有匹配的请求认证策略组合起来，
 下面的对等认证策略要求命名空间 `foo` 中的所有工作负载都使用双向 TLS：
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "example-policy"
@@ -347,7 +347,7 @@ spec:
 并对所有其他端口使用命名空间范围的对等认证策略的双向 TLS 设置：
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "example-workload-policy"

--- a/content/zh/docs/concepts/traffic-management/index.md
+++ b/content/zh/docs/concepts/traffic-management/index.md
@@ -113,7 +113,7 @@ Envoy 会在所有的服务实例中使用轮询的负载均衡策略分发请�
 下面的虚拟服务根据请求是否来自特定的用户，把它们路由到服务的不同版本。
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews
@@ -225,7 +225,7 @@ destination 片段还指定了 Kubernetes 服务的子集，将符合此规则�
 虚拟服务规则根据请求的 URI 和指向适当服务的请求匹配流量。
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: bookinfo
@@ -311,7 +311,7 @@ Istio 流量路由功能的关键部分。您可以将虚拟服务视为将流�
 在下面的示例中，目标规则为 `my-svc` 目标服务配置了 3 个具有不同负载均衡策略的子集：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: my-destination-rule
@@ -371,7 +371,7 @@ Istio 提供了一些预先配置好的网关代理部署（`istio-ingressgatewa
 下面的示例展示了一个外部 HTTPS 入口流量的网关配置：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: ext-host-gwy
@@ -395,7 +395,7 @@ spec:
 正如下面的示例所示，使用虚拟服务的 `gateways` 字段进行设置：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: virtual-svc
@@ -428,7 +428,7 @@ spec:
 Istio 的服务注册中心：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: svc-entry
@@ -450,7 +450,7 @@ spec:
 下面的目标规则调整了使用服务入口配置的 `ext-svc.example.com` 外部服务的连接超时：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: ext-res-dr
@@ -482,7 +482,7 @@ spec:
 控制平面中的服务（Istio 的 Egress 和遥测功能需要使用）：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: default
@@ -514,7 +514,7 @@ Istio 允许您使用[虚拟服务](#virtual-services)按服务轻松地动态�
 下面的示例是一个虚拟服务，它对 ratings 服务的 v1 子集的调用指定 10 秒超时：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings
@@ -542,7 +542,7 @@ spec:
 下面的示例配置了在初始调用失败后最多重试 3 次来连接到服务子集，每个重试都有 2 秒的超时。
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings
@@ -570,7 +570,7 @@ spec:
 让配置应用于服务中的每个主机。下面的示例将 v1 子集的 `reviews` 服务工作负载的并发连接数限制为 100：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: reviews
@@ -612,7 +612,7 @@ spec:
 例如，下面的虚拟服务为千分之一的访问 `ratings` 服务的请求配置了一个 5 秒的延迟：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings

--- a/content/zh/docs/examples/microservices-istio/istio-ingress-gateway/index.md
+++ b/content/zh/docs/examples/microservices-istio/istio-ingress-gateway/index.md
@@ -30,7 +30,7 @@ test: no
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: Gateway
     metadata:
       name: bookinfo-gateway
@@ -45,7 +45,7 @@ test: no
         hosts:
         - $MY_INGRESS_GATEWAY_HOST
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: bookinfo

--- a/content/zh/docs/ops/best-practices/security/index.md
+++ b/content/zh/docs/ops/best-practices/security/index.md
@@ -437,7 +437,7 @@ SNI 必须在 `DestinationRule` 中设置，以确保主机正确处理请求。
 例如：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: google-tls
@@ -549,7 +549,7 @@ http 1 头部 `Host` 或者 http 2 伪头部 `:authority` 字段遵守 SNI 限�
 SNI TLS 连接来访问管理员`虚拟服务`。而 http 响应码 421 的设计目的便是 `Host` SNI 不匹配并且可以用于以上阻止目的。
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: disable-sensitive

--- a/content/zh/docs/ops/common-problems/network-issues/index.md
+++ b/content/zh/docs/ops/common-problems/network-issues/index.md
@@ -79,7 +79,7 @@ trafficPolicy:
 来访问一个内部的服务。举个例子，您的 `VirtualService` 配置可能和如下配置类似：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: myapp
@@ -102,7 +102,7 @@ spec:
 您还有一个 `VirtualService` 将访问 helloworld 服务的流量路由至该服务的一个特定子集：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: helloworld
@@ -128,7 +128,7 @@ helloworld `VirtualService`，其中的规则直接将流量路由至 v1 子集�
 的配置中包含此子集规则：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: myapp
@@ -152,7 +152,7 @@ spec:
 或者，您可以尽可能地将两个 `VirtualService` 配置合并成一个：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: myapp
@@ -343,7 +343,7 @@ $ kubectl exec -it $SOURCE_POD -c sleep -- curl 10.1.1.171 -s -o /dev/null -w "%
 将在转发请求时尝试将请求解析为 HTTP，这会使 HTTP 被意外加密，从而导致失败。
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: httpbin
@@ -384,7 +384,7 @@ spec:
 #### 网关终止 TLS {#gateway-with-TLS-termination}
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -403,7 +403,7 @@ spec:
       mode: SIMPLE
       credentialName: sds-credential
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin
@@ -443,7 +443,7 @@ spec:
 #### 网关启用 TLS 透传 {#gateway-with-TLS-passthrough}
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway
@@ -460,7 +460,7 @@ spec:
     tls:
       mode: PASSTHROUGH
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: virtual-service
@@ -510,7 +510,7 @@ spec:
 `ServiceEntry` 在端口 443 上将协议定义为 HTTPS。
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: httpbin
@@ -523,7 +523,7 @@ spec:
     protocol: HTTPS
   resolution: DNS
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: originate-tls
@@ -668,7 +668,7 @@ spec:
 目前，Istio 不支持在同一个 `VirtualService` 上配置故障注入和重试或超时策略。考虑以下配置：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: helloworld

--- a/content/zh/docs/ops/common-problems/security-issues/index.md
+++ b/content/zh/docs/ops/common-problems/security-issues/index.md
@@ -25,7 +25,7 @@ test: n/a
    是有效的 url，并且可以在浏览器中打开。
 
     {{< text yaml >}}
-    apiVersion: security.istio.io/v1beta1
+    apiVersion: security.istio.io/v1
     kind: RequestAuthentication
     metadata:
       name: "example-3"
@@ -96,7 +96,7 @@ test: n/a
 一个常见的错误是无意中在 YAML 文件中定义了多个项，例如下面的策略：
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: example

--- a/content/zh/docs/ops/common-problems/upgrade-issues/index.md
+++ b/content/zh/docs/ops/common-problems/upgrade-issues/index.md
@@ -40,7 +40,7 @@ spec:
 以下 `Telemetry` 配置替换上述配置：
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: namespace-metrics

--- a/content/zh/docs/ops/configuration/mesh/app-health-check/index.md
+++ b/content/zh/docs/ops/configuration/mesh/app-health-check/index.md
@@ -121,7 +121,7 @@ $ kubectl create ns istio-io-health
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "default"

--- a/content/zh/docs/ops/configuration/mesh/configuration-scoping/index.md
+++ b/content/zh/docs/ops/configuration/mesh/configuration-scoping/index.md
@@ -36,8 +36,7 @@ Istio 提供了一些工具来帮助控制配置范围以满足不同的用例�
 例如：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
-kind: Sidecar
+apiVersion: networking.istio.io/idecar
 metadata:
   name: default
 spec:

--- a/content/zh/docs/ops/configuration/security/security-policy-examples/index.md
+++ b/content/zh/docs/ops/configuration/security/security-policy-examples/index.md
@@ -26,7 +26,7 @@ JWT 校验通常用于 Ingress Gateway，您可能需要为不同的主机使用
 对其他主机的访问将始终被拒绝。
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: jwt-per-host
@@ -59,7 +59,7 @@ spec:
 允许来自相同命名空间的流量。
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -68,7 +68,7 @@ spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: foo-isolation
@@ -87,7 +87,7 @@ spec:
 Ingress Gateway 的流量。
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -96,7 +96,7 @@ spec:
   mtls:
     mode: STRICT
 ---
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: ns-isolation-except-ingress
@@ -121,7 +121,7 @@ spec:
 `"*"` 意味着非空匹配，与 `notPrincipals` 一起使用时意味着匹配空主体。
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: require-mtls
@@ -146,7 +146,7 @@ spec:
 `"*"` 意味着非空匹配，与 `notRequestPrincipals` 一起使用时意味着匹配空请求主体。
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: require-jwt
@@ -170,7 +170,7 @@ spec:
 此策略才允许请求。
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: ns-isolation-except-ingress

--- a/content/zh/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/zh/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -213,7 +213,7 @@ $ kubectl exec deploy/sleep -- curl -sS -v auto.internal
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1
-.   kind: ServiceEntry
+    kind: ServiceEntry
     metadata:
       name: external-svc-1
     spec:
@@ -226,7 +226,7 @@ $ kubectl exec deploy/sleep -- curl -sS -v auto.internal
       resolution: DNS
     ---
     apiVersion: networking.istio.io/v1
-.   kind: ServiceEntry
+    kind: ServiceEntry
     metadata:
       name: external-svc-2
     spec:

--- a/content/zh/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/zh/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -69,7 +69,7 @@ spec:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-address
@@ -129,7 +129,7 @@ TCP 携带的信息更少，只能在目标 IP 和端口号上路由。由于后
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-auto
@@ -212,8 +212,8 @@ $ kubectl exec deploy/sleep -- curl -sS -v auto.internal
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1beta1
-    kind: ServiceEntry
+    apiVersion: networking.istio.io/v1
+.   kind: ServiceEntry
     metadata:
       name: external-svc-1
     spec:
@@ -225,8 +225,8 @@ $ kubectl exec deploy/sleep -- curl -sS -v auto.internal
         protocol: TCP
       resolution: DNS
     ---
-    apiVersion: networking.istio.io/v1beta1
-    kind: ServiceEntry
+    apiVersion: networking.istio.io/v1
+.   kind: ServiceEntry
     metadata:
       name: external-svc-2
     spec:

--- a/content/zh/docs/ops/configuration/traffic-management/multicluster/index.md
+++ b/content/zh/docs/ops/configuration/traffic-management/multicluster/index.md
@@ -71,7 +71,7 @@ serviceSettings:
 `DestinationRule` 的子集选择器中允许按集群创建子集。
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: mysvc-per-cluster-dr
@@ -92,7 +92,7 @@ spec:
 这提供了另一种方案来创建集群内部流量规则，具体是在 `VirtualService` 中限制目标集群子集的流量：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: mysvc-cluster-local-vs

--- a/content/zh/docs/ops/configuration/traffic-management/tls-configuration/index.md
+++ b/content/zh/docs/ops/configuration/traffic-management/tls-configuration/index.md
@@ -118,7 +118,7 @@ kind: Gateway
 
     {{< text yaml >}}
     apiVersion: networking.istio.io/v1
-.   kind: Gateway
+    kind: Gateway
     ...
       servers:
       - port:
@@ -137,7 +137,7 @@ kind: Gateway
 
     {{< text yaml >}}
     apiVersion: networking.istio.io/v1
-.   kind: Gateway
+    kind: Gateway
     ...
       servers:
       - port:

--- a/content/zh/docs/ops/configuration/traffic-management/tls-configuration/index.md
+++ b/content/zh/docs/ops/configuration/traffic-management/tls-configuration/index.md
@@ -95,7 +95,7 @@ Istio 通过名为“自动 mTLS” 的功能使得配置更改容易。自动 m
 例如，如果入站连接是明文的 HTTP，则端口协议配置成 `HTTP`：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 ...
   servers:
@@ -117,8 +117,8 @@ kind: Gateway
     对于直通流量，将 TLS 模式字段配置为 `PASSTHROUGH`：
 
     {{< text yaml >}}
-    apiVersion: networking.istio.io/v1beta1
-    kind: Gateway
+    apiVersion: networking.istio.io/v1
+.   kind: Gateway
     ...
       servers:
       - port:
@@ -136,8 +136,8 @@ kind: Gateway
     `caCertificates` 或 `credentialName` 请求和验证：
 
     {{< text yaml >}}
-    apiVersion: networking.istio.io/v1beta1
-    kind: Gateway
+    apiVersion: networking.istio.io/v1
+.   kind: Gateway
     ...
       servers:
       - port:

--- a/content/zh/docs/ops/deployment/vm-architecture/index.md
+++ b/content/zh/docs/ops/deployment/vm-architecture/index.md
@@ -73,7 +73,7 @@ Istio 提供了两种机制来表示虚拟机工作负载：
 将虚拟机工作负载添加到网格时，您将需要创建 `WorkloadGroup`，作为每个 `WorkloadEntry` 实例的模板：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: product-vm
@@ -92,7 +92,7 @@ spec:
 相应的 `WorkloadEntry` 将被 Istio 控制面自动创建，例如：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: WorkloadEntry
 metadata:
   annotations:

--- a/content/zh/docs/ops/diagnostic-tools/istioctl-describe/index.md
+++ b/content/zh/docs/ops/diagnostic-tools/istioctl-describe/index.md
@@ -225,7 +225,7 @@ VirtualService: reviews
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: "security.istio.io/v1beta1"
+apiVersion: "security.istio.io/v1"
 kind: "PeerAuthentication"
 metadata:
   name: "ratings-strict"

--- a/content/zh/docs/ops/integrations/certmanager/index.md
+++ b/content/zh/docs/ops/integrations/certmanager/index.md
@@ -67,7 +67,7 @@ cert-manager 可用于向 Kubernetes 写入 Secret 秘钥，Gateway 可以引用
    配置下的 `cresentialName` 字段中引用它：
 
     {{< text yaml >}}
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: Gateway
     metadata:
       name: gateway
@@ -97,7 +97,7 @@ cert-manager 通过 [在 Ingress 对象上配置注解](https://cert-manager.io/
 `Certificate`，然后在 `Ingress` 对象中引用它：
 
 {{< text yaml >}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress

--- a/content/zh/docs/reference/config/analysis/ist0101/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0101/index.md
@@ -17,7 +17,7 @@ Error [IST0101] (VirtualService httpbin.default) Referenced gateway not found: "
 在以下例子中，`VirtualService` 指向了一个不存在的网关：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: httpbin-gateway
@@ -32,7 +32,7 @@ spec:
     hosts:
     - "*"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin

--- a/content/zh/docs/reference/config/analysis/ist0106/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0106/index.md
@@ -16,7 +16,7 @@ Error [IST0106] (VirtualService ratings-bogus-weight-default.default) Schema val
 并且您的 Istio 配置包含以下参数值：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings-bogus-weight-default

--- a/content/zh/docs/reference/config/analysis/ist0109/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0109/index.md
@@ -25,7 +25,7 @@ test: no
 * VirtualService 都定义了相同的主机 `productpage.default.svc.cluster.local`。
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: productpage
@@ -38,7 +38,7 @@ spec:
     - destination:
         host: productpage
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: custom
@@ -56,7 +56,7 @@ spec:
 您可以通过设置 `exportTo` 字段为 `.` 来解决此问题，让每个 VirtualService 都只限定在自己的命名空间：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: productpage
@@ -71,7 +71,7 @@ spec:
     - destination:
         host: productpage
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: custom

--- a/content/zh/docs/reference/config/analysis/ist0127/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0127/index.md
@@ -12,7 +12,7 @@ test: no
 当集群包含以下 AuthorizationPolicy 时：
 
 {{< text yaml >}}
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: httpbin-nopods

--- a/content/zh/docs/reference/config/analysis/ist0128/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0128/index.md
@@ -12,7 +12,7 @@ test: no
 当您的集群中包含以下 DestinationRule 时：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: db-tls

--- a/content/zh/docs/reference/config/analysis/ist0129/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0129/index.md
@@ -12,7 +12,7 @@ test: no
 当您的集群中具有以下 DestinationRule 时：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: db-tls

--- a/content/zh/docs/reference/config/analysis/ist0130/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0130/index.md
@@ -13,7 +13,7 @@ test: no
 当您的集群中包含下列 Virtual Service 时：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: sample-foo-cluster01

--- a/content/zh/docs/reference/config/analysis/ist0131/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0131/index.md
@@ -12,7 +12,7 @@ test: no
 当您的集群中包含下列 VirtualService 时：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: tls-routing

--- a/content/zh/docs/reference/config/analysis/ist0132/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0132/index.md
@@ -12,7 +12,7 @@ test: no
 当您的集群中包含以下 VirtualService 时：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: testing-service
@@ -34,7 +34,7 @@ spec:
 同时还包含如下 Gateway:
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: testing-gateway

--- a/content/zh/docs/reference/config/analysis/ist0134/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0134/index.md
@@ -18,7 +18,7 @@ Warning [IST0134] (ServiceEntry service-entry.default serviceentry.yaml:13) Serv
 当集群的 `ServiceEntry` 未设置 `protocol` 且缺少 `addresses` 时：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: service-entry
@@ -38,7 +38,7 @@ spec:
 这种分析器的另一个例子是 `ServiceEntry` 设置了 `protocol: TCP` 但缺少 `addresses` 时：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: service-entry

--- a/content/zh/docs/reference/config/analysis/ist0143/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0143/index.md
@@ -53,7 +53,7 @@ spec:
   来自定义 Pod 的入站网络配置。例如，对于上述应用程序：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: ratings

--- a/content/zh/docs/reference/config/analysis/ist0162/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0162/index.md
@@ -14,7 +14,7 @@ test: n/a
 {{< text yaml >}}
 # 端口定义错误的 Gateway
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-ingressgateway
@@ -71,7 +71,7 @@ spec:
 {{< text yaml >}}
 # 端口定义正确的 Gateway
 
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-ingressgateway

--- a/content/zh/docs/reference/config/analysis/ist0166/index.md
+++ b/content/zh/docs/reference/config/analysis/ist0166/index.md
@@ -60,7 +60,7 @@ spec:
 如果您在策略中同时设置了 `targetRef` 和 `selector`，将不会出现此消息。例如：
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: telemetry-example
@@ -86,7 +86,7 @@ spec:
 以下是一个例子：
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: telemetry-example

--- a/content/zh/docs/setup/additional-setup/gateway/index.md
+++ b/content/zh/docs/setup/additional-setup/gateway/index.md
@@ -237,7 +237,7 @@ $ kubectl apply -f ingress.yaml
 要将 `Gateway` 应用到这些 Deployment，您需要选择相同的标签：
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: gateway

--- a/content/zh/docs/setup/install/external-controlplane/index.md
+++ b/content/zh/docs/setup/install/external-controlplane/index.md
@@ -363,7 +363,7 @@ Webhook、ConfigMap 和 Secret，以便使用外部控制平面。
     {{< text syntax=bash snip_id=get_external_istiod_gateway_config >}}
     $ cat <<EOF > external-istiod-gw.yaml
     apiVersion: networking.istio.io/v1
-.   kind: Gateway
+    kind: Gateway
     metadata:
       name: external-istiod-gw
       namespace: external-istiod
@@ -391,7 +391,7 @@ Webhook、ConfigMap 和 Secret，以便使用外部控制平面。
           - $EXTERNAL_ISTIOD_ADDR
     ---
     apiVersion: networking.istio.io/v1
-.   kind: VirtualService
+    kind: VirtualService
     metadata:
        name: external-istiod-vs
        namespace: external-istiod

--- a/content/zh/docs/setup/install/external-controlplane/index.md
+++ b/content/zh/docs/setup/install/external-controlplane/index.md
@@ -362,8 +362,8 @@ Webhook、ConfigMap 和 Secret，以便使用外部控制平面。
 
     {{< text syntax=bash snip_id=get_external_istiod_gateway_config >}}
     $ cat <<EOF > external-istiod-gw.yaml
-    apiVersion: networking.istio.io/v1beta1
-    kind: Gateway
+    apiVersion: networking.istio.io/v1
+.   kind: Gateway
     metadata:
       name: external-istiod-gw
       namespace: external-istiod
@@ -390,8 +390,8 @@ Webhook、ConfigMap 和 Secret，以便使用外部控制平面。
           hosts:
           - $EXTERNAL_ISTIOD_ADDR
     ---
-    apiVersion: networking.istio.io/v1beta1
-    kind: VirtualService
+    apiVersion: networking.istio.io/v1
+.   kind: VirtualService
     metadata:
        name: external-istiod-vs
        namespace: external-istiod
@@ -416,7 +416,7 @@ Webhook、ConfigMap 和 Secret，以便使用外部控制平面。
               port:
                 number: 443
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: external-istiod-dr

--- a/content/zh/docs/setup/install/multiple-controlplanes/index.md
+++ b/content/zh/docs/setup/install/multiple-controlplanes/index.md
@@ -99,7 +99,7 @@ Istio 默认仅使用 `discoverySelectors` 确定工作负载端点的作用域�
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: security.istio.io/v1beta1
+    apiVersion: security.istio.io/v1
     kind: PeerAuthentication
     metadata:
       name: "usergroup-1-peerauth"
@@ -114,7 +114,7 @@ Istio 默认仅使用 `discoverySelectors` 确定工作负载端点的作用域�
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: security.istio.io/v1beta1
+    apiVersion: security.istio.io/v1
     kind: PeerAuthentication
     metadata:
       name: "usergroup-2-peerauth"

--- a/content/zh/docs/setup/install/virtual-machine/index.md
+++ b/content/zh/docs/setup/install/virtual-machine/index.md
@@ -204,7 +204,7 @@ test: yes
 
 {{< text bash >}}
 $ cat <<EOF > workloadgroup.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: "${VM_APP}"
@@ -229,7 +229,7 @@ EOF
 
 {{< text syntax=bash snip_id=create_wg >}}
 $ cat <<EOF > workloadgroup.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: "${VM_APP}"
@@ -258,7 +258,7 @@ $ kubectl --namespace "${VM_NAMESPACE}" apply -f workloadgroup.yaml
 
 {{< text bash >}}
 $ cat <<EOF > workloadgroup.yaml
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: WorkloadGroup
 metadata:
   name: "${VM_APP}"

--- a/content/zh/docs/tasks/observability/distributed-tracing/opentelemetry/index.md
+++ b/content/zh/docs/tasks/observability/distributed-tracing/opentelemetry/index.md
@@ -94,7 +94,7 @@ EOF
 
 {{< text syntax=bash snip_id=enable_telemetry >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: otel-demo

--- a/content/zh/docs/tasks/observability/distributed-tracing/sampling/index.md
+++ b/content/zh/docs/tasks/observability/distributed-tracing/sampling/index.md
@@ -64,7 +64,7 @@ EOF
 
 {{< text syntax=bash snip_id=enable_telemetry_no_sampling >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -131,7 +131,7 @@ EOF
 
 {{< text syntax=bash snip_id=enable_telemetry_with_sampling >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
    name: otel-demo

--- a/content/zh/docs/tasks/observability/distributed-tracing/skywalking/index.md
+++ b/content/zh/docs/tasks/observability/distributed-tracing/skywalking/index.md
@@ -42,7 +42,7 @@ spec:
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default

--- a/content/zh/docs/tasks/observability/distributed-tracing/telemetry-api/index.md
+++ b/content/zh/docs/tasks/observability/distributed-tracing/telemetry-api/index.md
@@ -47,7 +47,7 @@ $ istioctl install -f ./tracing.yaml --skip-confirmation
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -67,7 +67,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -94,7 +94,7 @@ EOF
 1.  literal 选项可以将一个静态的值添加到每个 span 中。
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: mesh-default
@@ -113,7 +113,7 @@ EOF
 1.  环境变量可以用于从工作负载代理环境中自定义标签。
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: mesh-default
@@ -138,7 +138,7 @@ EOF
 1.  客户端请求头选项可用于从传入的客户端请求头中添加标签。
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: mesh-default

--- a/content/zh/docs/tasks/observability/gateways/index.md
+++ b/content/zh/docs/tasks/observability/gateways/index.md
@@ -70,7 +70,7 @@ test: yes
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: grafana-gateway
@@ -89,7 +89,7 @@ test: yes
             hosts:
             - "grafana.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: grafana-vs
@@ -106,7 +106,7 @@ test: yes
                 port:
                   number: 3000
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: grafana
@@ -127,7 +127,7 @@ test: yes
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: kiali-gateway
@@ -146,7 +146,7 @@ test: yes
             hosts:
             - "kiali.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: kiali-vs
@@ -163,7 +163,7 @@ test: yes
                 port:
                   number: 20001
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: kiali
@@ -184,7 +184,7 @@ test: yes
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: prometheus-gateway
@@ -203,7 +203,7 @@ test: yes
             hosts:
             - "prometheus.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: prometheus-vs
@@ -220,7 +220,7 @@ test: yes
                 port:
                   number: 9090
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: prometheus
@@ -241,7 +241,7 @@ test: yes
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: tracing-gateway
@@ -260,7 +260,7 @@ test: yes
             hosts:
             - "tracing.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: tracing-vs
@@ -277,7 +277,7 @@ test: yes
                 port:
                   number: 80
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: tracing
@@ -313,7 +313,7 @@ test: yes
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: grafana-gateway
@@ -329,7 +329,7 @@ test: yes
             hosts:
             - "grafana.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: grafana-vs
@@ -346,7 +346,7 @@ test: yes
                 port:
                   number: 3000
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: grafana
@@ -367,7 +367,7 @@ test: yes
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: kiali-gateway
@@ -383,7 +383,7 @@ test: yes
             hosts:
             - "kiali.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: kiali-vs
@@ -400,7 +400,7 @@ test: yes
                 port:
                   number: 20001
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: kiali
@@ -421,7 +421,7 @@ test: yes
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: prometheus-gateway
@@ -437,7 +437,7 @@ test: yes
             hosts:
             - "prometheus.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: prometheus-vs
@@ -454,7 +454,7 @@ test: yes
                 port:
                   number: 9090
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: prometheus
@@ -475,7 +475,7 @@ test: yes
 
         {{< text bash >}}
         $ cat <<EOF | kubectl apply -f -
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: Gateway
         metadata:
           name: tracing-gateway
@@ -491,7 +491,7 @@ test: yes
             hosts:
             - "tracing.${INGRESS_DOMAIN}"
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: VirtualService
         metadata:
           name: tracing-vs
@@ -508,7 +508,7 @@ test: yes
                 port:
                   number: 80
         ---
-        apiVersion: networking.istio.io/v1alpha3
+        apiVersion: networking.istio.io/v1
         kind: DestinationRule
         metadata:
           name: tracing

--- a/content/zh/docs/tasks/observability/logs/access-log/index.md
+++ b/content/zh/docs/tasks/observability/logs/access-log/index.md
@@ -27,7 +27,7 @@ Istio 提供了几种启用访问日志的方法，建议使用 Telemetry API。
 Telemetry API 可以开启或关闭访问日志：
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default

--- a/content/zh/docs/tasks/observability/logs/otel-provider/index.md
+++ b/content/zh/docs/tasks/observability/logs/otel-provider/index.md
@@ -67,7 +67,7 @@ data:
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n default -f -
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: sleep-logging

--- a/content/zh/docs/tasks/observability/logs/telemetry-api/index.md
+++ b/content/zh/docs/tasks/observability/logs/telemetry-api/index.md
@@ -30,7 +30,7 @@ $ kubectl apply -f @samples/open-telemetry/loki/otel.yaml@ -n istio-system
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -n istio-system -f -
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: mesh-logging-default
@@ -49,7 +49,7 @@ $ kubectl apply -f @samples/open-telemetry/loki/otel.yaml@ -n istio-system
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -n default -f -
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: disable-sleep-logging
@@ -71,7 +71,7 @@ $ kubectl apply -f @samples/open-telemetry/loki/otel.yaml@ -n istio-system
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -n default -f -
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: disable-httpbin-logging

--- a/content/zh/docs/tasks/observability/metrics/classify-metrics/index.md
+++ b/content/zh/docs/tasks/observability/metrics/classify-metrics/index.md
@@ -56,7 +56,7 @@ spec:
         - value: "CreateReview"
           condition: "request.url_path == '/reviews/' && request.method == 'POST'"
 ---
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: custom-tags
@@ -121,7 +121,7 @@ spec:
            - value: 4xx
              condition: response.code >= 400 && response.code <= 499
 ---
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: custom-tags

--- a/content/zh/docs/tasks/observability/metrics/customize-metrics/index.md
+++ b/content/zh/docs/tasks/observability/metrics/customize-metrics/index.md
@@ -35,7 +35,7 @@ Istio 可以生成各种仪表盘所使用的遥测数据，帮助您直观地�
 
 {{< text bash >}}
 $ cat <<EOF > ./custom_metrics.yaml
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: namespace-metrics

--- a/content/zh/docs/tasks/observability/metrics/telemetry-api/index.md
+++ b/content/zh/docs/tasks/observability/metrics/telemetry-api/index.md
@@ -42,7 +42,7 @@ spec:
 1. 从 `REQUEST_COUNT` 指标中删除 `grpc_response_status` 标签
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: remove-tags
@@ -63,7 +63,7 @@ spec:
 1. 为 `REQUEST_COUNT` 指标添加自定义标签
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: custom-tags
@@ -92,7 +92,7 @@ spec:
 1. 通过以下配置禁用所有指标：
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: remove-all-metrics
@@ -111,7 +111,7 @@ spec:
 1. 通过以下配置禁用 `REQUEST_COUNT` 指标：
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: remove-request-count
@@ -130,7 +130,7 @@ spec:
 1. 通过以下配置禁用客户端的 `REQUEST_COUNT` 指标：
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: remove-client
@@ -149,7 +149,7 @@ spec:
 1. 通过以下配置禁用服务端的 `REQUEST_COUNT` 指标：
 
     {{< text yaml >}}
-    apiVersion: telemetry.istio.io/v1alpha1
+    apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
       name: remove-server

--- a/content/zh/docs/tasks/observability/telemetry/index.md
+++ b/content/zh/docs/tasks/observability/telemetry/index.md
@@ -94,7 +94,7 @@ Telemetry API 资源从网格的根配置命名空间（通常是 `istio-system`
 以下是上一节中使用提供程序配置的示例配置：
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: mesh-default
@@ -120,7 +120,7 @@ spec:
 例如：
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: namespace-override
@@ -152,7 +152,7 @@ spec:
 例如：
 
 {{< text yaml >}}
-apiVersion: telemetry.istio.io/v1alpha1
+apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
   name: workload-override

--- a/content/zh/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/zh/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -167,7 +167,7 @@ Envoy 中的全局速率限制使用 gRPC API 向速率限制服务请求配额�
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
     apiVersion: networking.istio.io/v1
-.   kind: VirtualService
+    kind: VirtualService
     metadata:
       name: bookinfo
     spec:

--- a/content/zh/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/zh/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -166,8 +166,8 @@ Envoy 中的全局速率限制使用 gRPC API 向速率限制服务请求配额�
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1beta1
-    kind: VirtualService
+    apiVersion: networking.istio.io/v1
+.   kind: VirtualService
     metadata:
       name: bookinfo
     spec:
@@ -332,7 +332,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: EnvoyFilter
 metadata:
   name: filter-local-ratelimit-svc

--- a/content/zh/docs/tasks/security/authentication/authn-policy/index.md
+++ b/content/zh/docs/tasks/security/authentication/authn-policy/index.md
@@ -120,7 +120,7 @@ $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metad
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "default"
@@ -178,7 +178,7 @@ $ kubectl delete peerauthentication -n istio-system default
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "default"
@@ -214,7 +214,7 @@ sleep.legacy to httpbin.legacy: 200
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n bar -f -
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "httpbin"
@@ -257,7 +257,7 @@ command terminated with exit code 56
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n bar -f -
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "httpbin"
@@ -300,7 +300,7 @@ TLS，发现从 `sleep.legacy` 到 `httpbin.foo` 的请求都会失败（如上�
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -n foo -f -
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: "overwrite-example"

--- a/content/zh/docs/tasks/security/authentication/claim-to-header/index.md
+++ b/content/zh/docs/tasks/security/authentication/claim-to-header/index.md
@@ -57,7 +57,7 @@ JWT 声明复制到 HTTP 头。
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: security.istio.io/v1beta1
+    apiVersion: security.istio.io/v1
     kind: RequestAuthentication
     metadata:
       name: "jwt-example"

--- a/content/zh/docs/tasks/security/authentication/jwt-route/index.md
+++ b/content/zh/docs/tasks/security/authentication/jwt-route/index.md
@@ -84,7 +84,7 @@ Istio 入口网关支持基于经过身份验证的 JWT 的路由，
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: httpbin

--- a/content/zh/docs/tasks/security/authentication/mtls-migration/index.md
+++ b/content/zh/docs/tasks/security/authentication/mtls-migration/index.md
@@ -96,7 +96,7 @@ STRICT 双向 TLS 来尝试迁移过程。
 
 {{< text bash >}}
 $ kubectl apply -n foo -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -139,7 +139,7 @@ listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
 
 {{< text bash >}}
 $ kubectl apply -n istio-system -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default

--- a/content/zh/docs/tasks/security/authorization/authz-custom/index.md
+++ b/content/zh/docs/tasks/security/authorization/authz-custom/index.md
@@ -70,7 +70,7 @@ test: yes
 以下是将外部授权器部署在需要外部授权的应用程序同一 Pod 内时，您需要配置的示例 ServiceEntry。
 
 {{< text yaml >}}
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: external-authz-grpc-local

--- a/content/zh/docs/tasks/security/cert-management/plugin-ca-cert/index.md
+++ b/content/zh/docs/tasks/security/cert-management/plugin-ca-cert/index.md
@@ -121,7 +121,7 @@ Istio CA 签发中间证书。Istio CA 可以使用管理员指定的证书和�
 
     {{< text bash >}}
     $ kubectl apply -n foo -f - <<EOF
-    apiVersion: security.istio.io/v1beta1
+    apiVersion: security.istio.io/v1
     kind: PeerAuthentication
     metadata:
       name: "default"

--- a/content/zh/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/zh/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -35,7 +35,7 @@ test: yes
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: httpbin

--- a/content/zh/docs/tasks/traffic-management/egress/egress-control/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-control/index.md
@@ -162,7 +162,7 @@ Istio 代理允许调用未知的服务。如果这个选项设置为 `REGISTRY_
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: httpbin-ext
@@ -210,7 +210,7 @@ Istio 代理允许调用未知的服务。如果这个选项设置为 `REGISTRY_
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: google
@@ -270,7 +270,7 @@ Istio 代理允许调用未知的服务。如果这个选项设置为 `REGISTRY_
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin-ext

--- a/content/zh/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -77,7 +77,7 @@ Sidecar 完成。
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: cnn
@@ -119,7 +119,7 @@ Sidecar 完成。
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -136,7 +136,7 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -183,7 +183,7 @@ spec:
       namespaces:
         from: Same
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -213,7 +213,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-cnn-through-egress-gateway
@@ -294,7 +294,7 @@ EOF
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: originate-tls-for-edition-cnn-com
@@ -580,7 +580,7 @@ $ kubectl delete destinationrule originate-tls-for-edition-cnn-com
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: nginx
@@ -600,7 +600,7 @@ $ kubectl delete destinationrule originate-tls-for-edition-cnn-com
         ports:
           https: 443
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: nginx
@@ -672,7 +672,7 @@ $ kubectl create secret -n default generic client-credential --from-file=tls.key
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -689,7 +689,7 @@ spec:
     tls:
       mode: ISTIO_MUTUAL
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-nginx
@@ -762,7 +762,7 @@ subjects:
 - kind: ServiceAccount
   name: nginx-egressgateway-istio
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-nginx
@@ -792,7 +792,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-nginx-through-egress-gateway
@@ -833,7 +833,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-nginx-to-egress-gateway
@@ -900,7 +900,7 @@ TODO：弄清楚为什么使用 `HTTPRoute` 而不是上面不起作用的 `Virt
 
 {{< text bash >}}
 $ kubectl apply -n istio-system -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: originate-mtls-for-nginx
@@ -927,7 +927,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: originate-mtls-for-nginx

--- a/content/zh/docs/tasks/traffic-management/egress/egress-gateway/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-gateway/index.md
@@ -123,7 +123,7 @@ Egress 网关节点，用它引导所有的出站流量，可以使应用节点�
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: cnn
@@ -173,7 +173,7 @@ Egress 网关节点，用它引导所有的出站流量，可以使应用节点�
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -188,7 +188,7 @@ spec:
     hosts:
     - edition.cnn.com
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -236,7 +236,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-cnn-through-egress-gateway
@@ -434,7 +434,7 @@ $ kubectl delete httproute forward-cnn-from-egress-gateway
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: cnn
@@ -474,7 +474,7 @@ $ kubectl delete httproute forward-cnn-from-egress-gateway
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -491,7 +491,7 @@ spec:
     tls:
       mode: PASSTHROUGH
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn
@@ -500,7 +500,7 @@ spec:
   subsets:
   - name: cnn
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-cnn-through-egress-gateway
@@ -885,7 +885,7 @@ sleep istio-proxy
 
 {{< text bash >}}
 $ kubectl apply -n test-egress -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-cnn

--- a/content/zh/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-kubernetes-services/index.md
@@ -105,7 +105,7 @@ Kubernetes [ExternalName](https://kubernetes.io/zh-cn/docs/concepts/services-net
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: my-httpbin
@@ -204,7 +204,7 @@ $ kubectl delete service my-httpbin
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: my-wikipedia

--- a/content/zh/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -64,7 +64,7 @@ test: yes
 
     {{< text syntax=bash snip_id=apply_simple >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: edition-cnn-com
@@ -118,7 +118,7 @@ test: yes
 
     {{< text syntax=bash snip_id=apply_origination >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: edition-cnn-com
@@ -135,7 +135,7 @@ test: yes
         protocol: HTTPS
       resolution: DNS
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: edition-cnn-com
@@ -410,7 +410,7 @@ $ kubectl delete destinationrule edition-cnn-com
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: originate-mtls-for-nginx
@@ -427,7 +427,7 @@ $ kubectl delete destinationrule edition-cnn-com
         protocol: HTTPS
       resolution: DNS
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: originate-mtls-for-nginx

--- a/content/zh/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -140,7 +140,7 @@ test: yes
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: proxy

--- a/content/zh/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
@@ -98,7 +98,7 @@ $ istioctl install --set profile=minimal -y \
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: wikipedia
@@ -141,7 +141,7 @@ $ kubectl delete serviceentry wikipedia
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: istio-egressgateway
@@ -158,7 +158,7 @@ spec:
     tls:
       mode: PASSTHROUGH
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: egressgateway-for-wikipedia
@@ -167,7 +167,7 @@ spec:
   subsets:
     - name: wikipedia
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: direct-wikipedia-through-egress-gateway
@@ -261,7 +261,7 @@ spec:
       name: www.wikipedia.org
       port: 443
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 metadata:
   name: wikipedia
@@ -283,7 +283,7 @@ EOF
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: ServiceEntry
     metadata:
       name: www-wikipedia

--- a/content/zh/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -57,7 +57,7 @@ Ingress `Gateway` 描述在网格边界运作的负载均衡器，用于接收�
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: httpbin-gateway
@@ -78,7 +78,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin
@@ -327,7 +327,7 @@ $ export SECURE_INGRESS_PORT=$(kubectl get gtw my-gateway -o jsonpath='{.spec.li
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: httpbin-gateway
@@ -342,7 +342,7 @@ spec:
     hosts:
     - "*"
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin

--- a/content/zh/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/ingress-sidecar-tls-termination/index.md
@@ -38,7 +38,7 @@ test: yes
 
 {{< text bash >}}
 $ kubectl -n test apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: default
@@ -55,7 +55,7 @@ TLS 终止。请注意，这里是 httpbin 服务的 `targetPort`，专门用于
 
 {{< text bash >}}
 $ kubectl -n test apply -f - <<EOF
-apiVersion: security.istio.io/v1beta1
+apiVersion: security.istio.io/v1
 kind: PeerAuthentication
 metadata:
   name: disable-peer-auth-for-external-mtls-port
@@ -169,7 +169,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl -n test apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Sidecar
 metadata:
   name: ingress-sidecar

--- a/content/zh/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
@@ -180,7 +180,7 @@ test: yes
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: Gateway
     metadata:
       name: mygateway
@@ -203,7 +203,7 @@ test: yes
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: nginx

--- a/content/zh/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -116,7 +116,7 @@ example.com.key         httpbin.example.com.csr
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway
@@ -140,7 +140,7 @@ EOF
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: httpbin
@@ -340,7 +340,7 @@ $ export SECURE_INGRESS_PORT=$(kubectl get gtw mygateway -n istio-system -o json
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway
@@ -373,7 +373,7 @@ EOF
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: helloworld
@@ -532,7 +532,7 @@ EOF
 
 {{< text bash >}}
 $ cat <<EOF | kubectl apply -f -
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   name: mygateway

--- a/content/zh/docs/tasks/traffic-management/locality-load-balancing/distribute/index.md
+++ b/content/zh/docs/tasks/traffic-management/locality-load-balancing/distribute/index.md
@@ -35,7 +35,7 @@ owner: istio/wg-networking-maintainers
 
 {{< text bash >}}
 $ kubectl --context="${CTX_PRIMARY}" apply -n sample -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: helloworld

--- a/content/zh/docs/tasks/traffic-management/locality-load-balancing/failover/index.md
+++ b/content/zh/docs/tasks/traffic-management/locality-load-balancing/failover/index.md
@@ -50,7 +50,7 @@ owner: istio/wg-networking-maintainers
 
 {{< text bash >}}
 $ kubectl --context="${CTX_PRIMARY}" apply -n sample -f - <<EOF
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: helloworld

--- a/content/zh/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/zh/docs/tasks/traffic-management/mirroring/index.md
@@ -140,7 +140,7 @@ test: yes
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: httpbin
@@ -154,7 +154,7 @@ test: yes
             subset: v1
           weight: 100
     ---
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: DestinationRule
     metadata:
       name: httpbin
@@ -264,7 +264,7 @@ test: yes
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
-    apiVersion: networking.istio.io/v1alpha3
+    apiVersion: networking.istio.io/v1
     kind: VirtualService
     metadata:
       name: httpbin

--- a/content/zh/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/zh/docs/tasks/traffic-management/request-routing/index.md
@@ -238,7 +238,7 @@ $ kubectl apply -f @samples/bookinfo/networking/virtual-service-reviews-test-v2.
 
 {{< text bash yaml >}}
 $ kubectl get virtualservice reviews -o yaml
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 ...
 spec:

--- a/content/zh/docs/tasks/traffic-management/request-timeouts/index.md
+++ b/content/zh/docs/tasks/traffic-management/request-timeouts/index.md
@@ -34,7 +34,7 @@ HTTP 请求的超时可以通过路由规则中的 timeout 字段来指定。
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews
@@ -84,7 +84,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings
@@ -113,7 +113,7 @@ Istio `VirtualService` 来添加延迟：
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: ratings
@@ -152,7 +152,7 @@ EOF
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   name: reviews

--- a/content/zh/test/tb/index.md
+++ b/content/zh/test/tb/index.md
@@ -26,7 +26,7 @@ Foo Bar
 
 {{< text bash >}}
 $ kubectl apply -f - <<EOF
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1
 kind: ServiceEntry
 {{< /text >}}
 


### PR DESCRIPTION
Smart search and replace across the docs to remove `v1alpha3` and `v1beta1` from APIs that have been promoted to v1.

The only remaining `v1alpha3` examples should be `EnvoyFilter`:

`networking.istio.io/v1alpha3\n(\s*)kind: [^E]`: no results

The only remaining `v1beta1` examples should be `ProxyConfig`:

`istio.io/v1beta1\n\s*kind: [^P]`: no results

Two `telemetry.istio.io/v1alpha1` examples remain, related to `accessLogging.filter` which remains in Alpha.  I understand that the CRD will have the field in v1, but it might pay to keep this to be obvious to users?