### PR TITLE
Adjust fonts for code snippets

### DIFF
--- a/src/sass/misc/_code-blocks.scss
+++ b/src/sass/misc/_code-blocks.scss
@@ -1,6 +1,6 @@
 code {
     color: $textCodeColor;
-    font-size: 80%;
+    font-size: 87.5%;
     font-weight: $textCodeWeight;
     font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     word-break: break-word;
@@ -29,6 +29,11 @@ pre {
         display: block;
         padding: .5em;
         color: $textColor;
+
+        a {
+            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-weight: $textCodeWeight;
+        }
     }
 
     code.command-output {


### PR DESCRIPTION
* `<a>` tags inside `<pre>` were not rendering in monotype
* code was always just a tiny bit too small, so bumped `<code>` to the same size as `<pre>`

see https://istio.io/latest/docs/examples/bookinfo/#cleanup for a good before and after