### PR TITLE
Add note on Cilium's bpf masquerading

### DIFF
--- a/content/en/docs/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ambient/install/platform-prerequisites/index.md
@@ -73,7 +73,7 @@ and capture pods on the node.
 
 1. Cilium currently defaults to proactively deleting other CNI plugins and their config, and must be configured with
 `cni.exclusive = false` to properly support chaining. See [the Cilium documentation](https://docs.cilium.io/en/stable/helm-reference/) for more details.
-
+1. Cilium's BPF masquerading is currently disabled by default, and has issues with Istio's use of link-local IPs for K8S health checking. Enabling BPF-based masquerading via `bpf.masquerade=true` is not currently supported, and results in non-functional pod health checks in Istio ambient. Cilium's non-BPF-based masquerading should continue to function correctly.
 1. Due to how Cilium manages node identity and internally allow-lists node-level health probes to pods,
 applying default-DENY `NetworkPolicy` in a Cilium CNI install underlying Istio in ambient mode, will cause `kubelet` health probes (which are by-default exempted from NetworkPolicy enforcement by Cilium) to be blocked.
 

--- a/content/en/docs/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ambient/install/platform-prerequisites/index.md
@@ -73,7 +73,7 @@ and capture pods on the node.
 
 1. Cilium currently defaults to proactively deleting other CNI plugins and their config, and must be configured with
 `cni.exclusive = false` to properly support chaining. See [the Cilium documentation](https://docs.cilium.io/en/stable/helm-reference/) for more details.
-1. Cilium's BPF masquerading is currently disabled by default, and has issues with Istio's use of link-local IPs for K8S health checking. Enabling BPF-based masquerading via `bpf.masquerade=true` is not currently supported, and results in non-functional pod health checks in Istio ambient. Cilium's non-BPF-based masquerading should continue to function correctly.
+1. Cilium's BPF masquerading is currently disabled by default, and has issues with Istio's use of link-local IPs for Kubernetes health checking. Enabling BPF masquerading via `bpf.masquerade=true` is not currently supported, and results in non-functional pod health checks in Istio ambient. Cilium's default iptables masquerading implementation should continue to function correctly.
 1. Due to how Cilium manages node identity and internally allow-lists node-level health probes to pods,
 applying default-DENY `NetworkPolicy` in a Cilium CNI install underlying Istio in ambient mode, will cause `kubelet` health probes (which are by-default exempted from NetworkPolicy enforcement by Cilium) to be blocked.
 


### PR DESCRIPTION
## Description

It seems as though Cilium's BPF-based masquerading does not actually ignore link-local packets: https://github.com/istio/istio/issues/52208

 Since this feature currently defaults to "off" in Cilium and regular iptables masquerading should work, add document note for now that we do not support `bpf.masquerade=true` as it interferes with Ambient health checks (which use link-local SNAT).

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
