### PR TITLE
Attempt at modernizing the sidecar SPIRE integration doc

### DIFF
--- a/content/en/docs/ops/integrations/spire/automatic_registration_test.sh
+++ b/content/en/docs/ops/integrations/spire/automatic_registration_test.sh
@@ -25,7 +25,7 @@ set -o pipefail
 snip_install_spire_crds
 snip_install_spire_istio_overrides
 _wait_for_daemonset spire-server spire-agent
-_wait_for_deployment spire-server spire-server
+_wait_for_statefulset spire-server spire-server
 
 # Create ClusterSPIFFEID
 snip_spire_csid_istio_gateway

--- a/content/en/docs/ops/integrations/spire/automatic_registration_test.sh
+++ b/content/en/docs/ops/integrations/spire/automatic_registration_test.sh
@@ -24,8 +24,8 @@ set -o pipefail
 # Install SPIRE configured with k8s Controller Manager
 snip_install_spire_crds
 snip_install_spire_istio_overrides
-_wait_for_daemonset spire spire-agent
-_wait_for_deployment spire spire-server
+_wait_for_daemonset spire-server spire-agent
+_wait_for_deployment spire-server spire-server
 
 # Create ClusterSPIFFEID
 snip_spire_csid_istio_gateway

--- a/content/en/docs/ops/integrations/spire/automatic_registration_test.sh
+++ b/content/en/docs/ops/integrations/spire/automatic_registration_test.sh
@@ -46,12 +46,8 @@ _wait_for_deployment default sleep
 # Set spire-server pod variable
 snip_set_spire_server_pod_name_var
 
-# Verify registration identities were created for sleep and ingress gateway
-_verify_contains snip_verifying_that_identities_were_created_for_workloads_1 "spiffe://example.org/ns/default/sa/sleep"
-_verify_contains snip_verifying_that_identities_were_created_for_workloads_1 "spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account"
-
 # Set sleep pod and pod uid variables
-snip_set_sleep_pod_vars
+snip_set_sleep_pod_var
 
 # Verify sleep workload identity was issued by SPIRE
 snip_get_sleep_svid

--- a/content/en/docs/ops/integrations/spire/automatic_registration_test.sh
+++ b/content/en/docs/ops/integrations/spire/automatic_registration_test.sh
@@ -22,12 +22,14 @@ set -o pipefail
 # @setup profile=none
 
 # Install SPIRE configured with k8s Controller Manager
-snip_install_spire_with_controller_manager
+snip_install_spire_crds
+snip_install_spire_istio_overrides
 _wait_for_daemonset spire spire-agent
 _wait_for_deployment spire spire-server
 
 # Create ClusterSPIFFEID
-snip_create_clusterspiffeid
+snip_spire_csid_istio_gateway
+snip_spire_csid_istio_sidecar
 
 # Install Istio
 set +u # Do not exit when value is unset. CHECK_FILE in the IstioOperator might be unset
@@ -56,7 +58,9 @@ snip_get_sleep_svid
 _verify_contains snip_get_svid_subject "O = SPIRE"
 
 # @cleanup
+#
 kubectl delete -f samples/security/spire/sleep-spire.yaml
 istioctl uninstall --purge --skip-confirmation
 kubectl delete ns istio-system
-snip_cleanup_spire_1
+snip_uninstall_spire
+snip_uninstall_spire_crds

--- a/content/en/docs/ops/integrations/spire/automatic_registration_test.sh
+++ b/content/en/docs/ops/integrations/spire/automatic_registration_test.sh
@@ -60,3 +60,4 @@ istioctl uninstall --purge --skip-confirmation
 kubectl delete ns istio-system
 snip_uninstall_spire
 snip_uninstall_spire_crds
+kubectl delete ns spire-server

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -95,7 +95,7 @@ EOF
 
 #### Istio Sidecar ClusterSPIFFEID
 
-The following will create a ClusterSPIFFEID which will auto-register any pod with the `spiffe.io/spire-managed-identity: true` label that is deployed into the `default` namespace with SPIRE. These selectors are used as a simple example, consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
+The following will create a ClusterSPIFFEID which will auto-register any pod with the `spiffe.io/spire-managed-identity: true` label that is deployed into the `default` namespace with SPIRE. These selectors are used as a simple example; consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
 
 {{< text syntax=bash snip_id=spire_csid_istio_gateway >}}
 $ kubectl apply -f - <<EOF

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -290,7 +290,6 @@ The following steps assume you have [already followed the SPIRE documentation to
           metadata:
             labels:
               app: sleep
-              spiffe.io/spire-managed-identity: "true"
             # Injects custom sidecar template
             annotations:
                 inject.istio.io/templates: "sidecar,spire"

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -30,18 +30,14 @@ $ helm upgrade --install -n spire-server spire-crds spire-crds --repo https://sp
 {{< /text >}}
 
 {{< text syntax=bash snip_id=install_spire_istio_overrides >}}
-$ helm upgrade --install -n spire-server spire spire --repo https://spiffe.github.io/helm-charts-hardened/ --wait -f - <<EOF
-global:
-  spire:
-    trustDomain: example.org
-EOF
+$ helm upgrade --install -n spire-server spire spire --repo https://spiffe.github.io/helm-charts-hardened/ --wait --set global.spire.trustDomain="example.org"
 {{< /text >}}
 
 {{< tip >}}
 See the [SPIRE Helm chart](https://artifacthub.io/packages/helm/spiffe/spire) documentation for other values you can configure for your installation.
-{{< /tip >}}
 
-It is important that SPIRE and Istio are configured with the exact same trust domain, to prevent authentication and authorization errors.
+It is important that SPIRE and Istio are configured with the exact same trust domain, to prevent authentication and authorization errors, and that the [SPIFFE CSI driver](https://github.com/spiffe/spiffe-csi) is enabled and installed.
+{{< /tip >}}
 
 By default, the above will also install:
 
@@ -368,7 +364,7 @@ After registering an entry for the Ingress-gateway pod, Envoy receives the ident
         Subject: C = US, O = SPIRE, CN = sleep-5f4d47c948-njvpk
     {{< /text >}}
 
-## SPIFFE Federation
+## SPIFFE federation
 
 SPIRE Servers are able to authenticate SPIFFE identities originating from different trust domains. This is known as SPIFFE federation.
 

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -77,7 +77,7 @@ Both Istio sidecars and Istio gateways need to be registered with SPIRE, so that
 
 #### Istio Gateway ClusterSPIFFEID
 
-The following will create a ClusterSPIFFEID which will auto-register any Istio Ingress gateway pod with SPIRE if it is scheduled into the `istio-system` namespace, and has a service account named `istio-ingressgateway-service-account`. These selectors are used as a simple example, consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
+The following will create a `ClusterSPIFFEID` which will auto-register any Istio Ingress gateway pod with SPIRE if it is scheduled into the `istio-system` namespace, and has a service account named `istio-ingressgateway-service-account`. These selectors are used as a simple example; consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
 
 {{< text syntax=bash snip_id=spire_csid_istio_gateway >}}
 $ kubectl apply -f - <<EOF

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -56,7 +56,7 @@ This will also install:
 
 ## Register workloads
 
-SPIRE by-design only grants identities to workloads that have been registered with the SPIRE server.
+By design, SPIRE only grants identities to workloads that have been registered with the SPIRE server.
 
 This includes your user workloads, as well as Istio's own workloads - Istio sidecars and gateways, once configured for SPIRE integration, cannot get identities, and therefore cannot reach READY status, unless there is a preexisting, matching SPIRE registration created for them ahead of time.
 

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -94,7 +94,7 @@ $ kubectl apply -f - <<EOF
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: istio-ingressgateway-reg
+  name: istio-sidecar-reg
 spec:
   spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
   workloadSelectorTemplates:

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -50,7 +50,7 @@ EOF
 
 This will also install:
 
-- The [SPIFFE CSI driver](https://github.com/spiffe/spiffe-csi) which is used to mount an Envoy-compatible SDS socket into proxies. Using the SPIFFE CSI driver to mount SDS sockets is strongly recommended by both Istio and SPIRE, as `hostMounts` are a larger security risk and introduce operational hurdles.
+- The [SPIFFE CSI driver](https://github.com/spiffe/spiffe-csi), which is used to mount an Envoy-compatible SDS socket into proxies. Using the SPIFFE CSI driver to mount SDS sockets is strongly recommended by both Istio and SPIRE, as `hostMounts` are a larger security risk and introduce operational hurdles.
 
 - The [SPIRE Controller Manager](https://github.com/spiffe/spire-controller-manager), which eases the creation of SPIFFE registrations for workloads.
 

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -97,9 +97,11 @@ metadata:
   name: istio-sidecar-reg
 spec:
   spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  podSelector:
+    matchLabels:
+      spiffe.io/spire-managed-identity: "true"
   workloadSelectorTemplates:
     - "k8s:ns:default"
-    - "k8s:pod-label:spiffe.io/spire-managed-identity:true"
 EOF
 {{< /text >}}
 

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -44,7 +44,7 @@ EOF
 {{< /text >}}
 
 {{< tip >}}
-  See the [SPIRE Helm chart](https://artifacthub.io/packages/helm/spiffe/spire) documentation for other values you can configure for your installation - this doc only mentions the minimal subset required to achieve Istio integration.
+This is the minimal subset of changes required to integrate with Istio.  See the [SPIRE Helm chart](https://artifacthub.io/packages/helm/spiffe/spire) documentation for other values you can configure for your installation.
 {{< /tip >}}
 
 

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -27,71 +27,139 @@ The integration is compatible with Istio upgrades.
 
 ## Install SPIRE
 
-### Option 1: Quick start
+Istio recommends you follow SPIRE's installation instructions and general recommendations for installing SPIRE.
 
-Istio provides a basic sample installation to quickly get SPIRE up and running:
+For this guide, the [SPIRE Helm charts](https://artifacthub.io/packages/helm/spiffe/spire) will be used as a simple way to install SPIRE dependencies for Istio and illustrate the configuration necessary to integrate SPIRE and Istio.
 
-{{< text syntax=bash snip_id=install_spire_with_controller_manager >}}
-$ kubectl apply -f @samples/security/spire/spire-quickstart.yaml@
+{{< text syntax=bash snip_id=install_spire_crds >}}
+$ helm upgrade --install -n spire-server spire-crds spire-crds --repo https://spiffe.github.io/helm-charts-hardened/ --create-namespace
 {{< /text >}}
 
-This will deploy SPIRE into your cluster, along with two additional components: the [SPIFFE CSI Driver](https://github.com/spiffe/spiffe-csi) — used to share the SPIRE Agent's UNIX Domain Socket with the other
-pods throughout the node — and the [SPIRE Controller Manager](https://github.com/spiffe/spire-controller-manager), a facilitator that performs workload registration and establishes federation relationships
-within Kubernetes. See [Install Istio](#install-istio) to configure Istio and integrate with the SPIFFE CSI Driver.
-
-### Option 2: Configure a custom SPIRE installation
-
-See the [SPIRE's Quick start for Kubernetes guide](https://spiffe.io/docs/latest/try/getting-started-k8s/)
-to get started deploying SPIRE into your Kubernetes environment. See [SPIRE CA Integration Prerequisites](#spire-ca-integration-prerequisites)
-for more information on configuring SPIRE to integrate with Istio deployments.
-
-#### SPIRE CA Integration Prerequisites
-
-To integrate your SPIRE deployment with Istio, configure SPIRE:
-
-1. Access the [SPIRE Agent reference](https://spiffe.io/docs/latest/deploying/spire_agent/#agent-configuration-file) and
-    configure the SPIRE Agent socket path to match the Envoy SDS defined socket path.
-
-    {{< text plain >}}
-    socket_path = "/run/secrets/workload-spiffe-uds/socket"
-    {{< /text >}}
-
-1. Share the SPIRE Agent socket with the pods within the node by deploying the
-    [SPIFFE CSI Driver](https://github.com/spiffe/spiffe-csi).
-    The `-workload-api-socket-dir` argument to the driver should be the mount location of the socket's directory.
-
-See [Install Istio](#install-istio) to configure Istio to integrate with the SPIFFE CSI Driver.
+{{< text syntax-bash snip_id=install_spire_istio_overrides >}}
+$ helm upgrade --install -n spire-server spire spire --repo https://spiffe.github.io/helm-charts-hardened/ --wait -f - <<EOF
+global:
+  spire:
+    trustDomain: example.org
+EOF
+{{< /text >}}
 
 {{< tip >}}
-Istio will become the Envoy SDS listener if the socket is not created by SPIRE before the Istio agent starts up. This timing is controlled by customizing the IstioOperator.
+  See the [SPIRE Helm chart](https://artifacthub.io/packages/helm/spiffe/spire) documentation for other values you can configure for your installation - this doc only mentions the minimal subset required to achieve Istio integration.
 {{< /tip >}}
 
-## Install Istio
 
-### Option 1: Configuration for Workload Registration with the SPIRE Controller Manager
+This will also install 
 
-By deploying [SPIRE Controller Manager](https://github.com/spiffe/spire-controller-manager)
-along with a SPIRE Server, new entries can be automatically registered for each new pod that matches the selector defined in a [ClusterSPIFFEID](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) custom resource.
+- The [SPIFFE CSI driver](https://github.com/spiffe/spiffe-csi) which is used to mount an Envoy-compatible SDS socket into proxies. Using the SPIFFE CSI driver to mount SDS sockets is strongly recommended by both Istio and SPIRE, as `hostMounts` are a larger security risk and introduce operational hurdles.
 
-A ClusterSPIFFEID must be applied prior to installing Istio in order for the Ingress-gateway to obtain its certificates. Additionally, the Ingress-gateway pod must be configured to match the selector defined in the ClusterSPIFFEID. If a registration entry for the Ingress Gateway workload was not automatically created during install, the workload would not reach a `Ready` state and installation would fail.
+- The [SPIRE Controller Manager](https://github.com/spiffe/spire-controller-manager), which eases the creation of SPIFFE registrations for workloads.
 
-1. Create example ClusterSPIFFEID:
+## Register workloads
 
-    {{< text syntax=bash snip_id=create_clusterspiffeid >}}
-    $ kubectl apply -f - <<EOF
-    apiVersion: spire.spiffe.io/v1alpha1
-    kind: ClusterSPIFFEID
-    metadata:
-      name: example
-    spec:
-      spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
-      podSelector:
-        matchLabels:
-          spiffe.io/spire-managed-identity: "true"
-    EOF
+SPIRE by-design only grants identities to workloads that have been registered with the SPIRE server.
+
+This includes your user workloads, as well as Istio's own workloads - Istio sidecars and gateways, once configured for SPIRE integration, cannot get identities, and therefore cannot reach READY status, unless there is a preexisting, matching SPIRE registration created for them ahead of time.
+
+See the [SPIRE help on Registering workloads](https://spiffe.io/docs/latest/deploying/registering/) for more information on using multiple selectors to strengthen attestation criteria, and the selectors available.
+
+This section describes the options available for registering Istio workloads in a SPIRE Server and provides some example workload registrations.
+
+{{< warning >}}
+Istio currently requires a specific SPIFFE ID format for workloads. All registrations must follow the Istio SPIFFE ID pattern: `spiffe://<trust.domain>/ns/<namespace>/sa/<service-account>`
+{{< /warning >}}
+
+
+### Option 1: Auto-registration using the SPIRE Controller Manager
+
+New entries will be automatically registered for each new pod that matches the selector defined in a [ClusterSPIFFEID](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) custom resource. 
+
+Both Istio sidecars and Istio gateways need to be registered with SPIRE, so that they can request identities.
+
+#### Istio Gateway ClusterSPIFFEID
+
+The following will create a ClusterSPIFFEID which will auto-register any Istio Ingress gateway pod with SPIRE if it is scheduled into the `istio-system` namespace, and has a service account named `istio-ingressgateway-service-account`. These selectors are used as a simple example, consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
+
+{{< text syntax-bash snip_id=spire_csid_istio_gateway >}}
+kubectl apply -f - <<EOF
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: istio-ingressgateway-reg
+spec:
+  spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  workloadSelectorTemplates:
+    - "k8s:ns:istio-system"
+    - "k8s:sa:istio-ingressgateway-service-account"
+EOF
+{{< /text >}}
+
+#### Istio Sidecar ClusterSPIFFEID
+
+The following will create a ClusterSPIFFEID which will auto-register any pod with the `spiffe.io/spire-managed-identity: true` label that is deployed into the `default` namespace with SPIRE. These selectors are used as a simple example, consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
+
+{{< text syntax-bash snip_id=spire_csid_istio_gateway >}}
+kubectl apply -f - <<EOF
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: istio-ingressgateway-reg
+spec:
+  spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  workloadSelectorTemplates:
+    - "k8s:ns:default"
+    - "k8s:pod-label:spiffe.io/spire-managed-identity:true"
+EOF
+{{< /text >}}
+
+### Option 2: Manual Registration
+
+Skip these steps if you installed `SPIRE` by following the [quick start](#option-1-quick-start) since it uses automatic registration.
+
+If you wish to manually create your SPIRE registrations, rather than use the SPIRE Controller Manager mentioned in [the recommended Option 1](#option-1-auto-registration-using-the-spire-controller-manager), refer to the [SPIRE documentation on manual registration](https://spiffe.io/docs/latest/deploying/registering/).
+
+Below are the equivalent manual registrations based off the automatic registrations in [Option 1](#option-1-auto-registration-using-the-spire-controller-manager):
+
+The following steps assume you have [already followed the SPIRE documentation to manually register your SPIRE agent and node attestation](https://spiffe.io/docs/latest/deploying/registering/#1-defining-the-spiffe-id-of-the-agent) and that your SPIRE agent was registered with the SPIFFE identity `spiffe://example.org/ns/spire/sa/spire-agent`.
+
+1. Get the spire-server pod:
+
+    {{< text syntax=bash snip_id=set_spire_server_pod_name_var >}}
+    $ SPIRE_SERVER_POD=$(kubectl get pod -l app=spire-server -n spire -o jsonpath="{.items[0].metadata.name}")
     {{< /text >}}
 
-    The example ClusterSPIFFEID enables automatic workload registration for all workloads with the `spiffe.io/spire-managed-identity: "true"` label. For pods with this label, the values specified in the `spiffeIDTemplate` will be extracted to form the SPIFFE ID.
+1. Register an entry for the Istio Ingress gateway pod:
+
+    {{< text bash >}}
+    $ kubectl exec -n spire "$SPIRE_SERVER_POD" -- \
+    /opt/spire/bin/spire-server entry create \
+        -spiffeID spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account \
+        -parentID spiffe://example.org/ns/spire/sa/spire-agent \
+        -selector k8s:sa:istio-ingressgateway-service-account \
+        -selector k8s:ns:istio-system \
+        -socketPath /run/spire/sockets/server.sock
+
+    Entry ID         : 6f2fe370-5261-4361-ac36-10aae8d91ff7
+    SPIFFE ID        : spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account
+    Parent ID        : spiffe://example.org/ns/spire/sa/spire-agent
+    Revision         : 0
+    TTL              : default
+    Selector         : k8s:ns:istio-system
+    Selector         : k8s:sa:istio-ingressgateway-service-account
+    {{< /text >}}
+
+1. Register an entry for workloads injected with an Istio sidecar:
+
+    {{< text bash >}}
+    $ kubectl exec -n spire "$SPIRE_SERVER_POD" -- \
+    /opt/spire/bin/spire-server entry create \
+        -spiffeID spiffe://example.org/ns/default/sa/sleep \
+        -parentID spiffe://example.org/ns/spire/sa/spire-agent \
+        -selector k8s:ns:default \
+        -selector k8s:pod-label:spiffe.io/spire-managed-identity:true \
+        -socketPath /run/spire/sockets/server.sock
+    {{< /text >}}
+
+## Install Istio
 
 1. [Download the Istio release](/docs/setup/additional-setup/download-istio-release/).
 
@@ -109,10 +177,14 @@ A ClusterSPIFFEID must be applied prior to installing Istio in order for the Ing
         trustDomain: example.org
       values:
         global:
-        # This is used to customize the sidecar template
+        # This is used to customize the sidecar template.
+        # It adds both the label to indicate that SPIRE should manage the
+        # identity of this pod, as well as the CSI driver mounts.
         sidecarInjectorWebhook:
           templates:
             spire: |
+              labels:
+                spiffe.io/spire-managed-identity: "true"
               spec:
                 containers:
                 - name: istio-proxy
@@ -131,9 +203,11 @@ A ClusterSPIFFEID must be applied prior to installing Istio in order for the Ing
             enabled: true
             label:
               istio: ingressgateway
-              spiffe.io/spire-managed-identity: "true"
             k8s:
               overlays:
+                # This is used to customize the ingress gateway template.
+                # It adds the CSI driver mounts, as well as an init container
+                # to stall gateway startup until the CSI driver mounts the socket.
                 - apiVersion: apps/v1
                   kind: Deployment
                   name: istio-ingressgateway
@@ -152,7 +226,7 @@ A ClusterSPIFFEID must be applied prior to installing Istio in order for the Ing
                     - path: spec.template.spec.initContainers
                       value:
                         - name: wait-for-spire-socket
-                          image: busybox:1.28
+                          image: busybox:1.36
                           volumeMounts:
                             - name: workload-socket
                               mountPath: /run/secrets/workload-spiffe-uds
@@ -190,122 +264,7 @@ A ClusterSPIFFEID must be applied prior to installing Istio in order for the Ing
 
     The Ingress-gateway pod is `Ready` since the corresponding registration entry is automatically created for it on the SPIRE Server. Envoy is able to fetch cryptographic identities from SPIRE.
 
-Note that `SPIRE Controller Manager` is used in the [quick start](#option-1-quick-start) section.
-
-### Option 2: Configuration for Manual Workload Registration with SPIRE
-
-1. [Download the Istio release](/docs/setup/additional-setup/download-istio-release/).
-
-1. After [deploying SPIRE](#install-spire) into your environment, and verifying that all deployments are in `Ready` state, configure Istio with custom patches for the Ingress-gateway as well as for istio-proxy.
-
-    Create Istio configuration:
-
-    {{< text syntax=bash snip_id=define_istio_operator_for_manual_registration >}}
-    $ cat <<EOF > ./istio.yaml
-    apiVersion: install.istio.io/v1alpha1
-    kind: IstioOperator
-    metadata:
-      namespace: istio-system
-    spec:
-      profile: default
-      meshConfig:
-        trustDomain: example.org
-      values:
-        global:
-        # This is used to customize the sidecar template
-        sidecarInjectorWebhook:
-          templates:
-            spire: |
-              spec:
-                containers:
-                - name: istio-proxy
-                  volumeMounts:
-                  - name: workload-socket
-                    mountPath: /run/secrets/workload-spiffe-uds
-                    readOnly: true
-                volumes:
-                  - name: workload-socket
-                    csi:
-                      driver: "csi.spiffe.io"
-                      readOnly: true
-      components:
-        ingressGateways:
-          - name: istio-ingressgateway
-            enabled: true
-            label:
-              istio: ingressgateway
-            k8s:
-              overlays:
-                - apiVersion: apps/v1
-                  kind: Deployment
-                  name: istio-ingressgateway
-                  patches:
-                    - path: spec.template.spec.volumes.[name:workload-socket]
-                      value:
-                        name: workload-socket
-                        csi:
-                          driver: "csi.spiffe.io"
-                          readOnly: true
-                    - path: spec.template.spec.containers.[name:istio-proxy].volumeMounts.[name:workload-socket]
-                      value:
-                        name: workload-socket
-                        mountPath: "/run/secrets/workload-spiffe-uds"
-                        readOnly: true
-                    - path: spec.template.spec.initContainers
-                      value:
-                        - name: wait-for-spire-socket
-                          image: busybox:1.28
-                          volumeMounts:
-                            - name: workload-socket
-                              mountPath: /run/secrets/workload-spiffe-uds
-                              readOnly: true
-                          env:
-                            - name: CHECK_FILE
-                              value: /run/secrets/workload-spiffe-uds/socket
-                          command:
-                            - sh
-                            - "-c"
-                            - |-
-                              echo "$(date -Iseconds)" Waiting for: ${CHECK_FILE}
-                              while [[ ! -e ${CHECK_FILE} ]] ; do
-                                echo "$(date -Iseconds)" File does not exist: ${CHECK_FILE}
-                                sleep 15
-                              done
-                              ls -l ${CHECK_FILE}
-    EOF
-    {{< /text >}}
-
-1. Apply the configuration:
-
-    {{< text syntax=bash snip_id=none >}}
-    $ istioctl install --skip-confirmation -f ./istio.yaml
-    {{< /text >}}
-
-1. Check Ingress-gateway pod state:
-
-    {{< text syntax=bash snip_id=none >}}
-    $ kubectl get pods -n istio-system
-    NAME                                    READY   STATUS    RESTARTS   AGE
-    istio-ingressgateway-5b45864fd4-lgrxs   0/1     Running   0          20s
-    istiod-989f54d9c-sg7sn                  1/1     Running   0          25s
-    {{< /text >}}
-
-    The Ingress-gateway pod and data plane containers will only reach `Ready` if a corresponding registration entry is created for them on the SPIRE Server. Then,
-    Envoy will be able to fetch cryptographic identities from SPIRE.
-    See [Register workloads](#register-workloads) to register entries for services in your mesh.
-
-The Istio configuration shares the `spiffe-csi-driver` with the Ingress Gateway and the sidecars that are going to be injected on workload pods,
-granting them access to the SPIRE Agent's UNIX Domain Socket.
-
-This configuration also adds an initContainer to the gateway that will wait for SPIRE to create the UNIX Domain Socket before starting the istio-proxy. If the SPIRE agent is not ready or has not been properly configured with the same socket path, the Ingress Gateway initContainer will wait forever.
-
-## Register workloads
-
-This section describes the options available for registering workloads in a SPIRE Server.
-
-### Option 1: Registration using the SPIRE Controller Manager
-
-New entries will be automatically registered for each new pod that matches the selector defined in a [ClusterSPIFFEID](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) custom resource. See [Configuration for Workload Registration with the SPIRE Controller Manager](#option-1:-configuration-for-workload-registration-with-the-spire-controller-manager) for the example ClusterSPIFFEID configuration.
+    This configuration also adds an initContainer to the gateway that will wait for SPIRE to create the UNIX Domain Socket before starting the istio-proxy. If the SPIRE agent is not ready or has not been properly configured with the same socket path, the Ingress Gateway initContainer will wait forever.
 
 1. Deploy an example workload:
 
@@ -358,151 +317,10 @@ New entries will be automatically registered for each new pod that matches the s
                   readOnly: true
     {{< /text >}}
 
+The Istio configuration shares the `spiffe-csi-driver` with the Ingress Gateway and the sidecars that are going to be injected on workload pods, granting them access to the SPIRE Agent's UNIX Domain Socket.
+
 See [Verifying that identities were created for workloads](#verifying-that-identities-were-created-for-workloads)
 to check issued identities.
-
-Note that `SPIRE Controller Manager` is used in the [quick start](#option-1-quick-start) section.
-
-### Option 2: Manual Registration
-
-To improve workload attestation security robustness, SPIRE is able to verify against a group of selector values based on different parameters. Skip these steps if you installed `SPIRE` by following the [quick start](#option-1-quick-start) since it uses automatic registration.
-
-1. Generate an entry for an Ingress Gateway with a set of selectors such as the
-    pod name and pod UID:
-
-    {{< text bash >}}
-    $ INGRESS_POD=$(kubectl get pod -l istio=ingressgateway -n istio-system -o jsonpath="{.items[0].metadata.name}")
-    $ INGRESS_POD_UID=$(kubectl get pods -n istio-system "$INGRESS_POD" -o jsonpath='{.metadata.uid}')
-    {{< /text >}}
-
-1. Get the spire-server pod:
-
-    {{< text syntax=bash snip_id=set_spire_server_pod_name_var >}}
-    $ SPIRE_SERVER_POD=$(kubectl get pod -l app=spire-server -n spire -o jsonpath="{.items[0].metadata.name}")
-    {{< /text >}}
-
-1. Register an entry for the SPIRE Agent running on the node:
-
-    {{< text bash >}}
-    $ kubectl exec -n spire "$SPIRE_SERVER_POD" -- \
-    /opt/spire/bin/spire-server entry create \
-        -spiffeID spiffe://example.org/ns/spire/sa/spire-agent \
-        -selector k8s_psat:cluster:demo-cluster \
-        -selector k8s_psat:agent_ns:spire \
-        -selector k8s_psat:agent_sa:spire-agent \
-        -node -socketPath /run/spire/sockets/server.sock
-
-    Entry ID         : d38c88d0-7d7a-4957-933c-361a0a3b039c
-    SPIFFE ID        : spiffe://example.org/ns/spire/sa/spire-agent
-    Parent ID        : spiffe://example.org/spire/server
-    Revision         : 0
-    TTL              : default
-    Selector         : k8s_psat:agent_ns:spire
-    Selector         : k8s_psat:agent_sa:spire-agent
-    Selector         : k8s_psat:cluster:demo-cluster
-    {{< /text >}}
-
-1. Register an entry for the Ingress-gateway pod:
-
-    {{< text bash >}}
-    $ kubectl exec -n spire "$SPIRE_SERVER_POD" -- \
-    /opt/spire/bin/spire-server entry create \
-        -spiffeID spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account \
-        -parentID spiffe://example.org/ns/spire/sa/spire-agent \
-        -selector k8s:sa:istio-ingressgateway-service-account \
-        -selector k8s:ns:istio-system \
-        -selector k8s:pod-uid:"$INGRESS_POD_UID" \
-        -dns "$INGRESS_POD" \
-        -dns istio-ingressgateway.istio-system.svc \
-        -socketPath /run/spire/sockets/server.sock
-
-    Entry ID         : 6f2fe370-5261-4361-ac36-10aae8d91ff7
-    SPIFFE ID        : spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account
-    Parent ID        : spiffe://example.org/ns/spire/sa/spire-agent
-    Revision         : 0
-    TTL              : default
-    Selector         : k8s:ns:istio-system
-    Selector         : k8s:pod-uid:63c2bbf5-a8b1-4b1f-ad64-f62ad2a69807
-    Selector         : k8s:sa:istio-ingressgateway-service-account
-    DNS name         : istio-ingressgateway.istio-system.svc
-    DNS name         : istio-ingressgateway-5b45864fd4-lgrxs
-    {{< /text >}}
-
-1. Deploy an example workload:
-
-    {{< text bash >}}
-    $ istioctl kube-inject --filename @samples/security/spire/sleep-spire.yaml@ | kubectl apply -f -
-    {{< /text >}}
-
-    Note that the workload will need the SPIFFE CSI Driver volume to access the SPIRE Agent socket. To accomplish this,
-    you can leverage the `spire` pod annotation template from the [Install Istio](#install-istio) section or add the CSI volume to
-    the deployment spec of your workload. Both of these alternatives are highlighted on the example snippet below:
-
-    {{< text syntax=yaml snip_id=none >}}
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: sleep
-    spec:
-      replicas: 1
-      selector:
-          matchLabels:
-            app: sleep
-      template:
-          metadata:
-            labels:
-              app: sleep
-            # Injects custom sidecar template
-            annotations:
-                inject.istio.io/templates: "sidecar,spire"
-          spec:
-            terminationGracePeriodSeconds: 0
-            serviceAccountName: sleep
-            containers:
-            - name: sleep
-              image: curlimages/curl
-              command: ["/bin/sleep", "3650d"]
-              imagePullPolicy: IfNotPresent
-              volumeMounts:
-                - name: tmp
-                  mountPath: /tmp
-              securityContext:
-                runAsUser: 1000
-            volumes:
-              - name: tmp
-                emptyDir: {}
-              # CSI volume
-              - name: workload-socket
-                csi:
-                  driver: "csi.spiffe.io"
-                  readOnly: true
-    {{< /text >}}
-
-1. Get pod information:
-
-    {{< text syntax=bash snip_id=set_sleep_pod_vars >}}
-    $ SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath="{.items[0].metadata.name}")
-    $ SLEEP_POD_UID=$(kubectl get pods "$SLEEP_POD" -o jsonpath='{.metadata.uid}')
-    {{< /text >}}
-
-1. Register the workload:
-
-    {{< text bash >}}
-    $ kubectl exec -n spire "$SPIRE_SERVER_POD" -- \
-    /opt/spire/bin/spire-server entry create \
-        -spiffeID spiffe://example.org/ns/default/sa/sleep \
-        -parentID spiffe://example.org/ns/spire/sa/spire-agent \
-        -selector k8s:ns:default \
-        -selector k8s:pod-uid:"$SLEEP_POD_UID" \
-        -dns "$SLEEP_POD" \
-        -socketPath /run/spire/sockets/server.sock
-    {{< /text >}}
-
-{{< warning >}}
-SPIFFE IDs for workloads must follow the Istio SPIFFE ID pattern: `spiffe://<trust.domain>/ns/<namespace>/sa/<service-account>`
-{{< /warning >}}
-
-See the [SPIRE help on Registering workloads](https://spiffe.io/docs/latest/deploying/registering/) to learn how to create new entries for workloads and get them attested using multiple selectors to strengthen attestation criteria.
 
 ## Verifying that identities were created for workloads
 
@@ -593,29 +411,10 @@ This will allow Envoy to get federated bundles directly from SPIRE.
 
 ## Cleanup SPIRE
 
-If you installed SPIRE using the quick start SPIRE deployment provided by Istio,
-use the following commands to remove those Kubernetes resources:
+{{< text syntax-bash snip_id=uninstall_spire >}}
+$ helm delete -n spire-server spire
+{{< /text >}}
 
-{{< text bash >}}
-$ kubectl delete CustomResourceDefinition clusterspiffeids.spire.spiffe.io
-$ kubectl delete CustomResourceDefinition clusterfederatedtrustdomains.spire.spiffe.io
-$ kubectl delete -n spire configmap spire-bundle
-$ kubectl delete -n spire serviceaccount spire-agent
-$ kubectl delete -n spire configmap spire-agent
-$ kubectl delete -n spire daemonset spire-agent
-$ kubectl delete csidriver csi.spiffe.io
-$ kubectl delete ValidatingWebhookConfiguration spire-controller-manager-webhook
-$ kubectl delete -n spire configmap spire-controller-manager-config
-$ kubectl delete -n spire configmap spire-server
-$ kubectl delete -n spire service spire-controller-manager-webhook-service
-$ kubectl delete -n spire service spire-server-bundle-endpoint
-$ kubectl delete -n spire service spire-server
-$ kubectl delete -n spire serviceaccount spire-server
-$ kubectl delete -n spire deployment spire-server
-$ kubectl delete clusterrole spire-server-cluster-role spire-agent-cluster-role manager-role
-$ kubectl delete clusterrolebinding spire-server-cluster-role-binding spire-agent-cluster-role-binding manager-role-binding
-$ kubectl delete -n spire role spire-server-role leader-election-role
-$ kubectl delete -n spire rolebinding spire-server-role-binding leader-election-role-binding
-$ kubectl delete namespace spire
-$ rm istio.yaml chain.pem
+{{< text syntax=bash snip_id=uninstall_spire_crds >}}
+$ helm delete -n spire-server spire-crds
 {{< /text >}}

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -35,7 +35,7 @@ For this guide, the [SPIRE Helm charts](https://artifacthub.io/packages/helm/spi
 $ helm upgrade --install -n spire-server spire-crds spire-crds --repo https://spiffe.github.io/helm-charts-hardened/ --create-namespace
 {{< /text >}}
 
-{{< text syntax-bash snip_id=install_spire_istio_overrides >}}
+{{< text syntax=bash snip_id=install_spire_istio_overrides >}}
 $ helm upgrade --install -n spire-server spire spire --repo https://spiffe.github.io/helm-charts-hardened/ --wait -f - <<EOF
 global:
   spire:
@@ -79,7 +79,7 @@ Both Istio sidecars and Istio gateways need to be registered with SPIRE, so that
 
 The following will create a ClusterSPIFFEID which will auto-register any Istio Ingress gateway pod with SPIRE if it is scheduled into the `istio-system` namespace, and has a service account named `istio-ingressgateway-service-account`. These selectors are used as a simple example, consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
 
-{{< text syntax-bash snip_id=spire_csid_istio_gateway >}}
+{{< text syntax=bash snip_id=spire_csid_istio_gateway >}}
 kubectl apply -f - <<EOF
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
@@ -97,7 +97,7 @@ EOF
 
 The following will create a ClusterSPIFFEID which will auto-register any pod with the `spiffe.io/spire-managed-identity: true` label that is deployed into the `default` namespace with SPIRE. These selectors are used as a simple example, consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
 
-{{< text syntax-bash snip_id=spire_csid_istio_gateway >}}
+{{< text syntax=bash snip_id=spire_csid_istio_gateway >}}
 kubectl apply -f - <<EOF
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
@@ -410,7 +410,7 @@ This will allow Envoy to get federated bundles directly from SPIRE.
 
 ## Cleanup SPIRE
 
-{{< text syntax-bash snip_id=uninstall_spire >}}
+{{< text syntax=bash snip_id=uninstall_spire >}}
 $ helm delete -n spire-server spire
 {{< /text >}}
 

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -80,7 +80,7 @@ Both Istio sidecars and Istio gateways need to be registered with SPIRE, so that
 The following will create a ClusterSPIFFEID which will auto-register any Istio Ingress gateway pod with SPIRE if it is scheduled into the `istio-system` namespace, and has a service account named `istio-ingressgateway-service-account`. These selectors are used as a simple example, consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
 
 {{< text syntax=bash snip_id=spire_csid_istio_gateway >}}
-kubectl apply -f - <<EOF
+$ kubectl apply -f - <<EOF
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
@@ -98,7 +98,7 @@ EOF
 The following will create a ClusterSPIFFEID which will auto-register any pod with the `spiffe.io/spire-managed-identity: true` label that is deployed into the `default` namespace with SPIRE. These selectors are used as a simple example, consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
 
 {{< text syntax=bash snip_id=spire_csid_istio_gateway >}}
-kubectl apply -f - <<EOF
+$ kubectl apply -f - <<EOF
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -315,7 +315,7 @@ to check issued identities.
 
 Use the following command to confirm that identities were created for the workloads:
 
-{{< text syntax=bash snip_id=none>}}
+{{< text syntax=bash snip_id=none >}}
 $ kubectl exec -t "$SPIRE_SERVER_POD" -n spire-server -c spire-server -- ./bin/spire-server entry show
 Found 2 entries
 Entry ID         : c8dfccdc-9762-4762-80d3-5434e5388ae7

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -89,7 +89,7 @@ EOF
 
 The following will create a `ClusterSPIFFEID` which will auto-register any pod with the `spiffe.io/spire-managed-identity: true` label that is deployed into the `default` namespace with SPIRE. These selectors are used as a simple example; consult the [SPIRE Controller Manager documentation](https://github.com/spiffe/spire-controller-manager/blob/main/docs/clusterspiffeid-crd.md) for more details.
 
-{{< text syntax=bash snip_id=spire_csid_istio_gateway >}}
+{{< text syntax=bash snip_id=spire_csid_istio_sidecar >}}
 $ kubectl apply -f - <<EOF
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -48,7 +48,7 @@ EOF
 {{< /tip >}}
 
 
-This will also install 
+This will also install:
 
 - The [SPIFFE CSI driver](https://github.com/spiffe/spiffe-csi) which is used to mount an Envoy-compatible SDS socket into proxies. Using the SPIFFE CSI driver to mount SDS sockets is strongly recommended by both Istio and SPIRE, as `hostMounts` are a larger security risk and introduce operational hurdles.
 

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -315,7 +315,7 @@ to check issued identities.
 
 Use the following command to confirm that identities were created for the workloads:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none>}}
 $ kubectl exec -t "$SPIRE_SERVER_POD" -n spire-server -c spire-server -- ./bin/spire-server entry show
 Found 2 entries
 Entry ID         : c8dfccdc-9762-4762-80d3-5434e5388ae7
@@ -347,6 +347,12 @@ istiod-989f54d9c-sg7sn                  1/1     Running   0          45s
 After registering an entry for the Ingress-gateway pod, Envoy receives the identity issued by SPIRE and uses it for all TLS and mTLS communications.
 
 ### Check that the workload identity was issued by SPIRE
+
+1. Get pod information:
+
+    {{< text syntax=bash snip_id=set_sleep_pod_var >}}
+    $ SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath="{.items[0].metadata.name}")
+    {{< /text >}}
 
 1. Retrieve sleep's SVID identity document using the istioctl proxy-config secret command:
 

--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -114,7 +114,7 @@ Below are the equivalent manual registrations based off the automatic registrati
 1. Get the `spire-server` pod:
 
     {{< text syntax=bash snip_id=set_spire_server_pod_name_var >}}
-    $ SPIRE_SERVER_POD=$(kubectl get pod -l app=spire-server -n spire -o jsonpath="{.items[0].metadata.name}")
+    $ SPIRE_SERVER_POD=$(kubectl get pod -l statefulset.kubernetes.io/pod-name=spire-server-0 -n spire-server -o jsonpath="{.items[0].metadata.name}")
     {{< /text >}}
 
 1. Register an entry for the Istio Ingress gateway pod:
@@ -316,7 +316,7 @@ to check issued identities.
 Use the following command to confirm that identities were created for the workloads:
 
 {{< text bash >}}
-$ kubectl exec -t "$SPIRE_SERVER_POD" -n spire -c spire-server -- ./bin/spire-server entry show
+$ kubectl exec -t "$SPIRE_SERVER_POD" -n spire-server -c spire-server -- ./bin/spire-server entry show
 Found 2 entries
 Entry ID         : c8dfccdc-9762-4762-80d3-5434e5388ae7
 SPIFFE ID        : spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account

--- a/content/en/docs/ops/integrations/spire/snips.sh
+++ b/content/en/docs/ops/integrations/spire/snips.sh
@@ -20,26 +20,79 @@
 #          docs/ops/integrations/spire/index.md
 ####################################################################################################
 
-snip_install_spire_with_controller_manager() {
-kubectl apply -f samples/security/spire/spire-quickstart.yaml
+snip_install_spire_crds() {
+helm upgrade --install -n spire-server spire-crds spire-crds --repo https://spiffe.github.io/helm-charts-hardened/ --create-namespace
 }
 
-! IFS=$'\n' read -r -d '' snip_spire_ca_integration_prerequisites_1 <<\ENDSNIP
-socket_path = "/run/secrets/workload-spiffe-uds/socket"
-ENDSNIP
+snip_install_spire_istio_overrides() {
+helm upgrade --install -n spire-server spire spire --repo https://spiffe.github.io/helm-charts-hardened/ --wait -f - <<EOF
+global:
+  spire:
+    trustDomain: example.org
+EOF
+}
 
-snip_create_clusterspiffeid() {
+snip_spire_csid_istio_gateway() {
 kubectl apply -f - <<EOF
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: example
+  name: istio-ingressgateway-reg
 spec:
   spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
-  podSelector:
-    matchLabels:
-      spiffe.io/spire-managed-identity: "true"
+  workloadSelectorTemplates:
+    - "k8s:ns:istio-system"
+    - "k8s:sa:istio-ingressgateway-service-account"
 EOF
+}
+
+snip_spire_csid_istio_gateway() {
+kubectl apply -f - <<EOF
+apiVersion: spire.spiffe.io/v1alpha1
+kind: ClusterSPIFFEID
+metadata:
+  name: istio-ingressgateway-reg
+spec:
+  spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  workloadSelectorTemplates:
+    - "k8s:ns:default"
+    - "k8s:pod-label:spiffe.io/spire-managed-identity:true"
+EOF
+}
+
+snip_set_spire_server_pod_name_var() {
+SPIRE_SERVER_POD=$(kubectl get pod -l app=spire-server -n spire -o jsonpath="{.items[0].metadata.name}")
+}
+
+snip_option_2_manual_registration_2() {
+kubectl exec -n spire "$SPIRE_SERVER_POD" -- \
+/opt/spire/bin/spire-server entry create \
+    -spiffeID spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account \
+    -parentID spiffe://example.org/ns/spire/sa/spire-agent \
+    -selector k8s:sa:istio-ingressgateway-service-account \
+    -selector k8s:ns:istio-system \
+    -socketPath /run/spire/sockets/server.sock
+}
+
+! IFS=$'\n' read -r -d '' snip_option_2_manual_registration_2_out <<\ENDSNIP
+
+Entry ID         : 6f2fe370-5261-4361-ac36-10aae8d91ff7
+SPIFFE ID        : spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account
+Parent ID        : spiffe://example.org/ns/spire/sa/spire-agent
+Revision         : 0
+TTL              : default
+Selector         : k8s:ns:istio-system
+Selector         : k8s:sa:istio-ingressgateway-service-account
+ENDSNIP
+
+snip_option_2_manual_registration_3() {
+kubectl exec -n spire "$SPIRE_SERVER_POD" -- \
+/opt/spire/bin/spire-server entry create \
+    -spiffeID spiffe://example.org/ns/default/sa/sleep \
+    -parentID spiffe://example.org/ns/spire/sa/spire-agent \
+    -selector k8s:ns:default \
+    -selector k8s:pod-label:spiffe.io/spire-managed-identity:true \
+    -socketPath /run/spire/sockets/server.sock
 }
 
 snip_define_istio_operator_for_auto_registration() {
@@ -54,10 +107,14 @@ spec:
     trustDomain: example.org
   values:
     global:
-    # This is used to customize the sidecar template
+    # This is used to customize the sidecar template.
+    # It adds both the label to indicate that SPIRE should manage the
+    # identity of this pod, as well as the CSI driver mounts.
     sidecarInjectorWebhook:
       templates:
         spire: |
+          labels:
+            spiffe.io/spire-managed-identity: "true"
           spec:
             containers:
             - name: istio-proxy
@@ -76,9 +133,11 @@ spec:
         enabled: true
         label:
           istio: ingressgateway
-          spiffe.io/spire-managed-identity: "true"
         k8s:
           overlays:
+            # This is used to customize the ingress gateway template.
+            # It adds the CSI driver mounts, as well as an init container
+            # to stall gateway startup until the CSI driver mounts the socket.
             - apiVersion: apps/v1
               kind: Deployment
               name: istio-ingressgateway
@@ -97,7 +156,7 @@ spec:
                 - path: spec.template.spec.initContainers
                   value:
                     - name: wait-for-spire-socket
-                      image: busybox:1.28
+                      image: busybox:1.36
                       volumeMounts:
                         - name: workload-socket
                           mountPath: /run/secrets/workload-spiffe-uds
@@ -122,161 +181,8 @@ snip_apply_istio_operator_configuration() {
 istioctl install --set values.pilot.env.PILOT_ENABLE_CONFIG_DISTRIBUTION_TRACKING=true --skip-confirmation -f ./istio.yaml
 }
 
-snip_define_istio_operator_for_manual_registration() {
-cat <<EOF > ./istio.yaml
-apiVersion: install.istio.io/v1alpha1
-kind: IstioOperator
-metadata:
-  namespace: istio-system
-spec:
-  profile: default
-  meshConfig:
-    trustDomain: example.org
-  values:
-    global:
-    # This is used to customize the sidecar template
-    sidecarInjectorWebhook:
-      templates:
-        spire: |
-          spec:
-            containers:
-            - name: istio-proxy
-              volumeMounts:
-              - name: workload-socket
-                mountPath: /run/secrets/workload-spiffe-uds
-                readOnly: true
-            volumes:
-              - name: workload-socket
-                csi:
-                  driver: "csi.spiffe.io"
-                  readOnly: true
-  components:
-    ingressGateways:
-      - name: istio-ingressgateway
-        enabled: true
-        label:
-          istio: ingressgateway
-        k8s:
-          overlays:
-            - apiVersion: apps/v1
-              kind: Deployment
-              name: istio-ingressgateway
-              patches:
-                - path: spec.template.spec.volumes.[name:workload-socket]
-                  value:
-                    name: workload-socket
-                    csi:
-                      driver: "csi.spiffe.io"
-                      readOnly: true
-                - path: spec.template.spec.containers.[name:istio-proxy].volumeMounts.[name:workload-socket]
-                  value:
-                    name: workload-socket
-                    mountPath: "/run/secrets/workload-spiffe-uds"
-                    readOnly: true
-                - path: spec.template.spec.initContainers
-                  value:
-                    - name: wait-for-spire-socket
-                      image: busybox:1.28
-                      volumeMounts:
-                        - name: workload-socket
-                          mountPath: /run/secrets/workload-spiffe-uds
-                          readOnly: true
-                      env:
-                        - name: CHECK_FILE
-                          value: /run/secrets/workload-spiffe-uds/socket
-                      command:
-                        - sh
-                        - "-c"
-                        - |-
-                          echo "$(date -Iseconds)" Waiting for: ${CHECK_FILE}
-                          while [[ ! -e ${CHECK_FILE} ]] ; do
-                            echo "$(date -Iseconds)" File does not exist: ${CHECK_FILE}
-                            sleep 15
-                          done
-                          ls -l ${CHECK_FILE}
-EOF
-}
-
 snip_apply_sleep() {
 istioctl kube-inject --filename samples/security/spire/sleep-spire.yaml | kubectl apply -f -
-}
-
-snip_option_2_manual_registration_1() {
-INGRESS_POD=$(kubectl get pod -l istio=ingressgateway -n istio-system -o jsonpath="{.items[0].metadata.name}")
-INGRESS_POD_UID=$(kubectl get pods -n istio-system "$INGRESS_POD" -o jsonpath='{.metadata.uid}')
-}
-
-snip_set_spire_server_pod_name_var() {
-SPIRE_SERVER_POD=$(kubectl get pod -l app=spire-server -n spire -o jsonpath="{.items[0].metadata.name}")
-}
-
-snip_option_2_manual_registration_3() {
-kubectl exec -n spire "$SPIRE_SERVER_POD" -- \
-/opt/spire/bin/spire-server entry create \
-    -spiffeID spiffe://example.org/ns/spire/sa/spire-agent \
-    -selector k8s_psat:cluster:demo-cluster \
-    -selector k8s_psat:agent_ns:spire \
-    -selector k8s_psat:agent_sa:spire-agent \
-    -node -socketPath /run/spire/sockets/server.sock
-}
-
-! IFS=$'\n' read -r -d '' snip_option_2_manual_registration_3_out <<\ENDSNIP
-
-Entry ID         : d38c88d0-7d7a-4957-933c-361a0a3b039c
-SPIFFE ID        : spiffe://example.org/ns/spire/sa/spire-agent
-Parent ID        : spiffe://example.org/spire/server
-Revision         : 0
-TTL              : default
-Selector         : k8s_psat:agent_ns:spire
-Selector         : k8s_psat:agent_sa:spire-agent
-Selector         : k8s_psat:cluster:demo-cluster
-ENDSNIP
-
-snip_option_2_manual_registration_4() {
-kubectl exec -n spire "$SPIRE_SERVER_POD" -- \
-/opt/spire/bin/spire-server entry create \
-    -spiffeID spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account \
-    -parentID spiffe://example.org/ns/spire/sa/spire-agent \
-    -selector k8s:sa:istio-ingressgateway-service-account \
-    -selector k8s:ns:istio-system \
-    -selector k8s:pod-uid:"$INGRESS_POD_UID" \
-    -dns "$INGRESS_POD" \
-    -dns istio-ingressgateway.istio-system.svc \
-    -socketPath /run/spire/sockets/server.sock
-}
-
-! IFS=$'\n' read -r -d '' snip_option_2_manual_registration_4_out <<\ENDSNIP
-
-Entry ID         : 6f2fe370-5261-4361-ac36-10aae8d91ff7
-SPIFFE ID        : spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account
-Parent ID        : spiffe://example.org/ns/spire/sa/spire-agent
-Revision         : 0
-TTL              : default
-Selector         : k8s:ns:istio-system
-Selector         : k8s:pod-uid:63c2bbf5-a8b1-4b1f-ad64-f62ad2a69807
-Selector         : k8s:sa:istio-ingressgateway-service-account
-DNS name         : istio-ingressgateway.istio-system.svc
-DNS name         : istio-ingressgateway-5b45864fd4-lgrxs
-ENDSNIP
-
-snip_option_2_manual_registration_5() {
-istioctl kube-inject --filename samples/security/spire/sleep-spire.yaml | kubectl apply -f -
-}
-
-snip_set_sleep_pod_vars() {
-SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath="{.items[0].metadata.name}")
-SLEEP_POD_UID=$(kubectl get pods "$SLEEP_POD" -o jsonpath='{.metadata.uid}')
-}
-
-snip_option_2_manual_registration_8() {
-kubectl exec -n spire "$SPIRE_SERVER_POD" -- \
-/opt/spire/bin/spire-server entry create \
-    -spiffeID spiffe://example.org/ns/default/sa/sleep \
-    -parentID spiffe://example.org/ns/spire/sa/spire-agent \
-    -selector k8s:ns:default \
-    -selector k8s:pod-uid:"$SLEEP_POD_UID" \
-    -dns "$SLEEP_POD" \
-    -socketPath /run/spire/sockets/server.sock
 }
 
 snip_verifying_that_identities_were_created_for_workloads_1() {
@@ -315,26 +221,10 @@ openssl x509 -in chain.pem -text | grep SPIRE
     Subject: C = US, O = SPIRE, CN = sleep-5f4d47c948-njvpk
 ENDSNIP
 
-snip_cleanup_spire_1() {
-kubectl delete CustomResourceDefinition clusterspiffeids.spire.spiffe.io
-kubectl delete CustomResourceDefinition clusterfederatedtrustdomains.spire.spiffe.io
-kubectl delete -n spire configmap spire-bundle
-kubectl delete -n spire serviceaccount spire-agent
-kubectl delete -n spire configmap spire-agent
-kubectl delete -n spire daemonset spire-agent
-kubectl delete csidriver csi.spiffe.io
-kubectl delete ValidatingWebhookConfiguration spire-controller-manager-webhook
-kubectl delete -n spire configmap spire-controller-manager-config
-kubectl delete -n spire configmap spire-server
-kubectl delete -n spire service spire-controller-manager-webhook-service
-kubectl delete -n spire service spire-server-bundle-endpoint
-kubectl delete -n spire service spire-server
-kubectl delete -n spire serviceaccount spire-server
-kubectl delete -n spire deployment spire-server
-kubectl delete clusterrole spire-server-cluster-role spire-agent-cluster-role manager-role
-kubectl delete clusterrolebinding spire-server-cluster-role-binding spire-agent-cluster-role-binding manager-role-binding
-kubectl delete -n spire role spire-server-role leader-election-role
-kubectl delete -n spire rolebinding spire-server-role-binding leader-election-role-binding
-kubectl delete namespace spire
-rm istio.yaml chain.pem
+snip_uninstall_spire() {
+helm delete -n spire-server spire
+}
+
+snip_uninstall_spire_crds() {
+helm delete -n spire-server spire-crds
 }

--- a/content/en/docs/ops/integrations/spire/snips.sh
+++ b/content/en/docs/ops/integrations/spire/snips.sh
@@ -25,11 +25,7 @@ helm upgrade --install -n spire-server spire-crds spire-crds --repo https://spif
 }
 
 snip_install_spire_istio_overrides() {
-helm upgrade --install -n spire-server spire spire --repo https://spiffe.github.io/helm-charts-hardened/ --wait -f - <<EOF
-global:
-  spire:
-    trustDomain: example.org
-EOF
+helm upgrade --install -n spire-server spire spire --repo https://spiffe.github.io/helm-charts-hardened/ --wait --set global.spire.trustDomain="example.org"
 }
 
 snip_spire_csid_istio_gateway() {

--- a/content/en/docs/ops/integrations/spire/snips.sh
+++ b/content/en/docs/ops/integrations/spire/snips.sh
@@ -46,7 +46,7 @@ spec:
 EOF
 }
 
-snip_spire_csid_istio_gateway() {
+snip_spire_csid_istio_sidecar() {
 kubectl apply -f - <<EOF
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID

--- a/content/en/docs/ops/integrations/spire/snips.sh
+++ b/content/en/docs/ops/integrations/spire/snips.sh
@@ -51,12 +51,14 @@ kubectl apply -f - <<EOF
 apiVersion: spire.spiffe.io/v1alpha1
 kind: ClusterSPIFFEID
 metadata:
-  name: istio-ingressgateway-reg
+  name: istio-sidecar-reg
 spec:
   spiffeIDTemplate: "spiffe://{{ .TrustDomain }}/ns/{{ .PodMeta.Namespace }}/sa/{{ .PodSpec.ServiceAccountName }}"
+  podSelector:
+    matchLabels:
+      spiffe.io/spire-managed-identity: "true"
   workloadSelectorTemplates:
     - "k8s:ns:default"
-    - "k8s:pod-label:spiffe.io/spire-managed-identity:true"
 EOF
 }
 

--- a/content/en/docs/ops/integrations/spire/snips.sh
+++ b/content/en/docs/ops/integrations/spire/snips.sh
@@ -63,7 +63,7 @@ EOF
 }
 
 snip_set_spire_server_pod_name_var() {
-SPIRE_SERVER_POD=$(kubectl get pod -l app=spire-server -n spire -o jsonpath="{.items[0].metadata.name}")
+SPIRE_SERVER_POD=$(kubectl get pod -l statefulset.kubernetes.io/pod-name=spire-server-0 -n spire-server -o jsonpath="{.items[0].metadata.name}")
 }
 
 snip_option_2_manual_registration_2() {
@@ -187,28 +187,9 @@ snip_apply_sleep() {
 istioctl kube-inject --filename samples/security/spire/sleep-spire.yaml | kubectl apply -f -
 }
 
-snip_verifying_that_identities_were_created_for_workloads_1() {
-kubectl exec -t "$SPIRE_SERVER_POD" -n spire -c spire-server -- ./bin/spire-server entry show
+snip_set_sleep_pod_var() {
+SLEEP_POD=$(kubectl get pod -l app=sleep -o jsonpath="{.items[0].metadata.name}")
 }
-
-! IFS=$'\n' read -r -d '' snip_verifying_that_identities_were_created_for_workloads_1_out <<\ENDSNIP
-Found 2 entries
-Entry ID         : c8dfccdc-9762-4762-80d3-5434e5388ae7
-SPIFFE ID        : spiffe://example.org/ns/istio-system/sa/istio-ingressgateway-service-account
-Parent ID        : spiffe://example.org/spire/agent/k8s_psat/demo-cluster/bea19580-ae04-4679-a22e-472e18ca4687
-Revision         : 0
-X509-SVID TTL    : default
-JWT-SVID TTL     : default
-Selector         : k8s:pod-uid:88b71387-4641-4d9c-9a89-989c88f7509d
-
-Entry ID         : af7b53dc-4cc9-40d3-aaeb-08abbddd8e54
-SPIFFE ID        : spiffe://example.org/ns/default/sa/sleep
-Parent ID        : spiffe://example.org/spire/agent/k8s_psat/demo-cluster/bea19580-ae04-4679-a22e-472e18ca4687
-Revision         : 0
-X509-SVID TTL    : default
-JWT-SVID TTL     : default
-Selector         : k8s:pod-uid:ee490447-e502-46bd-8532-5a746b0871d6
-ENDSNIP
 
 snip_get_sleep_svid() {
 istioctl proxy-config secret "$SLEEP_POD" -o json | jq -r \

--- a/tests/util/helpers.sh
+++ b/tests/util/helpers.sh
@@ -93,6 +93,18 @@ _wait_for_daemonset() {
     fi
 }
 
+# Wait for rollout of named statefulset
+# usage: _wait_for_statefulset <namespace> <statefulset name> <optional: context>
+_wait_for_statefulset() {
+    local namespace="$1"
+    local name="$2"
+    local context="${3:-}"
+    if ! kubectl --context="$context" -n "$namespace" rollout status statefulset "$name" --timeout 5m; then
+        echo "Failed rollout of statefulset $name in namespace $namespace"
+        exit 1
+    fi
+}
+
 # Wait for Istio config to propagate
 # usage: _wait_for_istio <kind> <namespace> <name>
 _wait_for_istio() {


### PR DESCRIPTION
## Description

1. SPIRE has Helm charts, we should refer to those and not have our own in-tree SPIRE installation YAML (with WAY out of date SPIRE image refs and config)

2. In general, refer back to the SPIRE docs and don't make this a SPIRE tutorial - focus on the Istio-specific bits.

3. Align with current best practices (use upstream Helm charts, recommend controller manager, CSI driver only, etc)

4. Misc tweaks.

Fixes: https://github.com/istio/istio.io/issues/15510

Will open an istio-side PR to delete [this](https://raw.githubusercontent.com/istio/istio/release-1.22/samples/security/spire/spire-quickstart.yaml) once this is in.

## Reviewers

- [ ] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
