### PR TITLE
remove istioctl --set from dualstack installation

### DIFF
--- a/content/en/docs/setup/additional-setup/dual-stack/index.md
+++ b/content/en/docs/setup/additional-setup/dual-stack/index.md
@@ -76,14 +76,6 @@ values:
 
 {{< /tab >}}
 
-{{< tab name="Istioctl" category-value="istioctl" >}}
-
-{{< text syntax=bash snip_id=none >}}
-$ istioctl install --set values.pilot.env.ISTIO_DUAL_STACK=true --set meshConfig.defaultConfig.proxyMetadata.ISTIO_DUAL_STACK="true" --set values.gateways.istio-ingressgateway.ipFamilyPolicy=RequireDualStack --set values.gateways.istio-egressgateway.ipFamilyPolicy=RequireDualStack -y
-{{< /text >}}
-
-{{< /tab >}}
-
 {{< /tabset >}}
 
 ## Verification

--- a/content/zh/docs/setup/additional-setup/dual-stack/index.md
+++ b/content/zh/docs/setup/additional-setup/dual-stack/index.md
@@ -76,14 +76,6 @@ values:
 
 {{< /tab >}}
 
-{{< tab name="Istioctl" category-value="istioctl" >}}
-
-{{< text syntax=bash snip_id=none >}}
-$ istioctl install --set values.pilot.env.ISTIO_DUAL_STACK=true --set meshConfig.defaultConfig.proxyMetadata.ISTIO_DUAL_STACK="true" --set values.gateways.istio-ingressgateway.ipFamilyPolicy=RequireDualStack --set values.gateways.istio-egressgateway.ipFamilyPolicy=RequireDualStack -y
-{{< /text >}}
-
-{{< /tab >}}
-
 {{< /tabset >}}
 
 ## 验证 {#verification}


### PR DESCRIPTION
## Description

As --set is not much encouraged, better to remove from the docs.
cc @zirain 

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
