### PR TITLE
Fix links and grammar in the recent ambient docs

### DIFF
--- a/content/en/docs/ambient/upgrade/helm/index.md
+++ b/content/en/docs/ambient/upgrade/helm/index.md
@@ -127,7 +127,7 @@ For each tag, you can upgrade the tag by running the following command, replacin
 $ helm template istiod istio/istiod -s templates/revision-tags.yaml --set revisionTags="{$MYTAG}" --set revision="$REVISION" -n istio-system | kubectl apply -f -
 {{< /text >}}
 
-This will upgrade all objects referencing that tag, except for those using [manual gateway deployment mode](docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment), which are dealt with below, and sidecars, which are not used in ambient mode.
+This will upgrade all objects referencing that tag, except for those using [manual gateway deployment mode](/docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment), which are dealt with below, and sidecars, which are not used in ambient mode.
 
 It is recommended that you closely monitor the health of applications using the upgraded data plane before upgrading the next tag. If you detect a problem, you can rollback a tag, resetting it to point to the name of your old revision:
 
@@ -137,7 +137,7 @@ $ helm template istiod istio/istiod -s templates/revision-tags.yaml --set revisi
 
 ### Upgrade manually deployed gateways (optional)
 
-`Gateway`s that were [deployed manually](docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment) must be upgraded individually using Helm:
+`Gateway`s that were [deployed manually](/docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment) must be upgraded individually using Helm:
 
 {{< text syntax=bash snip_id=upgrade_gateway >}}
 $ helm upgrade istio-ingress istio/gateway -n istio-ingress

--- a/content/en/docs/ambient/usage/extend-waypoint-wasm/index.md
+++ b/content/en/docs/ambient/usage/extend-waypoint-wasm/index.md
@@ -15,7 +15,7 @@ One of the key advantages of Wasm extensibility is that extensions can be loaded
 
 ## Before you begin
 
-1. Setup Istio by following the instructions in the [ambient mode Getting Started guide](/docs/ambient/getting-started).
+1. Set up Istio by following the instructions in the [ambient mode Getting Started guide](/docs/ambient/getting-started).
 1. Deploy the [Bookinfo sample application](/docs/ambient/getting-started/deploy-sample-app).
 1. [Add the default namespace to the ambient mesh](/docs/ambient/getting-started/secure-and-visualize).
 1. Deploy the [sleep]({{< github_tree >}}/samples/sleep) sample app to use as a test source for sending requests.

--- a/content/en/docs/ambient/usage/verify-mtls-enabled/index.md
+++ b/content/en/docs/ambient/usage/verify-mtls-enabled/index.md
@@ -28,7 +28,7 @@ Having HBONE configured on your workload doesn't mean your workload will reject 
 
 ## Validate mTLS from metrics
 
-If you have [installed Prometheus](docs/ops/integrations/prometheus/#installation), you can setup port-forwarding and open the Prometheus UI by using the following command:
+If you have [installed Prometheus](/docs/ops/integrations/prometheus/#installation), you can set up port-forwarding and open the Prometheus UI by using the following command:
 
 {{< text syntax=bash >}}
 $ istioctl dashboard prometheus
@@ -63,7 +63,7 @@ dst.workload="details-v1-857849f66-ft8wx" dst.namespace="default" dst.identity="
 direction="outbound" bytes_sent=84 bytes_recv=358 duration="15ms"
 {{< /text >}}
 
-Validate the `src.identity` and `dst.identity` values are correct. They are the identities used for the mTLS communication among the source and destination workloads. Refer to the [verifying ztunnel traffic through logs section](docs/ambient/usage/troubleshoot-ztunnel/#verifying-ztunnel-traffic-through-logs) for more details.
+Validate the `src.identity` and `dst.identity` values are correct. They are the identities used for the mTLS communication among the source and destination workloads. Refer to the [verifying ztunnel traffic through logs section](/docs/ambient/usage/troubleshoot-ztunnel/#verifying-ztunnel-traffic-through-logs) for more details.
 
 ## Validate with Kiali dashboard
 
@@ -71,7 +71,7 @@ If you have Kiali and Prometheus installed, you can visualize your workload comm
 
 {{< image link="./kiali-mtls.png" caption="Kiali dashboard" >}}
 
-Refer to the [Visualize the application and metrics](docs/ambient/getting-started/secure-and-visualize/#visualize-the-application-and-metrics) document for more details.
+Refer to the [Visualize the application and metrics](/docs/ambient/getting-started/secure-and-visualize/#visualize-the-application-and-metrics) document for more details.
 
 ## Validate with `tcpdump`
 


### PR DESCRIPTION
Perform minor changes like:

- `](docs/` to `](/docs/` in url
- `setup` to `set up` if it's a verb

No any more changes.

- [x] Ambient
- [x] Docs
