### PR TITLE
Support grpc configuration of opentelemetry provider

### DIFF
--- a/content/en/docs/tasks/observability/distributed-tracing/opentelemetry/index.md
+++ b/content/en/docs/tasks/observability/distributed-tracing/opentelemetry/index.md
@@ -33,8 +33,7 @@ traces via gRPC or HTTP. Only one exporter can be configured at a time (either g
 
 ### Exporting via gRPC
 
-In this example, traces will be exported via OTLP/gRPC to the OpenTelemetry Collector.
-The example also enables the [environment resource detector](https://opentelemetry.io/docs/languages/js/resources/#adding-resources-with-environment-variables). The environment detector adds attributes from the environment variable
+In this example, traces will be exported via OTLP/gRPC to the OpenTelemetry Collector, you can add headers or adjust the timeout settings of gRPC requests by modifying the `grpc` field. If this field is not configured, traces will be exported to the OpenTelemetry Collector using the default options via OTLP/gRPC. The example also enables the [environment resource detector](https://opentelemetry.io/docs/languages/js/resources/#adding-resources-with-environment-variables). The environment detector adds attributes from the environment variable
 `OTEL_RESOURCE_ATTRIBUTES` to the exported OpenTelemetry resource.
 
 {{< text syntax=bash snip_id=none >}}
@@ -49,6 +48,11 @@ spec:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+        grpc:
+          timeout: 3s
+          initialMetadata:
+            - name: "Authentication"
+              value: "token-xxxxx"
         resource_detectors:
           environment: {}
 EOF

--- a/content/zh/docs/tasks/observability/distributed-tracing/opentelemetry/index.md
+++ b/content/zh/docs/tasks/observability/distributed-tracing/opentelemetry/index.md
@@ -37,7 +37,7 @@ Istio 可以被配置为通过 gRPC 或 HTTP 导出
 
 ### 通过 gRPC 导出 {#exporting-via-grpc}
 
-在此示例中，链路将通过 OTLP/gRPC 导出到 OpenTelemetry Collector。
+在此示例中，链路将通过 OTLP/gRPC 导出到 OpenTelemetry Collector，您可以通过编辑 `grpc` 字段中的配置信息来配置 gRPC 请求携带的请求头以及超时时间，如果该字段未进行配置，则链路将使用默认的 OTLP/gRPC 配置导出到 OpenTelemetry Collector。
 该示例还启用了[环境资源检测器](https://opentelemetry.io/docs/languages/js/resources/#adding-resources-with-environment-variables)。
 环境检测器将环境变量 `OTEL_RESOURCE_ATTRIBUTES`
 中的属性添加到导出的 OpenTelemetry 资源中。
@@ -54,6 +54,11 @@ spec:
       opentelemetry:
         port: 4317
         service: opentelemetry-collector.observability.svc.cluster.local
+        grpc:
+          timeout: 3s
+          initialMetadata:
+            - name: "Authentication"
+              value: "token-xxxxx"  
         resource_detectors:
           environment: {}
 EOF


### PR DESCRIPTION
## Description

Add documents to introduce how to configure gRPC headers and timeout when export traces to OpenTelemetry for this feature request https://github.com/istio/istio/issues/52873.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [x] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
