### PR TITLE
[release-1.23] Fix tcpdump ports (#15632)

### DIFF
--- a/content/en/docs/ambient/usage/verify-mtls-enabled/index.md
+++ b/content/en/docs/ambient/usage/verify-mtls-enabled/index.md
@@ -87,5 +87,5 @@ If you don't have access to the worker nodes, you may be able to use the [netsho
 
 {{< text syntax=bash >}}
 $ POD=$(kubectl get pods -l app=details -o jsonpath="{.items[0].metadata.name}")
-$ kubectl debug $POD -i --image=nicolaka/netshoot -- tcpdump -nAi eth0 port 15008 or port 15008
+$ kubectl debug $POD -i --image=nicolaka/netshoot -- tcpdump -nAi eth0 port 9080 or port 15008
 {{< /text >}}


### PR DESCRIPTION
The document captures HBONE port twice instead of application port.

Signed-off-by: Sridhar Gaddam <sgaddam@redhat.com>
(cherry picked from commit 284b8969dbd1f963602bc30e56acc658ea666eaa)

Fixes: https://github.com/istio/istio.io/issues/15633