### PR TITLE
[zh] Sync #15635 to fix in-doc header links broken under <tip>

### DIFF
--- a/content/zh/docs/ops/best-practices/observability/index.md
+++ b/content/zh/docs/ops/best-practices/observability/index.md
@@ -151,7 +151,7 @@ spec:
 [Istio 标准指标](/zh/docs/reference/config/metrics/)中的全部项，包括全部的 Istio 维度。
 尽管这有助于通过联邦控制指标维度，您可能仍想进一步优化记录规则来匹配您现有的仪表盘、告警以及特定的引用。
 
-如需要更多关于如何配置您的记录规则。请参考[使用记录规则优化指标收集](#optimizing-metrics-collection-with-recording-rules)。
+如需要更多关于如何配置您的记录规则。请参考[使用记录规则优化指标收集](/zh/docs/ops/best-practices/observability/#optimizing-metrics-collection-with-recording-rules)。
 {{< /tip >}}
 
 ### 使用负载级别的聚合指标进行联邦 {#federation-using-workload-level-aggregated-metrics}

--- a/content/zh/docs/setup/additional-setup/cni/index.md
+++ b/content/zh/docs/setup/additional-setup/cni/index.md
@@ -28,7 +28,7 @@ Istio CNI 节点代理在 {{< gloss "sidecar" >}}Ambient{{< /gloss >}} 数据平
 除此之外，它还会安装一个**链式** CNI 插件或云提供商使用的集群 CNI，
 其中这种链式 CNI 插件设计为分层堆叠在另一个先前安装的主接口
 CNI（例如 [Calico](https://docs.projectcalico.org)）之上。
-有关详细信息，请参阅[与 CNI 的兼容性](#compatibility-with-other-cnis)。
+有关详细信息，请参阅[与 CNI 的兼容性](/zh/docs/setup/additional-setup/cni/#compatibility-with-other-cnis)。
 {{< /tip >}}
 
 按照本指南安装、配置和使用具有 Sidecar 数据平面模式的 Istio CNI 节点代理。


### PR DESCRIPTION
Sync with en #15635 

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
