### PR TITLE
updated the link for uninstallation of VM

### DIFF
--- a/content/en/docs/examples/virtual-machines/index.md
+++ b/content/en/docs/examples/virtual-machines/index.md
@@ -161,4 +161,4 @@ Istio's [DNS proxying](/docs/ops/configuration/traffic-management/dns-proxy/) au
     $ kubectl delete service mysqldb
     {{< /text >}}
 
-- Cleanup the VM following the steps in [virtual-machine uninstall](/docs/setup/install/virtual-machine/#configure-the-virtual-machine).
+- Cleanup the VM following the steps in [virtual-machine uninstall](/docs/setup/install/virtual-machine/#uninstall).


### PR DESCRIPTION
Updated the link for uninstalling VM  in the cleanup section of [https://istio.io/latest/docs/examples/virtual-machines/](https://istio.io/latest/docs/examples/virtual-machines/)
