### PR TITLE
Update dualstack validation commands

### DIFF
--- a/content/en/docs/setup/additional-setup/dual-stack/index.md
+++ b/content/en/docs/setup/additional-setup/dual-stack/index.md
@@ -139,7 +139,7 @@ values:
 1. Verify the envoy listeners:
 
     {{< text syntax=bash snip_id=none >}}
-    $ istioctl proxy-config listeners "$(kubectl get pod -n dual-stack -l app=tcp-echo -o jsonpath='{.items[0].metadata.name}')" -n dual-stack --port 9000
+    $ istioctl proxy-config listeners "$(kubectl get pod -n dual-stack -l app=tcp-echo -o jsonpath='{.items[0].metadata.name}')" -n dual-stack --port 9000 -ojson | jq '.[] | {name: .name, address: .address, additionalAddresses: .additionalAddresses}'
     {{< /text >}}
 
     You will see listeners are now bound to multiple addresses, but only for dual stack services. Other services will only be listening on a single IP address.
@@ -165,6 +165,10 @@ values:
     {{< /text >}}
 
 1. Verify virtual inbound addresses are configured to listen on both `0.0.0.0` and `[::]`.
+
+    {{< text syntax=bash snip_id=none >}}
+    $ istioctl proxy-config listeners "$(kubectl get pod -n dual-stack -l app=tcp-echo -o jsonpath='{.items[0].metadata.name}')" -n dual-stack -o json | jq '.[] | select(.name=="virtualInbound") | {name: .name, address: .address, additionalAddresses: .additionalAddresses}'
+    {{< /text >}}
 
     {{< text syntax=json snip_id=none >}}
     "name": "virtualInbound",

--- a/content/zh/docs/setup/additional-setup/dual-stack/index.md
+++ b/content/zh/docs/setup/additional-setup/dual-stack/index.md
@@ -139,7 +139,7 @@ values:
 1. 验证 Envoy 侦听器：
 
     {{< text syntax=bash snip_id=none >}}
-    $ istioctl proxy-config listeners "$(kubectl get pod -n dual-stack -l app=tcp-echo -o jsonpath='{.items[0].metadata.name}')" -n dual-stack --port 9000
+    $ istioctl proxy-config listeners "$(kubectl get pod -n dual-stack -l app=tcp-echo -o jsonpath='{.items[0].metadata.name}')" -n dual-stack --port 9000 -ojson | jq '.[] | {name: .name, address: .address, additionalAddresses: .additionalAddresses}'
     {{< /text >}}
 
     您将看到侦听器现在绑定到多个地址，但仅限于双堆栈服务。其他服务将仅侦听单个 IP 地址。
@@ -165,6 +165,10 @@ values:
     {{< /text >}}
 
 1. 验证虚拟入站地址是否配置为同时侦听 `0.0.0.0` 和 `[::]`。
+
+    {{< text syntax=bash snip_id=none >}}
+    $ istioctl proxy-config listeners "$(kubectl get pod -n dual-stack -l app=tcp-echo -o jsonpath='{.items[0].metadata.name}')" -n dual-stack -o json | jq '.[] | select(.name=="virtualInbound") | {name: .name, address: .address, additionalAddresses: .additionalAddresses}'
+    {{< /text >}}
 
     {{< text syntax=json snip_id=none >}}
     "name": "virtualInbound",


### PR DESCRIPTION
The output of `istioctl proxy-config ...` is usually pretty huge. This PR updates the dualStack validation commands to capture only the info we are interested in.