### PR TITLE
edited base64 decode command

### DIFF
--- a/content/en/docs/tasks/security/authorization/authz-jwt/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-jwt/index.md
@@ -112,7 +112,7 @@ Caching and propagation can cause a delay.
    This causes Istio to generate the attribute `requestPrincipal` with the value `testing@secure.istio.io/testing@secure.istio.io`:
 
     {{< text syntax="bash" expandlinks="false" >}}
-    $ TOKEN=$(curl {{< github_file >}}/security/tools/jwt/samples/demo.jwt -s) && echo "$TOKEN" | cut -d '.' -f2 - | base64 --decode -
+    $ TOKEN=$(curl {{< github_file >}}/security/tools/jwt/samples/demo.jwt -s) && echo "$TOKEN" | cut -d '.' -f2 - | base64 --decode
     {"exp":4685989700,"foo":"bar","iat":1532389700,"iss":"testing@secure.istio.io","sub":"testing@secure.istio.io"}
     {{< /text >}}
 
@@ -162,7 +162,7 @@ Caching and propagation can cause a delay.
 1. Get the JWT that sets the `groups` claim to a list of strings: `group1` and `group2`:
 
     {{< text syntax="bash" expandlinks="false" >}}
-    $ TOKEN_GROUP=$(curl {{< github_file >}}/security/tools/jwt/samples/groups-scope.jwt -s) && echo "$TOKEN_GROUP" | cut -d '.' -f2 - | base64 --decode -
+    $ TOKEN_GROUP=$(curl {{< github_file >}}/security/tools/jwt/samples/groups-scope.jwt -s) && echo "$TOKEN_GROUP" | cut -d '.' -f2 - | base64 --decode
     {"exp":3537391104,"groups":["group1","group2"],"iat":1537391104,"iss":"testing@secure.istio.io","scope":["scope1","scope2"],"sub":"testing@secure.istio.io"}
     {{< /text >}}
 

--- a/content/en/docs/tasks/security/authorization/authz-jwt/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-jwt/snips.sh
@@ -87,7 +87,7 @@ EOF
 }
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_5() {
-TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt -s) && echo "$TOKEN" | cut -d '.' -f2 - | base64 --decode -
+TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/demo.jwt -s) && echo "$TOKEN" | cut -d '.' -f2 - | base64 --decode
 }
 
 ! IFS=$'\n' read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_5_out <<\ENDSNIP
@@ -133,7 +133,7 @@ EOF
 }
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_9() {
-TOKEN_GROUP=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/groups-scope.jwt -s) && echo "$TOKEN_GROUP" | cut -d '.' -f2 - | base64 --decode -
+TOKEN_GROUP=$(curl https://raw.githubusercontent.com/istio/istio/master/security/tools/jwt/samples/groups-scope.jwt -s) && echo "$TOKEN_GROUP" | cut -d '.' -f2 - | base64 --decode
 }
 
 ! IFS=$'\n' read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_9_out <<\ENDSNIP


### PR DESCRIPTION
## Description

Edited since the decode it's failing with message `base64: invalid argument -` It works alright when we remove the trailing `-`

<img width="1294" alt="Screenshot 2024-09-14 at 4 06 56 PM" src="https://github.com/user-attachments/assets/85f97f50-de5d-44e9-800e-71c2d28a0d7a">



## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
