### PR TITLE
added destinationrules yaml applying

### DIFF
--- a/content/en/docs/tasks/traffic-management/request-routing/index.md
+++ b/content/en/docs/tasks/traffic-management/request-routing/index.md
@@ -59,6 +59,12 @@ Run the following command to apply virtual services that will route all traffic 
 $ kubectl apply -f @samples/bookinfo/networking/virtual-service-all-v1.yaml@
 {{< /text >}}
 
+Run the following command to apply destination rules:
+
+{{< text bash >}}
+$ kubectl apply -f @samples/bookinfo/networking/destination-rule-all-mtls.yaml@
+{{< /text >}}
+
 Because configuration propagation is eventually consistent, wait a few seconds
 for the virtual services to take effect.
 


### PR DESCRIPTION
Maybe I am wrong, but shouldn't the instruction include the applying DestinationRules files? I am new at istio and just get started. My minikube cluster doesn't work without applying it. If i not apply DestinationRules, it shows errors on review zone on web page on browser.

## Description

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ X ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
