### PR TITLE
Clarify subjectAltNames requires tls mode MUTUAL

### DIFF
--- a/content/en/docs/reference/config/networking/gateway/index.html
+++ b/content/en/docs/reference/config/networking/gateway/index.html
@@ -546,7 +546,7 @@ No
 <td><code>string[]</code></td>
 <td>
 <p>A list of alternate names to verify the subject identity in the
-certificate presented by the client.</p>
+certificate presented by the client. Requires TLS mode to be set to <code>MUTUAL</code>.</p>
 
 </td>
 <td>


### PR DESCRIPTION
## Description

The user might be confused about the usage of `subjectAltNames`, trying to use it to add more hostnames to an endpoint.
Make clear that it requires TLS mode mutual, and the the alternative names are those presented by the client for authentication.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
