### PR TITLE
Fixup ambient cilium platform prerequisites - CCWNP default-deny + wording

### DIFF
--- a/content/en/docs/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ambient/install/platform-prerequisites/index.md
@@ -4,7 +4,7 @@ description: Platform-specific prerequisites for installing Istio in ambient mod
 weight: 2
 aliases:
   - /docs/ops/ambient/install/platform-prerequisites
-  - /latest/docs/ops/ambient/install/platform-prerequisites  
+  - /latest/docs/ops/ambient/install/platform-prerequisites
 owner: istio/wg-environments-maintainers
 test: no
 ---
@@ -200,6 +200,6 @@ applying any default-DENY `NetworkPolicy` in a Cilium CNI install underlying Ist
         - "169.254.7.127/32"
     {{< /text >}}
 
-    This policy override is *not* required unless you already have other default-deny `NetworkPolicies` or `CiliumNetworkPolicies` applied in your cluster. 
+    This policy override is *not* required unless you already have other default-deny `NetworkPolicies` or `CiliumNetworkPolicies` applied in your cluster.
 
     Please see [issue #49277](https://github.com/istio/istio/issues/49277) and [CiliumClusterWideNetworkPolicy](https://docs.cilium.io/en/stable/network/kubernetes/policy/#ciliumclusterwidenetworkpolicy) for more details.

--- a/content/en/docs/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ambient/install/platform-prerequisites/index.md
@@ -180,7 +180,7 @@ The following configurations apply to all platforms, when certain {{< gloss "CNI
 `cni.exclusive = false` to properly support chaining. See [the Cilium documentation](https://docs.cilium.io/en/stable/helm-reference/) for more details.
 1. Cilium's BPF masquerading is currently disabled by default, and has issues with Istio's use of link-local IPs for Kubernetes health checking. Enabling BPF masquerading via `bpf.masquerade=true` is not currently supported, and results in non-functional pod health checks in Istio ambient. Cilium's default iptables masquerading implementation should continue to function correctly.
 1. Due to how Cilium manages node identity and internally allow-lists node-level health probes to pods,
-applying default-DENY `NetworkPolicy` in a Cilium CNI install underlying Istio in ambient mode, will cause `kubelet` health probes (which are by-default exempted from NetworkPolicy enforcement by Cilium) to be blocked.
+applying any default-DENY `NetworkPolicy` in a Cilium CNI install underlying Istio in ambient mode will cause `kubelet` health probes (which are by-default silently exempted from all policy enforcement by Cilium) to be blocked. This is because Istio uses a link-local SNAT address, which Cilium is not aware of, and Cilium does not have an option to exempt link-local addresses from policy enforcement.
 
     This can be resolved by applying the following `CiliumClusterWideNetworkPolicy`:
 
@@ -191,10 +191,15 @@ applying default-DENY `NetworkPolicy` in a Cilium CNI install underlying Istio i
       name: "allow-ambient-hostprobes"
     spec:
       description: "Allows SNAT-ed kubelet health check probes into ambient pods"
+      enableDefaultDeny:
+        egress: false
+        ingress: false
       endpointSelector: {}
       ingress:
       - fromCIDR:
         - "169.254.7.127/32"
     {{< /text >}}
+
+    This policy override is *not* required unless you already have other default-deny `NetworkPolicies` or `CiliumNetworkPolicies` applied in your cluster. 
 
     Please see [issue #49277](https://github.com/istio/istio/issues/49277) and [CiliumClusterWideNetworkPolicy](https://docs.cilium.io/en/stable/network/kubernetes/policy/#ciliumclusterwidenetworkpolicy) for more details.


### PR DESCRIPTION
## Description

The Cilium policy override in the ambient platform prerequisites doc is only intended to be applied _IF_ you already have default-deny policies in place that would necessitate it - otherwise it's pointless.

Update the wording a bit to hopefully make this clearer, and also just turn off default deny for this policy inline, so it doesn't matter either way.

Slack ref: https://istio.slack.com/archives/C041EQL1XMY/p1727452508062729

Cilium ref: https://docs.cilium.io/en/latest/security/policy/intro/

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
