### PR TITLE
Make Cilium net pol safe

### DIFF
--- a/content/en/docs/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ambient/install/platform-prerequisites/index.md
@@ -221,6 +221,9 @@ applying default-DENY `NetworkPolicy` in a Cilium CNI install underlying Istio i
       ingress:
       - fromCIDR:
         - "169.254.7.127/32"
+      # Ensure we do not trigger the default deny-all
+      enableDefaultDeny:
+        ingress: false
     {{< /text >}}
 
     Please see [issue #49277](https://github.com/istio/istio/issues/49277) and [CiliumClusterWideNetworkPolicy](https://docs.cilium.io/en/stable/network/kubernetes/policy/#ciliumclusterwidenetworkpolicy) for more details.


### PR DESCRIPTION
Before: If a workload has no other policies, this makes them ONLY allow the
  snat IP

After: This only allows more traffic (the snat source) without denying
anything additional.
