### PR TITLE
Update gateway-api-install-crds.md

### DIFF
--- a/content/en/boilerplates/gateway-api-install-crds.md
+++ b/content/en/boilerplates/gateway-api-install-crds.md
@@ -5,5 +5,5 @@ installed before using the Gateway API:
 
 {{< text syntax=bash snip_id=install_crds >}}
 $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml; }
+  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml ; }
 {{< /text >}}


### PR DESCRIPTION
## Description

In the Gateway API installation section of the Istio documentation, there was a missing space before the semicolon in a command using the `kubectl get crd` and `kubectl apply` with an `||` operator. This caused bash to misinterpret the command inside the curly braces, preventing the second command from executing properly.

This PR adds the missing space to ensure the command functions correctly when users follow the installation steps. This change should resolve issues users may encounter when running this command in a bash shell.

## Reviewers

- [x] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation
