### PR TITLE
Remove OpenShift warning from bookinfo page

### DIFF
--- a/content/en/docs/examples/bookinfo/index.md
+++ b/content/en/docs/examples/bookinfo/index.md
@@ -82,10 +82,6 @@ If you use GKE, please ensure your cluster has at least 4 standard GKE nodes. If
     $ kubectl label namespace default istio-injection=enabled
     {{< /text >}}
 
-    {{< warning >}}
-    If you use OpenShift, make sure to give appropriate permissions to service accounts on the namespace as described in [OpenShift setup page](/docs/setup/platform-setup/openshift/#privileged-security-context-constraints-for-application-sidecars).
-    {{< /warning >}}
-
 1.  Deploy your application using the `kubectl` command:
 
     {{< text bash >}}


### PR DESCRIPTION
This does not seem to be necessary since https://github.com/istio/istio.io/pull/9053.