### PR TITLE
[zh] Sync #15751 remove OpenShift warning from bookinfo page into Chinese

### DIFF
--- a/content/zh/docs/examples/bookinfo/index.md
+++ b/content/zh/docs/examples/bookinfo/index.md
@@ -74,12 +74,6 @@ Bookinfo 应用中的几个微服务是由不同的编程语言编写的。
     $ kubectl label namespace default istio-injection=enabled
     {{< /text >}}
 
-    {{< warning >}}
-    如果您使用 OpenShift，请确保按照
-    [OpenShift 设置页面](/zh/docs/setup/platform-setup/openshift/#privileged-security-context-constraints-for-application-sidecars)中所述，
-    为命名空间上的服务账户授予适当的权限。
-    {{< /warning >}}
-
 1. 使用 `kubectl` 命令来部署应用：
 
     {{< text bash >}}


### PR DESCRIPTION
## Description

Sync #15751 remove OpenShift warning from bookinfo page into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
