### PR TITLE
Add back ambient helm inplace upgrade docs

### DIFF
--- a/content/en/docs/ambient/upgrade/helm/index.md
+++ b/content/en/docs/ambient/upgrade/helm/index.md
@@ -15,22 +15,18 @@ Follow this guide to upgrade and configure an ambient mode installation using
 [Helm](https://helm.sh/docs/). This guide assumes you have already performed an [ambient mode installation with Helm](/docs/ambient/install/helm/) with a previous version of Istio.
 
 {{< warning >}}
-In contrast to sidecar mode, ambient mode supports moving application pods to an upgraded ztunnel proxy without a mandatory restart or reschedule of running application pods. However, upgrading ztunnel **will** cause all long-lived TCP connections on the upgraded node to reset, and Istio does not currently support canary upgrades of ztunnel.
+In contrast to sidecar mode, ambient mode supports moving application pods to an upgraded ztunnel proxy without a mandatory restart or reschedule of running application pods. However, upgrading ztunnel **will** cause all long-lived TCP connections on the upgraded node to reset, and Istio does not currently support canary upgrades of ztunnel, **even with the use of revisions**
 
 Node cordoning and blue/green node pools are recommended to limit the blast radius of resets on application traffic during production upgrades. See your Kubernetes provider documentation for details.
 {{< /warning >}}
 
 ## Understanding ambient mode upgrades
 
-All Istio upgrades involve upgrading the control plane, data plane, and Istio CRDs. Because the ambient data plane is split across [two components](/docs/ambient/architecture/data-plane), the ztunnel and waypoints, upgrades involve separate steps for these components. Upgrading the control plane and CRDs is covered here in brief, but is essentially identical to [the process for upgrading these components in sidecar mode](/docs/setup/upgrade/canary/).
+All Istio upgrades involve upgrading the control plane, data plane, and Istio CRDs. Because the ambient data plane is split across [two components](/docs/ambient/architecture/data-plane), the ztunnel and gateways (which includes waypoints), upgrades involve separate steps for these components. Upgrading the control plane and CRDs is covered here in brief, but is essentially identical to [the process for upgrading these components in sidecar mode](/docs/setup/upgrade/canary/).
 
-Like sidecar mode, gateways can make use of [revision tags](/docs/setup/upgrade/canary/#stable-revision-labels) to allow fine-grained control over ({{< gloss >}}gateway{{</ gloss >}}) upgrades, including waypoints, with simple controls for rolling back at any point. However, unlike sidecar mode, the ztunnel runs as a DaemonSet — a per-node proxy — meaning that ztunnel upgrades affect, at minimum, an entire node at a time. While this may be acceptable in many cases, applications with long-lived TCP connections may be disrupted.  In such cases, we recommend using node cordoning and draining before upgrading the ztunnel for a given node. For the sake of simplicity, this document will demonstrate in-place upgrades of the ztunnel, which may involve a short downtime.
+Like sidecar mode, gateways can make use of [revision tags](/docs/setup/upgrade/canary/#stable-revision-labels) to allow fine-grained control over ({{< gloss >}}gateway{{</ gloss >}}) upgrades, including waypoints, with simple controls for rolling back to a previous version of the Istio control plane at any point. However, unlike sidecar mode, the ztunnel runs as a DaemonSet — a per-node proxy — meaning that ztunnel upgrades affect, at minimum, an entire node at a time. While this may be acceptable in many cases, applications with long-lived TCP connections may be disrupted.  In such cases, we recommend using node cordoning and draining before upgrading the ztunnel for a given node. For the sake of simplicity, this document will demonstrate in-place upgrades of the ztunnel, which may involve a short downtime.
 
 ## Prerequisites
-
-### Organize your tags and revisions
-
-In order to safely upgrade a mesh in ambient mode, your gateways and namespaces should be using the `istio.io/rev` label to specify a revision tag which controls the version of the proxy that is running. We recommend dividing your production cluster into multiple tags to organize your upgrade. All members of a given tag will be upgraded simultaneously, so it is wise to begin your upgrade with your lowest risk applications. We do not recommend referencing revisions directly via labels for upgrades, as this process can easily result in the accidental upgrade of a large number of proxies, and is difficult to segment. To see what tags and revisions you are using in your cluster, see the section on upgrading tags.
 
 ### Prepare for the upgrade
 
@@ -48,6 +44,20 @@ Now, update the Helm repository:
 $ helm repo update istio
 {{< /text >}}
 
+{{< tabset category-name="upgrade-prerequisites" >}}
+
+{{< tab name="In-place upgrade" category-value="in-place" >}}
+
+No additional preparations for in-place upgrades, proceed to the next step.
+
+{{< /tab >}}
+
+{{< tab name="Revisioned upgrade" category-value="revisions" >}}
+
+### Organize your tags and revisions
+
+In order to upgrade a mesh in ambient mode in a controlled manner, we recommend that your gateways and namespaces should be using the `istio.io/rev` label to specify a revision tag to manage which gateway and control plane versions will be used for your workloads. We recommend dividing your production cluster into multiple tags to organize your upgrade. All members of a given tag will be upgraded simultaneously, so it is wise to begin your upgrade with your lowest risk applications. We do not recommend referencing revisions directly via labels for upgrades, as this process can easily result in the accidental upgrade of a large number of proxies, and is difficult to segment. To see what tags and revisions you are using in your cluster, see the section on upgrading tags.
+
 ### Choose a revision name
 
 Revisions identify unique instances of the Istio control plane, allowing you to run multiple distinct versions of the control plane simultaneously in a single mesh.
@@ -63,6 +73,10 @@ $ export REVISION=istio-1-22-1
 $ export OLD_REVISION=istio-1-21-2
 {{< /text >}}
 
+{{< /tab >}}
+
+{{< /tabset >}}
+
 ## Upgrade the control plane
 
 ### Base components
@@ -77,13 +91,29 @@ $ helm upgrade istio-base istio/base -n istio-system
 
 ### istiod control plane
 
-The [Istiod](/docs/ops/deployment/architecture/#istiod) control plane manages and configures the proxies that route traffic within the mesh. The following command will install a new instance of the control plane alongside the current, but will not introduce any new proxies, or take over control of existing proxies.
+The [Istiod](/docs/ops/deployment/architecture/#istiod) control plane manages and configures the proxies that route traffic within the mesh. The following command will install a new instance of the control plane alongside the current one, but will not introduce any new gateway proxies, or take over control of existing gateway proxies.
 
 If you have customized your istiod installation, you can reuse the `values.yaml` file from previous upgrades or installs to keep your control planes consistent.
 
-{{< text syntax=bash snip_id=upgrade_istiod >}}
+{{< tabset category-name="upgrade-control-plane" >}}
+
+{{< tab name="In-place upgrade" category-value="in-place" >}}
+
+{{< text syntax=bash snip_id=upgrade_istiod_inplace >}}
+$ helm upgrade istiod istio/istiod -n istio-system --wait
+{{< /text >}}
+
+{{< /tab >}}
+
+{{< tab name="Revisioned upgrade" category-value="revisions" >}}
+
+{{< text syntax=bash snip_id=upgrade_istiod_revisioned >}}
 $ helm install istiod-"$REVISION" istio/istiod -n istio-system --set revision="$REVISION" --set profile=ambient --wait
 {{< /text >}}
+
+{{< /tab >}}
+
+{{< /tabset >}}
 
 ### CNI node agent
 
@@ -92,7 +122,9 @@ The Istio CNI node agent is responsible for detecting pods added to the ambient 
 The CNI at version 1.x is compatible with the control plane at version 1.x+1 and 1.x. This means the control plane must be upgraded before Istio CNI, as long as their version difference is within one minor version.
 
 {{< warning >}}
-Upgrading the Istio CNI node agent to a compatible version in-place will not disrupt networking for running pods already successfully added to an ambient mesh, but no ambient-captured pods will be successfully scheduled (or rescheduled) on the node until the upgrade is complete and the upgraded Istio CNI agent on the node passes readiness checks. If this is a significant disruption concern, or stricter blast radius controls are desired for CNI upgrades, node taints and/or node cordons are recommended.
+Istio does not currently support canary upgrades of istio-cni, **even with the use of revisions**.
+
+Upgrading the Istio CNI node agent to a compatible version in-place will not disrupt networking for running pods already successfully added to an ambient mesh, but no new pods should be scheduled on the node until the upgrade is complete and the upgraded Istio CNI agent on the node passes readiness checks. If this is a significant disruption concern, or stricter blast radius controls are desired for CNI upgrades, node taints and/or node cordons are recommended.
 {{< /warning >}}
 
 {{< text syntax=bash snip_id=upgrade_cni >}}
@@ -106,14 +138,46 @@ $ helm upgrade istio-cni istio/cni -n istio-system
 The {{< gloss >}}ztunnel{{< /gloss >}} DaemonSet is the node proxy component. The ztunnel at version 1.x is compatible with the control plane at version 1.x+1 and 1.x. This means the control plane must be upgraded before ztunnel, as long as their version difference is within one minor version. If you have previously customized your ztunnel installation, you can reuse the `values.yaml` file from previous upgrades or installs to keep your {{< gloss >}}data plane{{< /gloss >}} consistent.
 
 {{< warning >}}
-Upgrading ztunnel in-place will briefly disrupt all ambient mesh traffic on the node, regardless of the use of revisions. In practice the disruption period is a very small window, primarily affecting long-running connections.
+Upgrading ztunnel in-place will briefly disrupt all ambient mesh traffic on the node,  **even with the use of revisions**. In practice the disruption period is a very small window, primarily affecting long-running connections.
 
 Node cordoning and blue/green node pools are recommended to mitigate blast radius risk during production upgrades. See your Kubernetes provider documentation for details.
 {{< /warning >}}
 
-{{< text syntax=bash snip_id=upgrade_ztunnel >}}
+{{< tabset category-name="upgrade-ztunnel" >}}
+
+{{< tab name="In-place upgrade" category-value="in-place" >}}
+
+{{< text syntax=bash snip_id=upgrade_ztunnel_inplace >}}
+$ helm upgrade ztunnel istio/ztunnel -n istio-system --wait
+{{< /text >}}
+
+{{< /tab >}}
+
+{{< tab name="Revisioned upgrade" category-value="revisions" >}}
+
+{{< text syntax=bash snip_id=upgrade_ztunnel_revisioned >}}
 $ helm upgrade ztunnel istio/ztunnel -n istio-system --set revision="$REVISION" --wait
 {{< /text >}}
+
+{{< /tab >}}
+
+{{< /tabset >}}
+
+{{< tabset category-name="change-gateway-revision" >}}
+
+{{< tab name="In-place upgrade" category-value="in-place" >}}
+
+### Upgrade manually deployed gateways (optional)
+
+`Gateway`s that were [deployed manually](/docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment) must be upgraded individually using Helm:
+
+{{< text syntax=bash snip_id=none >}}
+$ helm upgrade istio-ingress istio/gateway -n istio-ingress
+{{< /text >}}
+
+{{< /tab >}}
+
+{{< tab name="Revisioned upgrade" category-value="revisions" >}}
 
 ### Upgrade waypoints and gateways using tags
 
@@ -147,8 +211,12 @@ $ helm upgrade istio-ingress istio/gateway -n istio-ingress
 
 ## Uninstall the previous control plane
 
-If you have upgraded all data plane components to use the new version of Istio, and are satisfied that you do not need to roll back, you can remove the previous version of the control plane by running:
+If you have upgraded all gateway components to use the new revision of the Istio control plane, and are satisfied that you do not need to roll back, you can remove the previous revision of the control plane by running:
 
 {{< text syntax=bash snip_id=none >}}
 $ helm delete istiod-"$REVISION" -n istio-system
 {{< /text >}}
+
+{{< /tab >}}
+
+{{< /tabset >}}

--- a/content/en/docs/ambient/upgrade/helm/index.md
+++ b/content/en/docs/ambient/upgrade/helm/index.md
@@ -211,7 +211,7 @@ $ helm upgrade istio-ingress istio/gateway -n istio-ingress
 
 ## Uninstall the previous control plane
 
-If you have upgraded all gateway components to use the new revision of the Istio control plane, and are satisfied that you do not need to roll back, you can remove the previous revision of the control plane by running:
+If you have upgraded all data plane components to use the new revision of the Istio control plane, and are satisfied that you do not need to roll back, you can remove the previous revision of the control plane by running:
 
 {{< text syntax=bash snip_id=none >}}
 $ helm delete istiod-"$REVISION" -n istio-system

--- a/content/en/docs/ambient/upgrade/helm/index.md
+++ b/content/en/docs/ambient/upgrade/helm/index.md
@@ -15,7 +15,7 @@ Follow this guide to upgrade and configure an ambient mode installation using
 [Helm](https://helm.sh/docs/). This guide assumes you have already performed an [ambient mode installation with Helm](/docs/ambient/install/helm/) with a previous version of Istio.
 
 {{< warning >}}
-In contrast to sidecar mode, ambient mode supports moving application pods to an upgraded ztunnel proxy without a mandatory restart or reschedule of running application pods. However, upgrading ztunnel **will** cause all long-lived TCP connections on the upgraded node to reset, and Istio does not currently support canary upgrades of ztunnel, **even with the use of revisions**
+In contrast to sidecar mode, ambient mode supports moving application pods to an upgraded ztunnel proxy without a mandatory restart or reschedule of running application pods. However, upgrading ztunnel **will** cause all long-lived TCP connections on the upgraded node to reset, and Istio does not currently support canary upgrades of ztunnel, **even with the use of revisions**.
 
 Node cordoning and blue/green node pools are recommended to limit the blast radius of resets on application traffic during production upgrades. See your Kubernetes provider documentation for details.
 {{< /warning >}}

--- a/content/en/docs/ambient/upgrade/helm/index.md
+++ b/content/en/docs/ambient/upgrade/helm/index.md
@@ -167,7 +167,7 @@ $ helm upgrade ztunnel istio/ztunnel -n istio-system --set revision="$REVISION" 
 
 {{< tab name="In-place upgrade" category-value="in-place" >}}
 
-### Upgrade manually deployed gateways (optional)
+### Upgrade manually deployed gateway chart (optional)
 
 `Gateway`s that were [deployed manually](/docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment) must be upgraded individually using Helm:
 

--- a/content/en/docs/ambient/upgrade/helm/index.md
+++ b/content/en/docs/ambient/upgrade/helm/index.md
@@ -56,7 +56,7 @@ No additional preparations for in-place upgrades, proceed to the next step.
 
 ### Organize your tags and revisions
 
-In order to upgrade a mesh in ambient mode in a controlled manner, we recommend that your gateways and namespaces should be using the `istio.io/rev` label to specify a revision tag to manage which gateway and control plane versions will be used for your workloads. We recommend dividing your production cluster into multiple tags to organize your upgrade. All members of a given tag will be upgraded simultaneously, so it is wise to begin your upgrade with your lowest risk applications. We do not recommend referencing revisions directly via labels for upgrades, as this process can easily result in the accidental upgrade of a large number of proxies, and is difficult to segment. To see what tags and revisions you are using in your cluster, see the section on upgrading tags.
+In order to upgrade a mesh in ambient mode in a controlled manner, we recommend that your gateways and namespaces use the `istio.io/rev` label to specify a revision tag to control which gateway and control plane versions will be used to manage traffic for your workloads. We recommend dividing your production cluster into multiple tags to organize your upgrade. All members of a given tag will be upgraded simultaneously, so it is wise to begin your upgrade with your lowest risk applications. We do not recommend referencing revisions directly via labels for upgrades, as this process can easily result in the accidental upgrade of a large number of proxies, and is difficult to segment. To see what tags and revisions you are using in your cluster, see the section on upgrading tags.
 
 ### Choose a revision name
 
@@ -91,7 +91,7 @@ $ helm upgrade istio-base istio/base -n istio-system
 
 ### istiod control plane
 
-The [Istiod](/docs/ops/deployment/architecture/#istiod) control plane manages and configures the proxies that route traffic within the mesh. The following command will install a new instance of the control plane alongside the current one, but will not introduce any new gateway proxies, or take over control of existing gateway proxies.
+The [Istiod](/docs/ops/deployment/architecture/#istiod) control plane manages and configures the proxies that route traffic within the mesh. The following command will install a new instance of the control plane alongside the current one, but will not introduce any new gateway proxies or waypoints, or take over control of existing ones.
 
 If you have customized your istiod installation, you can reuse the `values.yaml` file from previous upgrades or installs to keep your control planes consistent.
 

--- a/content/en/docs/ambient/upgrade/helm/inplace_test.sh
+++ b/content/en/docs/ambient/upgrade/helm/inplace_test.sh
@@ -30,7 +30,7 @@ snip_istioctl_precheck
 _rewrite_helm_repo snip_upgrade_crds
 _rewrite_helm_repo snip_upgrade_istiod_inplace
 _wait_for_deployment istio-system istiod
-_rewrite_helm_repo snip_upgrade_ztunnel
+_rewrite_helm_repo snip_upgrade_ztunnel_inplace
 _wait_for_daemonset istio-system ztunnel
 _rewrite_helm_repo snip_upgrade_cni
 _wait_for_daemonset istio-system istio-cni-node

--- a/content/en/docs/ambient/upgrade/helm/inplace_test.sh
+++ b/content/en/docs/ambient/upgrade/helm/inplace_test.sh
@@ -23,16 +23,13 @@ source "content/en/docs/ambient/upgrade/helm/common.sh"
 # @setup profile=none
 _install_istio_ambient_helm
 
-export MYTAG=tagname
-
-snip_list_revisions
 snip_update_helm
 snip_istioctl_precheck
 
 
 _rewrite_helm_repo snip_upgrade_crds
-_rewrite_helm_repo snip_upgrade_istiod
-_wait_for_deployment istio-system istiod-"$REVISION"
+_rewrite_helm_repo snip_upgrade_istiod_inplace
+_wait_for_deployment istio-system istiod
 _rewrite_helm_repo snip_upgrade_ztunnel
 _wait_for_daemonset istio-system ztunnel
 _rewrite_helm_repo snip_upgrade_cni
@@ -40,14 +37,6 @@ _wait_for_daemonset istio-system istio-cni-node
 _rewrite_helm_repo snip_upgrade_gateway
 _wait_for_deployment istio-ingress istio-ingress
 
-snip_list_tags
-_rewrite_helm_repo snip_upgrade_tag
-_rewrite_helm_repo snip_rollback_tag
-
 # @cleanup
 
-# upgrading a tag creates an MWC, let's clean it up 
-export REVISION=istio-1-22-1
-helm template istiod istio/istiod -s templates/revision-tags.yaml --set revisionTags="{tagname}" --set revision="$OLD_REVISION" -n istio-system | kubectl delete -f -
-helm delete istiod-"$REVISION" -n istio-system
 _remove_istio_ambient_helm

--- a/content/en/docs/ambient/upgrade/helm/revision_test.sh
+++ b/content/en/docs/ambient/upgrade/helm/revision_test.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+
+set -o pipefail
+
+source "content/en/docs/ambient/upgrade/helm/common.sh"
+
+# @setup profile=none
+_install_istio_ambient_helm
+
+export MYTAG=tagname
+
+snip_list_revisions
+snip_update_helm
+snip_istioctl_precheck
+
+
+_rewrite_helm_repo snip_upgrade_crds
+_rewrite_helm_repo snip_upgrade_istiod_revisioned
+_wait_for_deployment istio-system istiod-"$REVISION"
+_rewrite_helm_repo snip_upgrade_ztunnel_revisioned
+_wait_for_daemonset istio-system ztunnel
+_rewrite_helm_repo snip_upgrade_cni
+_wait_for_daemonset istio-system istio-cni-node
+_rewrite_helm_repo snip_upgrade_gateway
+_wait_for_deployment istio-ingress istio-ingress
+
+snip_list_tags
+_rewrite_helm_repo snip_upgrade_tag
+_rewrite_helm_repo snip_rollback_tag
+
+# @cleanup
+
+# upgrading a tag creates an MWC, let's clean it up 
+export REVISION=istio-1-22-1
+helm template istiod istio/istiod -s templates/revision-tags.yaml --set revisionTags="{tagname}" --set revision="$OLD_REVISION" -n istio-system | kubectl delete -f -
+helm delete istiod-"$REVISION" -n istio-system
+_remove_istio_ambient_helm

--- a/content/en/docs/ambient/upgrade/helm/snips.sh
+++ b/content/en/docs/ambient/upgrade/helm/snips.sh
@@ -45,7 +45,11 @@ snip_upgrade_crds() {
 helm upgrade istio-base istio/base -n istio-system
 }
 
-snip_upgrade_istiod() {
+snip_upgrade_istiod_inplace() {
+helm upgrade istiod istio/istiod -n istio-system --wait
+}
+
+snip_upgrade_istiod_revisioned() {
 helm install istiod-"$REVISION" istio/istiod -n istio-system --set revision="$REVISION" --set profile=ambient --wait
 }
 
@@ -53,7 +57,11 @@ snip_upgrade_cni() {
 helm upgrade istio-cni istio/cni -n istio-system
 }
 
-snip_upgrade_ztunnel() {
+snip_upgrade_ztunnel_inplace() {
+helm upgrade ztunnel istio/ztunnel -n istio-system --wait
+}
+
+snip_upgrade_ztunnel_revisioned() {
 helm upgrade ztunnel istio/ztunnel -n istio-system --set revision="$REVISION" --wait
 }
 


### PR DESCRIPTION
## Description

Previous to https://github.com/istio/istio.io/pull/15247 we (only) had an "in-place" Helm upgrade guide.

After that we had complete a "revisioned" upgrade guide but that guide contains several steps that are not necessary if you do not care about using revisions in your environment.

This adds both flavors back as tabs (both with doctests) and tidies up a few bits of language/warnings, which was originally suggested as a followup in https://github.com/istio/istio.io/pull/15247.


cc @therealmitchconnors and @howardjohn 

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
