### PR TITLE
Mark the Operator as deprecated

### DIFF
--- a/content/en/about/faq/setup/install-method-selection.md
+++ b/content/en/about/faq/setup/install-method-selection.md
@@ -57,8 +57,7 @@ The following lists some of the pros and cons of each of the available methods:
 1. [Istio Operator](/docs/setup/install/operator/)
 
     {{< warning >}}
-    Using the operator is not recommended for new installations. While the operator will continue to be supported,
-    new feature requests will not be prioritized.
+    [The Istio operator is deprecated](/blog/2024/in-cluster-operator-deprecation-announcement/). Operator-based Installations of Istio will continue to run indefinitely, but cannot be upgraded past 1.23.x. Please see the [announcement](/blog/2024/in-cluster-operator-deprecation-announcement/) to learn how to upgrade to a supported installation method.
     {{< /warning >}}
 
     The Istio operator provides an installation path without needing the `istioctl` binary.

--- a/content/en/docs/setup/install/operator/index.md
+++ b/content/en/docs/setup/install/operator/index.md
@@ -7,13 +7,11 @@ aliases:
     - /docs/setup/install/standalone-operator
 owner: istio/wg-environments-maintainers
 test: yes
-status: Beta
+status: Deprecated
 ---
 
 {{< warning >}}
-Use of the operator for new Istio installations is discouraged in favor of the [Istioctl](/docs/setup/install/istioctl)
-and [Helm](/docs/setup/install/helm) installation methods. While the operator will continue to be supported,
-new feature requests will not be prioritized.
+[The Istio operator is deprecated](/blog/2024/in-cluster-operator-deprecation-announcement/). Operator-based Installations of Istio will continue to run indefinitely, but cannot be upgraded past 1.23.x. Please see the [announcement](/blog/2024/in-cluster-operator-deprecation-announcement/) to learn how to upgrade to a supported installation method.
 {{< /warning >}}
 
 Instead of manually installing, upgrading, and uninstalling Istio,


### PR DESCRIPTION
1.23 only - denote that the operator is deprecated.

Not required for master as the pages are removed for 1.24.
