### PR TITLE
Mention `ip_set` kmods in requirements

### DIFF
--- a/content/en/docs/ops/deployment/platform-requirements/index.md
+++ b/content/en/docs/ops/deployment/platform-requirements/index.md
@@ -31,6 +31,7 @@ For reference, the following lists all the `iptables`-related kernel modules req
 | `xt_owner` |  |
 | `xt_tcpudp` |  |
 | `xt_multiport`|  |
+| `ip_set`| Needed for ambient dataplane mode |
 
 The following additional modules are used by the above listed modules and should be also loaded on the cluster node:
 
@@ -47,6 +48,7 @@ The following additional modules are used by the above listed modules and should
 | `nf_nat_ipv6` | Only needed for IPv6/dual-stack clusters |
 | `nf_nat_redirect` |  |
 | `x_tables` |  |
+| `ip_set_hash_ip`| Needed for ambient dataplane mode |
 
 While uncommon, the use of custom or nonstandard Linux kernels or Linux distributions may result in scenarios where the specific modules listed above are not available on the host, or could not be automatically loaded by `iptables`. For example, this [`selinux issue`](https://www.suse.com/support/kb/doc/?id=000020241) describes a scenario in some RHEL releases where `selinux` configuration may prevent the automatic loading of some of the above mentioned kernel modules.
 


### PR DESCRIPTION
## Description

Every kernel I've ever seen either loads or builds in `ip_set` but technically you can disable it in `kconfig` and build kernels without it, so better to be explicit that we need it, I guess.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
