### PR TITLE
[zh] Sync replace "sleep" to “curl” for setup and task docs into Chinese

### DIFF
--- a/content/zh/docs/setup/upgrade/canary/index.md
+++ b/content/zh/docs/setup/upgrade/canary/index.md
@@ -84,7 +84,7 @@ istiod-canary-6956db645c-vwhsk
 `istiod-canary` 控制平面。这是在基于命名空间标签的 Sidecar 注入期间控制的 `istio.io/rev`。
 
 创建一个命名空间 `test-ns` 并启用 `istio-injection`。
-在 `test-ns` 命名空间中，部署一个示例 sleep Pod：
+在 `test-ns` 命名空间中，部署一个示例 curl Pod：
 
 1. 创建命名空间 `test-ns`。
 
@@ -98,10 +98,10 @@ istiod-canary-6956db645c-vwhsk
     $ kubectl label namespace test-ns istio-injection=enabled
     {{< /text >}}
 
-1. 在 `test-ns` 命名空间中启动一个示例 sleep Pod。
+1. 在 `test-ns` 命名空间中启动一个示例 curl Pod。
 
     {{< text bash >}}
-    $ kubectl apply -n test-ns -f samples/sleep/sleep.yaml
+    $ kubectl apply -n test-ns -f samples/curl/curl.yaml
     {{< /text >}}
 
 要升级命名空间 `test-ns`，请删除 `istio-injection` 标签，然后添加 `istio.io/rev` 标签以指向
@@ -164,12 +164,12 @@ $ istioctl proxy-status | grep "\.test-ns "
     $ kubectl label ns app-ns-3 istio.io/rev=prod-canary
     {{< /text >}}
 
-1. 在每个命名空间中部署一个 sleep Pod 示例:
+1. 在每个命名空间中部署一个 curl Pod 示例:
 
     {{< text bash >}}
-    $ kubectl apply -n app-ns-1 -f samples/sleep/sleep.yaml
-    $ kubectl apply -n app-ns-2 -f samples/sleep/sleep.yaml
-    $ kubectl apply -n app-ns-3 -f samples/sleep/sleep.yaml
+    $ kubectl apply -n app-ns-1 -f samples/curl/curl.yaml
+    $ kubectl apply -n app-ns-2 -f samples/curl/curl.yaml
+    $ kubectl apply -n app-ns-3 -f samples/curl/curl.yaml
     {{< /text >}}
 
 1. 使用 `istioctl proxy-status` 命令验证应用程序与控制平面的映射:
@@ -177,9 +177,9 @@ $ istioctl proxy-status | grep "\.test-ns "
     {{< text bash >}}
     $ istioctl ps
     NAME                                CLUSTER        CDS        LDS        EDS        RDS        ECDS         ISTIOD                             VERSION
-    sleep-78ff5975c6-62pzf.app-ns-3     Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-{{< istio_full_version_revision >}}-7f6fc6cfd6-s8zfg     {{< istio_full_version >}}
-    sleep-78ff5975c6-8kxpl.app-ns-1     Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-{{< istio_previous_version_revision >}}-1-bdf5948d5-n72r2      {{< istio_previous_version >}}.1
-    sleep-78ff5975c6-8q7m6.app-ns-2     Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-{{< istio_previous_version_revision >}}-1-bdf5948d5-n72r2      {{< istio_previous_version_revision >}}.1
+    curl-78ff5975c6-62pzf.app-ns-3      Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-{{< istio_full_version_revision >}}-7f6fc6cfd6-s8zfg     {{< istio_full_version >}}
+    curl-78ff5975c6-8kxpl.app-ns-1      Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-{{< istio_previous_version_revision >}}-1-bdf5948d5-n72r2      {{< istio_previous_version >}}.1
+    curl-78ff5975c6-8q7m6.app-ns-2      Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED     NOT SENT     istiod-{{< istio_previous_version_revision >}}-1-bdf5948d5-n72r2      {{< istio_previous_version_revision >}}.1
     {{< /text >}}
 
 {{< boilerplate revision-tags-middle >}}
@@ -200,9 +200,9 @@ $ kubectl rollout restart deployment -n app-ns-2
 {{< text bash >}}
 $ istioctl ps
 NAME                                                   CLUSTER        CDS        LDS        EDS        RDS          ECDS         ISTIOD                             VERSION
-sleep-5984f48bc7-kmj6x.app-ns-1                        Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED       NOT SENT     istiod-{{< istio_full_version_revision >}}-7f6fc6cfd6-jsktb     {{< istio_full_version >}}
-sleep-78ff5975c6-jldk4.app-ns-3                        Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED       NOT SENT     istiod-{{< istio_full_version_revision >}}-7f6fc6cfd6-jsktb     {{< istio_full_version >}}
-sleep-7cdd8dccb9-5bq5n.app-ns-2                        Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED       NOT SENT     istiod-{{< istio_full_version_revision >}}-7f6fc6cfd6-jsktb     {{< istio_full_version >}}
+curl-5984f48bc7-kmj6x.app-ns-1                         Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED       NOT SENT     istiod-{{< istio_full_version_revision >}}-7f6fc6cfd6-jsktb     {{< istio_full_version >}}
+curl-78ff5975c6-jldk4.app-ns-3                         Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED       NOT SENT     istiod-{{< istio_full_version_revision >}}-7f6fc6cfd6-jsktb     {{< istio_full_version >}}
+curl-7cdd8dccb9-5bq5n.app-ns-2                         Kubernetes     SYNCED     SYNCED     SYNCED     SYNCED       NOT SENT     istiod-{{< istio_full_version_revision >}}-7f6fc6cfd6-jsktb     {{< istio_full_version >}}
 {{< /text >}}
 
 ### 默认版本 {#default-tag}

--- a/content/zh/docs/tasks/observability/distributed-tracing/mesh-and-proxy-config/index.md
+++ b/content/zh/docs/tasks/observability/distributed-tracing/mesh-and-proxy-config/index.md
@@ -105,13 +105,13 @@ EOF
 ### 使用 `proxy.istio.io/config` 注解配置链路追踪  {#using-proxy-istio-io-config-annotation-for-trace-settings}
 
 您可以添加 `proxy.istio.io/config` 注解到 Pod 元数据规约中，以覆盖任何网格范围的链路追踪配置。
-例如，要修改 Istio 附带的 `sleep` Deployment，您需要在 `samples/sleep/sleep.yaml` 中添加以下内容：
+例如，要修改 Istio 附带的 `curl` Deployment，您需要在 `samples/curl/curl.yaml` 中添加以下内容：
 
 {{< text yaml >}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sleep
+  name: curl
 spec:
   ...
   template:

--- a/content/zh/docs/tasks/observability/distributed-tracing/sampling/index.md
+++ b/content/zh/docs/tasks/observability/distributed-tracing/sampling/index.md
@@ -87,7 +87,7 @@ EOF
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sleep
+  name: curl
 spec:
   ...
   template:

--- a/content/zh/docs/tasks/observability/logs/access-log/index.md
+++ b/content/zh/docs/tasks/observability/logs/access-log/index.md
@@ -82,9 +82,9 @@ $ istioctl install <flags-you-used-to-install-Istio> --set meshConfig.accessLogF
 \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%\n
 {{< /text >}}
 
-下表显示了一个使用默认的访问日志格式的示例，请求从 `sleep` 发送到 `httpbin`：
+下表显示了一个使用默认的访问日志格式的示例，请求从 `curl` 发送到 `httpbin`：
 
-| 日志运算符 | sleep 中的访问日志 | httpbin 中的访问日志  |
+| 日志运算符 | curl 中的访问日志 | httpbin 中的访问日志  |
 |--------------|---------------------|-----------------------|
 | `[%START_TIME%]` | `[2020-11-25T21:26:18.409Z]` | `[2020-11-25T21:26:18.409Z]`
 | `\"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\"` | `"GET /status/418 HTTP/1.1"` | `"GET /status/418 HTTP/1.1"`
@@ -111,10 +111,10 @@ $ istioctl install <flags-you-used-to-install-Istio> --set meshConfig.accessLogF
 
 ## 测试访问日志  {#test-the-access-log}
 
-1. 从 `sleep` 向 `httpbin` 发送一个请求：
+1. 从 `curl` 向 `httpbin` 发送一个请求：
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v httpbin:8000/status/418
+    $ kubectl exec "$SOURCE_POD" -c curl -- curl -sS -v httpbin:8000/status/418
     ...
     < HTTP/1.1 418 Unknown
     ...
@@ -125,10 +125,10 @@ $ istioctl install <flags-you-used-to-install-Istio> --set meshConfig.accessLogF
     ...
     {{< /text >}}
 
-1. 检查 `sleep` 的日志：
+1. 检查 `curl` 的日志：
 
     {{< text bash >}}
-    $ kubectl logs -l app=sleep -c istio-proxy
+    $ kubectl logs -l app=curl -c istio-proxy
     [2019-03-06T09:31:27.354Z] "GET /status/418 HTTP/1.1" 418 - "-" 0 135 11 10 "-" "curl/7.60.0" "d209e46f-9ed5-9b61-bbdd-43e22662702a" "httpbin:8000" "172.30.146.73:80" outbound|8000||httpbin.default.svc.cluster.local - 172.21.13.94:8000 172.30.146.82:60290 -
     {{< /text >}}
 
@@ -139,17 +139,17 @@ $ istioctl install <flags-you-used-to-install-Istio> --set meshConfig.accessLogF
     [2019-03-06T09:31:27.360Z] "GET /status/418 HTTP/1.1" 418 - "-" 0 135 5 2 "-" "curl/7.60.0" "d209e46f-9ed5-9b61-bbdd-43e22662702a" "httpbin:8000" "127.0.0.1:80" inbound|8000|http|httpbin.default.svc.cluster.local - 172.30.146.73:80 172.30.146.82:38618 outbound_.8000_._.httpbin.default.svc.cluster.local
     {{< /text >}}
 
-请注意，与请求相对应的信息分别出现在源（`sleep`）和目标（`httpbin`）的 Istio
+请注意，与请求相对应的信息分别出现在源（`curl`）和目标（`httpbin`）的 Istio
 代理日志中。您可以在日志中看到 HTTP 动词（`GET`）、HTTP 路径（`/status/418`）、
 响应码（`418`）和其他[请求相关信息](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-rules)。
 
 ## 清理 {#cleanup}
 
-关闭 [sleep]({{<github_tree>}}/samples/sleep) 和
+关闭 [curl]({{<github_tree>}}/samples/curl) 和
 [httpbin]({{<github_tree>}}/samples/httpbin) 服务：
 
 {{< text bash >}}
-$ kubectl delete -f @samples/sleep/sleep.yaml@
+$ kubectl delete -f @samples/curl/curl.yaml@
 $ kubectl delete -f @samples/httpbin/httpbin.yaml@
 {{< /text >}}
 

--- a/content/zh/docs/tasks/observability/logs/otel-provider/index.md
+++ b/content/zh/docs/tasks/observability/logs/otel-provider/index.md
@@ -70,11 +70,11 @@ $ cat <<EOF | kubectl apply -n default -f -
 apiVersion: telemetry.istio.io/v1
 kind: Telemetry
 metadata:
-  name: sleep-logging
+  name: curl-logging
 spec:
   selector:
     matchLabels:
-      app: sleep
+      app: curl
   accessLogging:
     - providers:
       - name: otel
@@ -122,10 +122,10 @@ $ istioctl install -f <your-istio-operator-config-file>
 \"%REQ(:AUTHORITY)%\" \"%UPSTREAM_HOST%\" %UPSTREAM_CLUSTER% %UPSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_LOCAL_ADDRESS% %DOWNSTREAM_REMOTE_ADDRESS% %REQUESTED_SERVER_NAME% %ROUTE_NAME%\n
 {{< /text >}}
 
-下表显示的示例针对从 `sleep` 发送到 `httpbin` 的请求使用默认的访问日志格式：
+下表显示的示例针对从 `curl` 发送到 `httpbin` 的请求使用默认的访问日志格式：
 
-| 日志运算符 | sleep 中的访问日志 | httpbin 中的访问日志 |
-|--------------|---------------------|-----------------------|
+| 日志运算符 | curl 中的访问日志 | httpbin 中的访问日志 |
+|--------------|--------------------|-----------------------|
 | `[%START_TIME%]` | `[2020-11-25T21:26:18.409Z]` | `[2020-11-25T21:26:18.409Z]`
 | `\"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%\"` | `"GET /status/418 HTTP/1.1"` | `"GET /status/418 HTTP/1.1"`
 | `%RESPONSE_CODE%` | `418` | `418`
@@ -151,10 +151,10 @@ $ istioctl install -f <your-istio-operator-config-file>
 
 ## 测试访问日志  {#test-access-log}
 
-1.  将请求从 `sleep` 发送到 `httpbin`：
+1.  将请求从 `curl` 发送到 `httpbin`：
 
     {{< text bash >}}
-    $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v httpbin:8000/status/418
+    $ kubectl exec "$SOURCE_POD" -c curl -- curl -sS -v httpbin:8000/status/418
     ...
     < HTTP/1.1 418 Unknown
     ...
@@ -171,17 +171,17 @@ $ istioctl install -f <your-istio-operator-config-file>
     [2020-11-25T21:26:18.409Z] "GET /status/418 HTTP/1.1" 418 - via_upstream - "-" 0 135 3 1 "-" "curl/7.73.0-DEV" "84961386-6d84-929d-98bd-c5aee93b5c88" "httpbin:8000" "127.0.0.1:80" inbound|8000|| 127.0.0.1:41854 10.44.1.27:80 10.44.1.23:37652 outbound_.8000_._.httpbin.foo.svc.cluster.local default
     {{< /text >}}
 
-请注意，与请求对应的消息分别出现在来源和目的地（即 `sleep` 和 `httpbin`）的 Istio 代理日志中。
+请注意，与请求对应的消息分别出现在来源和目的地（即 `curl` 和 `httpbin`）的 Istio 代理日志中。
 您可以在此日志中看到 HTTP 动作（`GET`）、HTTP 路径（`/status/418`）、响应码（`418`）
 和其他[请求相关的信息](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log/usage#format-rules)。
 
 ## 清理  {#cleanup}
 
-关闭 [sleep]({{< github_tree >}}/samples/sleep) 和 [httpbin]({{< github_tree >}}/samples/httpbin) 服务：
+关闭 [curl]({{< github_tree >}}/samples/curl) 和 [httpbin]({{< github_tree >}}/samples/httpbin) 服务：
 
 {{< text bash >}}
-$ kubectl delete telemetry sleep-logging
-$ kubectl delete -f @samples/sleep/sleep.yaml@
+$ kubectl delete telemetry curl-logging
+$ kubectl delete -f @samples/curl/curl.yaml@
 $ kubectl delete -f @samples/httpbin/httpbin.yaml@
 $ kubectl delete -f @samples/open-telemetry/otel.yaml@ -n istio-system
 {{< /text >}}

--- a/content/zh/docs/tasks/observability/logs/telemetry-api/index.md
+++ b/content/zh/docs/tasks/observability/logs/telemetry-api/index.md
@@ -45,19 +45,19 @@ $ kubectl apply -f @samples/open-telemetry/loki/otel.yaml@ -n istio-system
 
 1. 禁用特定工作负载的访问日志
 
-    您可以使用以下配置禁用 `sleep` 服务的访问日志：
+    您可以使用以下配置禁用 `curl` 服务的访问日志：
 
     {{< text bash >}}
     $ cat <<EOF | kubectl apply -n default -f -
     apiVersion: telemetry.istio.io/v1
     kind: Telemetry
     metadata:
-      name: disable-sleep-logging
+      name: disable-curl-logging
       namespace: default
     spec:
       selector:
         matchLabels:
-          app: sleep
+          app: curl
       accessLogging:
       - providers:
         - name: otel
@@ -97,11 +97,11 @@ $ kubectl apply -f @samples/open-telemetry/loki/otel.yaml@ -n istio-system
     apiVersion: telemetry.istio.io/v1alpha1
     kind: Telemetry
     metadata:
-      name: filter-sleep-logging
+      name: filter-curl-logging
     spec:
       selector:
         matchLabels:
-          app: sleep
+          app: curl
       accessLogging:
       - providers:
         - name: otel


### PR DESCRIPTION
## Description

Sync replace "sleep" to “curl” for setup and task docs into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
