### PR TITLE
Remove global.externalIstiod from remote examples

### DIFF
--- a/content/en/docs/setup/install/external-controlplane/index.md
+++ b/content/en/docs/setup/install/external-controlplane/index.md
@@ -191,7 +191,6 @@ and installing the sidecar injector webhook configuration on the remote cluster 
         global:
           istioNamespace: external-istiod
           configCluster: true
-          externalIstiod: true
         pilot:
           configMap: true
         istiodRemote:
@@ -743,7 +742,6 @@ $ export SECOND_CLUSTER_NAME=<your second remote cluster name>
       values:
         global:
           istioNamespace: external-istiod
-          externalIstiod: true
         istiodRemote:
           injectionURL: https://${EXTERNAL_ISTIOD_ADDR}:15017/inject/cluster/${SECOND_CLUSTER_NAME}/net/network2
     EOF

--- a/content/en/docs/setup/install/external-controlplane/snips.sh
+++ b/content/en/docs/setup/install/external-controlplane/snips.sh
@@ -85,7 +85,6 @@ spec:
     global:
       istioNamespace: external-istiod
       configCluster: true
-      externalIstiod: true
     pilot:
       configMap: true
     istiodRemote:
@@ -460,7 +459,6 @@ spec:
   values:
     global:
       istioNamespace: external-istiod
-      externalIstiod: true
     istiodRemote:
       injectionURL: https://${EXTERNAL_ISTIOD_ADDR}:15017/inject/cluster/${SECOND_CLUSTER_NAME}/net/network2
 EOF

--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -153,7 +153,6 @@ spec:
       injectionPath: /inject/cluster/cluster2/net/network1
     global:
       remotePilotAddress: ${DISCOVERY_ADDRESS}
-      externalIstiod: true
 EOF
 {{< /text >}}
 

--- a/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
@@ -85,7 +85,6 @@ spec:
       injectionPath: /inject/cluster/cluster2/net/network1
     global:
       remotePilotAddress: ${DISCOVERY_ADDRESS}
-      externalIstiod: true
 EOF
 }
 

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -164,7 +164,6 @@ spec:
       injectionPath: /inject/cluster/cluster2/net/network2
     global:
       remotePilotAddress: ${DISCOVERY_ADDRESS}
-      externalIstiod: true
 EOF
 {{< /text >}}
 

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
@@ -94,7 +94,6 @@ spec:
       injectionPath: /inject/cluster/cluster2/net/network2
     global:
       remotePilotAddress: ${DISCOVERY_ADDRESS}
-      externalIstiod: true
 EOF
 }
 


### PR DESCRIPTION
## Description

The need to use this value was removed in https://github.com/istio/istio/pull/53542.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
