### PR TITLE
Use `global.externalIstiod` instead of `pilot.env.EXTERNAL_ISTIOD`

### DIFF
--- a/content/en/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote/index.md
@@ -54,16 +54,17 @@ spec:
       multiCluster:
         clusterName: cluster1
       network: network1
+      externalIstiod: true
 EOF
 {{< /text >}}
 
 Apply the configuration to `cluster1`:
 
 {{< text bash >}}
-$ istioctl install --set values.pilot.env.EXTERNAL_ISTIOD=true --context="${CTX_CLUSTER1}" -f cluster1.yaml
+$ istioctl install --context="${CTX_CLUSTER1}" -f cluster1.yaml
 {{< /text >}}
 
-Notice that `values.pilot.env.EXTERNAL_ISTIOD` is set to `true`. This enables the control plane
+Notice that `values.global.externalIstiod` is set to `true`. This enables the control plane
 installed on `cluster1` to also serve as an external control plane for other remote clusters.
 When this feature is enabled, `istiod` will attempt to acquire the leadership lock, and consequently manage,
 [appropriately annotated](#set-the-control-plane-cluster-for-cluster2) remote clusters that will be

--- a/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote/snips.sh
@@ -31,11 +31,12 @@ spec:
       multiCluster:
         clusterName: cluster1
       network: network1
+      externalIstiod: true
 EOF
 }
 
 snip_configure_cluster1_as_a_primary_2() {
-istioctl install --set values.pilot.env.EXTERNAL_ISTIOD=true --context="${CTX_CLUSTER1}" -f cluster1.yaml
+istioctl install --context="${CTX_CLUSTER1}" -f cluster1.yaml
 }
 
 snip_install_the_eastwest_gateway_in_cluster1_1() {

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -58,16 +58,17 @@ spec:
       multiCluster:
         clusterName: cluster1
       network: network1
+      externalIstiod: true
 EOF
 {{< /text >}}
 
 Apply the configuration to `cluster1`:
 
 {{< text bash >}}
-$ istioctl install --set values.pilot.env.EXTERNAL_ISTIOD=true --context="${CTX_CLUSTER1}" -f cluster1.yaml
+$ istioctl install --context="${CTX_CLUSTER1}" -f cluster1.yaml
 {{< /text >}}
 
-Notice that `values.pilot.env.EXTERNAL_ISTIOD` is set to `true`. This enables the control plane
+Notice that `values.global.externalIstiod` is set to `true`. This enables the control plane
 installed on `cluster1` to also serve as an external control plane for other remote clusters.
 When this feature is enabled, `istiod` will attempt to acquire the leadership lock, and consequently manage,
 [appropriately annotated](#set-the-control-plane-cluster-for-cluster2) remote clusters that will be

--- a/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
+++ b/content/en/docs/setup/install/multicluster/primary-remote_multi-network/snips.sh
@@ -36,11 +36,12 @@ spec:
       multiCluster:
         clusterName: cluster1
       network: network1
+      externalIstiod: true
 EOF
 }
 
 snip_configure_cluster1_as_a_primary_2() {
-istioctl install --set values.pilot.env.EXTERNAL_ISTIOD=true --context="${CTX_CLUSTER1}" -f cluster1.yaml
+istioctl install --context="${CTX_CLUSTER1}" -f cluster1.yaml
 }
 
 snip_install_the_eastwest_gateway_in_cluster1_1() {

--- a/content/zh/docs/setup/install/multicluster/primary-remote/index.md
+++ b/content/zh/docs/setup/install/multicluster/primary-remote/index.md
@@ -52,16 +52,17 @@ spec:
       multiCluster:
         clusterName: cluster1
       network: network1
+      externalIstiod: true
 EOF
 {{< /text >}}
 
 将配置文件应用到 `cluster1`：
 
 {{< text bash >}}
-$ istioctl install --set values.pilot.env.EXTERNAL_ISTIOD=true --context="${CTX_CLUSTER1}" -f cluster1.yaml
+$ istioctl install --context="${CTX_CLUSTER1}" -f cluster1.yaml
 {{< /text >}}
 
-需要注意的是，当 `values.pilot.env.EXTERNAL_ISTIOD` 被设置为 `true` 时，
+需要注意的是，当 `values.global.externalIstiod` 被设置为 `true` 时，
 安装在 `cluster1` 上的控制平面也可以作为其他从集群的外部控制平面。
 当这个功能被启用时，`istiod` 将尝试获取领导权锁，
 并因此管理将附加到它的并且带有[适当注解的](#set-the-control-plane-cluster-for-cluster2)从集群

--- a/content/zh/docs/setup/install/multicluster/primary-remote_multi-network/index.md
+++ b/content/zh/docs/setup/install/multicluster/primary-remote_multi-network/index.md
@@ -54,16 +54,17 @@ spec:
       multiCluster:
         clusterName: cluster1
       network: network1
+      externalIstiod: true
 EOF
 {{< /text >}}
 
 将配置应用到 `cluster1`：
 
 {{< text bash >}}
-$ istioctl install --set values.pilot.env.EXTERNAL_ISTIOD=true --context="${CTX_CLUSTER1}" -f cluster1.yaml
+$ istioctl install --context="${CTX_CLUSTER1}" -f cluster1.yaml
 {{< /text >}}
 
-请注意，`values.pilot.env.EXTERNAL_ISTIOD` 设置为 `true`。
+请注意，`values.global.externalIstiod` 设置为 `true`。
 这将启用安装在 `cluster1` 上的控制平面，使其也用作其他从集群的外部控制平面。
 启用此特性后，`istiod` 将尝试获取领导选举锁，
 并因此管理将附加到它的并且带有[适当注解的](#set-the-control-plane-cluster-for-cluster2)从集群


### PR DESCRIPTION
## Description

The `global.externalIstiod` value, introduced in https://github.com/istio/istio/pull/51596, is now preferred over `pilot.env.EXTERNAL_ISTIOD`. 

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
