### PR TITLE
Remove note for preview DNS proxying

### DIFF
--- a/content/en/docs/ops/deployment/deployment-models/index.md
+++ b/content/en/docs/ops/deployment/deployment-models/index.md
@@ -160,11 +160,6 @@ feature of [Istio DNS Proxying](/docs/ops/configuration/traffic-management/dns-p
 {{< tip >}}
 There are a few efforts in progress that will help simplify the DNS story:
 
-- [DNS sidecar proxy](/blog/2020/dns-proxy/)
-  support is available for preview in Istio 1.8. This provides DNS interception
-  for all workloads with a sidecar, allowing Istio to perform DNS lookup
-  on behalf of the application.
-
 - [Admiral](https://github.com/istio-ecosystem/admiral) is an Istio community
   project that provides a number of multicluster capabilities. If you need to support multi-network
   topologies, managing this configuration across multiple clusters at scale is challenging.


### PR DESCRIPTION
## Description

DNS proxying is no longer in preview. Note links to article from 2020 about istio 1.8.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [x] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
