### PR TITLE
Update clusterLocal docs to allow for exceptions when using wide clusterLocal configs

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/multicluster/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/multicluster/index.md
@@ -61,6 +61,20 @@ serviceSettings:
 
 {{< /tabset >}}
 
+You can also refine service access down by setting a global cluster-local rule and adding explicit exceptions, which can be specific or wildcard. In the following example, all services in the cluster will be kept cluster-local, except any service in the `myns` namespace.
+
+{{< text yaml >}}
+serviceSettings:
+- settings:
+    clusterLocal: true
+  hosts:
+  - "*"
+- settings:
+    clusterLocal: false
+  hosts:
+  - "*.myns.svc.cluster.local"
+{{< /text >}}
+
 ## Partitioning Services {#partitioning-services}
 
 [`DestinationRule.subsets`](/docs/reference/config/networking/destination-rule/#Subset) allows partitioning a service

--- a/content/en/docs/ops/configuration/traffic-management/multicluster/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/multicluster/index.md
@@ -61,7 +61,7 @@ serviceSettings:
 
 {{< /tabset >}}
 
-You can also refine service access down by setting a global cluster-local rule and adding explicit exceptions, which can be specific or wildcard. In the following example, all services in the cluster will be kept cluster-local, except any service in the `myns` namespace.
+You can also refine service access down by setting a global cluster-local rule and adding explicit exceptions, which can be specific or wildcard. In the following example, all services in the cluster will be kept cluster-local, except any service in the `myns` namespace:
 
 {{< text yaml >}}
 serviceSettings:


### PR DESCRIPTION
## Description

Updates documentation related to `clusterLocal` changes made here (https://github.com/istio/istio/pull/52367) and backported to 1.22 and 1.23.

Changes are simple, can now set wider services/namespaces/global as `clusterLocal`, and then set more refined services and namespaces contained in the `clusterLocal` config to not be `clusterLocal`, allowing us to stop sharing all but certain services.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
