### PR TITLE
Dual-stack is experimental on 1.23

### DIFF
--- a/content/en/docs/setup/additional-setup/dual-stack/index.md
+++ b/content/en/docs/setup/additional-setup/dual-stack/index.md
@@ -7,7 +7,7 @@ owner: istio/wg-networking-maintainers
 test: yes
 ---
 
-{{< boilerplate alpha >}}
+{{< boilerplate experimental >}}
 
 ## Prerequisites
 


### PR DESCRIPTION
## Description

Dual-stack is Alpha only in 1.24. Something wrong with the branch cutting timelines, that the feature page is still experimental however the docs say Alpha on 1.23.

https://istio.io/latest/docs/setup/additional-setup/dual-stack/

https://istio.io/latest/docs/releases/feature-stages/#core

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
