### PR TITLE
Add details about auto_san_validation behavior

### DIFF
--- a/content/en/boilerplates/auto-san-validation.md
+++ b/content/en/boilerplates/auto-san-validation.md
@@ -1,0 +1,3 @@
+---
+---
+Istio has `auto_sni` and `auto_san_validation` enabled by default. This means, whenever there is no explicit `sni` set in your `DestinationRule`, transport socket SNI for new upstream connections will be set based on the downstream HTTP host/authority header. And if there are no `subjectAltNames` set in the `DestinationRule` when `sni` is unset, `auto_san_validation` will kick in, and the upstream presented certificate for new upstream connections will be automatically validated based on the downstream HTTP host/authority header.

--- a/content/en/boilerplates/auto-san-validation.md
+++ b/content/en/boilerplates/auto-san-validation.md
@@ -1,3 +1,5 @@
 ---
 ---
-Istio has `auto_sni` and `auto_san_validation` enabled by default. This means, whenever there is no explicit `sni` set in your `DestinationRule`, transport socket SNI for new upstream connections will be set based on the downstream HTTP host/authority header. And if there are no `subjectAltNames` set in the `DestinationRule` when `sni` is unset, `auto_san_validation` will kick in, and the upstream presented certificate for new upstream connections will be automatically validated based on the downstream HTTP host/authority header.
+{{< tip >}}
+Istio has `auto_sni` and `auto_san_validation` enabled by default. This means, whenever there is no explicit `sni` set in your `DestinationRule`, transport socket SNI for new upstream connections will be set based on the downstream HTTP host/authority header. If there are no `subjectAltNames` set in the `DestinationRule` when `sni` is unset, `auto_san_validation` will kick in, and the upstream-presented certificate for new upstream connections will be automatically validated based on the downstream HTTP host/authority header.
+{{< /tip >}}

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -904,6 +904,10 @@ EOF
 
 {{< /tabset >}}
 
+{{< warning >}}
+{{< boilerplate auto-san-validation >}}
+{{< /warning >}}
+
 5)  Verify that the credential is supplied to the egress gateway and active:
 
 {{< tabset category-name="config-api" >}}

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -904,9 +904,7 @@ EOF
 
 {{< /tabset >}}
 
-{{< warning >}}
 {{< boilerplate auto-san-validation >}}
-{{< /warning >}}
 
 5)  Verify that the credential is supplied to the egress gateway and active:
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -449,12 +449,18 @@ to hold the configuration of the NGINX server:
           tls:
             mode: MUTUAL
             credentialName: client-credential # this must match the secret created earlier to hold client certs, and works only when DR has a workloadSelector
-            sni: my-nginx.mesh-external.svc.cluster.local # this is optional
+            sni: my-nginx.mesh-external.svc.cluster.local
+            # subjectAltNames: # can be enabled if the certificate was generated with SAN as specified in previous section
+            # - my-nginx.mesh-external.svc.cluster.local
     EOF
     {{< /text >}}
 
     The above `DestinationRule` will perform mTLS origination for HTTP requests on port 80 and the `ServiceEntry`
     will then redirect the requests on port 80 to target port 443.
+
+    {{< warning >}}
+    {{< boilerplate auto-san-validation >}}
+    {{< /warning >}}
 
 1.  Verify that the credential is supplied to the sidecar and active.
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -458,9 +458,7 @@ to hold the configuration of the NGINX server:
     The above `DestinationRule` will perform mTLS origination for HTTP requests on port 80 and the `ServiceEntry`
     will then redirect the requests on port 80 to target port 443.
 
-    {{< warning >}}
     {{< boilerplate auto-san-validation >}}
-    {{< /warning >}}
 
 1.  Verify that the credential is supplied to the sidecar and active.
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/snips.sh
@@ -286,7 +286,9 @@ spec:
       tls:
         mode: MUTUAL
         credentialName: client-credential # this must match the secret created earlier to hold client certs, and works only when DR has a workloadSelector
-        sni: my-nginx.mesh-external.svc.cluster.local # this is optional
+        sni: my-nginx.mesh-external.svc.cluster.local
+        # subjectAltNames: # can be enabled if the certificate was generated with SAN as specified in previous section
+        # - my-nginx.mesh-external.svc.cluster.local
 EOF
 }
 


### PR DESCRIPTION
## Description

Add a warning about auto_sni and auto_san_validation behavior which is now enabled by default

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
