### PR TITLE
[release-1.23] Manual backport 1.23-relevant parts of #15744

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/index.md
@@ -164,25 +164,8 @@ $ export GATEWAY_URL=$(kubectl get gateways.gateway.networking.k8s.io httpbin-ga
 7) Run the following `curl` command to simulate a request with proxy addresses in the `X-Forwarded-For` header:
 
     {{< text syntax=bash snip_id=curl_xff_headers >}}
-    $ curl -s -H 'X-Forwarded-For: 56.5.6.7, 72.9.5.6, 98.1.2.3' "$GATEWAY_URL/get?show_env=true"
-    {
-    "args": {
-      "show_env": "true"
-    },
-      "headers": {
-      "Accept": ...
-      "Host": ...
-      "User-Agent": ...
-      "X-Envoy-Attempt-Count": ...
-      "X-Envoy-External-Address": "72.9.5.6",
-      "X-Forwarded-Client-Cert": ...
-      "X-Forwarded-For": "56.5.6.7, 72.9.5.6, 98.1.2.3,10.244.0.1",
-      "X-Forwarded-Proto": ...
-      "X-Request-Id": ...
-    },
-      "origin": "56.5.6.7, 72.9.5.6, 98.1.2.3,10.244.0.1",
-      "url": ...
-    }
+    $ curl -s -H 'X-Forwarded-For: 56.5.6.7, 72.9.5.6, 98.1.2.3' "$GATEWAY_URL/get?show_env=true" | jq '.headers["X-Forwarded-For"][0]'
+      "56.5.6.7, 72.9.5.6, 98.1.2.3,10.244.0.1"
     {{< /text >}}
 
 {{< tip >}}

--- a/content/en/docs/ops/configuration/traffic-management/network-topologies/snips.sh
+++ b/content/en/docs/ops/configuration/traffic-management/network-topologies/snips.sh
@@ -72,28 +72,11 @@ export GATEWAY_URL=$(kubectl get gateways.gateway.networking.k8s.io httpbin-gate
 }
 
 snip_curl_xff_headers() {
-curl -s -H 'X-Forwarded-For: 56.5.6.7, 72.9.5.6, 98.1.2.3' "$GATEWAY_URL/get?show_env=true"
+curl -s -H 'X-Forwarded-For: 56.5.6.7, 72.9.5.6, 98.1.2.3' "$GATEWAY_URL/get?show_env=true" | jq '.headers["X-Forwarded-For"][0]'
 }
 
 ! IFS=$'\n' read -r -d '' snip_curl_xff_headers_out <<\ENDSNIP
-{
-"args": {
-  "show_env": "true"
-},
-  "headers": {
-  "Accept": ...
-  "Host": ...
-  "User-Agent": ...
-  "X-Envoy-Attempt-Count": ...
-  "X-Envoy-External-Address": "72.9.5.6",
-  "X-Forwarded-Client-Cert": ...
-  "X-Forwarded-For": "56.5.6.7, 72.9.5.6, 98.1.2.3,10.244.0.1",
-  "X-Forwarded-Proto": ...
-  "X-Request-Id": ...
-},
-  "origin": "56.5.6.7, 72.9.5.6, 98.1.2.3,10.244.0.1",
-  "url": ...
-}
+  "56.5.6.7, 72.9.5.6, 98.1.2.3,10.244.0.1"
 ENDSNIP
 
 ! IFS=$'\n' read -r -d '' snip_proxy_protocol_2 <<\ENDSNIP

--- a/content/en/docs/tasks/observability/distributed-tracing/opentelemetry/http_test.sh
+++ b/content/en/docs/tasks/observability/distributed-tracing/opentelemetry/http_test.sh
@@ -47,5 +47,5 @@ snip_cleanup_collector
 
 # clean up istio to restore state of profile=none
 istioctl uninstall --purge -y
-kubectl delete ns istio-system external-1 external-2
+kubectl delete ns istio-system external-1 external-2 --wait=true --timeout=30s
 kubectl label namespace default istio-injection-

--- a/content/en/docs/tasks/observability/logs/access-log/index.md
+++ b/content/en/docs/tasks/observability/logs/access-log/index.md
@@ -118,17 +118,11 @@ The following table shows an example using the default access log format for a r
     $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v httpbin:8000/status/418
     ...
     < HTTP/1.1 418 Unknown
+    ...
     < server: envoy
     ...
-        -=[ teapot ]=-
-
-           _...._
-         .'  _ _ `.
-        | ."` ^ `". _,
-        \_;`"---"`|//
-          |       ;/
-          \_     _/
-            `"""`
+    I'm a teapot!
+    ...
     {{< /text >}}
 
 1.  Check `sleep`'s log:

--- a/content/en/docs/tasks/observability/logs/access-log/snips.sh
+++ b/content/en/docs/tasks/observability/logs/access-log/snips.sh
@@ -53,17 +53,11 @@ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v httpbin:8000/status/418
 ! IFS=$'\n' read -r -d '' snip_test_the_access_log_1_out <<\ENDSNIP
 ...
 < HTTP/1.1 418 Unknown
+...
 < server: envoy
 ...
-    -=[ teapot ]=-
-
-       _...._
-     .'  _ _ `.
-    | ."` ^ `". _,
-    \_;`"---"`|//
-      |       ;/
-      \_     _/
-        `"""`
+I'm a teapot!
+...
 ENDSNIP
 
 snip_test_the_access_log_2() {

--- a/content/en/docs/tasks/observability/logs/otel-provider/index.md
+++ b/content/en/docs/tasks/observability/logs/otel-provider/index.md
@@ -153,17 +153,11 @@ The following table shows an example using the default access log format for a r
     $ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v httpbin:8000/status/418
     ...
     < HTTP/1.1 418 Unknown
+    ...
     < server: envoy
     ...
-        -=[ teapot ]=-
-
-           _...._
-         .'  _ _ `.
-        | ."` ^ `". _,
-        \_;`"---"`|//
-          |       ;/
-          \_     _/
-            `"""`
+    I'm a teapot!
+    ...
     {{< /text >}}
 
 1.  Check `otel-collector`'s log:

--- a/content/en/docs/tasks/observability/logs/otel-provider/snips.sh
+++ b/content/en/docs/tasks/observability/logs/otel-provider/snips.sh
@@ -101,17 +101,11 @@ kubectl exec "$SOURCE_POD" -c sleep -- curl -sS -v httpbin:8000/status/418
 ! IFS=$'\n' read -r -d '' snip_test_the_access_log_1_out <<\ENDSNIP
 ...
 < HTTP/1.1 418 Unknown
+...
 < server: envoy
 ...
-    -=[ teapot ]=-
-
-       _...._
-     .'  _ _ `.
-    | ."` ^ `". _,
-    \_;`"---"`|//
-      |       ;/
-      \_     _/
-        `"""`
+I'm a teapot!
+...
 ENDSNIP
 
 snip_test_the_access_log_2() {

--- a/content/en/docs/tasks/security/authentication/authn-policy/index.md
+++ b/content/en/docs/tasks/security/authentication/authn-policy/index.md
@@ -99,8 +99,8 @@ upstream request to the backend. That header's presence is evidence that mutual 
 used. For example:
 
 {{< text bash >}}
-$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl -s http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
-    "X-Forwarded-Client-Cert": "By=spiffe://cluster.local/ns/foo/sa/httpbin;Hash=<redacted>;Subject=\"\";URI=spiffe://cluster.local/ns/foo/sa/sleep"
+$ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl -s http://httpbin.foo:8000/headers -s | jq '.headers["X-Forwarded-Client-Cert"][0]' | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
+  "By=spiffe://cluster.local/ns/foo/sa/httpbin;Hash=<redacted>;Subject=\"\";URI=spiffe://cluster.local/ns/foo/sa/sleep"
 {{< /text >}}
 
 When the server doesn't have sidecar, the `X-Forwarded-Client-Cert` header is not there, which implies requests are in plain text.

--- a/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
+++ b/content/en/docs/tasks/security/authentication/authn-policy/snips.sh
@@ -78,11 +78,11 @@ kubectl get destinationrules.networking.istio.io --all-namespaces -o yaml | grep
 ENDSNIP
 
 snip_auto_mutual_tls_1() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl -s http://httpbin.foo:8000/headers -s | grep X-Forwarded-Client-Cert | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl -s http://httpbin.foo:8000/headers -s | jq '.headers["X-Forwarded-Client-Cert"][0]' | sed 's/Hash=[a-z0-9]*;/Hash=<redacted>;/'
 }
 
 ! IFS=$'\n' read -r -d '' snip_auto_mutual_tls_1_out <<\ENDSNIP
-    "X-Forwarded-Client-Cert": "By=spiffe://cluster.local/ns/foo/sa/httpbin;Hash=<redacted>;Subject=\"\";URI=spiffe://cluster.local/ns/foo/sa/sleep"
+  "By=spiffe://cluster.local/ns/foo/sa/httpbin;Hash=<redacted>;Subject=\"\";URI=spiffe://cluster.local/ns/foo/sa/sleep"
 ENDSNIP
 
 snip_auto_mutual_tls_2() {

--- a/content/en/docs/tasks/security/authentication/claim-to-header/index.md
+++ b/content/en/docs/tasks/security/authentication/claim-to-header/index.md
@@ -99,8 +99,8 @@ Before you begin this task, do the following:
 1. Verify that a request contains a valid HTTP header with JWT claim value:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -H "Authorization: Bearer $TOKEN" | grep "X-Jwt-Claim-Foo" | sed -e 's/^[ \t]*//'
-    "X-Jwt-Claim-Foo": "bar"
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -H "Authorization: Bearer $TOKEN" | jq '.headers["X-Jwt-Claim-Foo"][0]'
+    "bar"
     {{< /text >}}
 
 ## Clean up

--- a/content/en/docs/tasks/security/authentication/claim-to-header/snips.sh
+++ b/content/en/docs/tasks/security/authentication/claim-to-header/snips.sh
@@ -80,11 +80,11 @@ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadat
 ENDSNIP
 
 snip_allow_requests_with_valid_jwt_and_listtyped_claims_5() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -H "Authorization: Bearer $TOKEN" | grep "X-Jwt-Claim-Foo" | sed -e 's/^[ \t]*//'
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -sS -H "Authorization: Bearer $TOKEN" | jq '.headers["X-Jwt-Claim-Foo"][0]'
 }
 
 ! IFS=$'\n' read -r -d '' snip_allow_requests_with_valid_jwt_and_listtyped_claims_5_out <<\ENDSNIP
-"X-Jwt-Claim-Foo": "bar"
+"bar"
 ENDSNIP
 
 snip_clean_up_1() {

--- a/content/en/docs/tasks/security/authorization/authz-custom/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-custom/index.md
@@ -192,22 +192,12 @@ The external authorizer is now ready to be used by the authorization policy.
 1. Verify a request to path `/headers` with header `x-ext-authz: allow` is allowed by the sample `ext_authz` server:
 
     {{< text bash >}}
-    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -H "x-ext-authz: allow" -s
-    {
-      "headers": {
-        "Accept": "*/*",
-        "Host": "httpbin:8000",
-        "User-Agent": "curl/7.76.0-DEV",
-        "X-B3-Parentspanid": "430f770aeb7ef215",
-        "X-B3-Sampled": "0",
-        "X-B3-Spanid": "60ff95c5acdf5288",
-        "X-B3-Traceid": "fba72bb5765daf5a430f770aeb7ef215",
-        "X-Envoy-Attempt-Count": "1",
-        "X-Ext-Authz": "allow",
-        "X-Ext-Authz-Check-Result": "allowed",
-        "X-Forwarded-Client-Cert": "By=spiffe://cluster.local/ns/foo/sa/httpbin;Hash=e5178ee79066bfbafb1d98044fcd0cf80db76be8714c7a4b630c7922df520bf2;Subject=\"\";URI=spiffe://cluster.local/ns/foo/sa/sleep"
-      }
-    }
+    $ kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -H "x-ext-authz: allow" -s | jq '.headers'
+    ...
+      "X-Ext-Authz-Check-Result": [
+        "allowed"
+      ],
+    ...
     {{< /text >}}
 
 1. Verify a request to path `/ip` is allowed and does not trigger the external authorization:

--- a/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-custom/snips.sh
@@ -136,25 +136,15 @@ denied by ext_authz for not found header `x-ext-authz: allow` in the request
 ENDSNIP
 
 snip_enable_with_external_authorization_3() {
-kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -H "x-ext-authz: allow" -s
+kubectl exec "$(kubectl get pod -l app=sleep -n foo -o jsonpath={.items..metadata.name})" -c sleep -n foo -- curl "http://httpbin.foo:8000/headers" -H "x-ext-authz: allow" -s | jq '.headers'
 }
 
 ! IFS=$'\n' read -r -d '' snip_enable_with_external_authorization_3_out <<\ENDSNIP
-{
-  "headers": {
-    "Accept": "*/*",
-    "Host": "httpbin:8000",
-    "User-Agent": "curl/7.76.0-DEV",
-    "X-B3-Parentspanid": "430f770aeb7ef215",
-    "X-B3-Sampled": "0",
-    "X-B3-Spanid": "60ff95c5acdf5288",
-    "X-B3-Traceid": "fba72bb5765daf5a430f770aeb7ef215",
-    "X-Envoy-Attempt-Count": "1",
-    "X-Ext-Authz": "allow",
-    "X-Ext-Authz-Check-Result": "allowed",
-    "X-Forwarded-Client-Cert": "By=spiffe://cluster.local/ns/foo/sa/httpbin;Hash=e5178ee79066bfbafb1d98044fcd0cf80db76be8714c7a4b630c7922df520bf2;Subject=\"\";URI=spiffe://cluster.local/ns/foo/sa/sleep"
-  }
-}
+...
+  "X-Ext-Authz-Check-Result": [
+    "allowed"
+  ],
+...
 ENDSNIP
 
 snip_enable_with_external_authorization_4() {

--- a/content/en/docs/tasks/security/authorization/authz-custom/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-custom/test.sh
@@ -54,9 +54,8 @@ _wait_for_deployment istio-system istiod
 snip_enable_with_external_authorization_1
 
 _verify_same snip_enable_with_external_authorization_2 "$snip_enable_with_external_authorization_2_out"
-_verify_lines snip_enable_with_external_authorization_3 "
-+ \"X-Ext-Authz-Check-Result\": \"allowed\",
-"
+_verify_elided snip_enable_with_external_authorization_3 "$snip_enable_with_external_authorization_3_out"
+
 _verify_same snip_enable_with_external_authorization_4 "$snip_enable_with_external_authorization_4_out"
 _verify_lines snip_enable_with_external_authorization_5 "
 + [gRPCv3][allowed]

--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -159,6 +159,7 @@ Next, you must configure the traffic from the Istio-enabled pods to use the HTTP
         name: tcp
         protocol: TCP
       location: MESH_EXTERNAL
+      resolution: NONE
     EOF
     {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/snips.sh
@@ -121,6 +121,7 @@ spec:
     name: tcp
     protocol: TCP
   location: MESH_EXTERNAL
+  resolution: NONE
 EOF
 }
 

--- a/content/en/docs/tasks/traffic-management/ingress/gateway-api/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/gateway-api/index.md
@@ -121,7 +121,9 @@ In this example, we will deploy a simple application and expose it externally us
 
     {{< text bash >}}
     $ curl -s -I -HHost:httpbin.example.com "http://$INGRESS_HOST/get"
+    ...
     HTTP/1.1 200 OK
+    ...
     server: istio-envoy
     ...
     {{< /text >}}
@@ -175,12 +177,9 @@ In this example, we will deploy a simple application and expose it externally us
 1.  Access `/headers` again and notice header `My-Added-Header` has been added to the request:
 
     {{< text bash >}}
-    $ curl -s -HHost:httpbin.example.com "http://$INGRESS_HOST/headers"
-    {
-      "headers": {
-        "Accept": "*/*",
-        "Host": "httpbin.example.com",
-        "My-Added-Header": "added-value",
+    $ curl -s -HHost:httpbin.example.com "http://$INGRESS_HOST/headers" | jq '.headers["My-Added-Header"][0]'
+    ...
+    "added-value"
     ...
     {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/ingress/gateway-api/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/gateway-api/snips.sh
@@ -83,7 +83,9 @@ curl -s -I -HHost:httpbin.example.com "http://$INGRESS_HOST/get"
 }
 
 ! IFS=$'\n' read -r -d '' snip_configuring_a_gateway_4_out <<\ENDSNIP
+...
 HTTP/1.1 200 OK
+...
 server: istio-envoy
 ...
 ENDSNIP
@@ -130,15 +132,12 @@ EOF
 }
 
 snip_configuring_a_gateway_7() {
-curl -s -HHost:httpbin.example.com "http://$INGRESS_HOST/headers"
+curl -s -HHost:httpbin.example.com "http://$INGRESS_HOST/headers" | jq '.headers["My-Added-Header"][0]'
 }
 
 ! IFS=$'\n' read -r -d '' snip_configuring_a_gateway_7_out <<\ENDSNIP
-{
-  "headers": {
-    "Accept": "*/*",
-    "Host": "httpbin.example.com",
-    "My-Added-Header": "added-value",
+...
+"added-value"
 ...
 ENDSNIP
 

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -307,7 +307,9 @@ $ export SECURE_INGRESS_PORT=$(kubectl get gtw my-gateway -o jsonpath='{.spec.li
 
     {{< text bash >}}
     $ curl -s -I -HHost:httpbin.example.com "http://$INGRESS_HOST:$INGRESS_PORT/status/200"
+    ...
     HTTP/1.1 200 OK
+    ...
     server: istio-envoy
     ...
     {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/snips.sh
@@ -171,7 +171,9 @@ curl -s -I -HHost:httpbin.example.com "http://$INGRESS_HOST:$INGRESS_PORT/status
 }
 
 ! IFS=$'\n' read -r -d '' snip_accessing_ingress_services_1_out <<\ENDSNIP
+...
 HTTP/1.1 200 OK
+...
 server: istio-envoy
 ...
 ENDSNIP

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
@@ -55,7 +55,9 @@ Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
 
     {{< text bash >}}
     $ curl -s -I -HHost:httpbin.example.com "http://$INGRESS_HOST:$INGRESS_PORT/status/200"
+    ...
     HTTP/1.1 200 OK
+    ...
     server: istio-envoy
     ...
     {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/snips.sh
@@ -48,7 +48,9 @@ curl -s -I -HHost:httpbin.example.com "http://$INGRESS_HOST:$INGRESS_PORT/status
 }
 
 ! IFS=$'\n' read -r -d '' snip_configuring_ingress_using_an_ingress_resource_2_out <<\ENDSNIP
+...
 HTTP/1.1 200 OK
+...
 server: istio-envoy
 ...
 ENDSNIP

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/test.sh
@@ -44,9 +44,9 @@ _verify_elided snip_configuring_ingress_using_an_ingress_resource_3 "$snip_confi
 kubectl apply -f - <<< "$snip_specifying_ingressclass_1"
 
 get_headers() {
-curl -s -H "Foo: bar" -HHost:httpbin.example.com "http://$INGRESS_HOST:$INGRESS_PORT/headers"
+curl -s -H "Foo: bar" -HHost:httpbin.example.com "http://$INGRESS_HOST:$INGRESS_PORT/headers" | jq '.headers["Foo"][0]'
 }
-_verify_contains get_headers '"Foo": "bar"'
+_verify_contains get_headers '"bar"'
 
 # @cleanup
 snip_cleanup_1

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -251,15 +251,8 @@ $ export SECURE_INGRESS_PORT=$(kubectl get gtw mygateway -n istio-system -o json
     ...
     HTTP/2 418
     ...
-        -=[ teapot ]=-
-
-           _...._
-         .'  _ _ `.
-        | ."` ^ `". _,
-        \_;`"---"`|//
-          |       ;/
-          \_     _/
-            `"""`
+    I'm a teapot!
+    ...
     {{< /text >}}
 
     The `httpbin` service will return the [418 I'm a Teapot](https://tools.ietf.org/html/rfc7168#section-2.3.3) code.
@@ -282,15 +275,8 @@ $ export SECURE_INGRESS_PORT=$(kubectl get gtw mygateway -n istio-system -o json
     ...
     HTTP/2 418
     ...
-        -=[ teapot ]=-
-
-           _...._
-         .'  _ _ `.
-        | ."` ^ `". _,
-        \_;`"---"`|//
-          |       ;/
-          \_     _/
-            `"""`
+    I'm a teapot!
+    ...
     {{< /text >}}
 
 1) If you try to access `httpbin` using the previous certificate chain, the attempt now fails:
@@ -490,21 +476,16 @@ EOF
     ...
     {{< /text >}}
 
-1) Send an HTTPS request to `httpbin.example.com` and still get a teapot in return:
+1) Send an HTTPS request to `httpbin.example.com` and still get [HTTP 418](https://datatracker.ietf.org/doc/html/rfc2324) in return:
 
     {{< text bash >}}
     $ curl -v -HHost:httpbin.example.com --resolve "httpbin.example.com:$SECURE_INGRESS_PORT:$INGRESS_HOST" \
       --cacert example_certs1/example.com.crt "https://httpbin.example.com:$SECURE_INGRESS_PORT/status/418"
     ...
-        -=[ teapot ]=-
-
-           _...._
-         .'  _ _ `.
-        | ."` ^ `". _,
-        \_;`"---"`|//
-          |       ;/
-          \_     _/
-            `"""`
+    HTTP/2 418
+    ...
+    server: istio-envoy
+    ...
     {{< /text >}}
 
 ### Configure a mutual TLS ingress gateway
@@ -628,15 +609,12 @@ EOF
       --cacert example_certs1/example.com.crt --cert example_certs1/client.example.com.crt --key example_certs1/client.example.com.key \
       "https://httpbin.example.com:$SECURE_INGRESS_PORT/status/418"
     ...
-        -=[ teapot ]=-
-
-           _...._
-         .'  _ _ `.
-        | ."` ^ `". _,
-        \_;`"---"`|//
-          |       ;/
-          \_     _/
-            `"""`
+    HTTP/2 418
+    ...
+    server: istio-envoy
+    ...
+    I'm a teapot!
+    ...
     {{< /text >}}
 
 ## More info

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/snips.sh
@@ -196,15 +196,8 @@ curl -v -HHost:httpbin.example.com --resolve "httpbin.example.com:$SECURE_INGRES
 ...
 HTTP/2 418
 ...
-    -=[ teapot ]=-
-
-       _...._
-     .'  _ _ `.
-    | ."` ^ `". _,
-    \_;`"---"`|//
-      |       ;/
-      \_     _/
-        `"""`
+I'm a teapot!
+...
 ENDSNIP
 
 snip_configure_a_tls_ingress_gateway_for_a_single_host_8() {
@@ -223,15 +216,8 @@ curl -v -HHost:httpbin.example.com --resolve "httpbin.example.com:$SECURE_INGRES
 ...
 HTTP/2 418
 ...
-    -=[ teapot ]=-
-
-       _...._
-     .'  _ _ `.
-    | ."` ^ `". _,
-    \_;`"---"`|//
-      |       ;/
-      \_     _/
-        `"""`
+I'm a teapot!
+...
 ENDSNIP
 
 snip_configure_a_tls_ingress_gateway_for_a_single_host_10() {
@@ -401,15 +387,10 @@ curl -v -HHost:httpbin.example.com --resolve "httpbin.example.com:$SECURE_INGRES
 
 ! IFS=$'\n' read -r -d '' snip_configure_a_tls_ingress_gateway_for_multiple_hosts_9_out <<\ENDSNIP
 ...
-    -=[ teapot ]=-
-
-       _...._
-     .'  _ _ `.
-    | ."` ^ `". _,
-    \_;`"---"`|//
-      |       ;/
-      \_     _/
-        `"""`
+HTTP/2 418
+...
+server: istio-envoy
+...
 ENDSNIP
 
 snip_configure_a_mutual_tls_ingress_gateway_1() {
@@ -499,15 +480,12 @@ curl -v -HHost:httpbin.example.com --resolve "httpbin.example.com:$SECURE_INGRES
 
 ! IFS=$'\n' read -r -d '' snip_configure_a_mutual_tls_ingress_gateway_5_out <<\ENDSNIP
 ...
-    -=[ teapot ]=-
-
-       _...._
-     .'  _ _ `.
-    | ."` ^ `". _,
-    \_;`"---"`|//
-      |       ;/
-      \_     _/
-        `"""`
+HTTP/2 418
+...
+server: istio-envoy
+...
+I'm a teapot!
+...
 ENDSNIP
 
 snip_troubleshooting_1() {


### PR DESCRIPTION
## Description

Backport of https://github.com/istio/istio.io/pull/15744 with only the `httpbin` related test changes to 1.23, from 1.24. Originally I did not backport these separately because I didn't realize 1.23 had gotten the image changes as well.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
