### PR TITLE
[zh] Sync #15847 details about auto_san_validation behavior into Chinese

### DIFF
--- a/content/zh/boilerplates/auto-san-validation.md
+++ b/content/zh/boilerplates/auto-san-validation.md
@@ -1,0 +1,9 @@
+---
+---
+{{< tip >}}
+Istio 默认启用了 `auto_sni` 和 `auto_san_validation`。
+这意味着，只要您的 `DestinationRule` 中没有显式设置 `sni`，
+新上游连接的传输套接字 SNI 将根据下游 HTTP 主机/授权标头进行设置。
+如果在 `sni` 未设置时 `DestinationRule` 中没有设置 `subjectAltNames`，
+则 `auto_san_validation` 将启动，并且新上游连接的上游出示的证书将根据下游 HTTP 主机/授权标头自动验证。
+{{< /tip >}}

--- a/content/zh/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-gateway-tls-origination/index.md
@@ -952,6 +952,8 @@ EOF
 
 {{< /tabset >}}
 
+{{< boilerplate auto-san-validation >}}
+
 5)  验证凭证是否已提供给 Egress 网关并且处于活动状态：
 
 {{< tabset category-name="config-api" >}}

--- a/content/zh/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/egress-tls-origination/index.md
@@ -445,12 +445,16 @@ $ kubectl delete destinationrule edition-cnn-com
           tls:
             mode: MUTUAL
             credentialName: client-credential # 这必须与之前创建的用于保存客户端证书的 Secret 相匹配，并且仅当 DR 具有工作负载选择器时才有效
-            sni: my-nginx.mesh-external.svc.cluster.local # 这是可选的
+            sni: my-nginx.mesh-external.svc.cluster.local
+            # subjectAltNames: # 如果证书是使用 SAN 生成的，则可以启用该功能（如上一节所述）
+            # - my-nginx.mesh-external.svc.cluster.local
     EOF
     {{< /text >}}
 
     上面 `DestinationRule` 将在 80 端口对 HTTP 执行发起 mTLS 请求，
     之后 `ServiceEntry` 将把 80 端口的请求重定向到 443 端口。
+
+    {{< boilerplate auto-san-validation >}}
 
 1.  验证凭据是否已提供给 Sidecar 并且处于活跃状态：
 


### PR DESCRIPTION
## Description

Sync #15847 details about auto_san_validation behavior into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
