### PR TITLE
Add encoding to RSS feed

### DIFF
--- a/layouts/blog/rss.xml
+++ b/layouts/blog/rss.xml
@@ -1,5 +1,5 @@
 {{ $home := .Site.BaseURL | printf "%s%s" (os.Getenv "URL") }}
-
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Istio Blog</title>

--- a/layouts/news/rss.xml
+++ b/layouts/news/rss.xml
@@ -1,5 +1,5 @@
 {{ $home := .Site.BaseURL | printf "%s%s" (os.Getenv "URL") }}
-
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Istio News</title>

--- a/layouts/rss.xml
+++ b/layouts/rss.xml
@@ -1,5 +1,5 @@
 {{ $home := .Site.BaseURL | printf "%s%s" (os.Getenv "URL") }}
-
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Istio Blog and News</title>


### PR DESCRIPTION
Right now, Feedly doesn't like U+2019 RIGHT SINGLE QUOTATION MARK being used as an apostrophe, which I think is down to a UTF-8 file being served as `application+xml` with no encoding specified.  This forces an encoding. 

<img width="941" alt="Screenshot 2024-11-08 at 10 36 18 PM" src="https://github.com/user-attachments/assets/5042fbd9-b8d3-4d86-882e-f5d6ec8c7404">
