### PR TITLE
Fix revision in uninstall previous control plane

### DIFF
--- a/content/en/docs/ambient/upgrade/helm/index.md
+++ b/content/en/docs/ambient/upgrade/helm/index.md
@@ -30,7 +30,7 @@ Like sidecar mode, gateways can make use of [revision tags](/docs/setup/upgrade/
 
 ### Prepare for the upgrade
 
-Before upgrading Istio, we recommend downloading the new version of istioctl, and running `istioctl x precheck` to make sure the upgrade is compatible with your environment. The output should looks something like this:
+Before upgrading Istio, we recommend downloading the new version of istioctl, and running `istioctl x precheck` to make sure the upgrade is compatible with your environment. The output should look something like this:
 
 {{< text syntax=bash snip_id=istioctl_precheck >}}
 $ istioctl x precheck
@@ -214,7 +214,7 @@ $ helm upgrade istio-ingress istio/gateway -n istio-ingress
 If you have upgraded all data plane components to use the new revision of the Istio control plane, and are satisfied that you do not need to roll back, you can remove the previous revision of the control plane by running:
 
 {{< text syntax=bash snip_id=none >}}
-$ helm delete istiod-"$REVISION" -n istio-system
+$ helm delete istiod-"$OLD_REVISION" -n istio-system
 {{< /text >}}
 
 {{< /tab >}}

--- a/content/en/docs/ambient/upgrade/helm/index.md
+++ b/content/en/docs/ambient/upgrade/helm/index.md
@@ -213,7 +213,7 @@ $ helm upgrade istio-ingress istio/gateway -n istio-ingress
 
 If you have upgraded all data plane components to use the new revision of the Istio control plane, and are satisfied that you do not need to roll back, you can remove the previous revision of the control plane by running:
 
-{{< text syntax=bash snip_id=none >}}
+{{< text syntax=bash snip_id=delete_old_revision >}}
 $ helm delete istiod-"$OLD_REVISION" -n istio-system
 {{< /text >}}
 

--- a/content/en/docs/ambient/upgrade/helm/revision_test.sh
+++ b/content/en/docs/ambient/upgrade/helm/revision_test.sh
@@ -48,8 +48,7 @@ _rewrite_helm_repo snip_rollback_tag
 
 # upgrading a tag creates an MWC, let's clean it up 
 export REVISION=istio-1-22-1
-export OLD_REVISION=istio-1-21-2
 helm template istiod istio/istiod -s templates/revision-tags.yaml --set revisionTags="{tagname}" --set revision="$OLD_REVISION" -n istio-system | kubectl delete -f -
-helm delete istiod-"$OLD_REVISION" -n istio-system
 helm delete istiod-"$REVISION" -n istio-system
+snip_delete_old_revision
 _remove_istio_ambient_helm

--- a/content/en/docs/ambient/upgrade/helm/revision_test.sh
+++ b/content/en/docs/ambient/upgrade/helm/revision_test.sh
@@ -48,6 +48,8 @@ _rewrite_helm_repo snip_rollback_tag
 
 # upgrading a tag creates an MWC, let's clean it up 
 export REVISION=istio-1-22-1
+export OLD_REVISION=istio-1-21-2
 helm template istiod istio/istiod -s templates/revision-tags.yaml --set revisionTags="{tagname}" --set revision="$OLD_REVISION" -n istio-system | kubectl delete -f -
 helm delete istiod-"$OLD_REVISION" -n istio-system
+helm delete istiod-"$REVISION" -n istio-system
 _remove_istio_ambient_helm

--- a/content/en/docs/ambient/upgrade/helm/revision_test.sh
+++ b/content/en/docs/ambient/upgrade/helm/revision_test.sh
@@ -49,5 +49,5 @@ _rewrite_helm_repo snip_rollback_tag
 # upgrading a tag creates an MWC, let's clean it up 
 export REVISION=istio-1-22-1
 helm template istiod istio/istiod -s templates/revision-tags.yaml --set revisionTags="{tagname}" --set revision="$OLD_REVISION" -n istio-system | kubectl delete -f -
-helm delete istiod-"$REVISION" -n istio-system
+helm delete istiod-"$OLD_REVISION" -n istio-system
 _remove_istio_ambient_helm

--- a/content/en/docs/ambient/upgrade/helm/snips.sh
+++ b/content/en/docs/ambient/upgrade/helm/snips.sh
@@ -80,3 +80,7 @@ helm template istiod istio/istiod -s templates/revision-tags.yaml --set revision
 snip_upgrade_gateway() {
 helm upgrade istio-ingress istio/gateway -n istio-ingress
 }
+
+snip_delete_old_revision() {
+helm delete istiod-"$OLD_REVISION" -n istio-system
+}

--- a/content/uk/docs/ambient/upgrade/helm/index.md
+++ b/content/uk/docs/ambient/upgrade/helm/index.md
@@ -213,7 +213,7 @@ $ helm upgrade istio-ingress istio/gateway -n istio-ingress
 Якщо ви оновили всі компоненти панелі даних до нової ревізії панелі управління Istio і задоволені тим, що вам не потрібно виконувати відкат, ви можете видалити попередню ревізію панелі управління, виконавши:
 
 {{< text syntax=bash snip_id=none >}}
-$ helm delete istiod-"$REVISION" -n istio-system
+$ helm delete istiod-"$OLD_REVISION" -n istio-system
 {{< /text >}}
 
 {{< /tab >}}

--- a/content/uk/docs/ambient/upgrade/helm/index.md
+++ b/content/uk/docs/ambient/upgrade/helm/index.md
@@ -212,7 +212,7 @@ $ helm upgrade istio-ingress istio/gateway -n istio-ingress
 
 Якщо ви оновили всі компоненти панелі даних до нової ревізії панелі управління Istio і задоволені тим, що вам не потрібно виконувати відкат, ви можете видалити попередню ревізію панелі управління, виконавши:
 
-{{< text syntax=bash snip_id=none >}}
+{{< text syntax=bash snip_id=delete_old_revision >}}
 $ helm delete istiod-"$OLD_REVISION" -n istio-system
 {{< /text >}}
 

--- a/content/zh/docs/ambient/upgrade/helm/index.md
+++ b/content/zh/docs/ambient/upgrade/helm/index.md
@@ -270,7 +270,7 @@ $ helm upgrade istio-ingress istio/gateway -n istio-ingress
 并且认为不需要回滚，则可以通过运行以下命令删除控制平面的先前版本：
 
 {{< text syntax=bash snip_id=none >}}
-$ helm delete istiod-"$REVISION" -n istio-system
+$ helm delete istiod-"$OLD_REVISION" -n istio-system
 {{< /text >}}
 
 {{< /tab >}}

--- a/content/zh/docs/ambient/upgrade/helm/index.md
+++ b/content/zh/docs/ambient/upgrade/helm/index.md
@@ -269,7 +269,7 @@ $ helm upgrade istio-ingress istio/gateway -n istio-ingress
 如果您已升级所有数据平面组件以使用 Istio 控制平面的新版本，
 并且认为不需要回滚，则可以通过运行以下命令删除控制平面的先前版本：
 
-{{< text syntax=bash snip_id=none >}}
+{{< text syntax=bash snip_id=delete_old_revision >}}
 $ helm delete istiod-"$OLD_REVISION" -n istio-system
 {{< /text >}}
 


### PR DESCRIPTION
The upgrade documentation uses references to both `OLD_REVISION` as well as `REVISION`, but as part of "Uninstall the previous control plane" section instead of using "OLD_REVISION", it uses "REVISION". This PR fixes it.
