### PR TITLE
add a remote cluster check step to "verify the installation" multicluster setup docs

### DIFF
--- a/content/en/docs/setup/install/multicluster/common.sh
+++ b/content/en/docs/setup/install/multicluster/common.sh
@@ -102,7 +102,8 @@ function cleanup_cluster2
 function verify_load_balancing
 {
   # Verify istiod is synced
-  snip_verify_multicluster_1
+  echo "Verifying istiod is synced to remote cluster."
+  _verify_like snip_verify_multicluster_1 "$snip_verify_multicluster_1_out"
 
   # Deploy the HelloWorld service.
   snip_deploy_the_helloworld_service_1

--- a/content/en/docs/setup/install/multicluster/common.sh
+++ b/content/en/docs/setup/install/multicluster/common.sh
@@ -101,6 +101,9 @@ function cleanup_cluster2
 # between CLUSTER1 and CLUSTER2.
 function verify_load_balancing
 {
+  # Verify istiod is synced
+  snip_verify_multicluster_1
+
   # Deploy the HelloWorld service.
   snip_deploy_the_helloworld_service_1
   snip_deploy_the_helloworld_service_2

--- a/content/en/docs/setup/install/multicluster/verify/index.md
+++ b/content/en/docs/setup/install/multicluster/verify/index.md
@@ -29,9 +29,9 @@ of the remote cluster.
 
 {{< text bash >}}
 $ istioctl remote-clusters --context="${CTX_CLUSTER1}"
-NAME        SECRET                                  STATUS     ISTIOD
-cluster1                                            synced     istiod-a5jg5df5bd-2dfa9
-cluster2    istio-system/istio-remote-secret-two    synced     istiod-a5jg5df5bd-2dfa9
+NAME        SECRET                              STATUS     ISTIOD
+cluster1                                        synced     istiod-a5jg5df5bd-2dfa9
+cluster2    istio-system/istio-remote-secret    synced     istiod-a5jg5df5bd-2dfa9
 {{< /text >}}
 
 All clusters should indicate their status as `synced`. If a cluster is listed with

--- a/content/en/docs/setup/install/multicluster/verify/index.md
+++ b/content/en/docs/setup/install/multicluster/verify/index.md
@@ -39,7 +39,7 @@ a `STATUS` of `timeout` that means that Istiod in the primary cluster is unable 
 communicate with the remote cluster. See the Istiod logs for detailed error
 messages.
 
-Note: if there is an intermediary host (such as the [Rancher auth proxy](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/authorized-cluster-endpoint#two-authentication-methods-for-rke-clusters))
+Note: if you do see `timeout` issues and there is an intermediary host (such as the [Rancher auth proxy](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/authorized-cluster-endpoint#two-authentication-methods-for-rke-clusters))
 sitting between Istiod in the primary cluster and the Kubernetes control plane in
 the remote cluster, you may need to update the `certificate-authority-data` field
 of the kubeconfig that `istioctl create-remote-secret` generates in order to

--- a/content/en/docs/setup/install/multicluster/verify/index.md
+++ b/content/en/docs/setup/install/multicluster/verify/index.md
@@ -13,14 +13,37 @@ Before proceeding, be sure to complete the steps under
 [before you begin](/docs/setup/install/multicluster/before-you-begin) as well as
 choosing and following one of the multicluster installation guides.
 
-In this guide, we will deploy the `HelloWorld` application `V1` to `cluster1`
-and `V2` to `cluster2`. Upon receiving a request, `HelloWorld` will include
-its version in its response.
+In this guide, we will verify multicluster is functional, deploy the `HelloWorld`
+application `V1` to `cluster1` and `V2` to `cluster2`. Upon receiving a request,
+`HelloWorld` will include its version in its response.
 
 We will also deploy the `curl` container to both clusters. We will use these
 pods as the source of requests to the `HelloWorld` service,
 simulating in-mesh traffic. Finally, after generating traffic, we will observe
 which cluster received the requests.
+
+## Verify Multicluster
+
+To confirm that Istiod is now able to communicate with the Kubernetes control plane
+of the remote cluster.
+
+{{< text bash >}}
+$ istioctl remote-clusters --context="${CTX_CLUSTER1}"
+NAME        SECRET                                  STATUS     ISTIOD
+cluster1                                            synced     istiod-a5jg5df5bd-2dfa9
+cluster2    istio-system/istio-remote-secret-two    synced     istiod-a5jg5df5bd-2dfa9
+{{< /text >}}
+
+All clusters should indicate their status as `synced`. If a cluster is listed with
+a `STATUS` of `timeout` that means that Istiod in the primary cluster is unable to
+communicate with the remote cluster. See the Istiod logs for detailed error
+messages.
+
+Note: if there is an intermediary host (such as the [Rancher auth proxy](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/access-clusters/authorized-cluster-endpoint#two-authentication-methods-for-rke-clusters))
+sitting between Istiod in the primary cluster and the Kubernetes control plane in
+the remote cluster, you may need to update the `certificate-authority-data` field
+of the kubeconfig that `istioctl create-remote-secret` generates in order to
+match the certificate being used by the intermediate host.
 
 ## Deploy the `HelloWorld` Service
 

--- a/content/en/docs/setup/install/multicluster/verify/snips.sh
+++ b/content/en/docs/setup/install/multicluster/verify/snips.sh
@@ -20,6 +20,16 @@
 #          docs/setup/install/multicluster/verify/index.md
 ####################################################################################################
 
+snip_verify_multicluster_1() {
+istioctl remote-clusters --context="${CTX_CLUSTER1}"
+}
+
+! IFS=$'\n' read -r -d '' snip_verify_multicluster_1_out <<\ENDSNIP
+NAME        SECRET                              STATUS     ISTIOD
+cluster1                                        synced     istiod-a5jg5df5bd-2dfa9
+cluster2    istio-system/istio-remote-secret    synced     istiod-a5jg5df5bd-2dfa9
+ENDSNIP
+
 snip_deploy_the_helloworld_service_1() {
 kubectl create --context="${CTX_CLUSTER1}" namespace sample
 kubectl create --context="${CTX_CLUSTER2}" namespace sample


### PR DESCRIPTION
## Description

Add a step to the [verify the installation](https://istio.io/latest/docs/setup/install/multicluster/verify/) multicluster setup docs for executing `istioctl remote clusters`, and some notes about interpreting the results.

Fixes #15911 

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
