### PR TITLE
remove reference to MetalLB in Kind related Docs

### DIFF
--- a/content/en/docs/setup/platform-setup/kind/index.md
+++ b/content/en/docs/setup/platform-setup/kind/index.md
@@ -68,7 +68,7 @@ Follow these instructions to prepare a kind cluster for Istio installation.
     Deleting cluster "istio-testing" ...
     {{< /text >}}
 
-## Setup MetalLB for kind
+## Setup LoadBalancer for kind
 
 kind does not have any built-in way to provide IP addresses to your `Loadbalancer` service types, to ensure IP address assignments to `Gateway` Services please consult [this guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) for more information.
 

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/index.md
@@ -213,7 +213,7 @@ in some environments (e.g., test) you may need to do the following:
     $ minikube tunnel
     {{< /text >}}
 
-* `kind` - follow the [guide for setting up MetalLB](https://kind.sigs.k8s.io/docs/user/loadbalancer/) to get `LoadBalancer` type services to work.
+* `kind` - follow the [guide](https://kind.sigs.k8s.io/docs/user/loadbalancer/) to get `LoadBalancer` type services to work.
 
 * other platforms - you may be able to use [MetalLB](https://metallb.universe.tf/installation/) to get an `EXTERNAL-IP` for `LoadBalancer` services.
 


### PR DESCRIPTION
## Description

Here we link to Kind docs and expect `Kind` uses `MetalLB` to support `LoadBalancer` service. Kind seems to have moved on to use `cloud-provider-kind`. This fix avoids confusion.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
