### PR TITLE
update ttl for proxy dns resolution

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/dns/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns/index.md
@@ -58,7 +58,7 @@ a static list of IPs or by doing its own DNS resolution (potentially of the same
 Unlike most clients, which will do DNS requests on demand at the time of requests (and then typically cache the results),
 the Istio proxy never does synchronous DNS requests.
 When a `resolution: DNS` type `ServiceEntry` is configured, the proxy will periodically resolve the configured hostnames and use those for all requests.
-This interval is set to the 30s and cannot be changed.
+This interval is set to 30s and cannot currently be changed.
 This happens even if the proxy never sends any requests to these applications.
 
 For meshes with many proxies or many `resolution: DNS` type `ServiceEntries`, especially when low `TTL`s are used, this may cause a high load on DNS servers.

--- a/content/en/docs/ops/configuration/traffic-management/dns/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns/index.md
@@ -58,7 +58,7 @@ a static list of IPs or by doing its own DNS resolution (potentially of the same
 Unlike most clients, which will do DNS requests on demand at the time of requests (and then typically cache the results),
 the Istio proxy never does synchronous DNS requests.
 When a `resolution: DNS` type `ServiceEntry` is configured, the proxy will periodically resolve the configured hostnames and use those for all requests.
-This interval is set to 30s and cannot currently be changed.
+This interval is fixed at 30 seconds and cannot be changed at this time.
 This happens even if the proxy never sends any requests to these applications.
 
 For meshes with many proxies or many `resolution: DNS` type `ServiceEntries`, especially when low `TTL`s are used, this may cause a high load on DNS servers.

--- a/content/en/docs/ops/configuration/traffic-management/dns/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns/index.md
@@ -58,7 +58,7 @@ a static list of IPs or by doing its own DNS resolution (potentially of the same
 Unlike most clients, which will do DNS requests on demand at the time of requests (and then typically cache the results),
 the Istio proxy never does synchronous DNS requests.
 When a `resolution: DNS` type `ServiceEntry` is configured, the proxy will periodically resolve the configured hostnames and use those for all requests.
-This interval is determined by the [TTL](https://en.wikipedia.org/wiki/Time_to_live#DNS_records) of the DNS response.
+This interval is set to the 30s and cannot be changed.
 This happens even if the proxy never sends any requests to these applications.
 
 For meshes with many proxies or many `resolution: DNS` type `ServiceEntries`, especially when low `TTL`s are used, this may cause a high load on DNS servers.


### PR DESCRIPTION
## Description

The [default TTL](https://github.com/istio/istio/blob/master/pkg/dns/client/dns.go#L87) for proxy DNS resolution is constant at 30 seconds. Update the documentation to reflect this and avoid misinterpretation

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
