### PR TITLE
Removing deprecated `istioctl verify-install` from "Getting Started" with ambient

### DIFF
--- a/content/en/docs/ambient/getting-started/_index.md
+++ b/content/en/docs/ambient/getting-started/_index.md
@@ -51,10 +51,6 @@ It might take a minute for the Istio components to be installed. Once the instal
 ✔ Installation complete
 {{< /text >}}
 
-{{< tip >}}
-You can verify the installed components using the command `kubectl get all -n istio-system`.
-{{< /tip >}}
-
 ## Install the Kubernetes Gateway API CRDs
 
 {{< boilerplate gateway-api-install-crds >}}

--- a/content/en/docs/ambient/getting-started/_index.md
+++ b/content/en/docs/ambient/getting-started/_index.md
@@ -52,7 +52,7 @@ It might take a minute for the Istio components to be installed. Once the instal
 {{< /text >}}
 
 {{< tip >}}
-You can verify the installed components using the command `istioctl verify-install`.
+You can verify the installed components using the command `kubectl get all -n istio-system`.
 {{< /tip >}}
 
 ## Install the Kubernetes Gateway API CRDs


### PR DESCRIPTION
## Description

This PR removes a reference to the deprecated command `istioctl verify-install`. It uses a `kubectl` check instead.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [X] Ambient
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
