### PR TITLE
[Doc] Fix kubectl command namespace selections

### DIFF
--- a/content/en/docs/setup/install/multiple-controlplanes/index.md
+++ b/content/en/docs/setup/install/multiple-controlplanes/index.md
@@ -113,7 +113,7 @@ Istio revisions and `discoverySelectors` are then used to scope the resources an
 1. Check the labels on the system namespaces for each control plane:
 
     {{< text bash >}}
-    $ kubectl get ns usergroup-1 usergroup2 --show-labels
+    $ kubectl get ns usergroup-1 usergroup-2 --show-labels
     NAME              STATUS   AGE     LABELS
     usergroup-1       Active   13m     kubernetes.io/metadata.name=usergroup-1,usergroup=usergroup-1
     usergroup-2       Active   12m     kubernetes.io/metadata.name=usergroup-2,usergroup=usergroup-2

--- a/content/en/docs/setup/install/multiple-controlplanes/snips.sh
+++ b/content/en/docs/setup/install/multiple-controlplanes/snips.sh
@@ -89,7 +89,7 @@ EOF
 }
 
 snip_verify_the_multiple_control_plane_creation_1() {
-kubectl get ns usergroup-1 usergroup2 --show-labels
+kubectl get ns usergroup-1 usergroup-2 --show-labels
 }
 
 ! IFS=$'\n' read -r -d '' snip_verify_the_multiple_control_plane_creation_1_out <<\ENDSNIP

--- a/content/zh/docs/setup/install/multiple-controlplanes/index.md
+++ b/content/zh/docs/setup/install/multiple-controlplanes/index.md
@@ -119,7 +119,7 @@ Istio 修订和 `discoverySelectors` 然后用于确定每个控制面托管的�
 1. 查看每个控制面的系统命名空间上的标签：
 
     {{< text bash >}}
-    $ kubectl get ns usergroup-1 usergroup2 --show-labels
+    $ kubectl get ns usergroup-1 usergroup-2 --show-labels
     NAME              STATUS   AGE     LABELS
     usergroup-1       Active   13m     kubernetes.io/metadata.name=usergroup-1,usergroup=usergroup-1
     usergroup-2       Active   12m     kubernetes.io/metadata.name=usergroup-2,usergroup=usergroup-2


### PR DESCRIPTION
## Description

Hi Istio Community, when I try to follow the documentation about [multiple controlplane in single cluster](https://istio.io/latest/docs/setup/install/multiple-controlplanes/), I believe below command has some [error](https://istio.io/latest/docs/setup/install/multiple-controlplanes/#:~:text=kubectl%20get%20ns%20usergroup%2D1%20usergroup2%20%2D%2Dshow%2Dlabels)
```bash
kubectl get ns usergroup-1 usergroup2 --show-labels
```
It should be namespace of `usergroup-2` because that is the namespace created previously, I realize that this error also happen in chinese language, so I modified the english and chinese version. 

![image](https://github.com/user-attachments/assets/fa77d8dd-b342-460c-97f4-33a17e62bd90)

Extra Note: I able to assist to modify the [test script](https://github.com/istio/istio.io/blob/baf2a3da9d3a283fb15df0289914edd3c1e675e8/content/en/docs/setup/install/multiple-controlplanes/snips.sh#L92C1-L93C1) if this is identify as mistake.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
