### PR TITLE
Make compat version support more explicit

### DIFF
--- a/content/en/docs/setup/additional-setup/compatibility-versions/index.md
+++ b/content/en/docs/setup/additional-setup/compatibility-versions/index.md
@@ -42,7 +42,7 @@ $ helm install ... --set compatibilityVersion={{< istio_previous_version >}}
 
 Compatibility versions should be used only when an incompatibility between releases exists, as a temporary measure. You should plan to migrate to the new behavior as soon as practical.
 
-Compatibility versions for a release will be removed, and will no longer be supported, when the release they refer to reaches end-of-life. Refer to the [current Istio release support status chart](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) for the status of specific releases.
+Compatibility versions for a release will be removed, and will no longer be supported, when the release they refer to reaches end-of-life. Refer to the [current Istio release support status chart](/docs/releases/supported-releases/#support-status-of-istio-releases) for the status of specific releases.
 
 To help detect if a compatibility version should be used, `istioctl x precheck` can be used with the `--from-version` flag.
 For instance, if you are upgrading from version {{< istio_previous_version >}}:

--- a/content/en/docs/setup/additional-setup/compatibility-versions/index.md
+++ b/content/en/docs/setup/additional-setup/compatibility-versions/index.md
@@ -40,9 +40,9 @@ $ helm install ... --set compatibilityVersion={{< istio_previous_version >}}
 
 ## When should I use compatibility versions?
 
-Compatibility versions should be used only when an incompatibility between releases exists, as a temporary measure. Eventually, you will need to migrate to the new behavior.
+Compatibility versions should be used only when an incompatibility between releases exists, as a temporary measure. You should plan to migrate to the new behavior as soon as practical.
 
-Compatibility versions for a release will be removed and will no longer be supported when the release they refer to reaches end-of-life. Refer to the [https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases](current Istio release support status chart for the status of specific releases).
+Compatibility versions for a release will be removed, and will no longer be supported, when the release they refer to reaches end-of-life. Refer to the [current Istio release support status chart](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) for the status of specific releases.
 
 To help detect if a compatibility version should be used, `istioctl x precheck` can be used with the `--from-version` flag.
 For instance, if you are upgrading from version {{< istio_previous_version >}}:

--- a/content/en/docs/setup/additional-setup/compatibility-versions/index.md
+++ b/content/en/docs/setup/additional-setup/compatibility-versions/index.md
@@ -40,9 +40,9 @@ $ helm install ... --set compatibilityVersion={{< istio_previous_version >}}
 
 ## When should I use compatibility versions?
 
-Compatibility versions are recommended to be used only when an incompatibility is found, rather than as the default.
-Each compatibility version will only persist for a few releases, so eventually you will need to migrate to the new behavior.
-Currently, each compatibility version is intended to remain for at least two versions, though this is subject to change.
+Compatibility versions should be used only when an incompatibility between releases exists, as a temporary measure. Eventually, you will need to migrate to the new behavior.
+
+Compatibility versions for a release will be removed and will no longer be supported when the release they refer to reaches end-of-life. Refer to the [https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases](current Istio release support status chart for the status of specific releases).
 
 To help detect if a compatibility version should be used, `istioctl x precheck` can be used with the `--from-version` flag.
 For instance, if you are upgrading from version {{< istio_previous_version >}}:


### PR DESCRIPTION
## Description
Explicitly say we don't sign up to support compat profiles for releases that are EOL'd/out of the support window.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
