### PR TITLE
Move Blog Year Buttons to Grid Layout

### DIFF
--- a/src/sass/misc/_blog.scss
+++ b/src/sass/misc/_blog.scss
@@ -29,20 +29,17 @@
     }
 
     .year-buttons {
-        display: flex;
-        overflow: auto;
-        white-space: nowrap;
-        @media (min-width: $bp-xl) {
-            white-space: normal;
-            overflow: unset;
-            justify-content: center;
+        display: grid;
+        grid-template-columns: repeat(1, 1fr);
+        @media (min-width: $bp-md) {
+            grid-template-columns: repeat(4, 1fr);
         }
 
         .year-button {
             padding: .5em 3.5em;
             min-width: 168px;
             height: 36px;
-            margin: 2.5em .5em 3.75em;
+            margin: 1.0em;
             border-radius: 28px;
             border: solid 2px $inputBorderColor;
             background-color: #fff;
@@ -51,8 +48,6 @@
             letter-spacing: normal;
             color: $linkActiveColor;
             @media (min-width: $bp-md) {
-                margin: 2.5em 1.15em 3.75em 0;
-
                 &:hover {
                     outline: 0;
                     -webkit-box-shadow: 2px 2px 15px 0 rgba(101, 126, 186, 1);
@@ -60,7 +55,9 @@
                     box-shadow: 2px 2px 15px 0 rgba(101, 126, 186, 1);
                 }
             }
-
+            &:hover {
+                cursor: pointer
+            }
         }
 
         .active {

--- a/src/sass/misc/_blog.scss
+++ b/src/sass/misc/_blog.scss
@@ -30,14 +30,12 @@
 
     .year-buttons {
         display: grid;
-        grid-template-columns: repeat(1, 1fr);
+        grid-template-columns: repeat(2, 1fr);
         @media (min-width: $bp-md) {
             grid-template-columns: repeat(4, 1fr);
         }
 
         .year-button {
-            padding: .5em 3.5em;
-            min-width: 168px;
             height: 36px;
             margin: 1em;
             border-radius: 28px;
@@ -48,6 +46,8 @@
             letter-spacing: normal;
             color: $linkActiveColor;
             @media (min-width: $bp-md) {
+                min-width: 168px;
+                padding: .5em 3.5em;
                 &:hover {
                     outline: 0;
                     -webkit-box-shadow: 2px 2px 15px 0 rgba(101, 126, 186, 1);

--- a/src/sass/misc/_blog.scss
+++ b/src/sass/misc/_blog.scss
@@ -29,30 +29,33 @@
     }
 
     .year-buttons {
-        display: grid;
-        grid-template-columns: repeat(2, 1fr);
-        @media (min-width: $bp-md) {
-            grid-template-columns: repeat(4, 1fr);
-        }
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
 
         .year-button {
-            margin: 1em;
-            border-radius: 28px;
-            border: solid 2px $inputBorderColor;
             background-color: #fff;
-            font-weight: $boldTextWeight;
-            line-height: 1.5;
-            letter-spacing: normal;
+            border: solid 2px $inputBorderColor;
+            border-radius: 28px;
             color: $linkActiveColor;
+            font-weight: $boldTextWeight;
+            letter-spacing: normal;
+            line-height: 1.5;
+            margin-top: 1em;
+            margin-right: 1em;
+            margin-bottom: 1em;
+            padding: .5em 1.5em;
+
             @media (min-width: $bp-md) {
                 min-width: 168px;
                 padding: .5em 3.5em;
 
                 &:hover {
-                    outline: 0;
+                    box-shadow: 2px 2px 15px 0 rgba(101, 126, 186, 1);
                     -webkit-box-shadow: 2px 2px 15px 0 rgba(101, 126, 186, 1);
                     -moz-box-shadow: 2px 2px 15px 0 rgba(101, 126, 186, 1);
-                    box-shadow: 2px 2px 15px 0 rgba(101, 126, 186, 1);
+                    outline: 0;
                 }
             }
 

--- a/src/sass/misc/_blog.scss
+++ b/src/sass/misc/_blog.scss
@@ -47,7 +47,7 @@
             @media (min-width: $bp-md) {
                 min-width: 168px;
                 padding: .5em 3.5em;
-                
+
                 &:hover {
                     outline: 0;
                     -webkit-box-shadow: 2px 2px 15px 0 rgba(101, 126, 186, 1);

--- a/src/sass/misc/_blog.scss
+++ b/src/sass/misc/_blog.scss
@@ -36,7 +36,6 @@
         }
 
         .year-button {
-            height: 36px;
             margin: 1em;
             border-radius: 28px;
             border: solid 2px $inputBorderColor;
@@ -48,6 +47,7 @@
             @media (min-width: $bp-md) {
                 min-width: 168px;
                 padding: .5em 3.5em;
+                
                 &:hover {
                     outline: 0;
                     -webkit-box-shadow: 2px 2px 15px 0 rgba(101, 126, 186, 1);

--- a/src/sass/misc/_blog.scss
+++ b/src/sass/misc/_blog.scss
@@ -39,7 +39,7 @@
             padding: .5em 3.5em;
             min-width: 168px;
             height: 36px;
-            margin: 1.0em;
+            margin: 1em;
             border-radius: 28px;
             border: solid 2px $inputBorderColor;
             background-color: #fff;
@@ -55,8 +55,9 @@
                     box-shadow: 2px 2px 15px 0 rgba(101, 126, 186, 1);
                 }
             }
+
             &:hover {
-                cursor: pointer
+                cursor: pointer;
             }
         }
 

--- a/src/sass/misc/_blog.scss
+++ b/src/sass/misc/_blog.scss
@@ -42,13 +42,12 @@
             font-weight: $boldTextWeight;
             letter-spacing: normal;
             line-height: 1.5;
-            margin-top: 1em;
-            margin-right: 1em;
-            margin-bottom: 1em;
+            margin: 1em .5em;
+            min-width: 5rem;
             padding: .5em 1.5em;
 
             @media (min-width: $bp-md) {
-                min-width: 168px;
+                min-width: 10rem;
                 padding: .5em 3.5em;
 
                 &:hover {


### PR DESCRIPTION
## Description

Fixes: https://github.com/istio/istio.io/issues/16012

This PR:

- Moves the year buttons on https://istio.io/latest/blog/ to a flex layout that allows for wrapping.
- Remove the overflow support and instead use an `@media` query to adjust button sizing.
- Reduces the spacing between the year buttons.
- Change the cursor to the hover cursor type when a person hovers on the year buttons.


## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
