### PR TITLE
[zh] Sync #16045 fix typo in OpenShift pre-requisites for ambient into Chinese

### DIFF
--- a/content/zh/docs/ambient/install/platform-prerequisites/index.md
+++ b/content/zh/docs/ambient/install/platform-prerequisites/index.md
@@ -236,7 +236,7 @@ OpenShift 要求在 `kube-system` 命名空间中安装 `ztunnel` 和 `istio-cni
     此外，必须在 `kube-system` 命名空间中安装 `istio-cni` 和 `ztunnel`，例如：
 
     {{< text syntax=bash >}}
-    $ helm install istio-cni istio/istio-cni -n kube-system --set profile=ambient --set global.platform=openshift --wait
+    $ helm install istio-cni istio/cni -n kube-system --set profile=ambient --set global.platform=openshift --wait
     $ helm install ztunnel istio/ztunnel -n kube-system --set profile=ambient --set global.platform=openshift --wait
     {{< /text >}}
 


### PR DESCRIPTION

## Description

Sync #16045 fix typo in OpenShift pre-requisites for ambient into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
