### PR TITLE
Using the `openshift` profile is deprecated in favor of setting the platform

### DIFF
--- a/content/en/docs/setup/platform-setup/openshift/index.md
+++ b/content/en/docs/setup/platform-setup/openshift/index.md
@@ -13,10 +13,10 @@ test: no
 
 Follow these instructions to prepare an OpenShift cluster for Istio.
 
-Install Istio using the OpenShift profile:
+Install Istio using the OpenShift platform profile:
 
 {{< text bash >}}
-$ istioctl install --set profile=openshift
+$ istioctl install --set values.global.platform=openshift
 {{< /text >}}
 
 After installation is complete, expose an OpenShift route for the ingress gateway.

--- a/content/uk/docs/setup/platform-setup/openshift/index.md
+++ b/content/uk/docs/setup/platform-setup/openshift/index.md
@@ -16,7 +16,7 @@ test: no
 Встановіть Istio, використовуючи профіль OpenShift:
 
 {{< text bash >}}
-$ istioctl install --set profile=openshift
+$ istioctl install --set values.global.platform=openshift
 {{< /text >}}
 
 Після завершення встановлення, створіть маршрут OpenShift для ingress gateway:

--- a/content/zh/docs/setup/platform-setup/openshift/index.md
+++ b/content/zh/docs/setup/platform-setup/openshift/index.md
@@ -16,7 +16,7 @@ test: no
 使用 OpenShift 配置文件进行安装 Istio：
 
 {{< text bash >}}
-$ istioctl install --set profile=openshift
+$ istioctl install --set values.global.platform=openshift
 {{< /text >}}
 
 安装 Istio 完成后，通过以下命令为 Ingress Gateway 暴露 OpenShift 路由：


### PR DESCRIPTION
Openshift is a platform, not a profile. This is important because we want people to be able to specifiy platform and profile independently (e.g. `--set values.global.platform=gke --set values.global.profile=ambient`), and also want to share the same profiles and platforms between `istioctl` and `helm`.

Fixup for https://github.com/istio/istio.io/pull/16049



## Description

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
