### PR TITLE
Explicitly document how to template manifests with both `helm` and `istioctl` and remove references to `istioctl manifest diff`

### DIFF
--- a/content/en/about/faq/setup/install-method-selection.md
+++ b/content/en/about/faq/setup/install-method-selection.md
@@ -37,7 +37,7 @@ The following lists some of the pros and cons of each of the available methods:
     - Fewer checks and validations compared to `istioctl install`.
     - Some administrative tasks require more steps and have higher complexity.
 
-1. Generated Kubernetes manifest
+1. Apply a generated Kubernetes manifest
 
     - [Generating Kubernetes manifests with `istioctl`](/docs/setup/install/istioctl/#generate-a-manifest-before-installation)
     - [Generating Kubernetes manifests with `helm`](/docs/setup/install/helm/#generate-a-manifest-before-installation)

--- a/content/en/about/faq/setup/install-method-selection.md
+++ b/content/en/about/faq/setup/install-method-selection.md
@@ -23,22 +23,6 @@ The following lists some of the pros and cons of each of the available methods:
     - The `istioctl` command can set values automatically based on your running environment,
       thereby producing varying installations in different Kubernetes environments.
 
-1. [istioctl manifest generate](/docs/setup/install/istioctl/#generate-a-manifest-before-installation)
-
-    Generate the Kubernetes manifest and then apply with `kubectl apply --prune`.
-    This method is suitable where strict auditing or augmentation of output manifests is needed.
-
-    Pros:
-
-    - Resources are generated from the same `IstioOperator` API as used in `istioctl install`.
-    - Uses the `IstioOperator` API which provides extensive configuration/customization options.
-
-    Cons:
-
-    - Some checks performed in `istioctl install` are not done.
-    - UX is less streamlined compared to `istioctl install`.
-    - Error reporting is not as robust as `istioctl install` for the apply step.
-
 1. [Install using Helm](/docs/setup/install/helm/)
 
     Using Helm charts allows easy integration with Helm based workflows and automated resource pruning during upgrades.
@@ -52,5 +36,25 @@ The following lists some of the pros and cons of each of the available methods:
 
     - Fewer checks and validations compared to `istioctl install`.
     - Some administrative tasks require more steps and have higher complexity.
+
+1. Pregenerated Kubernetes manifest
+
+    - [Pregenerating Kubernetes manifests with `istioctl`](/docs/setup/install/istioctl/#generate-a-manifest-before-installation)
+    - [Pregenerating Kubernetes manifests with `helm`](/docs/setup/install/helm/#generate-a-manifest-before-installation)
+
+    This method is suitable where strict auditing or augmentation of output manifests is required, or there are 3rd party tooling constraints.
+
+    Pros:
+
+    - Easier to integrate with tooling that doesn't use `helm` or `istioctl`.
+    - No installation tools required other than `kubectl`.
+
+    Cons:
+
+    - No install-time checks, environment detection, or validations supported by either of the above methods are performed.
+    - No installation management or upgrade capability is supported.
+    - UX is less streamlined.
+    - Error reporting duirng installation is not as robust.
+
 
 Installation instructions for all of these methods are available on the [Istio install page](/docs/setup/install).

--- a/content/en/about/faq/setup/install-method-selection.md
+++ b/content/en/about/faq/setup/install-method-selection.md
@@ -37,10 +37,10 @@ The following lists some of the pros and cons of each of the available methods:
     - Fewer checks and validations compared to `istioctl install`.
     - Some administrative tasks require more steps and have higher complexity.
 
-1. Pregenerated Kubernetes manifest
+1. Generated Kubernetes manifest
 
-    - [Pregenerating Kubernetes manifests with `istioctl`](/docs/setup/install/istioctl/#generate-a-manifest-before-installation)
-    - [Pregenerating Kubernetes manifests with `helm`](/docs/setup/install/helm/#generate-a-manifest-before-installation)
+    - [Generating Kubernetes manifests with `istioctl`](/docs/setup/install/istioctl/#generate-a-manifest-before-installation)
+    - [Generating Kubernetes manifests with `helm`](/docs/setup/install/helm/#generate-a-manifest-before-installation)
 
     This method is suitable where strict auditing or augmentation of output manifests is required, or there are 3rd party tooling constraints.
 
@@ -54,7 +54,6 @@ The following lists some of the pros and cons of each of the available methods:
     - No install-time checks, environment detection, or validations supported by either of the above methods are performed.
     - No installation management or upgrade capability is supported.
     - UX is less streamlined.
-    - Error reporting duirng installation is not as robust.
-
+    - Error reporting during installation is not as robust.
 
 Installation instructions for all of these methods are available on the [Istio install page](/docs/setup/install).

--- a/content/en/about/faq/setup/install-method-selection.md
+++ b/content/en/about/faq/setup/install-method-selection.md
@@ -42,7 +42,7 @@ The following lists some of the pros and cons of each of the available methods:
     - [Generating Kubernetes manifests with `istioctl`](/docs/setup/install/istioctl/#generate-a-manifest-before-installation)
     - [Generating Kubernetes manifests with `helm`](/docs/setup/install/helm/#generate-a-manifest-before-installation)
 
-    This method is suitable where strict auditing or augmentation of output manifests is required, or there are 3rd party tooling constraints.
+    This method is suitable where strict auditing or augmentation of output manifests is required, or there are third-party tooling constraints.
 
     Pros:
 

--- a/content/en/about/faq/setup/install-method-selection.md
+++ b/content/en/about/faq/setup/install-method-selection.md
@@ -25,7 +25,7 @@ The following lists some of the pros and cons of each of the available methods:
 
 1. [Install using Helm](/docs/setup/install/helm/)
 
-    Using Helm charts allows easy integration with Helm based workflows and automated resource pruning during upgrades.
+    Allows easy integration with Helm-based workflows and automated resource pruning during upgrades.
 
     Pros:
 

--- a/content/en/docs/ambient/install/helm/index.md
+++ b/content/en/docs/ambient/install/helm/index.md
@@ -199,3 +199,49 @@ installed above.
     {{< text syntax=bash snip_id=delete_system_namespace >}}
     $ kubectl delete namespace istio-system
     {{< /text >}}
+
+## Generate a manifest before installation
+
+You can generate the manifests for each component before installing Istio using the `helm template`
+sub-command.
+For example, to generate a manifest that can be installed with `kubectl` for the `istiod` component:
+
+{{< text syntax=bash snip_id=none >}}
+$ helm template istiod istio/istiod -n istio-system --kube-version {Kubernetes version of target cluster} > istiod.yaml
+{{< /text >}}
+
+The generated manifest can be used to inspect what exactly is installed as well as to track changes to the manifest over time.
+
+{{< tip >}}
+Any additional flags or custom values overrides you would normally use for installation should also be supplied to the `helm template` command.
+{{< /tip >}}
+
+To install the manifest generated above, which will create the `istiod` component in the target cluster:
+
+{{< text syntax=bash snip_id=none >}}
+$ kubectl apply -f istiod.yaml
+{{< /text >}}
+
+{{< warning >}}
+If attempting to install and manage Istio using `helm template`, please note the following caveats:
+
+1. The Istio namespace (`istio-system` by default) must be created manually.
+
+1. Resources may not be installed with the same sequencing of dependencies as
+`helm install`
+
+1. This method is not tested as part of Istio releases.
+
+1. While `helm install` will automatically detect environment specific settings from your Kubernetes context,
+`helm template` cannot as it runs offline, which may lead to unexpected results. In particular, you must ensure
+that you follow [these steps](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) if your
+Kubernetes environment does not support third party service account tokens.
+
+1. `kubectl apply` of the generated manifest may show transient errors due to resources not being available in the
+cluster in the correct order.
+
+1. `helm install` automatically prunes any resources that should be removed when the configuration changes (e.g.
+if you remove a gateway). This does not happen when you use `helm template` with `kubectl`, and these
+resources must be removed manually.
+
+{{< /warning >}}

--- a/content/en/docs/ambient/install/istioctl/index.md
+++ b/content/en/docs/ambient/install/istioctl/index.md
@@ -88,7 +88,7 @@ You can generate the manifest before installing Istio using the `manifest genera
 sub-command.
 For example, use the following command to generate a manifest for the `default` profile that can be installed with `kubectl`:
 
-{{< text bash >}}
+{{< text syntax=bash snip_id=none >}}
 $ istioctl manifest generate > $HOME/generated-manifest.yaml
 {{< /text >}}
 
@@ -106,7 +106,7 @@ If attempting to install and manage Istio using `istioctl manifest generate`, pl
 1. Istio validation will not be enabled by default. Unlike `istioctl install`, the `manifest generate` command will
 not create the `istiod-default-validator` validating webhook configuration unless `values.defaultRevision` is set:
 
-    {{< text bash >}}
+    {{< text syntax=bash snip_id=none >}}
     $ istioctl manifest generate --set values.defaultRevision=default
     {{< /text >}}
 

--- a/content/en/docs/ambient/install/istioctl/index.md
+++ b/content/en/docs/ambient/install/istioctl/index.md
@@ -81,3 +81,50 @@ If no longer needed, use the following command to remove it:
 {{< text syntax=bash snip_id=remove_namespace >}}
 $ kubectl delete namespace istio-system
 {{< /text >}}
+
+## Generate a manifest before installation
+
+You can generate the manifest before installing Istio using the `manifest generate`
+sub-command.
+For example, use the following command to generate a manifest for the `default` profile that can be installed with `kubectl`:
+
+{{< text bash >}}
+$ istioctl manifest generate > $HOME/generated-manifest.yaml
+{{< /text >}}
+
+The generated manifest can be used to inspect what exactly is installed as well as to track changes to the manifest over time. While the `IstioOperator` CR represents the full user configuration and is sufficient for tracking it, the output from `manifest generate` also captures possible changes in the underlying charts and therefore can be used to track the actual installed resources.
+
+{{< tip >}}
+Any additional flags or custom values overrides you would normally use for installation should also be supplied to the `istioctl manifest generate` command.
+{{< /tip >}}
+
+{{< warning >}}
+If attempting to install and manage Istio using `istioctl manifest generate`, please note the following caveats:
+
+1. The Istio namespace (`istio-system` by default) must be created manually.
+
+1. Istio validation will not be enabled by default. Unlike `istioctl install`, the `manifest generate` command will
+not create the `istiod-default-validator` validating webhook configuration unless `values.defaultRevision` is set:
+
+    {{< text bash >}}
+    $ istioctl manifest generate --set values.defaultRevision=default
+    {{< /text >}}
+
+1. Resources may not be installed with the same sequencing of dependencies as
+`istioctl install`.
+
+1. This method is not tested as part of Istio releases.
+
+1. While `istioctl install` will automatically detect environment specific settings from your Kubernetes context,
+`manifest generate` cannot as it runs offline, which may lead to unexpected results. In particular, you must ensure
+that you follow [these steps](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) if your
+Kubernetes environment does not support third party service account tokens. It is recommended to append `--cluster-specific` to your `istio manifest generate` command to detect the target cluster's environment, which will embed those cluster-specific environment settings into the generated manifests. This requires network access to your running cluster.
+
+1. `kubectl apply` of the generated manifest may show transient errors due to resources not being available in the
+cluster in the correct order.
+
+1. `istioctl install` automatically prunes any resources that should be removed when the configuration changes (e.g.
+if you remove a gateway). This does not happen when you use `istio manifest generate` with `kubectl` and these
+resources must be removed manually.
+
+{{< /warning >}}

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -238,7 +238,7 @@ $ helm template istiod istio/istiod -n istio-system --kube-version <Kubernetes v
 
 The generated manifest can be used to inspect what exactly is installed as well as to track changes to the manifest over time. Note that any additional flags or values overrides you would normally use for installation should also be supplied to the `helm template` command.
 
-The following can be used to install the manifest generated above, which will create the `istiod` component in the target cluster:
+To install the manifest generated above, which will create the `istiod` component in the target cluster:
 
 {{< text syntax=bash snip_id=none >}}
 $ kubectl apply -f istiod.yaml

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -233,7 +233,7 @@ sub-command.
 For example, to generate a manifest that can be installed with `kubectl` for the `istiod` component:
 
 {{< text syntax=bash snip_id=none >}}
-$ helm template istiod istio/istiod -n istio-system --kube-version <Kubernetes version of target cluster> > istiod.yaml
+$ helm template istiod istio/istiod -n istio-system --kube-version {Kubernetes version of target cluster} > istiod.yaml
 {{< /text >}}
 
 The generated manifest can be used to inspect what exactly is installed as well as to track changes to the manifest over time.

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -236,7 +236,11 @@ For example, to generate a manifest that can be installed with `kubectl` for the
 $ helm template istiod istio/istiod -n istio-system --kube-version <Kubernetes version of target cluster> > istiod.yaml
 {{< /text >}}
 
-The generated manifest can be used to inspect what exactly is installed as well as to track changes to the manifest over time. Note that any additional flags or values overrides you would normally use for installation should also be supplied to the `helm template` command.
+The generated manifest can be used to inspect what exactly is installed as well as to track changes to the manifest over time.
+
+{{< tip >}}
+Any additional flags or custom values overrides you would normally use for installation should also be supplied to the `helm template` command.
+{{< /tip >}}
 
 To install the manifest generated above, which will create the `istiod` component in the target cluster:
 
@@ -244,12 +248,13 @@ To install the manifest generated above, which will create the `istiod` componen
 $ kubectl apply -f istiod.yaml
 {{< /text >}}
 
-Note that this alternative installation method may not apply the resources with the same sequencing of dependencies as `helm install` and is not tested as part of Istio releases.
-
 {{< warning >}}
 If attempting to install and manage Istio using `helm template`, please note the following caveats:
 
 1. The Istio namespace (`istio-system` by default) must be created manually.
+
+1. Resources may not be installed with the same sequencing of dependencies as
+`helm install` and is not tested as part of Istio releases.
 
 1. While `helm install` will automatically detect environment specific settings from your Kubernetes context,
 `helm template` cannot as it runs offline, which may lead to unexpected results. In particular, you must ensure

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -230,7 +230,7 @@ $ kubectl get crd -oname | grep --color=never 'istio.io' | xargs kubectl delete
 
 You can generate the manifests for each component before installing Istio using the `helm template`
 sub-command.
-For example, use the following command to generate a `kubectl`-installable manifest for the `istiod` component:
+For example, use the following command to generate a manifest that can be installed with `kubectl` for the `istiod` component:
 
 {{< text syntax=bash snip_id=none >}}
 $ helm template istiod istio/istiod -n istio-system --kube-version <Kubernetes version of target cluster> > istiod.yaml

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -254,7 +254,9 @@ If attempting to install and manage Istio using `helm template`, please note the
 1. The Istio namespace (`istio-system` by default) must be created manually.
 
 1. Resources may not be installed with the same sequencing of dependencies as
-`helm install` and is not tested as part of Istio releases.
+`helm install`
+
+1. This method is not tested as part of Istio releases.
 
 1. While `helm install` will automatically detect environment specific settings from your Kubernetes context,
 `helm template` cannot as it runs offline, which may lead to unexpected results. In particular, you must ensure

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -244,7 +244,7 @@ To install the manifest generated above, which will create the `istiod` componen
 $ kubectl apply -f istiod.yaml
 {{< /text >}}
 
-Note that this alternative installation method may not apply the resources with the same sequencing of dependencies as `helm install` and is not tested in Istio releases.
+Note that this alternative installation method may not apply the resources with the same sequencing of dependencies as `helm install` and is not tested as part of Istio releases.
 
 {{< warning >}}
 If attempting to install and manage Istio using `helm template`, please note the following caveats:

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -225,3 +225,42 @@ To delete Istio CRDs installed in your cluster:
 {{< text syntax=bash snip_id=delete_crds >}}
 $ kubectl get crd -oname | grep --color=never 'istio.io' | xargs kubectl delete
 {{< /text >}}
+
+## Generate a manifest before installation
+
+You can generate the manifests for each component before installing Istio using the `helm template`
+sub-command.
+For example, use the following command to generate a `kubectl`-installable manifest for the `istiod` component:
+
+{{< text syntax=bash snip_id=none >}}
+$ helm template istiod istio/istiod -n istio-system --kube-version <Kubernetes version of target cluster> > istiod.yaml
+{{< /text >}}
+
+The generated manifest can be used to inspect what exactly is installed as well as to track changes to the manifest over time. Note that any additional flags or values overrides you would normally use for installation should also be supplied to the `helm template` command.
+
+The following can be used to install the manifest generated above, which will create the `istiod` component in the target cluster:
+
+{{< text syntax=bash snip_id=none >}}
+$ kubectl apply -f istiod.yaml
+{{< /text >}}
+
+Note that this alternative installation method may not apply the resources with the same sequencing of dependencies as `helm install` and is not tested in Istio releases.
+
+{{< warning >}}
+If attempting to install and manage Istio using `helm template`, please note the following caveats:
+
+1. The Istio namespace (`istio-system` by default) must be created manually.
+
+1. While `helm install` will automatically detect environment specific settings from your Kubernetes context,
+`helm template` cannot as it runs offline, which may lead to unexpected results. In particular, you must ensure
+that you follow [these steps](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) if your
+Kubernetes environment does not support third party service account tokens.
+
+1. `kubectl apply` of the generated manifest may show transient errors due to resources not being available in the
+cluster in the correct order.
+
+1. `helm install` automatically prunes any resources that should be removed when the configuration changes (e.g.
+if you remove a gateway). This does not happen when you use `helm template` with `kubectl`, and these
+resources must be removed manually.
+
+{{< /warning >}}

--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -230,7 +230,7 @@ $ kubectl get crd -oname | grep --color=never 'istio.io' | xargs kubectl delete
 
 You can generate the manifests for each component before installing Istio using the `helm template`
 sub-command.
-For example, use the following command to generate a manifest that can be installed with `kubectl` for the `istiod` component:
+For example, to generate a manifest that can be installed with `kubectl` for the `istiod` component:
 
 {{< text syntax=bash snip_id=none >}}
 $ helm template istiod istio/istiod -n istio-system --kube-version <Kubernetes version of target cluster> > istiod.yaml

--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -142,7 +142,7 @@ not create the `istiod-default-validator` validating webhook configuration unles
 that you follow [these steps](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) if your
 Kubernetes environment does not support third party service account tokens.
 
-Note that it is recommended to append `--cluster-specific` to your `istio manifest generate` command to detect the target cluster's environment, which will embed those cluster-specific environment settings into the generated manifests. This does require network access to a live cluster, however.
+Note that it is recommended to append `--cluster-specific` to your `istio manifest generate` command to detect the target cluster's environment, which will embed those cluster-specific environment settings into the generated manifests. This requires network access to your running cluster.
 
 1. `kubectl apply` of the generated manifest may show transient errors due to resources not being available in the
 cluster in the correct order.

--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -140,9 +140,7 @@ not create the `istiod-default-validator` validating webhook configuration unles
 1. While `istioctl install` will automatically detect environment specific settings from your Kubernetes context,
 `manifest generate` cannot as it runs offline, which may lead to unexpected results. In particular, you must ensure
 that you follow [these steps](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) if your
-Kubernetes environment does not support third party service account tokens.
-
-Note that it is recommended to append `--cluster-specific` to your `istio manifest generate` command to detect the target cluster's environment, which will embed those cluster-specific environment settings into the generated manifests. This requires network access to your running cluster.
+Kubernetes environment does not support third party service account tokens. It is recommended to append `--cluster-specific` to your `istio manifest generate` command to detect the target cluster's environment, which will embed those cluster-specific environment settings into the generated manifests. This requires network access to your running cluster.
 
 1. `kubectl apply` of the generated manifest may show transient errors due to resources not being available in the
 cluster in the correct order.

--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -142,6 +142,8 @@ not create the `istiod-default-validator` validating webhook configuration unles
 that you follow [these steps](/docs/ops/best-practices/security/#configure-third-party-service-account-tokens) if your
 Kubernetes environment does not support third party service account tokens.
 
+Note that it is recommended to append `--cluster-specific` to your `istio manifest generate` command to detect the target cluster's environment, which will embed those cluster-specific environment settings into the generated manifests. This does require network access to a live cluster, however.
+
 1. `kubectl apply` of the generated manifest may show transient errors due to resources not being available in the
 cluster in the correct order.
 
@@ -150,38 +152,6 @@ if you remove a gateway). This does not happen when you use `istio manifest gene
 resources must be removed manually.
 
 {{< /warning >}}
-
-## Show differences in manifests
-
-You can show the differences in the generated manifests in a YAML style diff between the default profile and a
-customized install using these commands:
-
-{{< text bash >}}
-$ istioctl manifest generate > 1.yaml
-$ istioctl manifest generate -f samples/operator/pilot-k8s.yaml > 2.yaml
-$ istioctl manifest diff 1.yaml 2.yaml
-Differences in manifests are:
-
-
-Object Deployment:istio-system:istiod has diffs:
-
-spec:
-  template:
-    spec:
-      containers:
-        '[#0]':
-          resources:
-            requests:
-              cpu: 500m -> 1000m
-              memory: 2048Mi -> 4096Mi
-
-
-Object HorizontalPodAutoscaler:istio-system:istiod has diffs:
-
-spec:
-  maxReplicas: 5 -> 10
-  minReplicas: 1 -> 2
-{{< /text >}}
 
 ## Verify a successful installation
 

--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -135,7 +135,9 @@ not create the `istiod-default-validator` validating webhook configuration unles
     {{< /text >}}
 
 1. Resources may not be installed with the same sequencing of dependencies as
-`istioctl install` and is not tested as part of Istio releases.
+`istioctl install`.
+
+1. This method is not tested as part of Istio releases.
 
 1. While `istioctl install` will automatically detect environment specific settings from your Kubernetes context,
 `manifest generate` cannot as it runs offline, which may lead to unexpected results. In particular, you must ensure

--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -110,20 +110,17 @@ $ istioctl install --set profile=demo
 
 You can generate the manifest before installing Istio using the `manifest generate`
 sub-command.
-For example, use the following command to generate a manifest for the `default` profile:
+For example, use the following command to generate a manifest for the `default` profile that can be installed with `kubectl`:
 
 {{< text bash >}}
 $ istioctl manifest generate > $HOME/generated-manifest.yaml
 {{< /text >}}
 
-The generated manifest can be used to inspect what exactly is installed as well as to track changes to the manifest
-over time. While the `IstioOperator` CR represents the full user configuration and is sufficient for tracking it,
-the output from `manifest generate` also captures possible changes in the underlying charts and therefore can be
-used to track the actual installed resources.
+The generated manifest can be used to inspect what exactly is installed as well as to track changes to the manifest over time. While the `IstioOperator` CR represents the full user configuration and is sufficient for tracking it, the output from `manifest generate` also captures possible changes in the underlying charts and therefore can be used to track the actual installed resources.
 
-The output from `manifest generate` can also be used to install Istio using `kubectl apply` or equivalent. However,
-these alternative installation methods may not apply the resources with the same sequencing of dependencies as
-`istioctl install` and are not tested in an Istio release.
+{{< tip >}}
+Any additional flags or custom values overrides you would normally use for installation should also be supplied to the `istioctl manifest generate` command.
+{{< /tip >}}
 
 {{< warning >}}
 If attempting to install and manage Istio using `istioctl manifest generate`, please note the following caveats:
@@ -136,6 +133,9 @@ not create the `istiod-default-validator` validating webhook configuration unles
     {{< text bash >}}
     $ istioctl manifest generate --set values.defaultRevision=default
     {{< /text >}}
+
+1. Resources may not be installed with the same sequencing of dependencies as
+`istioctl install` and is not tested as part of Istio releases.
 
 1. While `istioctl install` will automatically detect environment specific settings from your Kubernetes context,
 `manifest generate` cannot as it runs offline, which may lead to unexpected results. In particular, you must ensure


### PR DESCRIPTION
## Description

https://github.com/istio/istio.io/issues/16056 is fixed in 1.25 but indicates the need for

- More details in the `istioctl manifest generate` section about `--cluster-specific`
- remove `manifest diff` stuff, as that is gone in 1.24+
- Add a section in the Helm install guide about how to generate manifests with that tool as well.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
