### PR TITLE
fix Helm test error introduced in #16060

### DIFF
--- a/content/en/docs/setup/upgrade/helm/common.sh
+++ b/content/en/docs/setup/upgrade/helm/common.sh
@@ -20,7 +20,6 @@ _install_istio_helm() {
     # This can be dropped once tests start pulling 1.24 charts
     bpsnip_crd_upgrade_123_adopt_legacy_crds
 
-    _rewrite_helm_repo snip_create_istio_system_namespace
     _rewrite_helm_repo snip_install_base
     _rewrite_helm_repo snip_install_discovery
     _rewrite_helm_repo snip_install_ingressgateway


### PR DESCRIPTION
#16060 removed a load-bearing snippet: the `doc.test.profile-none_istio.io` test, which obviously wasn't invoked in #16060 itself, relied on this snippet existing via the `_install_istio_helm` common function.