### PR TITLE
Create hidden parallel doctest docs for ambient wrapper chart, so it at least gets exercised a bit

### DIFF
--- a/content/en/docs/ambient/install/helm/all-in-one/index.md
+++ b/content/en/docs/ambient/install/helm/all-in-one/index.md
@@ -52,7 +52,7 @@ ambient via this wrapper chart - you cannot upgrade or uninstall sub-components 
 {{< /warning >}}
 
 {{< text syntax=bash snip_id=install_ambient_aio >}}
-$ helm install ambient istio/ambient --namespace istio-system --create-namespace --wait
+$ helm install istio-ambient istio/ambient --namespace istio-system --create-namespace --wait
 {{< /text >}}
 
 ### Ingress gateway (optional)
@@ -144,7 +144,7 @@ installed above.
 1. Uninstall all Istio components
 
     {{< text syntax=bash snip_id=delete_ambient_aio >}}
-    $ helm delete ambient -n istio-system
+    $ helm delete istio-ambient -n istio-system
     {{< /text >}}
 
 1. (Optional) Delete any Istio gateway chart installations:

--- a/content/en/docs/ambient/install/helm/all-in-one/index.md
+++ b/content/en/docs/ambient/install/helm/all-in-one/index.md
@@ -28,7 +28,6 @@ We encourage the use of Helm to install Istio for production use in ambient mode
     $ helm repo update
     {{< /text >}}
 
-
 <!-- ### Base components -->
 
 <!-- The `base` chart contains the basic CRDs and cluster roles required to set up Istio. -->
@@ -49,7 +48,7 @@ ambient, using a Helm wrapper chart that composes the individual component chart
 
 {{< warning >}}
 Note that if you install everything as part of this wrapper chart, you can only upgrade or uninstall
-ambient via this wrapper chart - you cannot upgrade or uninstall subcomponents individually.
+ambient via this wrapper chart - you cannot upgrade or uninstall sub-components individually.
 {{< /warning >}}
 
 {{< text syntax=bash snip_id=install_ambient_aio >}}
@@ -89,18 +88,18 @@ the components individually, by prefixing the value path with the name of the co
 Example:
 
 {{< text syntax=bash snip_id=none >}}
-$ helm install istiod istio/istiod --set hub=gcr.io/istio-testing 
+$ helm install istiod istio/istiod --set hub=gcr.io/istio-testing
 {{< /text >}}
 
 Becomes:
 
 {{< text syntax=bash snip_id=none >}}
-$ helm install ambient istio/ambient --set istiod.hub=gcr.io/istio-testing 
+$ helm install istio-ambient istio/ambient --set istiod.hub=gcr.io/istio-testing
 {{< /text >}}
 
 when set via the wrapper chart.
 
-To view supported configuration options and documentation for each subcomponent, run:
+To view supported configuration options and documentation for each sub-component, run:
 
 {{< text syntax=bash >}}
 $ helm show values istio/istiod
@@ -119,10 +118,7 @@ After installing all the components, you can check the Helm deployment status wi
 {{< text syntax=bash snip_id=show_components >}}
 $ helm ls -n istio-system
 NAME            NAMESPACE       REVISION    UPDATED                                 STATUS      CHART           APP VERSION
-istio-base      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    base-{{< istio_full_version >}}     {{< istio_full_version >}}
-istio-cni       istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    cni-{{< istio_full_version >}}      {{< istio_full_version >}}
-istiod          istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    istiod-{{< istio_full_version >}}   {{< istio_full_version >}}
-ztunnel         istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ztunnel-{{< istio_full_version >}}  {{< istio_full_version >}}
+ambient      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ambient-{{< istio_full_version >}}     {{< istio_full_version >}}
 {{< /text >}}
 
 You can check the status of the deployed pods with:
@@ -142,10 +138,11 @@ After installing ambient mode with Helm, you can follow the [Deploy the sample a
 
 ## Uninstall
 
-You can uninstall Istio and its components by uninstalling the charts
+You can uninstall Istio and its components by uninstalling the chart
 installed above.
 
-1. 
+1. Uninstall all Istio components
+
     {{< text syntax=bash snip_id=delete_ambient_aio >}}
     $ helm delete ambient -n istio-system
     {{< /text >}}

--- a/content/en/docs/ambient/install/helm/all-in-one/index.md
+++ b/content/en/docs/ambient/install/helm/all-in-one/index.md
@@ -118,7 +118,7 @@ After installing all the components, you can check the Helm deployment status wi
 {{< text syntax=bash snip_id=show_components >}}
 $ helm ls -n istio-system
 NAME            NAMESPACE       REVISION    UPDATED                                 STATUS      CHART           APP VERSION
-ambient      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ambient-{{< istio_full_version >}}     {{< istio_full_version >}}
+istio-ambient      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ambient-{{< istio_full_version >}}     {{< istio_full_version >}}
 {{< /text >}}
 
 You can check the status of the deployed pods with:

--- a/content/en/docs/ambient/install/helm/all-in-one/snips.sh
+++ b/content/en/docs/ambient/install/helm/all-in-one/snips.sh
@@ -27,7 +27,7 @@ helm repo update
 }
 
 snip_install_ambient_aio() {
-helm install ambient istio/ambient --namespace istio-system --create-namespace --wait
+helm install istio-ambient istio/ambient --namespace istio-system --create-namespace --wait
 }
 
 snip_install_ingress() {
@@ -59,7 +59,7 @@ ztunnel-c2z4s                    1/1     Running   0          10m
 ENDSNIP
 
 snip_delete_ambient_aio() {
-helm delete ambient -n istio-system
+helm delete istio-ambient -n istio-system
 }
 
 snip_delete_ingress() {

--- a/content/en/docs/ambient/install/helm/all-in-one/snips.sh
+++ b/content/en/docs/ambient/install/helm/all-in-one/snips.sh
@@ -44,7 +44,7 @@ helm ls -n istio-system
 
 ! IFS=$'\n' read -r -d '' snip_show_components_out <<\ENDSNIP
 NAME            NAMESPACE       REVISION    UPDATED                                 STATUS      CHART           APP VERSION
-ambient      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ambient-1.25.0     1.25.0
+istio-ambient      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ambient-1.25.0     1.25.0
 ENDSNIP
 
 snip_check_pods() {

--- a/content/en/docs/ambient/install/helm/all-in-one/snips.sh
+++ b/content/en/docs/ambient/install/helm/all-in-one/snips.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2153,SC2155,SC2164
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          docs/ambient/install/helm/all-in-one/index.md
+####################################################################################################
+source "content/en/boilerplates/snips/gateway-api-install-crds.sh"
+
+snip_configure_helm() {
+helm repo add istio https://istio-release.storage.googleapis.com/charts
+helm repo update
+}
+
+snip_install_ambient_aio() {
+helm install ambient istio/ambient --namespace istio-system --create-namespace --wait
+}
+
+snip_install_ingress() {
+helm install istio-ingress istio/gateway -n istio-ingress --create-namespace --wait
+}
+
+snip_configuration_3() {
+helm show values istio/istiod
+}
+
+snip_show_components() {
+helm ls -n istio-system
+}
+
+! IFS=$'\n' read -r -d '' snip_show_components_out <<\ENDSNIP
+NAME            NAMESPACE       REVISION    UPDATED                                 STATUS      CHART           APP VERSION
+istio-base      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    base-1.25.0     1.25.0
+istio-cni       istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    cni-1.25.0      1.25.0
+istiod          istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    istiod-1.25.0   1.25.0
+ztunnel         istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ztunnel-1.25.0  1.25.0
+ENDSNIP
+
+snip_check_pods() {
+kubectl get pods -n istio-system
+}
+
+! IFS=$'\n' read -r -d '' snip_check_pods_out <<\ENDSNIP
+NAME                             READY   STATUS    RESTARTS   AGE
+istio-cni-node-g97z5             1/1     Running   0          10m
+istiod-5f4c75464f-gskxf          1/1     Running   0          10m
+ztunnel-c2z4s                    1/1     Running   0          10m
+ENDSNIP
+
+snip_delete_ambient_aio() {
+helm delete ambient -n istio-system
+}
+
+snip_delete_ingress() {
+helm delete istio-ingress -n istio-ingress
+kubectl delete namespace istio-ingress
+}
+
+snip_delete_crds() {
+kubectl get crd -oname | grep --color=never 'istio.io' | xargs kubectl delete
+}
+
+snip_delete_system_namespace() {
+kubectl delete namespace istio-system
+}

--- a/content/en/docs/ambient/install/helm/all-in-one/snips.sh
+++ b/content/en/docs/ambient/install/helm/all-in-one/snips.sh
@@ -44,10 +44,7 @@ helm ls -n istio-system
 
 ! IFS=$'\n' read -r -d '' snip_show_components_out <<\ENDSNIP
 NAME            NAMESPACE       REVISION    UPDATED                                 STATUS      CHART           APP VERSION
-istio-base      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    base-1.25.0     1.25.0
-istio-cni       istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    cni-1.25.0      1.25.0
-istiod          istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    istiod-1.25.0   1.25.0
-ztunnel         istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ztunnel-1.25.0  1.25.0
+ambient      istio-system    1           2024-04-17 22:14:45.964722028 +0000 UTC deployed    ambient-1.25.0     1.25.0
 ENDSNIP
 
 snip_check_pods() {

--- a/content/en/docs/ambient/install/helm/all-in-one/test.sh
+++ b/content/en/docs/ambient/install/helm/all-in-one/test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+
+set -o pipefail
+
+# @setup profile=none
+
+snip_configure_helm
+_rewrite_helm_repo snip_install_ambient_aio
+
+_verify_like snip_show_components "$snip_show_components_out"
+_verify_like snip_check_pods "$snip_check_pods_out"
+
+# @cleanup
+snip_delete_ambient_aio
+snip_delete_crds
+snip_delete_system_namespace

--- a/content/en/docs/ambient/install/helm/all-in-one/test.sh
+++ b/content/en/docs/ambient/install/helm/all-in-one/test.sh
@@ -22,9 +22,6 @@ set -o pipefail
 
 # @setup profile=none
 
-snip_delete_crds
-snip_delete_system_namespace
-
 snip_configure_helm
 _rewrite_helm_repo snip_install_ambient_aio
 

--- a/content/en/docs/ambient/install/helm/all-in-one/test.sh
+++ b/content/en/docs/ambient/install/helm/all-in-one/test.sh
@@ -22,6 +22,9 @@ set -o pipefail
 
 # @setup profile=none
 
+snip_delete_crds
+snip_delete_system_namespace
+
 snip_configure_helm
 _rewrite_helm_repo snip_install_ambient_aio
 

--- a/content/en/docs/ambient/upgrade/helm/all-in-one/common.sh
+++ b/content/en/docs/ambient/upgrade/helm/all-in-one/common.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+source "content/en/docs/ambient/install/helm/all-in-one/snips.sh"
+
+_install_istio_ambient_helm_aio() {
+    snip_configure_helm
+    _rewrite_helm_repo snip_install_ambient_aio
+    _wait_for_deployment istio-system istiod
+    _wait_for_daemonset istio-system istio-cni-node
+    _wait_for_daemonset istio-system ztunnel
+}
+
+_remove_istio_ambient_helm_aio() {
+    snip_delete_ambient_aio
+    snip_delete_crds
+    snip_delete_system_namespace
+}

--- a/content/en/docs/ambient/upgrade/helm/all-in-one/index.md
+++ b/content/en/docs/ambient/upgrade/helm/all-in-one/index.md
@@ -1,0 +1,66 @@
+---
+title: Upgrade with Helm (simple)
+description: Upgrading an ambient mode installation with Helm using a single chart
+weight: 5
+owner: istio/wg-environments-maintainers
+test: yes
+draft: true
+---
+
+Follow this guide to upgrade and configure an ambient mode installation using
+[Helm](https://helm.sh/docs/). This guide assumes you have already performed an [ambient mode installation with Helm and the ambient wrapper chart](/docs/ambient/install/helm/all-in-one) with a previous version of Istio.
+
+{{< warning >}}
+Note that these upgrade instructions only apply if you are upgrading Helm installation created using the 
+ambient wrapper chart, if you installed via individual Helm component charts, see [the relevant upgrade docs](docs/ambient/upgrade/helm)
+{{< /warning >}}
+
+## Understanding ambient mode upgrades
+
+{{< warning >}}
+Note that if you install everything as part of this wrapper chart, you can only upgrade or uninstall
+ambient via this wrapper chart - you cannot upgrade or uninstall subcomponents individually.
+{{< /warning >}}
+
+## Prerequisites
+
+### Prepare for the upgrade
+
+Before upgrading Istio, we recommend downloading the new version of istioctl, and running `istioctl x precheck` to make sure the upgrade is compatible with your environment. The output should look something like this:
+
+{{< text syntax=bash snip_id=istioctl_precheck >}}
+$ istioctl x precheck
+✔ No issues found when checking the cluster. Istio is safe to install or upgrade!
+  To get started, check out <https://istio.io/latest/docs/setup/getting-started/>
+{{< /text >}}
+
+Now, update the Helm repository:
+
+{{< text syntax=bash snip_id=update_helm >}}
+$ helm repo update istio
+{{< /text >}}
+
+### Upgrade the Istio ambient control plane and data plane
+
+{{< warning >}}
+Upgrading using the wrapper chart in-place will briefly disrupt all ambient mesh traffic on the node,  **even with the use of revisions**. In practice the disruption period is a very small window, primarily affecting long-running connections.
+
+Node cordoning and blue/green node pools are recommended to mitigate blast radius risk during production upgrades. See your Kubernetes provider documentation for details.
+{{< /warning >}}
+
+The `ambient` chart upgrades all the Istio data plane and control plane components required for
+ambient, using a Helm wrapper chart that composes the individual component charts.
+
+If you have customized your istiod installation, you can reuse the `values.yaml` file from previous upgrades or installs to keep settings consistent.
+
+{{< text syntax=bash snip_id=upgrade_ambient_aio >}}
+$ helm upgrade ambient istio/ambient -n istio-system --wait
+{{< /text >}}
+
+### Upgrade manually deployed gateway chart (optional)
+
+`Gateway`s that were [deployed manually](/docs/tasks/traffic-management/ingress/gateway-api/#manual-deployment) must be upgraded individually using Helm:
+
+{{< text syntax=bash snip_id=none >}}
+$ helm upgrade istio-ingress istio/gateway -n istio-ingress
+{{< /text >}}

--- a/content/en/docs/ambient/upgrade/helm/all-in-one/index.md
+++ b/content/en/docs/ambient/upgrade/helm/all-in-one/index.md
@@ -11,7 +11,7 @@ Follow this guide to upgrade and configure an ambient mode installation using
 [Helm](https://helm.sh/docs/). This guide assumes you have already performed an [ambient mode installation with Helm and the ambient wrapper chart](/docs/ambient/install/helm/all-in-one) with a previous version of Istio.
 
 {{< warning >}}
-Note that these upgrade instructions only apply if you are upgrading Helm installation created using the 
+Note that these upgrade instructions only apply if you are upgrading Helm installation created using the
 ambient wrapper chart, if you installed via individual Helm component charts, see [the relevant upgrade docs](docs/ambient/upgrade/helm)
 {{< /warning >}}
 
@@ -19,7 +19,7 @@ ambient wrapper chart, if you installed via individual Helm component charts, se
 
 {{< warning >}}
 Note that if you install everything as part of this wrapper chart, you can only upgrade or uninstall
-ambient via this wrapper chart - you cannot upgrade or uninstall subcomponents individually.
+ambient via this wrapper chart - you cannot upgrade or uninstall sub-components individually.
 {{< /warning >}}
 
 ## Prerequisites
@@ -54,7 +54,7 @@ ambient, using a Helm wrapper chart that composes the individual component chart
 If you have customized your istiod installation, you can reuse the `values.yaml` file from previous upgrades or installs to keep settings consistent.
 
 {{< text syntax=bash snip_id=upgrade_ambient_aio >}}
-$ helm upgrade ambient istio/ambient -n istio-system --wait
+$ helm upgrade istio-ambient istio/ambient -n istio-system --wait
 {{< /text >}}
 
 ### Upgrade manually deployed gateway chart (optional)

--- a/content/en/docs/ambient/upgrade/helm/all-in-one/snips.sh
+++ b/content/en/docs/ambient/upgrade/helm/all-in-one/snips.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2153,SC2155,SC2164
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          docs/ambient/upgrade/helm/all-in-one/index.md
+####################################################################################################
+
+snip_istioctl_precheck() {
+istioctl x precheck
+}
+
+! IFS=$'\n' read -r -d '' snip_istioctl_precheck_out <<\ENDSNIP
+✔ No issues found when checking the cluster. Istio is safe to install or upgrade!
+  To get started, check out <https://istio.io/latest/docs/setup/getting-started/>
+ENDSNIP
+
+snip_update_helm() {
+helm repo update istio
+}
+
+snip_upgrade_ambient_aio() {
+helm upgrade ambient istio/ambient -n istio-system --wait
+}

--- a/content/en/docs/ambient/upgrade/helm/all-in-one/snips.sh
+++ b/content/en/docs/ambient/upgrade/helm/all-in-one/snips.sh
@@ -34,5 +34,5 @@ helm repo update istio
 }
 
 snip_upgrade_ambient_aio() {
-helm upgrade ambient istio/ambient -n istio-system --wait
+helm upgrade istio-ambient istio/ambient -n istio-system --wait
 }

--- a/content/en/docs/ambient/upgrade/helm/all-in-one/test.sh
+++ b/content/en/docs/ambient/upgrade/helm/all-in-one/test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+
+set -o pipefail
+
+source "content/en/docs/ambient/upgrade/helm/common.sh"
+
+# @setup profile=none
+_install_istio_ambient_helm_aio
+
+snip_update_helm
+
+_rewrite_helm_repo snip_upgrade_ambient_aio
+_wait_for_deployment istio-system istiod
+_wait_for_daemonset istio-system ztunnel
+_wait_for_daemonset istio-system istio-cni-node
+
+# @cleanup
+
+_remove_istio_ambient_helm_aio

--- a/content/en/docs/ambient/upgrade/helm/all-in-one/test.sh
+++ b/content/en/docs/ambient/upgrade/helm/all-in-one/test.sh
@@ -18,10 +18,11 @@ set -u
 
 set -o pipefail
 
+source "content/en/docs/ambient/install/helm/common.sh"
 source "content/en/docs/ambient/upgrade/helm/common.sh"
 
 # @setup profile=none
-_install_istio_ambient_helm_aio
+_rewrite_helm_repo snip_install_ambient_helm_aio
 
 snip_update_helm
 

--- a/content/en/docs/ambient/upgrade/helm/all-in-one/test.sh
+++ b/content/en/docs/ambient/upgrade/helm/all-in-one/test.sh
@@ -18,8 +18,8 @@ set -u
 
 set -o pipefail
 
-source "content/en/docs/ambient/install/helm/common.sh"
-source "content/en/docs/ambient/upgrade/helm/common.sh"
+source "content/en/docs/ambient/upgrade/helm/all-in-one/common.sh"
+source "content/en/docs/ambient/upgrade/helm/all-in-one/snips.sh"
 
 # @setup profile=none
 _rewrite_helm_repo snip_install_ambient_helm_aio

--- a/content/en/docs/ambient/upgrade/helm/all-in-one/test.sh
+++ b/content/en/docs/ambient/upgrade/helm/all-in-one/test.sh
@@ -22,7 +22,7 @@ source "content/en/docs/ambient/upgrade/helm/all-in-one/common.sh"
 source "content/en/docs/ambient/upgrade/helm/all-in-one/snips.sh"
 
 # @setup profile=none
-_rewrite_helm_repo snip_install_ambient_helm_aio
+_install_istio_ambient_helm_aio
 
 snip_update_helm
 

--- a/content/en/docs/setup/upgrade/helm/index.md
+++ b/content/en/docs/setup/upgrade/helm/index.md
@@ -159,7 +159,7 @@ preserve your custom configuration during Helm upgrades.
     $ helm upgrade istiod istio/istiod -n istio-system
     {{< /text >}}
 
-1. (Optional) Upgrade and gateway charts  installed in your cluster:
+1. (Optional) Upgrade any gateway charts installed in your cluster:
 
     {{< text bash >}}
     $ helm upgrade istio-ingress istio/gateway -n istio-ingress

--- a/tests/util/helpers.sh
+++ b/tests/util/helpers.sh
@@ -149,6 +149,14 @@ _rewrite_helm_repo() {
   cmd="$(echo "${cmd}" | sed 's|istio/cni|manifests/charts/istio-cni|')"
   cmd="$(echo "${cmd}" | sed 's|istio/ztunnel|manifests/charts/ztunnel|')"
   cmd="$(echo "${cmd}" | sed 's|istio/gateway|manifests/charts/gateway|')"
+  cmd="$(echo "${cmd}" | sed 's|istio/ambient|manifests/sample-charts/ambient|')"
   cmd="$(echo "${cmd}" | sed -E "s|(helm[[:space:]]+[^[:space:]]+)|\1 --set global.tag=${ISTIO_IMAGE_VERSION=SHOULD_BE_SET}.${ISTIO_LONG_SHA=latest}|g")"
+  # Since we are using local charts here, we may need to manually rebundle the updates
+  # This is not required if installing directly from a real Helm repo
+  if [[ $cmd =~ "manifests/sample-charts/ambient" ]]; then
+    pushd manifests/sample-charts/ambient && helm dep update
+    popd || exit
+  fi
+
   eval "${cmd}"
 }


### PR DESCRIPTION
## Description

[As per Dec 9th 2024 TOC](https://docs.google.com/document/d/13lxJqtlaQhmV2EwsNnS6h-_O4pobZQZuMjrzOeMgVI0/edit?tab=t.0), the outcome was

- to NOT delete the ambient wrapper chart (which we had previously decided not to document, despite people using it)
- suggestion was to instead write some "hidden" doctests so we can actually ensure it has some test coverage.

This is a stab at the latter. 

I still don't think this is terribly useful - most of the potential ways we might break chart composition come from bad value scoping practices, which require exercising various options in the charts the tests do not typically set, but which people encounter when using them in the real world.

But, it's better than nothing.


## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
