### PR TITLE
CSS changes for code blocks & message fields tables

### DIFF
--- a/assets/sass/_all.scss
+++ b/assets/sass/_all.scss
@@ -38,6 +38,7 @@
 @import "misc/landing";
 @import "misc/logo-gallery";
 @import "misc/menu";
+@import "misc/message-fields";
 @import "misc/modal";
 @import "misc/multi-block";
 @import "misc/notfound";

--- a/assets/sass/misc/_code-blocks.scss
+++ b/assets/sass/misc/_code-blocks.scss
@@ -1,9 +1,18 @@
 code {
     color: $textCodeColor;
-    font-size: 87.5%;
+    background-color: $textCodeBackgroundColor;
+    padding: .2em .4em;
+    font-size: 85%;
     font-weight: $textCodeWeight;
-    font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     word-break: break-word;
+    background: $textCodeBackgroundColor;
+    padding: .2em .4em;
+
+    a {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-weight: $textCodeWeight;
+    }
 }
 
 pre {
@@ -14,7 +23,7 @@ pre {
     min-width: 12em;
     max-height: 31em;
     border-left: 4px solid $preBlockBorderColor;
-    font-size: 87.5%;
+    font-size: 85%;
     text-align: left;
     white-space: pre;
     word-spacing: normal;
@@ -29,6 +38,8 @@ pre {
         display: block;
         padding: .5em;
         color: $textColor;
+        font-size: 100%;
+        background: $preBlockBackgroundColor;
 
         a {
             font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;

--- a/assets/sass/misc/_code-blocks.scss
+++ b/assets/sass/misc/_code-blocks.scss
@@ -1,7 +1,5 @@
 code {
     color: $textCodeColor;
-    background-color: $textCodeBackgroundColor;
-    padding: .2em .4em;
     font-size: 85%;
     font-weight: $textCodeWeight;
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -42,7 +40,7 @@ pre {
         background: $preBlockBackgroundColor;
 
         a {
-            font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
             font-weight: $textCodeWeight;
         }
     }

--- a/assets/sass/misc/_message-fields.scss
+++ b/assets/sass/misc/_message-fields.scss
@@ -1,0 +1,14 @@
+.message-fields {
+    .type {
+        font-size: 85%;
+        padding-left: .4em;
+    }
+
+    .required {
+        font-size: 85%;
+        font-weight: bold;
+        padding-left: .4em;
+        padding-right: .4em;
+        padding-top: 1em;
+    }
+}

--- a/assets/sass/themes/_light-theme.scss
+++ b/assets/sass/themes/_light-theme.scss
@@ -1,7 +1,6 @@
 html {
     --backgroundColor: #ffffff;
 
-    --textCodeColor: #7dc6f2;
     --primaryColor: #293655;            //dark-grey-blue
     --secondaryColor: #516ba9;          //dull-blue
     --accentColor: #7dc6f2;             //light-blue
@@ -10,7 +9,8 @@ html {
 
     --inputBorderColor: #566ca5;
     --textColor: #293655;
-    --textCodeColor: #d14;
+    --textCodeColor: #293655;
+    --textCodeBackgroundColor: rgba(129, 139, 152, .12);
     --disabledTextColor: #{lighten(#535f61, 50%)};
     --textGray: #8a8a8c;
 

--- a/assets/sass/themes/_vars.scss
+++ b/assets/sass/themes/_vars.scss
@@ -8,6 +8,7 @@ $secondaryAccentColor: var(--secondaryAccentColor);
 
 $textColor: var(--textColor);
 $textCodeColor: var(--textCodeColor);
+$textCodeBackgroundColor: var(--textCodeBackgroundColor);
 $disabledTextColor: var(--disabledTextColor);
 
 $inputBorderColor: var(--inputBorderColor);

--- a/layouts/partials/code_block.html
+++ b/layouts/partials/code_block.html
@@ -55,7 +55,7 @@
         {{- if $snippet -}}
             {{- errorf "Snippets only work for imported text blocks (%s)" .Position -}}
         {{- end -}}
-        {{- $text = partial "strip_indent.html" (dict "content" .Inner "pos" .Position) -}}
+        {{- $text = chomp (partial "strip_indent.html" (dict "content" .Inner "pos" .Position)) -}}
     {{- end -}}
 
     {{- if (hasPrefix $text " ") -}}


### PR DESCRIPTION
Change the CSS for istio.io:

- introduce classes needed for [improved reference doc tables](https://github.com/istio/istio.io/pull/16076/)
- modernize `code` & `pre` styling to bring the non-contentious parts of https://github.com/istio/istio.io/pull/16010 forward
