### PR TITLE
Expand config profiles doc to mention helm + istioctl usage, and also mention platform profiles

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -474,6 +474,7 @@ edition.cnn.com
 Eilers
 Eitan
 Ekansh
+eks
 Elasticsearch
 embeddable
 emojis
@@ -548,6 +549,7 @@ git
 GitHub
 GitOps
 GKE
+gke
 glibc
 Gloo
 GlueCon
@@ -818,6 +820,7 @@ metaprotocol
 metaresources
 MiB
 MicroK8s
+microk8s
 microservice
 microservices
 middleboxes
@@ -914,6 +917,7 @@ OpenID_Connect
 OpenMetrics
 OpenPolicyAgent
 OpenShift
+openshift
 OpenSSL
 openssl
 OpenTelemetry

--- a/content/en/docs/setup/additional-setup/config-profiles/index.md
+++ b/content/en/docs/setup/additional-setup/config-profiles/index.md
@@ -26,13 +26,13 @@ There are 2 kinds of configuration profiles: _deployment_ profiles and _platform
 - _deployment_ profiles are intended to provide good defaults for a given deployment topology (`default`, `remote`, `ambient`, etc).
 - _platform_ profiles are intended to provide necessary platform-specific defaults, for a given target platform (`eks`, `gke`, `openshift`, etc).
 
-For example, if you are installing `default` sidecar dataplane on `gke`, we recommend using the following deployment and platform profiles to get started.
+For example, if you are installing `default` sidecar dataplane on `gke`, we recommend using the following deployment and platform profiles to get started:
 
 {{< tabset category-name="install-method" >}}
 
 {{< tab name="Helm" category-value="helm" >}}
 
-For Helm, supply the same `profile` and `platform` for every chart you install, for example `istiod`:
+    For Helm, supply the same `profile` and `platform` for every chart you install, for example `istiod`:
 
     {{< text syntax=bash snip_id=install_istiod_helm_platform >}}
     $ helm install istiod istio/istiod -n istio-system --set profile=default --set global.platform=gke --wait
@@ -42,7 +42,7 @@ For Helm, supply the same `profile` and `platform` for every chart you install, 
 
 {{< tab name="istioctl" category-value="istioctl" >}}
 
-For `istioctl`, supply the same `profile` and `platform` as arguments:
+    For `istioctl`, supply the same `profile` and `platform` as arguments:
 
     {{< text syntax=bash snip_id=install_istiod_istioctl_platform >}}
     $ istioctl install --set profile=default --set values.global.platform=gke
@@ -95,7 +95,7 @@ beyond what the deployment profile includes, for your specific needs. The follow
 
 Istio's [deployment profile value sets are defined here]({{< github_tree >}}/manifests/helm-profiles), for both `istioctl` and `helm`.
 
-For `istioctl` only, specifying configuration profiles additionally automatically selects certain Istio components for installation, as marked with &#x2714; below
+For `istioctl` only, specifying configuration profiles additionally automatically selects certain Istio components for installation, as marked with &#x2714; below:
 
 |     | default | demo | minimal | remote | empty | preview | ambient |
 | --- | --- | --- | --- | --- | --- | --- | --- |

--- a/content/en/docs/setup/additional-setup/config-profiles/index.md
+++ b/content/en/docs/setup/additional-setup/config-profiles/index.md
@@ -12,7 +12,7 @@ test: n/a
 This page describes the built-in configuration profiles that can be used when
 [installing Istio](/docs/setup/install).
 
-Configuration profiles are simply named groups of Helm chart value overrides that are built into the charts, 
+Configuration profiles are simply named groups of Helm chart value overrides that are built into the charts,
 and can be used when installing via either `helm` or `istioctl`.
 
 The profiles provide high-level customization of the Istio control plane and data plane for common deployment topologies and target platforms.
@@ -60,8 +60,8 @@ With `helm`, this is not the case - users are expected to install each required 
 You can think of this as `istioctl` and `helm` sharing exactly the same configuration profiles with the same names, but when you use `istioctl`, it will additionally choose what components to install for you based on the configuration profile you select, so only one command is needed to achieve the same result.
 {{< /warning >}}
 
-
 ## Deployment Profiles
+
 The following built-in deployment profiles are currently available for both `istioctl` and `helm` install mechanisms. Note that as these are just sets of Helm values overrides, using them is not strictly required to install Istio, but they do provide a convenient baseline and are recommended for new installs. Additionally, you may [customize the configuration](/docs/setup/additional-setup/customize-installation/)
 beyond what the deployment profile includes, for your specific needs. The following built-in deployment profiles are currently available:
 
@@ -112,13 +112,14 @@ Refer to [integrations](/docs/ops/integrations) for more details.
 {{< /tip >}}
 
 ## Platform Profiles
+
 The following built-in platform profiles are currently available for both `istioctl` and `helm` install mechanisms. Note that as these are just sets of Helm values overrides, using them is not strictly required to install Istio in these environments, but they do provide a convenient baseline and are recommended for new installs:
 
 1. **gke**: Sets chart options required or recommended for installing Istio in Google Kubernetes Engine (GKE) environments.
 
 1. **eks**: Sets chart options required or recommended for installing Istio in Amazon's Elastic Kubernetes Service (EKS) environments.
 
-1. **openshift**: Sets chart options required or recommended for installing Istio in Openshift environments.
+1. **openshift**: Sets chart options required or recommended for installing Istio in OpenShift environments.
 
 1. **k3d**: Sets chart options required or recommended for installing Istio in [k3d](https://k3d.io/) environments.
 

--- a/content/en/docs/setup/additional-setup/config-profiles/index.md
+++ b/content/en/docs/setup/additional-setup/config-profiles/index.md
@@ -26,7 +26,7 @@ There are 2 kinds of configuration profiles: _deployment_ profiles and _platform
 - _deployment_ profiles are intended to provide good defaults for a given deployment topology (`default`, `remote`, `ambient`, etc).
 - _platform_ profiles are intended to provide necessary platform-specific defaults, for a given target platform (`eks`, `gke`, `openshift`, etc).
 
-For example, if you are installing `default` sidecar dataplane on `gke`, we recommend using the following deployment and platform profiles to get started:
+For example, if you are installing `default` sidecar dataplane on GKE, we recommend using the following deployment and platform profiles to get started:
 
 {{< tabset category-name="install-method" >}}
 

--- a/content/en/docs/setup/additional-setup/config-profiles/index.md
+++ b/content/en/docs/setup/additional-setup/config-profiles/index.md
@@ -10,12 +10,60 @@ test: n/a
 ---
 
 This page describes the built-in configuration profiles that can be used when
-[installing Istio](/docs/setup/install/istioctl/).
-The profiles provide customization of the Istio control plane and of the sidecars for the Istio data plane.
+[installing Istio](/docs/setup/install).
 
-You can start with one of [Istio’s built-in configuration profiles]({{< github_tree >}}/manifests/profiles) and then further
-[customize the configuration](/docs/setup/additional-setup/customize-installation/)
-for your specific needs. The following built-in configuration profiles are currently available:
+Configuration profiles are simply named groups of Helm chart value overrides that are built into the charts, 
+and can be used when installing via either `helm` or `istioctl`.
+
+The profiles provide high-level customization of the Istio control plane and data plane for common deployment topologies and target platforms.
+
+{{< tip >}}
+Configuration profiles compose with other values overrides or flags, so any individual value a configuration profile sets can be manually overridden by specifying a `--set` flag after it in the command.
+{{< /tip >}}
+
+There are 2 kinds of configuration profiles: _deployment_ profiles and _platform_ profiles, and using both is recommended.
+
+- _deployment_ profiles are intended to provide good defaults for a given deployment topology (`default`, `remote`, `ambient`, etc).
+- _platform_ profiles are intended to provide necessary platform-specific defaults, for a given target platform (`eks`, `gke`, `openshift`, etc).
+
+For example, if you are installing `default` sidecar dataplane on `gke`, we recommend using the following deployment and platform profiles to get started.
+
+{{< tabset category-name="install-method" >}}
+
+{{< tab name="Helm" category-value="helm" >}}
+
+For Helm, supply the same `profile` and `platform` for every chart you install, for example `istiod`:
+
+    {{< text syntax=bash snip_id=install_istiod_helm_platform >}}
+    $ helm install istiod istio/istiod -n istio-system --set profile=default --set global.platform=gke --wait
+    {{< /text >}}
+
+{{< /tab >}}
+
+{{< tab name="istioctl" category-value="istioctl" >}}
+
+For `istioctl`, supply the same `profile` and `platform` as arguments:
+
+    {{< text syntax=bash snip_id=install_istiod_istioctl_platform >}}
+    $ istioctl install --set profile=default --set values.global.platform=gke
+    {{< /text >}}
+
+{{< /tab >}}
+
+{{< /tabset >}}
+
+{{< warning >}}
+Note that a key difference between `helm` and `istioctl` install mechanisms is that `istioctl` configuration profiles also include a list of Istio components that will be installed automatically by `istioctl`.
+
+With `helm`, this is not the case - users are expected to install each required Istio component individually via `helm install`, and supply the desired configuration profile flags for each component manually.
+
+You can think of this as `istioctl` and `helm` sharing exactly the same configuration profiles with the same names, but when you use `istioctl`, it will additionally choose what components to install for you based on the configuration profile you select, so only one command is needed to achieve the same result.
+{{< /warning >}}
+
+
+## Deployment Profiles
+The following built-in deployment profiles are currently available for both `istioctl` and `helm` install mechanisms. Note that as these are just sets of Helm values overrides, using them is not strictly required to install Istio, but they do provide a convenient baseline and are recommended for new installs. Additionally, you may [customize the configuration](/docs/setup/additional-setup/customize-installation/)
+beyond what the deployment profile includes, for your specific needs. The following built-in deployment profiles are currently available:
 
 1. **default**: enables components according to the default settings of the
     [`IstioOperator` API](/docs/reference/config/istio.operator.v1alpha1/).
@@ -38,19 +86,16 @@ for your specific needs. The following built-in configuration profiles are curre
     {{< gloss >}}external control plane{{< /gloss >}} or by a control plane in a {{< gloss >}}primary cluster{{< /gloss >}}
     of a [multicluster mesh](/docs/ops/deployment/deployment-models/#multiple-clusters).
 
+1. **ambient**: the ambient profile is designed to help you get started with [ambient mode](/docs/ambient).
+
 1. **empty**: deploys nothing. This can be useful as a base profile for custom configuration.
 
 1. **preview**: the preview profile contains features that are experimental. This is intended to explore new features
                 coming to Istio. Stability, security, and performance are not guaranteed - use at your own risk.
 
-1. **ambient**: the ambient profile is designed to help you get started with [ambient mode](/docs/ambient).
+Istio's [deployment profile value sets are defined here]({{< github_tree >}}/manifests/helm-profiles), for both `istioctl` and `helm`.
 
-{{< tip >}}
-Some additional vendor-specific configuration profiles are also available.
-For more information, refer to the [setup instructions](/docs/setup/platform-setup) for your platform.
-{{< /tip >}}
-
-The components marked as &#x2714; are installed within each profile:
+For `istioctl` only, specifying configuration profiles additionally automatically selects certain Istio components for installation, as marked with &#x2714; below
 
 |     | default | demo | minimal | remote | empty | preview | ambient |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -61,5 +106,26 @@ The components marked as &#x2714; are installed within each profile:
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`CNI` | | | | | | | &#x2714; |
 | &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`Ztunnel` | | | | | | | &#x2714; |
 
+{{< tip >}}
 To further customize Istio, a number of addon components can also be installed.
 Refer to [integrations](/docs/ops/integrations) for more details.
+{{< /tip >}}
+
+## Platform Profiles
+The following built-in platform profiles are currently available for both `istioctl` and `helm` install mechanisms. Note that as these are just sets of Helm values overrides, using them is not strictly required to install Istio in these environments, but they do provide a convenient baseline and are recommended for new installs:
+
+1. **gke**: Sets chart options required or recommended for installing Istio in Google Kubernetes Engine (GKE) environments.
+
+1. **eks**: Sets chart options required or recommended for installing Istio in Amazon's Elastic Kubernetes Service (EKS) environments.
+
+1. **openshift**: Sets chart options required or recommended for installing Istio in Openshift environments.
+
+1. **k3d**: Sets chart options required or recommended for installing Istio in [k3d](https://k3d.io/) environments.
+
+1. **k3s**: Sets chart options required or recommended for installing Istio in [K3s](https://k3s.io/) environments.
+
+1. **microk8s**: Sets chart options required or recommended for installing Istio in [MicroK8s](https://microk8s.io/) environments.
+
+1. **minikube**: Sets chart options required or recommended for installing Istio in [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) environments.
+
+Istio's [platform profiles are defined here]({{< github_tree >}}/manifests/helm-profiles), for both `istioctl` and `helm`.


### PR DESCRIPTION
## Description

- Explicitly mention profiles can be used by `helm` and `istioctl`
- Explain the difference between `platform profiles` and `regular profiles` - I have dubbed the latter `deployment profiles`, better names welcome.


There are still some UX gubbins here I do not like (mostly having to get into the weeds that even though they're directly shared with `istioctl`, with `istioctl` they also select specific components, which is not true in our helm impl ATM) - but better to document how it currently works than not.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
