### PR TITLE
Remove installation verification with istioctl verify-install

### DIFF
--- a/content/en/docs/setup/install/istioctl/index.md
+++ b/content/en/docs/setup/install/istioctl/index.md
@@ -153,26 +153,6 @@ resources must be removed manually.
 
 {{< /warning >}}
 
-## Verify a successful installation
-
-You can check if the Istio installation succeeded using the `verify-install` command
-which compares the installation on your cluster to a manifest you specify.
-
-If you didn't generate your manifest prior to deployment, run the following command to
-generate it now:
-
-{{< text bash >}}
-$ istioctl manifest generate <your original installation options> > $HOME/generated-manifest.yaml
-{{< /text >}}
-
-Then run the following `verify-install` command to see if the installation was successful:
-
-{{< text bash >}}
-$ istioctl verify-install -f $HOME/generated-manifest.yaml
-{{< /text >}}
-
-See [Customizing the installation configuration](/docs/setup/additional-setup/customize-installation/) for additional information on customizing the install.
-
 ## Uninstall Istio
 
 To completely uninstall Istio from a cluster, run the following command:


### PR DESCRIPTION
## Description
`istioctl verify-install` command was removed in https://github.com/istio/istio/pull/52090. Remove its related document.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
