### PR TITLE
[zh] Sync #16100 remove reference to L7 EnvoyFilter for WayPoints from Ambient docs into Chinese

### DIFF
--- a/content/zh/docs/ambient/usage/l7-features/index.md
+++ b/content/zh/docs/ambient/usage/l7-features/index.md
@@ -67,12 +67,11 @@ ztunnel 无法强制执行 L7 策略。如果使用工作负载选择器（而�
 ## 扩展 {#extension}
 
 由于 waypoint 代理是 {{< gloss >}}Envoy{{< /gloss >}} 的部署，
-因此在 {{< gloss "sidecar">}}Sidecar 模式{{< /gloss >}}中 Envoy 可以使用的扩展机制模式也可用于 waypoint 代理。
+因此在 {{< gloss "sidecar">}}Sidecar 模式{{< /gloss >}}中 Envoy 可以使用的某些扩展机制模式也可用于 waypoint 代理。
 
 |  名称  | 功能状态 | 附加方式 |
 | --- | --- | --- |
 | `WasmPlugin` †  | Alpha | `targetRefs` |
-| `EnvoyFilter` | Alpha | `targetRefs` |
 
 † [阅读更多关于如何使用 WebAssembly 插件扩展 waypoint 的信息](/zh/docs/ambient/usage/extend-waypoint-wasm/)。
 


### PR DESCRIPTION

## Description

Sync #16100 remove reference to L7 EnvoyFilter for WayPoints from Ambient docs into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
