### PR TITLE
Don't pin us to a 3-4 year old Helm release

### DIFF
--- a/content/en/boilerplates/helm-preamble.md
+++ b/content/en/boilerplates/helm-preamble.md
@@ -1,6 +1,6 @@
 ---
 ---
-The Helm charts for `base` and `istiod` used
-in this guide are the same as those used when
-installing Istio via [Istioctl](/docs/setup/install/istioctl/).
-However installations via Istioctl use a different [gateway chart]({{< github_tree >}}/manifests/charts/gateways/istio-ingress) to the [chart]({{< github_tree >}}/manifests/charts/gateway) described in this guide
+The Helm charts used in this guide are the same as those used when
+installing Istio via [Istioctl](/docs/setup/install/istioctl/), with the exception of the `gateway` chart.
+
+Istioctl uses a different [gateway chart]({{< github_tree >}}/manifests/charts/gateways/istio-ingress) than the [gateway chart]({{< github_tree >}}/manifests/charts/gateway) described in this guide

--- a/content/en/boilerplates/helm-prereqs.md
+++ b/content/en/boilerplates/helm-prereqs.md
@@ -6,7 +6,7 @@
 
 1. Check the [Requirements for Pods and Services](/docs/ops/deployment/application-requirements/).
 
-1. [Install the latest Helm client](https://helm.sh/docs/intro/install/). Helm versions released before than the [oldest currently-supported Istio release](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) are not tested, supported, recommended.
+1. [Install the latest Helm client](https://helm.sh/docs/intro/install/). Helm versions released before than the [oldest currently-supported Istio release](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) are not tested, supported, or recommended.
 
 1. Configure the Helm repository:
 

--- a/content/en/boilerplates/helm-prereqs.md
+++ b/content/en/boilerplates/helm-prereqs.md
@@ -6,7 +6,7 @@
 
 1. Check the [Requirements for Pods and Services](/docs/ops/deployment/application-requirements/).
 
-1. [Install the latest Helm client](https://helm.sh/docs/intro/install/). Helm versions released before than the [oldest currently-supported Istio release](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) are not tested, supported, or recommended.
+1. [Install the latest Helm client](https://helm.sh/docs/intro/install/). Helm versions released before than the [oldest currently-supported Istio release](docs/releases/supported-releases/#support-status-of-istio-releases) are not tested, supported, or recommended.
 
 1. Configure the Helm repository:
 

--- a/content/en/boilerplates/helm-prereqs.md
+++ b/content/en/boilerplates/helm-prereqs.md
@@ -6,7 +6,7 @@
 
 1. Check the [Requirements for Pods and Services](/docs/ops/deployment/application-requirements/).
 
-1. [Install the Helm client](https://helm.sh/docs/intro/install/), version 3.6 or above.
+1. [Install the latest Helm client](https://helm.sh/docs/intro/install/). Helm versions released before than the [oldest currently-supported Istio release](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases) are not tested, supported, recommended.
 
 1. Configure the Helm repository:
 


### PR DESCRIPTION
## Description

Our Helm boilerplate currently says "At least Helm 3.6"

- Helm 3.6 is [3, nearly 4 years out of date at this point](https://github.com/helm/helm/releases/tag/v3.6.0).
- That's [much older than the oldest Istio release we support](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases)
- We have gotten [bugs from people using very-old versions of Helm that we do not test with or actively use anymore](https://github.com/istio/istio/issues/54389).

This updates the Helm boilerplate to say "if your Helm is older than the oldest Istio release we support, upgrade or YMMV" - which as of this moment is https://github.com/helm/helm/releases/tag/v3.14.3




## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
