### PR TITLE
docs: fixes doc for external control place setup

### DIFF
--- a/content/en/docs/setup/install/external-controlplane/index.md
+++ b/content/en/docs/setup/install/external-controlplane/index.md
@@ -259,7 +259,6 @@ and installing the sidecar injector webhook configuration on the remote cluster 
     it in the external cluster:
 
     {{< text bash >}}
-    $ kubectl create sa istiod-service-account -n external-istiod --context="${CTX_EXTERNAL_CLUSTER}"
     $ istioctl create-remote-secret \
       --context="${CTX_REMOTE_CLUSTER}" \
       --type=config \

--- a/content/en/docs/setup/install/external-controlplane/snips.sh
+++ b/content/en/docs/setup/install/external-controlplane/snips.sh
@@ -133,7 +133,6 @@ kubectl create namespace external-istiod --context="${CTX_EXTERNAL_CLUSTER}"
 }
 
 snip_set_up_the_control_plane_in_the_external_cluster_2() {
-kubectl create sa istiod-service-account -n external-istiod --context="${CTX_EXTERNAL_CLUSTER}"
 istioctl create-remote-secret \
   --context="${CTX_REMOTE_CLUSTER}" \
   --type=config \


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->
`kubectl create sa istiod-service-account -n external-istiod --context="${CTX_EXTERNAL_CLUSTER}"` is not required while setting up the external control plane. `istiod` sa is used in the command that creates remote secret. Moreover `istiod-service-account` is not being used anywhere else in the setup.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
