### PR TITLE
[zh] Sync #16143 fixes external control place setup into Chinese

### DIFF
--- a/content/zh/docs/setup/install/external-controlplane/index.md
+++ b/content/zh/docs/setup/install/external-controlplane/index.md
@@ -250,7 +250,6 @@ Webhook、ConfigMap 和 Secret，以便使用外部控制平面。
    Secret，以访问从集群的 `kube-apiserver` 并将其安装在外部集群中：
 
     {{< text bash >}}
-    $ kubectl create sa istiod-service-account -n external-istiod --context="${CTX_EXTERNAL_CLUSTER}"
     $ istioctl create-remote-secret \
       --context="${CTX_REMOTE_CLUSTER}" \
       --type=config \


### PR DESCRIPTION
## Description

Sync #16143 fixes external control place setup into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
