### PR TITLE
[zh] Sync #16044 set prev and next for Ambient get start doc into Chinese

### DIFF
--- a/content/zh/docs/ambient/getting-started/_index.md
+++ b/content/zh/docs/ambient/getting-started/_index.md
@@ -6,8 +6,9 @@ aliases:
   - /zh/docs/ops/ambient/getting-started
   - /zh/latest/docs/ops/ambient/getting-started
 owner: istio/wg-networking-maintainers
-skip_list: true
 test: yes
+skip_list: true
+next: /zh/docs/ambient/getting-started/deploy-sample-app
 ---
 
 本指南可让您快速评估 Istio 的 {{< gloss "ambient" >}}Ambient 模式{{< /gloss >}}。

--- a/content/zh/docs/ambient/getting-started/_index.md
+++ b/content/zh/docs/ambient/getting-started/_index.md
@@ -8,7 +8,7 @@ aliases:
 owner: istio/wg-networking-maintainers
 test: yes
 skip_list: true
-next: /zh/docs/ambient/getting-started/deploy-sample-app
+next: /docs/ambient/getting-started/deploy-sample-app
 ---
 
 本指南可让您快速评估 Istio 的 {{< gloss "ambient" >}}Ambient 模式{{< /gloss >}}。

--- a/content/zh/docs/ambient/getting-started/cleanup/index.md
+++ b/content/zh/docs/ambient/getting-started/cleanup/index.md
@@ -4,7 +4,7 @@ description: 删除 Istio 和相关资源。
 weight: 6
 owner: istio/wg-networking-maintainers
 test: yes
-next: /zh/docs/ambient/install
+next: /docs/ambient/install
 ---
 
 如果您不再需要 Istio 和相关资源，可以按照本节中的步骤删除它们。

--- a/content/zh/docs/ambient/getting-started/cleanup/index.md
+++ b/content/zh/docs/ambient/getting-started/cleanup/index.md
@@ -4,6 +4,7 @@ description: 删除 Istio 和相关资源。
 weight: 6
 owner: istio/wg-networking-maintainers
 test: yes
+next: /zh/docs/ambient/install
 ---
 
 如果您不再需要 Istio 和相关资源，可以按照本节中的步骤删除它们。

--- a/content/zh/docs/ambient/getting-started/deploy-sample-app/index.md
+++ b/content/zh/docs/ambient/getting-started/deploy-sample-app/index.md
@@ -4,7 +4,7 @@ description: 部署 Bookinfo 示例应用程序。
 weight: 2
 owner: istio/wg-networking-maintainers
 test: yes
-prev: /zh/docs/ambient/getting-started
+prev: /docs/ambient/getting-started
 ---
 
 为了探索 Istio，您需要安装示例

--- a/content/zh/docs/ambient/getting-started/deploy-sample-app/index.md
+++ b/content/zh/docs/ambient/getting-started/deploy-sample-app/index.md
@@ -4,6 +4,7 @@ description: 部署 Bookinfo 示例应用程序。
 weight: 2
 owner: istio/wg-networking-maintainers
 test: yes
+prev: /zh/docs/ambient/getting-started
 ---
 
 为了探索 Istio，您需要安装示例


### PR DESCRIPTION
## Description

Sync #16044 set prev and next for Ambient get start doc into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
