### PR TITLE
remove unnecessary semicolon which breaks zsh on mac

### DIFF
--- a/content/en/boilerplates/gateway-api-install-crds.md
+++ b/content/en/boilerplates/gateway-api-install-crds.md
@@ -5,5 +5,5 @@ installed before using the Gateway API:
 
 {{< text syntax=bash snip_id=install_crds >}}
 $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml }
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml
 {{< /text >}}

--- a/content/en/boilerplates/gateway-api-install-crds.md
+++ b/content/en/boilerplates/gateway-api-install-crds.md
@@ -5,5 +5,5 @@ installed before using the Gateway API:
 
 {{< text syntax=bash snip_id=install_crds >}}
 $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml; }
+  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml }
 {{< /text >}}

--- a/content/en/boilerplates/snips/gateway-api-install-crds.sh
+++ b/content/en/boilerplates/snips/gateway-api-install-crds.sh
@@ -22,5 +22,5 @@
 
 bpsnip_gateway_api_install_crds_install_crds() {
 kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml; }
+  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml }
 }

--- a/content/en/boilerplates/snips/gateway-api-install-crds.sh
+++ b/content/en/boilerplates/snips/gateway-api-install-crds.sh
@@ -22,5 +22,5 @@
 
 bpsnip_gateway_api_install_crds_install_crds() {
 kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml }
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
 }

--- a/content/uk/boilerplates/gateway-api-install-crds.md
+++ b/content/uk/boilerplates/gateway-api-install-crds.md
@@ -4,5 +4,5 @@
 
 {{< text syntax=bash snip_id=install_crds >}}
 $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml }
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml
 {{< /text >}}

--- a/content/uk/boilerplates/gateway-api-install-crds.md
+++ b/content/uk/boilerplates/gateway-api-install-crds.md
@@ -4,5 +4,5 @@
 
 {{< text syntax=bash snip_id=install_crds >}}
 $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml; }
+  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml }
 {{< /text >}}

--- a/content/zh/boilerplates/gateway-api-install-crds.md
+++ b/content/zh/boilerplates/gateway-api-install-crds.md
@@ -5,5 +5,5 @@
 
 {{< text syntax=bash snip_id=install_crds >}}
 $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml; }
+  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml }
 {{< /text >}}

--- a/content/zh/boilerplates/gateway-api-install-crds.md
+++ b/content/zh/boilerplates/gateway-api-install-crds.md
@@ -5,5 +5,5 @@
 
 {{< text syntax=bash snip_id=install_crds >}}
 $ kubectl get crd gateways.gateway.networking.k8s.io &> /dev/null || \
-  { kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml }
+  kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/{{< k8s_gateway_api_version >}}/standard-install.yaml
 {{< /text >}}


### PR DESCRIPTION
zsh, in many default configurations, escapes special characters on paste.  The `;` in the Gateway API example is replaced with `\;` which causes the command to fail.

As it's not a load-bearing semi-colon, lets just remove it.

Fixes #16162

