### PR TITLE
docs: added missing 15002 port in application-requirements

### DIFF
--- a/content/en/docs/ops/deployment/application-requirements/index.md
+++ b/content/en/docs/ops/deployment/application-requirements/index.md
@@ -90,6 +90,7 @@ To avoid port conflicts with sidecars, applications should not use any of the po
 |----|----|----|----|
 | 15000 | TCP | Envoy admin port (commands/diagnostics) | Yes |
 | 15001 | TCP | Envoy outbound | No |
+| 15002 | TCP | Listen port for failure detection | Yes |
 | 15004 | HTTP | Debug port | Yes |
 | 15006 | TCP | Envoy inbound | No |
 | 15008 | HTTP2 | {{< gloss >}}HBONE{{</ gloss >}} mTLS tunnel port | No |


### PR DESCRIPTION
## Description

This PR adds the undocumented 15002 port in application-requirements.

Noticed this on `istio-validation` logs after upgrading a cluster from 1.22.3 to 1.23.1 still using the deprecated [cni.repair.deletePods](https://istio.io/latest/docs/setup/additional-setup/cni/#race-condition--mitigation).
Problem solved on my side, but would be nice to add the port here.

Logs:

```
istio-validation 2025-01-20T15:31:22.062115Z    info    Starting iptables validation. This check verifies that iptables rules are properly established for the network.
istio-validation 2025-01-20T15:31:22.062187Z    info    Listening on 127.0.0.1:15001
istio-validation 2025-01-20T15:31:22.062508Z    info    Listening on 127.0.0.1:15006
istio-validation 2025-01-20T15:31:22.062880Z    error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
istio-validation 2025-01-20T15:31:23.064142Z    error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
istio-validation 2025-01-20T15:31:24.064767Z    error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
istio-validation 2025-01-20T15:31:25.066142Z    error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
istio-validation 2025-01-20T15:31:26.066739Z    error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
istio-validation 2025-01-20T15:31:27.062776Z    error   iptables validation failed; workload is not ready for Istio.
istio-validation When using Istio CNI, this can occur if a pod is scheduled before the node is ready.
istio-validation
istio-validation If installed with 'cni.repair.deletePods=true', this pod should automatically be deleted and retry.
istio-validation Otherwise, this pod will need to be manually removed so that it is scheduled on a node with istio-cni running, allowing iptables rules to be established.
```

Source:
- https://github.com/search?q=repo%3Aistio%2Fistio%2015002&type=code
- https://github.com/search?q=repo%3Aistio%2Fistio+IptablesProbePort&type=code

## Reviewers

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
