### PR TITLE
docs: modify network policy doc note

### DIFF
--- a/content/en/docs/ambient/usage/networkpolicy/index.md
+++ b/content/en/docs/ambient/usage/networkpolicy/index.md
@@ -54,7 +54,7 @@ spec:
       protocol: TCP
 {{< /text >}}
 
-if `my-app` is added to the ambient mesh.
+if `my-app` is added to the mesh.
 
 ## Ambient, health probes, and Kubernetes NetworkPolicy
 

--- a/content/en/docs/ambient/usage/networkpolicy/index.md
+++ b/content/en/docs/ambient/usage/networkpolicy/index.md
@@ -16,7 +16,7 @@ An implication of this is that it is possible to create a Kubernetes `NetworkPol
 
 Once you have added applications to the ambient mesh, ambient's secure L4 overlay will tunnel traffic between your pods over port 15008. Once secured traffic enters the target pod with a destination port of 15008, the traffic will be proxied back to the original destination port.
 
-However, `NetworkPolicy` is enforced on the host, outside the pod. This means that if you have preexisting `NetworkPolicy` in place that, for example, will deny list inbound traffic to an ambient pod on every port but 443, you will have to add an exception to that `NetworkPolicy` for port 15008.
+However, `NetworkPolicy` is enforced on the host, outside the pod. This means that if you have preexisting `NetworkPolicy` in place that, for example, will deny list inbound traffic to an ambient pod on every port but 443, you will have to add an exception to that `NetworkPolicy` for port 15008. Sidecar workloads receiving traffic will also need to allow inbound traffic on port 15008 to allow ambient workloads to communicate with them.
 
 For example, the following `NetworkPolicy` will block incoming {{< gloss >}}HBONE{{< /gloss >}} traffic to `my-app` on port 15008:
 


### PR DESCRIPTION
## Description

This PR updates the networkpolicy doc to add a clarifying note about the necessity of port 15008 when ambient workloads are communicating with sidecar workloads.

In addition I deleted the word `ambient` from one line, which lines up with the docs on the ambient mesh website as well: https://ambientmesh.io/docs/security/configure-networkpolicies/#allowing-access-for-secure-overlay

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
