### PR TITLE
docs: Change Platform Setup for Amazon EKS to more recent and refined instructions: Istio on EKS

### DIFF
--- a/content/en/docs/setup/platform-setup/amazon-eks/index.md
+++ b/content/en/docs/setup/platform-setup/amazon-eks/index.md
@@ -8,4 +8,4 @@ owner: istio/wg-environments-maintainers
 test: n/a
 ---
 
-Follow [EKS Blueprints for Istio](https://aws-ia.github.io/terraform-aws-eks-blueprints/patterns/istio/) instructions to provision EKS cluster with Istio setup in AWS cloud.
+Follow [Istio on EKS](https://github.com/aws-samples/istio-on-eks) instructions to provision EKS cluster with Istio setup in AWS cloud.


### PR DESCRIPTION
## Description

According to comments and history:
- https://github.com/aws-ia/terraform-aws-eks-blueprints/issues/1955#issuecomment-2151128984
- https://github.com/aws-ia/terraform-aws-eks-blueprints/pull/1956#issuecomment-2151004242
- https://github.com/aws-ia/terraform-aws-eks-blueprints/commits/main/patterns/istio

1. https://aws-ia.github.io/terraform-aws-eks-blueprints/patterns/istio/ doc is old and unsupported;
2. while https://github.com/aws-samples/istio-on-eks is active and more refined, it also supports Ambient.

(I also suggested the same edit here: https://github.com/istio/istio.io/pull/15425)

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
