### PR TITLE
Update index.md for GKE Autopilot

### DIFF
--- a/content/en/docs/setup/platform-setup/gke/index.md
+++ b/content/en/docs/setup/platform-setup/gke/index.md
@@ -37,8 +37,8 @@ Follow these instructions to prepare a GKE cluster for Istio.
     {{< /tip >}}
 
     {{< warning >}}
-    To use the Istio CNI feature on GKE, please check the [CNI installation guide](/docs/setup/additional-setup/cni/#prerequisites)
-    for prerequisite cluster configuration steps.
+    To use the Istio CNI feature on GKE Standard, please check the [CNI installation guide](/docs/setup/additional-setup/cni/#prerequisites)
+    for prerequisite cluster configuration steps. Since the CNI node agent requires the SYS_ADMIN capability, it is not available on GKE Autopilot. Instead, use the istio-init container.
     {{< /warning >}}
 
     {{< warning >}}


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

I executed `istioctl install` to  a GKE Autopilot cluster, but it failed.

```
CNI encountered an error: failed to update resource with server-side apply for obj DaemonSet/istio-system/istio-cni-node: admission webhook "warden-validating.common-webhooks.networking.gke.io" denied the request: GKE Warden rejected the request because it violates one or more constraints.
 Violations details: {"[denied by autogke-default-linux-capabilities]":["linux capability 'NET_ADMIN,SYS_ADMIN' on container 'install-cni' not allowed; Autopilot only allows the capabilities: 'AUDIT_WRITE,CHOWN,DAC_OVERRIDE,FOWNER,FSETID,KILL,MKNOD,NET_BIND_SERVICE,NET_RAW,SETFCAP,SETGID,SETPCAP,SETUID,SYS_CHROOT,SYS_PTRACE'."],"[denied by autogke-no-write-mode-hostpath]":["hostPath volume cni-bin-dir in container install-cni is accessed in write mode; disallowed in Autopilot.","hostPath volume cni-net-dir in container install-cni is accessed in write mode; disallowed in Autopilot.","hostPath volume cni-socket-dir in container install-cni is accessed in write mode; disallowed in Autopilot.","hostPath volume cni-host-procfs used in container install-cni uses path /proc which is not allowed in Autopilot. Allowed path prefixes for hostPath volumes are: [/var/log/]."]}
```

`NET_ADMIN` can be enabled on the Autopilot cluster, but `SYS_ADMIN` can't, so Autopilot users must use istio-init instead.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
