### PR TITLE
fix broken link in deprecation notice for ISTIO_META_DNS_AUTO_ALLOCATE

### DIFF
--- a/content/en/news/releases/1.25.x/announcing-1.25/change-notes/index.md
+++ b/content/en/news/releases/1.25.x/announcing-1.25/change-notes/index.md
@@ -14,7 +14,7 @@ aliases:
 
 These notices describe functionality that will be removed in a future release according to [Istio's deprecation policy](/docs/releases/feature-stages/#feature-phase-definition). Please consider upgrading your environment to remove the deprecated functionality.
 
-- **Deprecated** use of `ISTIO_META_DNS_AUTO_ALLOCATE` in `proxyMetadata` in favor of a newer version of [DNS Auto Allocation](/docs/ops/configuration/traffic-management/dns-proxy #dns-auto-allocation-v2). New users of Istio IP `auto-allocation` should adopt the new status based controller. Existing users may continue to use the older implementation.
+- **Deprecated** use of `ISTIO_META_DNS_AUTO_ALLOCATE` in `proxyMetadata` in favor of a newer version of [DNS Auto Allocation](/docs/ops/configuration/traffic-management/dns-proxy#dns-auto-allocation-v2). New users of Istio IP `auto-allocation` should adopt the new status based controller. Existing users may continue to use the older implementation.
   ([Issue #53596](https://github.com/istio/istio/issues/53596))
 
 - **Deprecated** `traffic.sidecar.istio.io/kubevirtInterfaces`, in favor of `istio.io/reroute-virtual-interfaces`.


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

minor fix for broken link on the 1.25 announcement

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
