### PR TITLE
Fix incorrectly-flipped flag in 1.25 relnotes

### DIFF
--- a/content/en/news/releases/1.25.x/announcing-1.25/change-notes/index.md
+++ b/content/en/news/releases/1.25.x/announcing-1.25/change-notes/index.md
@@ -25,7 +25,7 @@ These notices describe functionality that will be removed in a future release ac
 - **Promoted** the `cni.ambient.dnsCapture` value to default to `true`.
   This enables the DNS proxying for workloads in ambient mesh by default, improving security, performance, and enabling
   a number of features. This can be disabled explicitly or with `compatibilityVersion=1.24`.
-  Note: only new pods will have DNS enabled. To enable for existing pods, pods must be manually restarted, or the iptables reconciliation feature must be enabled with `--set cni.ambient.reconcileIptablesOnStartup=false`.
+  Note: only new pods will have DNS enabled. To enable for existing pods, pods must be manually restarted, or the iptables reconciliation feature must be enabled with `--set cni.ambient.reconcileIptablesOnStartup=true`.
 
 - **Promoted** the `PILOT_ENABLE_IP_AUTOALLOCATE` value to default to `true`.
   This enables the new iteration of [IP auto-allocation](/docs/ops/configuration/traffic-management/dns-proxy/#address-auto-allocation),


### PR DESCRIPTION
## Description

this should be `true` not `false`, it's correct in the upgrade notes.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
