### PR TITLE
add 1.23 initial eol announcement, fix 1.22 eol date in supportStatus.yml

### DIFF
--- a/content/en/news/support/announcing-1.23-eol/index.md
+++ b/content/en/news/support/announcing-1.23-eol/index.md
@@ -1,0 +1,12 @@
+---
+title: Support for Istio 1.23 ends on April 16, 2025
+subtitle: Support Announcement
+description: Upcoming Istio 1.23 end of life announcement.
+publishdate: 2024-03-17
+---
+
+According to Istio's [support policy](/docs/releases/supported-releases#support-policy), minor releases like 1.23 are supported until six weeks after the N+2 minor release (1.25 in this case). [Istio 1.25 was released on March 3rd, 2025](/news/releases/1.24.x/announcing-1.24/), and support for 1.23 will end on April 16th, 2025.
+
+At that point we will stop back-porting fixes for security issues and critical bugs to 1.23, so we encourage you to upgrade to the latest version of Istio ({{<istio_release_name>}}). If you don't do this you may put yourself in the position of having to do a major upgrade on a short timeframe to pick up a critical fix.
+
+We care about you and your clusters, so please be kind to yourself and upgrade.

--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -22,13 +22,13 @@
 - version: "1.23"
   supported: "Yes"
   releaseDate: "Aug 14, 2024"
-  eolDate: "~May 2025 (Expected)"
+  eolDate: "Apr 16, 2025"
   k8sVersions: ["1.27", "1.28", "1.29", "1.30"]
   testedK8sVersions: ["1.23", "1.24", "1.25", "1.26"]
 - version: "1.22"
   supported: "No"
   releaseDate: "May 13, 2024"
-  eolDate: "~Jan 2025 (Expected)"
+  eolDate: "Jan 22, 2025"
   k8sVersions: ["1.27", "1.28", "1.29", "1.30"]
   testedK8sVersions: ["1.23", "1.24", "1.25", "1.26"]
 - version: "1.21"


### PR DESCRIPTION
## Description

Add 30-day notice of 1.23 EOL status (16 April, 2025 [30 days from today]).

cc: @thedebugger @hzxuzhonghu @mikemorris as RMs for 1.23 to validate this date. DNM pending their approval.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
