### PR TITLE
Add information about separate CA secret support for TLS Secret

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -624,6 +624,7 @@ EOF
 Istio supports reading a few different Secret formats, to support integration with various tools such as [cert-manager](/docs/ops/integrations/certmanager/):
 
 * A TLS Secret with keys `tls.key` and `tls.crt`, as described above. For mutual TLS, a `ca.crt` key can be used.
+* A TLS Secret with keys `tls.key` and `tls.crt`, as described above. For mutual TLS, a separate generic Secret named `<secret>-cacert`, with a `cacert` key. For example, `httpbin-credential` has `tls.key` and `tls.crt`, and `httpbin-credential-cacert` has `cacert`.
 * A generic Secret with keys `key` and `cert`. For mutual TLS, a `cacert` key can be used.
 * A generic Secret with keys `key` and `cert`. For mutual TLS, a separate generic Secret named `<secret>-cacert`, with a `cacert` key. For example, `httpbin-credential` has `key` and `cert`, and `httpbin-credential-cacert` has `cacert`.
 * The `cacert` key value can be a CA bundle consisting of concatenated individual CA certificates.


### PR DESCRIPTION
## Description
Adding information that currently separate generic `-cacert` secret can be used in combination with TLS Secret for mTLS.

https://github.com/cloudflare/origin-ca-issuer/issues/25#issuecomment-2730126020

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
