### PR TITLE
[zh] Sync #15828 clusterLocal docs to allow for exceptions when using wide clusterLocal configs into Chinese

### DIFF
--- a/content/zh/docs/ops/configuration/traffic-management/multicluster/index.md
+++ b/content/zh/docs/ops/configuration/traffic-management/multicluster/index.md
@@ -62,6 +62,21 @@ serviceSettings:
 
 {{< /tabset >}}
 
+您还可以通过设置全局集群本地规则并添加显式例外（可以是特定例外或通配符）来细化服务访问。
+在以下示例中，集群中的所有服务都将保持集群本地，但 `myns` 命名空间中的任何服务除外：
+
+{{< text yaml >}}
+serviceSettings:
+- settings:
+    clusterLocal: true
+  hosts:
+  - "*"
+- settings:
+    clusterLocal: false
+  hosts:
+  - "*.myns.svc.cluster.local"
+{{< /text >}}
+
 ## 分区服务 {#partitioning-services}
 
 [`DestinationRule.subsets`](/zh/docs/reference/config/networking/destination-rule/#Subset)


### PR DESCRIPTION
## Description

Sync #15828 clusterLocal docs to allow for exceptions when using wide clusterLocal configs into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
