### PR TITLE
update ingress documentation to prefer ingressclass

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
@@ -45,7 +45,7 @@ Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
       - host: httpbin.example.com
         http:
           paths:
-          - path: /
+          - path: /status
             pathType: Prefix
             backend:
               service:

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/index.md
@@ -24,22 +24,28 @@ A [Kubernetes Ingress Resources](https://kubernetes.io/docs/concepts/services-ne
 
 Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
 
-1.  Create an `Ingress` resource:
+1.  Create an `Ingress` resource and an `IngressClass`:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
     apiVersion: networking.k8s.io/v1
+    kind: IngressClass
+    metadata:
+      name: istio
+    spec:
+      controller: istio.io/ingress-controller
+    ---
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
-      annotations:
-        kubernetes.io/ingress.class: istio
       name: ingress
     spec:
+      ingressClassName: istio
       rules:
       - host: httpbin.example.com
         http:
           paths:
-          - path: /status
+          - path: /
             pathType: Prefix
             backend:
               service:
@@ -49,7 +55,9 @@ Let's see how you can configure a `Ingress` on port 80 for HTTP traffic.
     EOF
     {{< /text >}}
 
-    The `kubernetes.io/ingress.class` annotation is required to tell the Istio gateway controller that it should handle this `Ingress`, otherwise it will be ignored.
+    The `IngressClass` resource identifies the Istio gateway controller to Kubernetes, and the `ingressClassName: istio` value instructs Kubernetes that the Istio gateway controller should handle the following `Ingress`.
+
+    Older versions of the Ingress API used the `kubernetes.io/ingress.class` annotation, and while it still works, [it has been deprecated in Kubernetes](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) for some time.
 
 1.  Access the _httpbin_ service using _curl_:
 
@@ -86,42 +94,12 @@ By default, Istio will treat paths as exact matches, unless they end in `/*` or 
 
 In Kubernetes 1.18, a new field, `pathType`, was added. This allows explicitly declaring a path as `Exact` or `Prefix`.
 
-### Specifying `IngressClass`
-
-In Kubernetes 1.18, a new resource, `IngressClass`, was added, replacing the `kubernetes.io/ingress.class` annotation on the `Ingress` resource. If you are using this resource, you will need to set the `controller` field to `istio.io/ingress-controller`. For example:
-
-{{< text yaml >}}
-apiVersion: networking.k8s.io/v1
-kind: IngressClass
-metadata:
-  name: istio
-spec:
-  controller: istio.io/ingress-controller
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ingress
-spec:
-  ingressClassName: istio
-  rules:
-  - host: httpbin.example.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: httpbin
-            port:
-              number: 8000
-{{< /text >}}
-
 ## Cleanup
 
-Delete the `Ingress` configuration, and shutdown the [httpbin]({{< github_tree >}}/samples/httpbin) service:
+Delete the `IngressClass` and `Ingress` configurations, and shutdown the [httpbin]({{< github_tree >}}/samples/httpbin) service:
 
 {{< text bash >}}
 $ kubectl delete ingress ingress
+$ kubectl delete ingressclass istio
 $ kubectl delete --ignore-not-found=true -f @samples/httpbin/httpbin.yaml@
 {{< /text >}}

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/snips.sh
@@ -23,17 +23,23 @@
 snip_configuring_ingress_using_an_ingress_resource_1() {
 kubectl apply -f - <<EOF
 apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: istio
+spec:
+  controller: istio.io/ingress-controller
+---
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  annotations:
-    kubernetes.io/ingress.class: istio
   name: ingress
 spec:
+  ingressClassName: istio
   rules:
   - host: httpbin.example.com
     http:
       paths:
-      - path: /status
+      - path: /
         pathType: Prefix
         backend:
           service:
@@ -64,34 +70,8 @@ HTTP/1.1 404 Not Found
 ...
 ENDSNIP
 
-! IFS=$'\n' read -r -d '' snip_specifying_ingressclass_1 <<\ENDSNIP
-apiVersion: networking.k8s.io/v1
-kind: IngressClass
-metadata:
-  name: istio
-spec:
-  controller: istio.io/ingress-controller
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ingress
-spec:
-  ingressClassName: istio
-  rules:
-  - host: httpbin.example.com
-    http:
-      paths:
-      - path: /
-        pathType: Prefix
-        backend:
-          service:
-            name: httpbin
-            port:
-              number: 8000
-ENDSNIP
-
 snip_cleanup_1() {
 kubectl delete ingress ingress
+kubectl delete ingressclass istio
 kubectl delete --ignore-not-found=true -f samples/httpbin/httpbin.yaml
 }

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/snips.sh
@@ -39,7 +39,7 @@ spec:
   - host: httpbin.example.com
     http:
       paths:
-      - path: /
+      - path: /status
         pathType: Prefix
         backend:
           service:

--- a/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/kubernetes-ingress/test.sh
@@ -40,14 +40,6 @@ _verify_elided snip_configuring_ingress_using_an_ingress_resource_2 "$snip_confi
 # Access other URL
 _verify_elided snip_configuring_ingress_using_an_ingress_resource_3 "$snip_configuring_ingress_using_an_ingress_resource_3_out"
 
-# Test IngressClass and pathType
-kubectl apply -f - <<< "$snip_specifying_ingressclass_1"
-
-get_headers() {
-curl -s -H "Foo: bar" -HHost:httpbin.example.com "http://$INGRESS_HOST:$INGRESS_PORT/headers" | jq '.headers["Foo"][0]'
-}
-_verify_contains get_headers '"bar"'
-
 # @cleanup
 snip_cleanup_1
 kubectl label namespace default istio-injection-


### PR DESCRIPTION
## Description

Rework the flow of the https://istio.io/latest/docs/tasks/traffic-management/ingress/kubernetes-ingress/ page to point users towards using `IngressClass`, rather than the deprecated `kubernetes.io/ingress.class` annotation. Resolves https://github.com/istio/istio.io/issues/16188

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
