### PR TITLE
Added Out-Of-Date Documentation Header for v1.24

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -156,6 +156,18 @@
 
         {{ partial "events.html" (dict "page" . "kind" "sticker") }}
         {{ partial "header.html" . }}
+
+        <!-- Archived Documentation Header -->
+        {{ $archiveVersion := "v1.24" }}
+        {{ if eq .Section "docs" }}
+        <div class="archive-warning-banner" role="alert" 
+        style="background-color: #fff3cd; color: #664d03; padding: 1rem; border-bottom: 1px solid #ffecb5; text-align: center;">
+        <p style="margin-bottom: 0;">⚠️ This documentation is for an older version (<strong>{{ $archiveVersion }}</strong>). 
+            We recommend using the <a href="/latest{{ .RelPermalink | safeURL }}" 
+            style="font-weight: bold; text-decoration: underline;">latest version</a>.</p>
+        </div>
+        {{ end }}
+
         {{ partial "events.html" (dict "page" . "kind" "banner") }}
 
         {{ block "main" . }}{{ end }}


### PR DESCRIPTION
## Description

Added a warning header to all docs pages warning user that this version is out-of-date with an option to go to /latest

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
