### PR TITLE
fix : Hugo partial rendering error

### DIFF
--- a/layouts/partials/navigation_level.html
+++ b/layouts/partials/navigation_level.html
@@ -23,7 +23,7 @@
     {{ end }}
 {{ end }}
 
-<ul role="{{ if $top }}tree{{ else }}group{{ end }}" aria-expanded="{{ if $collapse }}false{{ else }}true{{ end }}"{{ if $leafSection }} class="leaf-section"{{ end }} {{ if $labelledby}}aria-labelledby="{{ $labelledby }}"{{ end }}>
+<ul role="{{ if $top }}tree{{ else }}group{{ end }}" aria-expanded="{{ if $collapse }}false{{ else }}true{{ end }}"{{ if $leafSection }} class="leaf-section"{{ end }} {{ if $labelledby }}aria-labelledby="{{ $labelledby }}"{{ end }}>
     {{ range $pages }}
         {{ $pageLocation := (path.Dir (path.Dir .File.Dir)) }}
         {{ if and (eq $parentDir $pageLocation) (not .Params.draft) }}
@@ -42,22 +42,28 @@
             {{ end }}
 
             {{ if not .IsPage }}
-                <li role="treeitem" aria-label="{{ $linktitle}}">
+                <li role="treeitem" aria-label="{{ $linktitle }}">
                     {{ $collapse := not (.IsAncestor $current) }}
                     {{ if eq . $current }}
                         {{ $collapse = true }}
                     {{ end }}
 
-                    {{if lt (len $pageLocation) 6 -}}
-                        <a class='main' title="{{ $desc }}" href="{{ .Permalink }}">{{ $linktitle}}</a>
-                        {{ partial "navigation_level.html" (dict "pages" $pages "parent" . "current" $current "collapse" false "top" false "labelledby" "" ) .CurrentSection }}
-                    {{ else if (.CurrentSection.IsAncestor $current) }}
-                        <button {{ if not $collapse }} class="show" {{ end }} aria-hidden="true" tabindex="-1" ></button><a title="{{ $desc }}" href="{{ .Permalink }}">{{ $linktitle}}</a>
-                        {{ partial "navigation_level.html" (dict "pages" $pages "parent" . "current" $current "collapse" $collapse "top" false "labelledby" "" ) }}
-                    {{- else -}}
-                        <button {{ if not $collapse }} class="show" {{ end }} aria-hidden="true" tabindex="-1" ></button><a title="{{ $desc }}" href="{{ .Permalink }}">{{ $linktitle}}</a>
-                        {{ partialCached "navigation_level.html" (dict "pages" $pages "parent" . "current" $current "collapse" $collapse "top" false "labelledby" "" ) .CurrentSection }}
-                    {{- end -}}
+                    {{ if lt (len $pageLocation) 6 }}
+                        <a class='main' title="{{ $desc }}" href="{{ .Permalink }}">{{ $linktitle }}</a>
+                        {{ if and .CurrentSection (ne .CurrentSection .) (ne .CurrentSection $parent) (ne .CurrentSection $current) .CurrentSection.Pages }}
+                            {{ partial "navigation_level.html" (dict "pages" .CurrentSection.Pages "parent" . "current" $current "collapse" false "top" false "labelledby" "") }}
+                        {{ end }}
+                    {{ else if .CurrentSection.IsAncestor $current }}
+                        <button {{ if not $collapse }} class="show" {{ end }} aria-hidden="true" tabindex="-1"></button><a title="{{ $desc }}" href="{{ .Permalink }}">{{ $linktitle }}</a>
+                        {{ if and .CurrentSection (ne .CurrentSection .) (ne .CurrentSection $parent) (ne .CurrentSection $current) .CurrentSection.Pages }}
+                            {{ partial "navigation_level.html" (dict "pages" .CurrentSection.Pages "parent" . "current" $current "collapse" $collapse "top" false "labelledby" "") }}
+                        {{ end }}
+                    {{ else }}
+                        <button {{ if not $collapse }} class="show" {{ end }} aria-hidden="true" tabindex="-1"></button><a title="{{ $desc }}" href="{{ .Permalink }}">{{ $linktitle }}</a>
+                        {{ if and .CurrentSection (ne .CurrentSection .) (ne .CurrentSection $parent) (ne .CurrentSection $current) .CurrentSection.Pages }}
+                            {{ partial "navigation_level.html" (dict "pages" .CurrentSection.Pages "parent" . "current" $current "collapse" $collapse "top" false "labelledby" "") }}
+                        {{ end }}
+                    {{ end }}
                 </li>
             {{ else }}
                 <li role="none">


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

The updated Hugo release checks for infinite recursion and throws an error if a partial is called again and again and doesn`t terminate this was not the case with 0.145.0 as it has less stringent checks the new release checks for this errors and throws an error if an infinite recursion is detected.This PR solves the issue of the infinite recursion caused by layouts/partials/navigation_level.html file by fixing the logical error within the partial and the site is successfully build now without any errors.

Hugo Version:-0.147.2
Fixes:- #16436 

Screenshots:-
![Screenshot from 2025-05-11 12-19-48](https://github.com/user-attachments/assets/f9ee4b07-5671-43f1-b1bf-2bd540867e84)
![Screenshot from 2025-05-11 12-19-37](https://github.com/user-attachments/assets/7278d2a1-6f28-4b8e-8233-aab1f04d9d87)

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
