### PR TITLE
Add override for redirects

### DIFF
--- a/netlify/edge-functions/redirect-to-latest.ts
+++ b/netlify/edge-functions/redirect-to-latest.ts
@@ -2,6 +2,10 @@ export default async (request: Request, context) => {
   const url = new URL(request.url);
   let pathname = url.pathname;
 
+  if (url.searchParams.get('redirect') === 'false') {
+    return context.next();
+  }
+
   // Normalize consecutive slashes
   pathname = pathname.replace(/\/\/+/g, '/');
 


### PR DESCRIPTION
Add `?redirect=false` to a URL to stop the edge function from redirecting `v1.xx` paths to `latest`.