### PR TITLE
Fix: use correct link to install kiali

### DIFF
--- a/content/zh/docs/setup/getting-started/index.md
+++ b/content/zh/docs/setup/getting-started/index.md
@@ -217,7 +217,7 @@ Istio 和[几个遥测应用](/zh/docs/ops/integrations)做了集成。
 1.  安装 [Kiali 和其他插件]({{< github_tree >}}/samples/addons)，等待部署完成。
 
     {{< text bash >}}
-    $ kubectl apply -f @samples/addons@
+    $ kubectl apply -f @samples/addons/kiali.yaml@
     $ kubectl rollout status deployment/kiali -n istio-system
     Waiting for deployment "kiali" rollout to finish: 0 of 1 updated replicas are available...
     deployment "kiali" successfully rolled out


### PR DESCRIPTION
## Description

The link from page https://istio.io/latest/docs/setup/getting-started/#dashboard goes to a 404 page. With this fix, cliking on link redirect user to correct link

## Reviewers

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

https://istio.io/latest/docs/setup/getting-started/#dashboard
