### PR TITLE
serve single container port 1313

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 # expose port 1313 from the container in order to support 'make serve' which runs a Hugo web server
+ifeq ($(filter serve,$(MAKECMDGOALS)),serve)
 CONTAINER_OPTIONS = -p 1313:1313 ${ADDITIONAL_CONTAINER_OPTIONS}
+else
+CONTAINER_OPTIONS = ${ADDITIONAL_CONTAINER_OPTIONS}
+endif
 
 # this repo is on the container plan by default
 BUILD_WITH_CONTAINER ?= 1


### PR DESCRIPTION
## Description

This PR updates  `Makefile.overrides.mk` so that the Docker container only forwards port 1313 when running the serve target (i.e., make serve). For all other targets, such as make gen or make `lint-md`, port forwarding is omitted. This allows multiple build containers to run in parallel without port conflicts.
<!-- Please replace this line with a description of the PR. -->
fixes #15199 
## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
