### PR TITLE
fix: update dependencies to reduce npm warnings

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -139,13 +139,13 @@ archive-version:
 netlify_install:
 	@npm init -y
 	@npm install --omit=dev --global \
-	    sass@v1.52.1 \
-	    typescript@v4.7.2 \
-	    svgstore-cli@v1.3.2 \
-		@babel/core@v7.18.2 \
-		@babel/cli@v7.17.10 \
+	    sass@v1.89.1 \
+	    typescript@v5.8.3 \
+	    svgstore-cli@v2.0.1 \
+		@babel/core@v7.27.4 \
+		@babel/cli@v7.27.2 \
 		@babel/traverse@7.25.9 \
-		@babel/preset-env@v7.18.2
+		@babel/preset-env@v7.27.2
 	@npm install --omit=dev --save-dev \
 		babel-preset-minify@v0.5.2
 	@npm install --save \


### PR DESCRIPTION
## Description

Update `Makefile` dependencies to resolve `npm deprecation`  warnings (fixes a part of this issue #15059)

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
