### PR TITLE
add 1.24 initial eol announcement, update eol date in supportStatus.yml

### DIFF
--- a/content/en/news/support/announcing-1.24-eol/index.md
+++ b/content/en/news/support/announcing-1.24-eol/index.md
@@ -1,0 +1,12 @@
+---
+title: Support for Istio 1.24 ends on June 19, 2025
+subtitle: Support Announcement
+description: Upcoming Istio 1.24 end of life announcement.
+publishdate: 2025-06-11
+---
+
+According to Istio's [support policy](/docs/releases/supported-releases#support-policy), minor releases like 1.24 are supported until six weeks after the N+2 minor release (1.26 in this case). [Istio 1.26 was released on May 8th, 2025](/news/releases/1.26.x/announcing-1.26/), and support for 1.24 will end on June 19th, 2025.
+
+At that point we will stop back-porting fixes for security issues and critical bugs to 1.24, so we encourage you to upgrade to the latest version of Istio ({{<istio_release_name>}}). If you don't do this you may put yourself in the position of having to do a major upgrade on a short timeframe to pick up a critical fix.
+
+We care about you and your clusters, so please be kind to yourself and upgrade.

--- a/content/en/news/support/announcing-1.24-eol/index.md
+++ b/content/en/news/support/announcing-1.24-eol/index.md
@@ -2,7 +2,7 @@
 title: Support for Istio 1.24 ends on June 19, 2025
 subtitle: Support Announcement
 description: Upcoming Istio 1.24 end of life announcement.
-publishdate: 2025-06-11
+publishdate: 2025-06-12
 ---
 
 According to Istio's [support policy](/docs/releases/supported-releases#support-policy), minor releases like 1.24 are supported until six weeks after the N+2 minor release (1.26 in this case). [Istio 1.26 was released on May 8th, 2025](/news/releases/1.26.x/announcing-1.26/), and support for 1.24 will end on June 19th, 2025.

--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -22,7 +22,7 @@
 - version: "1.24"
   supported: "Yes"
   releaseDate: "November 7, 2024"
-  eolDate: "June 19, 2025"
+  eolDate: "June 19, 2025 (Expected)"
   k8sVersions: ["1.28", "1.29", "1.30", "1.31"]
   testedK8sVersions: ["1.23", "1.24", "1.25", "1.26", "1.27"]
 - version: "1.23"

--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -22,7 +22,7 @@
 - version: "1.24"
   supported: "Yes"
   releaseDate: "November 7, 2024"
-  eolDate: "~Aug 2025 (Expected)"
+  eolDate: "June 19, 2025"
   k8sVersions: ["1.28", "1.29", "1.30", "1.31"]
   testedK8sVersions: ["1.23", "1.24", "1.25", "1.26", "1.27"]
 - version: "1.23"


### PR DESCRIPTION
## Description

Add notice of 1.24 EOL status (19 June, 2025). We missed the date this should have been posted for full 30-day notice, should we backdate the announcement?

cc: @hzxuzhonghu @dhawton as RMs for 1.24 to validate this date. DNM pending their approval.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
