### PR TITLE
chore: fix npm warnings

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -138,9 +138,11 @@ archive-version:
 # to what is included in the tools repo in docker/build-tools/Dockerfile.
 netlify_install:
 	@npm init -y
+	@jq '. + {overrides: {"glob": "^10.0.0", "inflight": false}}' package.json > tmp.$$ && mv tmp.$$ package.json
 	@npm install --omit=dev --global \
 	    sass@v1.89.1 \
-	    typescript@v5.8.3 \
+	    typescript@v5.8.3 
+	@npm install --omit=dev \
 	    svgstore-cli@v2.0.1 \
 		@babel/core@v7.27.4 \
 		@babel/cli@v7.27.2 \


### PR DESCRIPTION


## Description
This PR resolves npm warnings caused by deprecated glob@7.2.3 and inflight@1.0.6 by overriding them.
few observations:
### Before 
```
$ npm explain inflight glob
inflight@1.0.6
node_modules/inflight
  inflight@"^1.0.4" from glob@7.2.3
  node_modules/glob
    glob@"^7.2.0" from @babel/cli@7.23.0
    node_modules/@babel/cli
      @babel/cli@"^7.23.0" from the root project
    glob@"^7.2.0" from svgstore-cli@2.0.1
    node_modules/svgstore-cli
      svgstore-cli@"^2.0.1" from the root project

glob@7.2.3
node_modules/glob
  glob@"^7.2.0" from @babel/cli@7.23.0
  node_modules/@babel/cli
    @babel/cli@"^7.23.0" from the root project
  glob@"^7.2.0" from svgstore-cli@2.0.1
  node_modules/svgstore-cli
    svgstore-cli@"^2.0.1" from the root project
```

 ### Now (After  the fix)
 ```
$  npm explain inflight glob
glob@10.4.5
node_modules/glob
  overridden glob@"^10.0.0" (was "^7.2.0") from @babel/cli@7.27.2
  node_modules/@babel/cli
    @babel/cli@"^7.27.2" from the root project
  overridden glob@"^10.0.0" (was "^7.2.0") from svgstore-cli@2.0.1
  node_modules/svgstore-cli
    svgstore-cli@"^2.0.1" from the root project
```
 
 


Fixes #16573
<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [x] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
