### PR TITLE
add 1.24 EOL final announcement, update supportStatus.yml

### DIFF
--- a/content/en/news/support/announcing-1.24-eol-final/index.md
+++ b/content/en/news/support/announcing-1.24-eol-final/index.md
@@ -1,0 +1,11 @@
+---
+title: Support for Istio 1.24 has ended
+subtitle: Support Announcement
+description: Istio 1.24 end of life announcement.
+publishdate: 2025-04-24
+---
+
+As [previously announced](/news/support/announcing-1.24-eol/), support for Istio 1.24 has now officially ended.
+
+At this point we will no longer back-port fixes for security issues and critical bugs to 1.24. We highly recommend that
+you upgrade to the latest version of Istio ({{<istio_release_name>}}) if you haven't already.

--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -20,9 +20,9 @@
   k8sVersions: ["1.29", "1.30", "1.31", "1.32"]
   testedK8sVersions: ["1.24", "1.25", "1.26", "1.27", "1.28"]
 - version: "1.24"
-  supported: "Yes"
+  supported: "No"
   releaseDate: "November 7, 2024"
-  eolDate: "June 19, 2025 (Expected)"
+  eolDate: "June 24, 2025"
   k8sVersions: ["1.28", "1.29", "1.30", "1.31"]
   testedK8sVersions: ["1.23", "1.24", "1.25", "1.26", "1.27"]
 - version: "1.23"


### PR DESCRIPTION
## Description

Add final notice of 1.24 EOL status (24 June, 2025 - expecting review and merge tomorrow because timezones).

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
