### PR TITLE
Replaced document exec Command ("copy");  

### DIFF
--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -45,7 +45,7 @@ function copyToClipboard(str: string): void {
         const oldSelection = sel.getRangeAt(0);
 
         el.select();                                     // Select the <textarea> content
-        document.execCommand("copy");                    // Copy - only works as a result of a user action (e.g. click events)
+        navigator.clipboard.writeText(str);              // Copy - only works as a result of a user action (e.g. click events)
         document.body.removeChild(el);                   // Remove the <textarea> element
 
         // restore the previous selection
@@ -53,7 +53,7 @@ function copyToClipboard(str: string): void {
         sel.addRange(oldSelection);
     } else {
         el.select();                                     // Select the <textarea> content
-        navigator.clipboard.writeText(str);                    // Copy - only works as a result of a user action (e.g. click events)
+        navigator.clipboard.writeText(str);              // Copy - only works as a result of a user action (e.g. click events)
         document.body.removeChild(el);                   // Remove the <textarea> element
     }
 }

--- a/src/ts/utils.ts
+++ b/src/ts/utils.ts
@@ -53,7 +53,7 @@ function copyToClipboard(str: string): void {
         sel.addRange(oldSelection);
     } else {
         el.select();                                     // Select the <textarea> content
-        document.execCommand("copy");                    // Copy - only works as a result of a user action (e.g. click events)
+        navigator.clipboard.writeText(str);                    // Copy - only works as a result of a user action (e.g. click events)
         document.body.removeChild(el);                   // Remove the <textarea> element
     }
 }


### PR DESCRIPTION
Replaced deprecated document.execCommand in utils.ts with modern Clipboard.

issue no #16584 

Replaced document.execCommand('copy') with navigator.clipboard.writeText(str) for modern, secure clipboard handling.


