### PR TITLE
[zh] Sync #16602 add restrictions on Gateway APIs and services in the same namespace into Chinese

### DIFF
--- a/content/zh/docs/tasks/traffic-management/ingress/gateway-api/index.md
+++ b/content/zh/docs/tasks/traffic-management/ingress/gateway-api/index.md
@@ -369,6 +369,10 @@ spec:
 
 要将 `Gateway` 链接到 `Service`，需要将 `addresses` 字段配置为指向**单个** `Hostname`。
 
+{{< tip >}}
+如果 `Service` 与 `Gateway` 位于不同的命名空间中，Istio 的控制器将不会配置 `Service`。
+{{< /tip >}}
+
 {{< text yaml >}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway


### PR DESCRIPTION
## Description

Sync #16602 add restrictions on Gateway APIs and services in the same namespace into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
