### PR TITLE
Add Kubernetes 1.33 support to 1.26 and master

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -5,13 +5,13 @@
   supported: "No, development only"
   releaseDate:
   eolDate:
-  k8sVersions: ["1.29", "1.30", "1.31", "1.32"]
+  k8sVersions: ["1.29", "1.30", "1.31", "1.32", "1.33"]
   testedK8sVersions: ["1.23", "1.24", "1.25", "1.26", "1.27", "1.28"]
 - version: "1.26"
   supported: "Yes"
   releaseDate: "May 08, 2025"
   eolDate: "~Jan 2026 (Expected)"
-  k8sVersions: ["1.29", "1.30", "1.31", "1.32"]
+  k8sVersions: ["1.29", "1.30", "1.31", "1.32", "1.33"]
   testedK8sVersions: ["1.24", "1.25", "1.26", "1.27", "1.28"]
 - version: "1.25"
   supported: "Yes"


### PR DESCRIPTION
## Description

Now that we've got master and 1.26 running k8s 1.33 in postsubmit, we can claim support for it

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
