### PR TITLE
fix: update cloudnative.to link, ref #16655

### DIFF
--- a/content/en/get-involved/_index.md
+++ b/content/en/get-involved/_index.md
@@ -41,7 +41,7 @@ doc_type: get-involved
 1. The [Istio Community README](https://github.com/istio/community/blob/master/README.md) is the **starting point for contributors** who want to work on code, docs or other parts of Istio.
 1. You can access our [**trove of technical content and working documents**](https://drive.google.com/drive/folders/1l_zqgBq_yfc1PfbJiWsFubXBtAz22sau) by joining the [istio-team-drive-access@ Google Group](https://groups.google.com/forum/#!forum/istio-team-drive-access).
 1. You can participate in the [**working groups**](https://github.com/istio/community/blob/master/WORKING-GROUPS.md) which focus on particular areas of interest, such as docs, security, and networking.
-1. Interested in helping with **Chinese language documentation**? Join the [Cloud Native Community (China)](https://cloudnative.to).
+1. Interested in helping with **Chinese language documentation**? Join the [Cloud Native Community (China)](https://cloudnativecn.com).
 {{% /involve_block %}}
 
 {{% involve_block title="Understand oversight and planning" subtitle="Istio has two key committees that oversee the project: Steering and Technical Oversight." icon="magnifier" %}}

--- a/content/uk/get-involved/_index.md
+++ b/content/uk/get-involved/_index.md
@@ -45,7 +45,7 @@ doc_type: get-involved
 1. [README спільноти Istio](https://github.com/istio/community/blob/master/README.md) є **відправною точкою для учасників**, які хочуть працювати над кодом, документацією чи іншими частинами Istio.
 1. Ви можете отримати доступ до нашого [**скарбу технічного контенту та робочих документів**](https://drive.google.com/drive/folders/1l_zqgBq_yfc1PfbJiWsFubXBtAz22sau), приєднавшись до [istio-team-drive-access@ Google Group](https://groups.google.com/forum/#!forum/istio-team-drive-access).
 1. Ви можете взяти участь у [**робочих групах**](https://github.com/istio/community/blob/master/WORKING-GROUPS.md), які зосереджені на конкретних сферах інтересів, таких як документація, безпека та мережі.
-<!-- 1. Зацікавлені в допомозі з **документацією китайською мовою**? Приєднуйтесь до [Cloud Native Community (China)](https://cloudnative.to). -->
+<!-- 1. Зацікавлені в допомозі з **документацією китайською мовою**? Приєднуйтесь до [Cloud Native Community (China)](https://cloudnativecn.com). -->
 {{% /involve_block %}}
 
 {{% involve_block title="Зрозуміти нагляд і планування" subtitle="Istio має два ключові комітети, які здійснюють нагляд за проєктом: Steering та Technical Oversight." icon="magnifier" %}}

--- a/content/zh/get-involved/_index.md
+++ b/content/zh/get-involved/_index.md
@@ -40,7 +40,7 @@ doc_type: get-involved
 2. 无论谁想要通过代码、文档还是其他部分进行贡献，[Istio 社区自述](https://github.com/istio/community/blob/master/README.md)都是 **贡献者的起点** 。
 3. 您可以加入 [istio-team-drive-access@ Google Group](https://groups.google.com/forum/#!forum/istio-team-drive-access) 来 [**访问我们的技术内容和工作文档**](https://drive.google.com/drive/folders/1l_zqgBq_yfc1PfbJiWsFubXBtAz22sau)。
 4. 您可以加入 [**工作组**](https://github.com/istio/community/blob/master/WORKING-GROUPS.md)，这些工作组专注于您感兴趣的特定领域，如文档、安全和网络。
-5. 有兴趣帮忙翻译 **中文文档** 吗？欢迎加入[云原生社区](https://cloudnative.to)。
+5. 有兴趣帮忙翻译 **中文文档** 吗？欢迎加入[云原生社区](https://cloudnativecn.com)。
 {{% /involve_block %}}
 
 {{% involve_block title="了解监督和规划" subtitle="Istio 有两个关键委员会负责监督项目：指导委员会和技术监督委员会。" icon="magnifier" %}}


### PR DESCRIPTION
## Description

Ref #16655 

The Cloud Native Community (China) domain has changed to <https://cloudnativecn.com> since last year.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
