### PR TITLE
clarify support for VirtualService in waypoints

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -611,6 +611,7 @@ httpbin
 httpbin.foo.svc.cluster.local
 httpbin.org
 HTTPRoute
+HTTPRoutes
 HTTPS
 https
 Hu
@@ -630,6 +631,7 @@ impactful
 incentivized
 Incrementality
 Indo-Pacific
+ingress2gateway
 initContainer
 initializer
 initializers

--- a/content/en/boilerplates/gateway-api-gamma-experimental.md
+++ b/content/en/boilerplates/gateway-api-gamma-experimental.md
@@ -7,7 +7,7 @@
 
 {{< warning >}}
 This document configures Istio using Gateway API features that are
-[experimental](https://gateway-api.sigs.k8s.io/geps/overview/#status)
+[experimental](https://gateway-api.sigs.k8s.io/concepts/versioning/#release-channels)
 Before using the Gateway API instructions, make sure to:
 
 1) Install the **experimental version** of the Gateway API CRDs:

--- a/content/en/docs/ambient/usage/add-workloads/index.md
+++ b/content/en/docs/ambient/usage/add-workloads/index.md
@@ -34,13 +34,15 @@ For example, setting a `PeerAuthentication` policy with mTLS mode set to `STRICT
 
 ### Pods inside the mesh using sidecar mode
 
-Istio supports East-West interoperability between a pod with a sidecar and a pod using ambient mode, within the same mesh. The sidecar proxy knows to use the HBONE protocol since the destination has been discovered to be an HBONE destination.
-
-{{< tip >}}
-For sidecar proxies to use the HBONE/mTLS signaling option when communicating with ambient destinations, they need to be configured with `ISTIO_META_ENABLE_HBONE` set to `true` in the proxy metadata. This is the default in `MeshConfig` when using the `ambient` profile, hence you do not have to do anything else when using this profile.
-{{< /tip >}}
+When Istio is installed with the `ambient` profile, sidecar proxies gain support for the HBONE protocol.  This enables east-west interoperability between a pod with a sidecar and a pod using ambient mode, within the same mesh. The sidecar proxy knows to use the HBONE protocol since the destination has been discovered to be an HBONE destination.
 
 A `PeerAuthentication` policy with mTLS mode set to `STRICT` will allow traffic from a pod with an Istio sidecar proxy.
+
+{{< warning >}}
+Istio does not currently support waypoint discovery from sidecars. If you configure a pod in an ambient mesh to use a waypoint, and attempt to connect to that pod from an HBONE-enabled sidecar, the sidecar will ignore the instruction to use the waypoint and instead connect directly to the destination ztunnel. Depending on your configuration, this may allow you to bypass policy. Support for waypoint discovery is planned for an upcoming release.
+{{< /warning >}}
+
+For sidecar proxies to use the HBONE/mTLS signaling option when communicating with ambient destinations, they need to be configured with `ISTIO_META_ENABLE_HBONE` set to `true` in the proxy metadata. This is the default in `MeshConfig` when using the `ambient` profile.
 
 ### Ingress and egress gateways and ambient mode pods
 

--- a/content/en/docs/ambient/usage/l7-features/index.md
+++ b/content/en/docs/ambient/usage/l7-features/index.md
@@ -132,16 +132,16 @@ spec:
 
 Some legacy Istio APIs are deliberately not supported by waypoints in ambient mode.  These APIs can still be used with [Istio Gateways](/docs/tasks/traffic-management/ingress/ingress-control/).
 
-### VirtualService 
+### VirtualService
 
-Istio's legacy traffic routing API is not supported for configuring waypoint traffic routing, though it works in some circumstances. 
+Istio's legacy traffic routing API is not supported for configuring waypoint traffic routing, though it works in some circumstances.
 
 Any use of VirtualService with waypoints is considered Alpha, and may be subject to change in future releases.
 Istio's maintainers do not intend to remove this support, but will not be progressing it to [any further feature phase](/docs/releases/feature-stages).
 
 #### Migrating from VirtualService to Gateway API routes
 
-[Only a single VirtualService](https://istio.io/latest/docs/reference/config/analysis/ist0109/) can be used for mesh traffic matching a certain hostname. However, multiple Gateway API routes can refer to the same host.
+[Only a single VirtualService](/docs/reference/config/analysis/ist0109/) can be used for mesh traffic matching a certain hostname. However, multiple Gateway API routes can refer to the same host.
 
 This is especially relevant when you are migrating from VirtualService to Gateway API routes. If you create one or more HTTPRoutes which specify a Service that is also in use with a VirtualService, the HTTPRoute/s will apply and the VirtualService will not.
 
@@ -149,7 +149,7 @@ To avoid this situation, users migrating from sidecars should look to convert th
 
 #### Using features that are not in Gateway API
 
-A small number of Istio's features cannot currently be expressed in Gateway API: for example, [fault injection](/docs/tasks/traffic-management/fault-injection/) and [direct response](/docs/reference/config/networking/virtual-service/#HTTPDirectResponse). It is technically possible to use VirtualService for these use cases, as long as the configured `hosts` do not conflict with the `parentRefs` of any Gateway API route as mentioned above. 
+A small number of Istio's features cannot currently be expressed in Gateway API: for example, [fault injection](/docs/tasks/traffic-management/fault-injection/) and [direct response](/docs/reference/config/networking/virtual-service/#HTTPDirectResponse). It is technically possible to use VirtualService for these use cases, as long as the configured `hosts` do not conflict with the `parentRefs` of any Gateway API route as mentioned above.
 
 #### DestinationRule subsets
 

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -35,7 +35,7 @@ Waypoint proxies are deployed using Kubernetes Gateway resources.
 
 {{< boilerplate gateway-api-install-crds >}}
 
-You can use istioctl waypoint subcommands to generate, apply or list these resources.
+You can use `istioctl waypoint` subcommands to generate, apply or list these resources.
 
 After the waypoint is deployed, the entire namespace (or whichever services or pods you choose) must be [enrolled](#useawaypoint) to use it.
 
@@ -243,7 +243,7 @@ $ kubectl label serviceentries.networking.istio.io istio-site istio.io/use-waypo
 serviceentries.networking.istio.io/istio-site labeled
 {{< /text >}}
 
-### Cleaning up
+## Removing waypoints
 
 You can remove all waypoints from a namespace by doing the following:
 
@@ -251,5 +251,3 @@ You can remove all waypoints from a namespace by doing the following:
 $ istioctl waypoint delete --all -n default
 $ kubectl label ns default istio.io/use-waypoint-
 {{< /text >}}
-
-{{< boilerplate gateway-api-remove-crds >}}

--- a/content/en/docs/ops/best-practices/traffic-management/index.md
+++ b/content/en/docs/ops/best-practices/traffic-management/index.md
@@ -279,7 +279,7 @@ caveats with this feature that must be considered carefully when using it.
    All such "catch-all" rules will be moved to the end of the list in the merged configuration, but
    since they catch all requests, whichever is applied first will essentially override and disable any others.
 1. A `VirtualService` can only be fragmented this way if it is bound to a gateway.
-   Host merging is not supported in sidecars.
+   Host merging is not supported in mesh routing (i.e. sidecars or waypoints).
 
 A `DestinationRule` can also be fragmented with similar merge semantics and restrictions.
 


### PR DESCRIPTION
Update the ambient docs to clarify that waypoint support for VirtualService is alpha, why that is, and what that means you have to think about during a migration.