### PR TITLE
make /latest the latest

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -21,7 +21,7 @@ description: A service mesh for observability, security in depth, and management
         "url": "https://istio.io/",
         "potentialAction": {
             "@type": "SearchAction",
-            "target": "https://istio.io/search?q={search_term_string}",
+            "target": "https://istio.io/latest/search?q={search_term_string}",
             "query-input": "required name=search_term_string"
         }
     }

--- a/layouts/index.redir
+++ b/layouts/index.redir
@@ -56,11 +56,14 @@ https://istio.netlify.com/* https://istio.io/:splat 301!
 /favicon.ico /latest/favicons/favicon.ico 200
 /logos/* /latest/logos/:splat
 
-# navigating to a page without /latest on front, add /latest
-{{ range $p := .Site.Pages }}
-{{ strings.TrimPrefix "/latest" $p.Permalink }} {{ $p.Permalink}}
-{{ strings.TrimPrefix "/latest" (printf "%s.html" (substr $p.Permalink 0 -1)) }} {{ $p.Permalink}}
-{{- end }}
+# Redirect root paths without /latest
+/about/* /latest/about/:splat
+/blog/* /latest/blog/:splat
+/docs/* /latest/docs/:splat
+/get-involved/* /latest/get-involved/:splat
+/news/* /latest/news/:splat
+/search/* /latest/search/:splat
+/test/* /latest/test/:splat
 
 # redirect current version to /latest
 /v{{ .Site.Data.args.version }}/* /latest/:splat
@@ -71,15 +74,11 @@ https://istio.netlify.com/* https://istio.io/:splat 301!
 # migration from old design to new
 /about / 301!
 /latest/about /latest 301!
-# /faq/ /about/faq
-/faq/* /about/faq/
-# /latest/faq/ /about/faq
-/latest/faq/* /about/faq/
-/about/faq/* /about/faq/
-/latest/about/faq/* /about/faq/
+/faq/* /latest/about/faq/
+/latest/faq/* /latest/about/faq/
+/about/faq/* /latest/about/faq/
 
 # media-resources page
-
 /about/media-resources https://github.com/cncf/artwork/tree/master/projects/istio
 /latest/about/media-resources https://github.com/cncf/artwork/tree/master/projects/istio
 /about/zh/media-resources https://github.com/cncf/artwork/tree/master/projects/istio

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -65,7 +65,7 @@
             {{ end }}
             <input type="hidden" name="ie" value="utf-8" />
             <input type="hidden" name="hl" value="{{ .Page.Lang }}" />
-            <input type="hidden" id="search-page-url" value="{{ "/search" | relLangURL }}" />
+            <input type="hidden" id="search-page-url" value="{{ "/latest/search" | relLangURL }}" />
             <input id="search-textbox" class="search-textbox form-control" name="q" type="search" aria-label='{{ i18n "search" }}' placeholder='{{ i18n "search_label" }}' />
             <button id="search-close" title='{{ i18n "search_cancel" }}' type="reset" aria-label='{{ i18n "search_cancel" }}'>{{ partial "icon.html" "menu-close" }}</button>
         </form>


### PR DESCRIPTION
Changing the baseURL from `/latest` to `https://istio.io/latest/` caused two related problems:

1. redirects stopped working
2. search stopped working because it relied on redirects

The latter is fixed by way of updating `/search` to `/latest/search`. For now at least, I assume we are going to only have one search index.

For the former, I have removed a redirect for every. single. page. (~2000 lines) and replaced with a wildcard redirect for the five paths we care about.

This only fixes links that don't include a version, which should only be links that were broken (like point 2), or older than 5 years, when we introduced `/latest/` to all the URLs.