### PR TITLE
[ES] broken links

### DIFF
--- a/content/es/_index.html
+++ b/content/es/_index.html
@@ -37,8 +37,8 @@ description: Una service mesh para observabilidad, seguridad en profundidad y ge
 
     <section id="landing-panels" class="container">
         <div class="panels">
-            {{< content_panel type="dark" title="latest_news" text="Rápido, seguro y simple: el modo ambient de Istio ya está Disponible de forma General." button="read_more" url="/blog/2024/ambient-reaches-ga/" >}}
-            {{< content_panel type="dark" title="join_the_community" text="Conecta con más de 10.000 de tus compañeros que usan, prueban e innovan con Istio." button="connect_with_us" url="/get-involved" >}}
+            {{< content_panel type="dark" title="latest_news" text="Rápido, seguro y simple: el modo ambient de Istio ya está Disponible de forma General." button="read_more" url="/es/blog/2024/ambient-reaches-ga/" >}}
+            {{< content_panel type="dark" title="join_the_community" text="Conecta con más de 10.000 de tus compañeros que usan, prueban e innovan con Istio." button="connect_with_us" url="/es/get-involved" >}}
             {{< content_panel type="dark" title="get_started" text="Prueba Istio hoy. Evalúa rápidamente el proyecto en cuatro pasos." button="learn_more" url="/es/docs/overview/quickstart" >}}
         </div>
     </section>
@@ -53,7 +53,7 @@ description: Una service mesh para observabilidad, seguridad en profundidad y ge
         </p>
 
         <div class="cta-container">
-            <a class="btn" href="/about/service-mesh">Aprende más</a>
+            <a class="btn" href="/es/about/service-mesh">Aprende más</a>
         </div>
     </section>
 
@@ -63,7 +63,7 @@ description: Una service mesh para observabilidad, seguridad en profundidad y ge
         {{< logo_carousel >}}
 
         <div class="cta-container">
-            <a class="btn" href="/about/case-studies">Lee nuestros casos de estudio</a>
+            <a class="btn" href="/es/about/case-studies">Lee nuestros casos de estudio</a>
         </div>
     </section>
     
@@ -97,7 +97,7 @@ description: Una service mesh para observabilidad, seguridad en profundidad y ge
         </div>
 
         <div class="cta-container">
-            <a class="btn" href="/about/ecosystem#providers">Ver todos los proveedores</a>
+            <a class="btn" href="/es/about/ecosystem#index">Ver todos los proveedores</a>
         </div>
     </section>
 

--- a/content/es/_index.html
+++ b/content/es/_index.html
@@ -97,7 +97,7 @@ description: Una service mesh para observabilidad, seguridad en profundidad y ge
         </div>
 
         <div class="cta-container">
-            <a class="btn" href="/es/about/ecosystem#index">Ver todos los proveedores</a>
+            <a class="btn" href="/es/about/ecosystem#providers">Ver todos los proveedores</a>
         </div>
     </section>
 

--- a/content/es/news/_index.md
+++ b/content/es/news/_index.md
@@ -1,0 +1,13 @@
+---
+title: Noticias
+linktitle: Noticias
+description: Selecciona boletines de seguridad, anuncios de lanzamientos o anuncios de soporte para mantenerte al día.
+sidebar_multicard: true
+decoration: pill
+layout: news-feed
+outputs:
+    - html
+    - rss
+---
+
+¡Bienvenido a la sección de noticias de Istio en español! 

--- a/content/es/news/releases/_index.md
+++ b/content/es/news/releases/_index.md
@@ -1,0 +1,7 @@
+---
+title: Anuncios de lanzamientos
+description: Anuncios de todos los lanzamientos principales y parches de Istio.
+weight: 8
+decoration: pill
+data_category: Anuncios de lanzamientos
+--- 

--- a/content/es/news/security/_index.md
+++ b/content/es/news/security/_index.md
@@ -1,0 +1,8 @@
+---
+title: Boletines de seguridad
+description: Vulnerabilidades de seguridad divulgadas y su mitigación.
+weight: 7
+list_by_publishdate: true
+layout: security-grid
+data_category: Boletines de seguridad
+--- 

--- a/content/es/news/support/_index.md
+++ b/content/es/news/support/_index.md
@@ -1,0 +1,7 @@
+---
+title: Anuncios de soporte
+description: Anuncios sobre ventanas de soporte.
+weight: 15
+list_by_publishdate: true
+data_category: Anuncios de soporte
+--- 

--- a/hugo.toml
+++ b/hugo.toml
@@ -197,7 +197,7 @@ disableAliases = true
   # i18n for Spanish
    [[languages.es.menu.main]]
     identifier = "about"
-    name = "About"
+    name = "Acerca de"
     title = "Acerca de la sección"
     weight = 1
 

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -391,3 +391,9 @@ other = "⚠️ This documentation is for an older version (<strong>%s</strong>)
 
 [archive_banner_link]
 other = "Read the latest version."
+
+[not_found_message]
+other = "We're sorry, the page you requested cannot be found"
+
+[not_found_explanation]
+other = "The URL may be misspelled or the page you're looking for is no longer available"

--- a/i18n/es.toml
+++ b/i18n/es.toml
@@ -390,3 +390,10 @@ other = "⚠️ Esta documentación es para una versión anterior (<strong>%s</s
 
 [archive_banner_link]
 other = "Lee la última versión."
+
+[not_found_message]
+other = "Lo sentimos, la página que solicitaste no se puede encontrar"
+
+[not_found_explanation]
+other = "La URL puede estar mal escrita o la página que buscas ya no está disponible"
+

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -6,11 +6,11 @@
     </svg>
 
     <div class="error">
-        We're sorry, the page you requested cannot be found
+        {{ i18n "not_found_message" }}
     </div>
 
     <div class="explanation">
-        The URL may be misspelled or the page you're looking for is no longer available
+        {{ i18n "not_found_explanation" }}
     </div>
 </main>
 

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -80,6 +80,8 @@
                     {{ end }}
                     {{ if eq $home.Lang "zh" }}
                         <a class="footer-policies-link" href="https://github.com/istio/istio.io/edit/{{ .Site.Data.args.doc_branch_name }}/content/zh/{{ $file }}">{{ i18n "edit_on_github" }}</a>
+                    {{ else if eq $home.Lang "es" }}
+                        <a class="footer-policies-link" href="https://github.com/istio/istio.io/edit/{{ .Site.Data.args.doc_branch_name }}/content/es/{{ $file }}">{{ i18n "edit_on_github" }}</a>
                     {{ else }}
                         <a class="footer-policies-link" href="https://github.com/istio/istio.io/edit/{{ .Site.Data.args.doc_branch_name }}/content/en/{{ $file }}">{{ i18n "edit_on_github" }}</a>
                     {{ end }}


### PR DESCRIPTION
## Description

Replace broken links: 
Main page in Spanish:

- Ultimas noticias link in main page redirects to English version, it should be redirecting to [here](https://deploy-preview-16651--preliminary-istio.netlify.app/latest/es/blog/2024/ambient-reaches-ga/)
- Unete a la comunidad link on the main page redirects to the English version
- Same with Aprende más link in the main page redirects to the English version
- Lee nuestros casos de estudio in the main page redirects to the English version
- Ver todos los proveedores link in the main page redirects to the English version
- Editar esta pagina link in the main page redirects to the English version
- Acerca de test in the header is in English (About)
- Noticias [link](https://deploy-preview-16651--preliminary-istio.netlify.app/latest/es/news/) is broken
- Error page when the link is broken has the headers in English
- TODO: 404 redirecting to the english page for some reason

Ref. https://github.com/istio/istio.io/issues/16684 

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [X] Localization/Translation

https://deploy-preview-16695--preliminary-istio.netlify.app/latest/
https://deploy-preview-16695--preliminary-istio.netlify.app/latest/es/
