### PR TITLE
multi-cluster: add pre-installation steps for KinD

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -838,6 +838,7 @@ macOS
 Maertens
 Maglev
 maintainership
+Makefile
 Mandar
 Manolache
 Mansing

--- a/content/en/docs/setup/install/multicluster/before-you-begin/index.md
+++ b/content/en/docs/setup/install/multicluster/before-you-begin/index.md
@@ -26,6 +26,7 @@ If you are testing multicluster setup on `kind`, you can use the script `samples
 $ samples/kind-lb/setupkind.sh --cluster-name cluster-1 --ip-space 254
 $ samples/kind-lb/setupkind.sh --cluster-name cluster-2 --ip-space 255
 {{< /text >}}
+
 {{< /tip >}}
 
 ### API Server Access
@@ -62,8 +63,8 @@ If you're using `kind`, set the following contexts:
 $ export CTX_CLUSTER1=$(kubectl config get-contexts -o name | grep kind-cluster-1)
 $ export CTX_CLUSTER2=$(kubectl config get-contexts -o name | grep kind-cluster-2)
 {{< /text >}}
-{{< /tip >}}
 
+{{< /tip >}}
 
 ## Configure Trust
 
@@ -99,7 +100,8 @@ below may have to be altered based on your choice of CA.
 {{< /tip >}}
 
 {{< tip >}}
-If you're using `kind`, you can quickly generate self-signed CA certificates for your clusters using the provided Makefile:
+If you're using `kind`, you can quickly generate self-signed CA certificates
+for your clusters using the provided Makefile:
 
 {{< text bash >}}
 $ make -f tools/certs/Makefile.selfsigned.mk \
@@ -127,7 +129,6 @@ $ kubectl --context="${CTX_CLUSTER1}" create secret generic cacerts -n istio-sys
     --from-file=ca-key.pem=cluster1/ca-key.pem \
     --from-file=root-cert.pem=cluster1/root-cert.pem \
     --from-file=cert-chain.pem=cluster1/cert-chain.pem
-
 $ kubectl --context="${CTX_CLUSTER2}" create namespace istio-system
 $ kubectl --context="${CTX_CLUSTER2}" create secret generic cacerts -n istio-system \
     --from-file=ca-cert.pem=cluster2/ca-cert.pem \
@@ -139,7 +140,6 @@ $ kubectl --context="${CTX_CLUSTER2}" create secret generic cacerts -n istio-sys
 This will create the `cacerts` secret in the `istio-system` namespace of each cluster, allowing Istio to use your custom CA certificates.
 
 {{< /tip >}}
-
 
 ## Next steps
 

--- a/content/en/docs/setup/install/multicluster/before-you-begin/index.md
+++ b/content/en/docs/setup/install/multicluster/before-you-begin/index.md
@@ -23,8 +23,8 @@ This guide requires that you have two Kubernetes clusters with any of the
 If you are testing multicluster setup on `kind`, you can use the script `samples/kind-lb/setupkind.sh` to quickly set up clusters with load balancer support:
 
 {{< text bash >}}
-$ samples/kind-lb/setupkind.sh --cluster-name cluster-1 --ip-space 254
-$ samples/kind-lb/setupkind.sh --cluster-name cluster-2 --ip-space 255
+$ @samples/kind-lb/setupkind.sh@ --cluster-name cluster-1 --ip-space 254
+$ @samples/kind-lb/setupkind.sh@ --cluster-name cluster-2 --ip-space 255
 {{< /text >}}
 
 {{< /tip >}}
@@ -104,15 +104,15 @@ If you're using `kind`, you can quickly generate self-signed CA certificates
 for your clusters using the provided Makefile:
 
 {{< text bash >}}
-$ make -f tools/certs/Makefile.selfsigned.mk \
+$ make -f @tools/certs/Makefile.selfsigned.mk@ \
     ROOTCA_CN="Root CA" \
     ROOTCA_ORG=istio.io \
     root-ca
-$ make -f tools/certs/Makefile.selfsigned.mk \
+$ make -f @tools/certs/Makefile.selfsigned.mk@ \
     INTERMEDIATE_CN="Cluster 1 Intermediate CA" \
     INTERMEDIATE_ORG=istio.io \
     cluster1-cacerts
-$ make -f tools/certs/Makefile.selfsigned.mk \
+$ make -f @tools/certs/Makefile.selfsigned.mk@ \
     INTERMEDIATE_CN="Cluster 2 Intermediate CA" \
     INTERMEDIATE_ORG=istio.io \
     cluster2-cacerts

--- a/content/en/docs/setup/install/multicluster/before-you-begin/index.md
+++ b/content/en/docs/setup/install/multicluster/before-you-begin/index.md
@@ -19,6 +19,15 @@ In addition, review the requirements and perform the initial steps below.
 This guide requires that you have two Kubernetes clusters with any of the
 [supported Kubernetes versions:](/docs/releases/supported-releases#support-status-of-istio-releases) {{< supported_kubernetes_versions >}}.
 
+{{< tip >}}
+If you are testing multicluster setup on `kind`, you can use the script `samples/kind-lb/setupkind.sh` to quickly set up clusters with load balancer support:
+
+{{< text bash >}}
+$ samples/kind-lb/setupkind.sh --cluster-name cluster-1 --ip-space 254
+$ samples/kind-lb/setupkind.sh --cluster-name cluster-2 --ip-space 255
+{{< /text >}}
+{{< /tip >}}
+
 ### API Server Access
 
 The API Server in each cluster must be accessible to the other clusters in the
@@ -45,6 +54,16 @@ Set the two variables before proceeding:
 $ export CTX_CLUSTER1=<your cluster1 context>
 $ export CTX_CLUSTER2=<your cluster2 context>
 {{< /text >}}
+
+{{< tip >}}
+If you're using `kind`, set the following contexts:
+
+{{< text bash >}}
+$ export CTX_CLUSTER1=$(kubectl config get-contexts -o name | grep kind-cluster-1)
+$ export CTX_CLUSTER2=$(kubectl config get-contexts -o name | grep kind-cluster-2)
+{{< /text >}}
+{{< /tip >}}
+
 
 ## Configure Trust
 
@@ -78,6 +97,49 @@ change the CA using one of the methods described in
 CA typically requires reinstalling Istio. The installation instructions
 below may have to be altered based on your choice of CA.
 {{< /tip >}}
+
+{{< tip >}}
+If you're using `kind`, you can quickly generate self-signed CA certificates for your clusters using the provided Makefile:
+
+{{< text bash >}}
+$ make -f tools/certs/Makefile.selfsigned.mk \
+    ROOTCA_CN="Root CA" \
+    ROOTCA_ORG=istio.io \
+    root-ca
+$ make -f tools/certs/Makefile.selfsigned.mk \
+    INTERMEDIATE_CN="Cluster 1 Intermediate CA" \
+    INTERMEDIATE_ORG=istio.io \
+    cluster1-cacerts
+$ make -f tools/certs/Makefile.selfsigned.mk \
+    INTERMEDIATE_CN="Cluster 2 Intermediate CA" \
+    INTERMEDIATE_ORG=istio.io \
+    cluster2-cacerts
+{{< /text >}}
+
+This will create a root CA and intermediate CA certificates for each cluster, which you can then use to set up trust between your clusters.
+
+To create the `cacerts` secret in each cluster, use the following command after generating the certificates:
+
+{{< text bash >}}
+$ kubectl --context="${CTX_CLUSTER1}" create namespace istio-system
+$ kubectl --context="${CTX_CLUSTER1}" create secret generic cacerts -n istio-system \
+    --from-file=ca-cert.pem=cluster1/ca-cert.pem \
+    --from-file=ca-key.pem=cluster1/ca-key.pem \
+    --from-file=root-cert.pem=cluster1/root-cert.pem \
+    --from-file=cert-chain.pem=cluster1/cert-chain.pem
+
+$ kubectl --context="${CTX_CLUSTER2}" create namespace istio-system
+$ kubectl --context="${CTX_CLUSTER2}" create secret generic cacerts -n istio-system \
+    --from-file=ca-cert.pem=cluster2/ca-cert.pem \
+    --from-file=ca-key.pem=cluster2/ca-key.pem \
+    --from-file=root-cert.pem=cluster2/root-cert.pem \
+    --from-file=cert-chain.pem=cluster2/cert-chain.pem
+{{< /text >}}
+
+This will create the `cacerts` secret in the `istio-system` namespace of each cluster, allowing Istio to use your custom CA certificates.
+
+{{< /tip >}}
+
 
 ## Next steps
 


### PR DESCRIPTION
## Description

This PR adds pre-installation steps for KinD users to ease getting started with multi-cluster setup.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation
