### PR TITLE
feat: add tls.caCertCredentialName

### DIFF
--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -627,8 +627,7 @@ Istio supports reading a few different Secret formats, to support integration wi
 * A TLS Secret with keys `tls.key` and `tls.crt`, as described above. For mutual TLS, a separate generic Secret named `<secret>-cacert`, with a `cacert` key. For example, `httpbin-credential` has `tls.key` and `tls.crt`, and `httpbin-credential-cacert` has `cacert`.
 * A generic Secret with keys `key` and `cert`. For mutual TLS, a `cacert` key can be used.
 * A generic Secret with keys `key` and `cert`. For mutual TLS, a separate generic Secret named `<secret>-cacert`, with a `cacert` key. For example, `httpbin-credential` has `key` and `cert`, and `httpbin-credential-cacert` has `cacert`.
-* For mutual TLS, a separate generic Secret can be referenced in `tls.credentialNames` in the form of `<secret>-cacert`, with a `cacert` key. For example, `my-httpbin-mtls-trustbundle` has `cacert` and `tls.credentialNames` has `my-httpbin-mtls-trustbundle-cacert`.
-* For mutual TLS, a separate ConfigMap can be referenced in `tls.credentialNames` in the form of `configmap://<namespace>/<configmap>-cacert`, with a `cacert` key. For example, `my-httpbin-mtls-trustbundle` ConfigMap in `httpbin` namespace has `cacert` and `tls.credentialNames` has `configmap://httpbin/my-httpbin-mtls-trustbundle-cacert`.
+* For mutual TLS, a separate generic Secret with a `cacert` or `ca.crt` key can be referenced with `caCertCredentialName`. It takes precedence over CA certificates in the Secret referenced with `credentialName(s)`.
 * The `cacert` key value can be a CA bundle consisting of concatenated individual CA certificates.
 
 ### SNI Routing


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

Updated docs for PR https://github.com/istio/istio/pull/56549. After a review we decided to move cacert from `credentialNames` into a new field `caCertCredentialName` (PR https://github.com/istio/api/pull/3544).

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
