### PR TITLE
[zh] Sync #16761 add a workaround to traffic mirroring task page into Chinese

### DIFF
--- a/content/zh/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/zh/docs/tasks/traffic-management/mirroring/index.md
@@ -7,6 +7,15 @@ owner: istio/wg-networking-maintainers
 test: yes
 ---
 
+<!--
+请不要尝试编辑此页面来更改缩进以修复示例。缩进是正确的，但模板渲染错误。请参阅下方标注。
+-->
+
+{{< warning >}}
+[Istio 网站代码中的模板错误](https://github.com/istio/istio.io/issues/15689)导致此页面上的示例无法正确渲染。
+您可以[查看页面源码](https://raw.githubusercontent.com/istio/istio.io/master/content/en/docs/tasks/traffic-management/mirroring/index.md)以查看正确的清单。
+{{< /warning >}}
+
 此任务演示了 Istio 的流量镜像功能。
 
 流量镜像，也称为影子流量，是一种以尽可能低的风险允许负责功能特性的团队改动生产环境的强大理念。


### PR DESCRIPTION
## Description

Sync #16761 add a workaround to traffic mirroring task page into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
