### PR TITLE
Indicate that "source" and "operation" are lists

### DIFF
--- a/content/en/docs/reference/config/security/authorization-policy/index.html
+++ b/content/en/docs/reference/config/security/authorization-policy/index.html
@@ -438,7 +438,7 @@ matches the request. An empty rule is always matched.</p>
 <tbody>
 <tr id="Rule-From-source">
 <td><div class="field"><div class="name"><code><a href="#Rule-From-source">source</a></code></div>
-<div class="type"><a href="#Source">Source</a></div>
+<div class="type"><a href="#Source">Source[]</a></div>
 </div></td>
 <td>
 <p>Source specifies the source of a request.</p>
@@ -462,7 +462,7 @@ matches the request. An empty rule is always matched.</p>
 <tbody>
 <tr id="Rule-To-operation">
 <td><div class="field"><div class="name"><code><a href="#Rule-To-operation">operation</a></code></div>
-<div class="type"><a href="#Operation">Operation</a></div>
+<div class="type"><a href="#Operation">Operation[]</a></div>
 </div></td>
 <td>
 <p>Operation specifies the operation of a request.</p>


### PR DESCRIPTION
## Description

Slightly improve docs: indicate that *source* and *operation* fields are lists. Just like other fields, such as *from* and *to*.

## Reviewers
- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation