### PR TITLE
add note about opting individual pods out of dns-proxy

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -26,6 +26,8 @@ DNS proxying is enabled by default in ambient mode from Istio 1.25 onwards.
 
 For versions prior to 1.25, you can enable DNS capture by setting `values.cni.ambient.dnsCapture=true` and `values.pilot.env.PILOT_ENABLE_IP_AUTOALLOCATE=true` during installation.
 
+Individual pods may opt-out of global ambient mode DNS capture by applying the`ambient.istio.io/dns-capture=false` annotation.
+
 ### Sidecar mode
 
 This feature is not currently enabled by default. To enable it, install Istio with the following settings:


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

adds a sentence about opting individual pods out of dns-proxy taken from the 1.25 upgrade note but otherwise missing from this section

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [X] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
