### PR TITLE
16760: Migrate to Non-Deprecated Hugo Build Option

### DIFF
--- a/content/en/about/_index.md
+++ b/content/en/about/_index.md
@@ -6,10 +6,10 @@ sidebar_none: true
 weight: 15
 doc_type: about
 cascade:
-  _build:
+  build:
     render: always
     list: always
-_build:
+build:
   render: never
   list: never
 ---

--- a/content/es/about/_index.md
+++ b/content/es/about/_index.md
@@ -6,10 +6,10 @@ sidebar_none: true
 weight: 15
 doc_type: about
 cascade:
-  _build:
+  build:
     render: always
     list: always
-_build:
+build:
   render: never
   list: never
 ---

--- a/content/uk/about/_index.md
+++ b/content/uk/about/_index.md
@@ -6,10 +6,10 @@ sidebar_none: true
 weight: 15
 doc_type: about
 cascade:
-  _build:
+  build:
     render: always
     list: always
-_build:
+build:
   render: never
   list: never
 ---

--- a/content/zh/about/_index.md
+++ b/content/zh/about/_index.md
@@ -7,10 +7,10 @@ weight: 15
 icon: about
 doc_type: about
 cascade:
-  _build:
+  build:
     render: always
     list: always
-_build:
+build:
   render: never
   list: never
 ---


### PR DESCRIPTION
## Description

Closes https://github.com/istio/istio.io/issues/16760. 

See https://gohugo.io/content-management/build-options/ for the documentation that `Hugo` provides showing this is the new, equivalent syntax.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
