### PR TITLE
Fix Regex when building URL for archive docs

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -162,7 +162,7 @@
         <div class="archive-warning-banner" role="alert">
             {{ (printf (i18n "archive_banner_text") .Site.Data.args.version) | safeHTML }}
             {{ $rel := .RelPermalink }}
-            {{ $path := replaceRE `^/v[0-9]+\.[0-9]+/` "" $rel }}
+            {{ $path := replaceRE `^/v[0-9]+\.[0-9]+/` "" $rel | strings.TrimPrefix "/" }}
             {{ $latestURL := printf "https://istio.io/latest/%s" $path }}
             <a href="{{ $latestURL | safeURL }}">{{ i18n "archive_banner_link" }}</a>
         </div>


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->
This PR fixes the Regex pattern which actually adds // before docs in the URL when regenerating archive docs. 
## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
