### PR TITLE
Add redirection rule to prevent redirection on ```istio.io/archive```

### DIFF
--- a/archive/archive/index.html
+++ b/archive/archive/index.html
@@ -11,109 +11,109 @@
     <input id=search-textbox class=form-control name=q type=search aria-label="Search this site">
     <button id=search-close title="Cancel search" type=reset aria-label="Cancel search"><svg class="icon"><use xlink:href="./img/icons.svg#cancel-x"/></svg></button></form></nav></header><div class=banner-container></div><main class="primary notoc"><div id=sidebar-container class="sidebar-container sidebar-offcanvas"></div><div class=article-container><h1>istio.io Archives</h1><p>Snapshots of the <a href=https://istio.io>istio.io</a> website for each release.</p><ul>
         <li>
-        <a href=/v1.26?redirect=false>v1.26</a>
+        <a href=/v1.26/docs>v1.26</a>
     </li>
     <li>
-        <a href=/v1.25?redirect=false>v1.25</a>
+        <a href=/v1.25/docs>v1.25</a>
     </li>
     <li>
-            <a href=/v1.24?redirect=false>v1.24</a>
+            <a href=/v1.24/docs>v1.24</a>
         </li>
         <li>
-            <a href=/v1.23?redirect=false>v1.23</a>
+            <a href=/v1.23/docs>v1.23</a>
         </li>
         <li>
-            <a href=/v1.22?redirect=false>v1.22</a>
+            <a href=/v1.22/docs>v1.22</a>
         </li>
         <li>
-            <a href=/v1.21?redirect=false>v1.21</a>
+            <a href=/v1.21/docs>v1.21</a>
         </li>
         <li>
-            <a href=/v1.20?redirect=false>v1.20</a>
+            <a href=/v1.20/docs>v1.20</a>
         </li>
         <li>
-            <a href=/v1.19?redirect=false>v1.19</a>
+            <a href=/v1.19/docs>v1.19</a>
         </li>
         <li>
-            <a href=/v1.18?redirect=false>v1.18</a>
+            <a href=/v1.18/docs>v1.18</a>
         </li>
         <li>
-            <a href=/v1.17?redirect=false>v1.17</a>
+            <a href=/v1.17/docs>v1.17</a>
         </li>
         <li>
-            <a href=/v1.16?redirect=false>v1.16</a>
+            <a href=/v1.16/docs>v1.16</a>
         </li>
         <li>
-            <a href=/v1.15?redirect=false>v1.15</a>
+            <a href=/v1.15/docs>v1.15</a>
         </li>
         <li>
-            <a href=/v1.14?redirect=false>v1.14</a>
+            <a href=/v1.14/docs>v1.14</a>
         </li>
         <li>
-            <a href=/v1.13?redirect=false>v1.13</a>
+            <a href=/v1.13/docs>v1.13</a>
         </li>
         <li>
-            <a href=/v1.12?redirect=false>v1.12</a>
+            <a href=/v1.12/docs>v1.12</a>
         </li>
         <li>
-            <a href=/v1.11?redirect=false>v1.11</a>
+            <a href=/v1.11/docs>v1.11</a>
         </li>
         <li>
-            <a href=/v1.10?redirect=false>v1.10</a>
+            <a href=/v1.10/docs>v1.10</a>
         </li>
         <li>
-            <a href=/v1.9?redirect=false>v1.9</a>
+            <a href=/v1.9/docs>v1.9</a>
         </li>
         <li>
-            <a href=/v1.8?redirect=false>v1.8</a>
+            <a href=/v1.8/docs>v1.8</a>
         </li>
         <li>
-            <a href=/v1.7?redirect=false>v1.7</a>
+            <a href=/v1.7/docs>v1.7</a>
         </li>
         <li>
-            <a href=/v1.6?redirect=false>v1.6</a>
+            <a href=/v1.6/docs>v1.6</a>
         </li>
         <li>
-            <a href=/v1.5?redirect=false>v1.5</a>
+            <a href=/v1.5/docs>v1.5</a>
         </li>
         <li>
-            <a href=/v1.4?redirect=false>v1.4</a>
+            <a href=/v1.4/docs>v1.4</a>
         </li>
         <li>
-            <a href=/v1.3?redirection=false>v1.3</a>
+            <a href=/v1.3/docs>v1.3</a>
         </li>
         <li>
-            <a href=/v1.2?redirect=false>v1.2</a>
+            <a href=/v1.2/docs>v1.2</a>
         </li>
         <li>
-            <a href=/v1.1?redirect=false>v1.1</a>
+            <a href=/v1.1/docs>v1.1</a>
         </li>
         <li>
-            <a href=/v1.0?redirect=false>v1.0</a>
+            <a href=/v1.0/docs>v1.0</a>
         </li>
         <li>
-            <a href=/v0.8?redirect=false>v0.8</a>
+            <a href=/v0.8/docs>v0.8</a>
         </li>
         <li>
-            <a href=/v0.7?redirect=false>v0.7</a>
+            <a href=/v0.7/docs>v0.7</a>
         </li>
         <li>
-            <a href=/v0.6?redirect=false>v0.6</a>
+            <a href=/v0.6/docs>v0.6</a>
         </li>
         <li>
-            <a href=/v0.5?redirect=false>v0.5</a>
+            <a href=/v0.5/docs>v0.5</a>
         </li>
         <li>
-            <a href=/v0.4?redirect=false>v0.4</a>
+            <a href=/v0.4/docs>v0.4</a>
         </li>
         <li>
-            <a href=/v0.3?redirect=false>v0.3</a>
+            <a href=/v0.3/docs>v0.3</a>
         </li>
         <li>
-            <a href=/v0.2?redirect=false>v0.2</a>
+            <a href=/v0.2/docs>v0.2</a>
         </li>
         <li>
-            <a href=/v0.1?redirect=false>v0.1</a>
+            <a href=/v0.1/docs>v0.1</a>
         </li>
     </ul></div></main><footer><div class=user-links><a class=channel title="Join the Istio discussion board to participate in discussions and get help troubleshooting problems" href=https://discuss.istio.io aria-label="Istio discussion board"><span>discuss</span><svg class="icon"><use xlink:href="./img/icons.svg#discourse"/></svg></a>
     <a class=channel title="Stack Overflow is where you can ask questions and find curated answers on deploying, configuring, and using Istio" href=https://stackoverflow.com/questions/tagged/istio aria-label="Stack Overflow"><span>stack overflow</span><svg class="icon"><use xlink:href="./img/icons.svg#stackoverflow"/></svg></a>


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

On ```istio.io/archive``` all the links are redirected to ```istio.io/latest``` . We only want the documentation to be served on ```istio.io/archive``` so added the URL for docs in the ```index.html``` for archive.

Fixes: #16692 
## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
