### PR TITLE
15200 - Improve Script for Detecting Snips Requiring PR Tests

### DIFF
--- a/scripts/pr_tests.py
+++ b/scripts/pr_tests.py
@@ -72,37 +72,54 @@ try:
 
     test_paths = set()
 
-    commits = pr.get_commits()
-    for commit in commits:
-        files = commit.files
-        for file in files:
-            filename = file.filename
-            if filename.startswith(doc_file_prefix):
-                if filename.endswith("test.sh") or filename.endswith("/snips.sh"):
-                    relative_file = filename[len(doc_file_prefix):]
-                    test_paths.add(relative_file.rsplit('/', 1)[0])
-                    # Tentatively add tests that externally imported other module files
-                    checked = set()
-                    to_check = {os.path.dirname(filename)}
-                    while to_check:
-                        el = to_check.pop()
-                        checked.add(el)
-                        if el in script_dependencies:
-                            to_add = script_dependencies[el] - checked
-                            to_check.update(to_add)
-                            test_paths.update(map(lambda file_path: file_path[len(doc_file_prefix):], to_add))
-            elif filename == istio_go_dependency or \
-                    filename.startswith(test_framework_pkg) or \
-                    filename.startswith(test_framework_util) or \
-                    filename.startswith(prow_dir) or \
-                    filename.startswith(boilerplate_snip_prefix):
-                print("ALL")
-                sys.exit(0)
+    # NOTE(mweiner): View [1] for schema of GitHub's API to list files in a PR.
+    # [1] https://docs.github.com/en/rest/pulls/pulls#list-pull-requests-files
+
+    for file in pr.get_files():
+        # Check for short-circuits up-front for efficiency.
+        if (
+            file.filename == istio_go_dependency or
+            file.filename.startswith(test_framework_pkg) or
+            file.filename.startswith(test_framework_util) or
+            file.filename.startswith(prow_dir) or
+            file.filename.startswith(boilerplate_snip_prefix)
+        ):
+            print("ALL")
+            sys.exit(0)
+
+        # Files being removed no longer require testing, so they will be skipped.
+        if file.status == "removed" or file.status == "unchanged":
+            continue
+
+        # At this point, only files with a status of "added", "modified", 
+        # "renamed", "copied", or "changed" will be analyzed.
+
+        # No need to consider files outside of the doc_file_prefix. Skip them.
+        if not file.filename.startswith(doc_file_prefix):
+            continue
+
+        # Of the files that remain, only those with certain naming conventions
+        # require testing.
+        if file.filename.endswith("test.sh") or file.filename.endswith("/snips.sh"):
+            relative_file = file.filename[len(doc_file_prefix):]
+            test_paths.add(relative_file.rsplit('/', 1)[0])
+
+            # Tentatively add tests that externally imported other module files
+            checked = set()
+            to_check = {os.path.dirname(file.filename)}
+            while to_check:
+                el = to_check.pop()
+                checked.add(el)
+                if el in script_dependencies:
+                    to_add = script_dependencies[el] - checked
+                    to_check.update(to_add)
+                    # keep paths relative to doc_file_prefix
+                    test_paths.update(map(lambda p: p[len(doc_file_prefix):], to_add))
 
     if len(test_paths) == 0:
         print("NONE")
     else:
-        print(*test_paths, sep=",")
+        print(*sorted(test_paths), sep=",")
 
 except Exception as e:
     # fall back to running all tests if anything goes wrong (e.g., rate-limiting)


### PR DESCRIPTION
## Description

Closes https://github.com/istio/istio.io/issues/15200. 

This PR refactors `scripts/pr_tests.py` to instead use the files changed portion of a PR to determine which snips require testing.

### Proof of Testing

@craigbox left some examples in https://github.com/istio/istio.io/issues/15200 of where problems were encountered. I used those as my testing for the updates to this script.

For folks that want to test, installing `uv` is straightforward and makes the dependency management of Python much easier. Installation instructions are [here](https://docs.astral.sh/uv/getting-started/installation/).

Correct found all snips requiring testing in a PR:
```
weiner istio.io (master) % uv run --with PyGithub ./scripts/pr_tests.py --token= 15168
ambient/getting-started,ambient/getting-started/cleanup,ambient/getting-started/deploy-sample-app,ambient/getting-started/enforce-auth-policies,ambient/getting-started/manage-traffic,ambient/getting-started/secure-and-visualize,ambient/getting-started/setup,ambient/usage/extend-waypoint-wasm
```

Correctly did not test snips being removed in a PR:
```
weiner istio.io (master) % uv run --with PyGithub ./scripts/pr_tests.py --token= 15227
NONE
```

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
