### PR TITLE
spire: remove init container wait-for-spire-socket

### DIFF
--- a/content/en/docs/ops/integrations/spire/index.md
+++ b/content/en/docs/ops/integrations/spire/index.md
@@ -208,27 +208,6 @@ Below are the equivalent manual registrations based off the automatic registrati
                         name: workload-socket
                         mountPath: "/run/secrets/workload-spiffe-uds"
                         readOnly: true
-                    - path: spec.template.spec.initContainers
-                      value:
-                        - name: wait-for-spire-socket
-                          image: busybox:1.36
-                          volumeMounts:
-                            - name: workload-socket
-                              mountPath: /run/secrets/workload-spiffe-uds
-                              readOnly: true
-                          env:
-                            - name: CHECK_FILE
-                              value: /run/secrets/workload-spiffe-uds/socket
-                          command:
-                            - sh
-                            - "-c"
-                            - |-
-                              echo "$(date -Iseconds)" Waiting for: ${CHECK_FILE}
-                              while [[ ! -e ${CHECK_FILE} ]] ; do
-                                echo "$(date -Iseconds)" File does not exist: ${CHECK_FILE}
-                                sleep 15
-                              done
-                              ls -l ${CHECK_FILE}
     EOF
     {{< /text >}}
 

--- a/content/en/docs/ops/integrations/spire/snips.sh
+++ b/content/en/docs/ops/integrations/spire/snips.sh
@@ -150,27 +150,6 @@ spec:
                     name: workload-socket
                     mountPath: "/run/secrets/workload-spiffe-uds"
                     readOnly: true
-                - path: spec.template.spec.initContainers
-                  value:
-                    - name: wait-for-spire-socket
-                      image: busybox:1.36
-                      volumeMounts:
-                        - name: workload-socket
-                          mountPath: /run/secrets/workload-spiffe-uds
-                          readOnly: true
-                      env:
-                        - name: CHECK_FILE
-                          value: /run/secrets/workload-spiffe-uds/socket
-                      command:
-                        - sh
-                        - "-c"
-                        - |-
-                          echo "$(date -Iseconds)" Waiting for: ${CHECK_FILE}
-                          while [[ ! -e ${CHECK_FILE} ]] ; do
-                            echo "$(date -Iseconds)" File does not exist: ${CHECK_FILE}
-                            sleep 15
-                          done
-                          ls -l ${CHECK_FILE}
 EOF
 }
 


### PR DESCRIPTION
## Description

I believe that the init container `wait-for-spire-socket` is an obsolete workaround, because Spire CSI driver requires the volume mount to be read-only and it also enforces it internally. I wasn't able to reproduce a scenario where the istio-agent created the socket on its own when spire-agent was not available, because it simply failed on write operation:

```
2025-09-03T10:12:04.958407Z     error   sds     SDS grpc server for workload proxies failed to set up UDS: failed to remove unix://var/run/secrets/workload-spiffe-uds/socket: remove var/run/secrets/workload-spiffe-uds/socket: read-only file system
2025-09-03T10:12:20.959464Z     warn    sds     SDS grpc server could not be started
```

So I think it does not make any sense to still keep this workaround in the documentation.

Alternatively, we might document the following configuration as a replacement:

```
apiVersion: install.istio.io/v1alpha1
kind: IstioOperator
metadata:
  namespace: istio-system
spec:
  profile: default
  meshConfig:
    trustDomain: example.org
    defaultConfig:
       proxyMetadata:
         WORKLOAD_IDENTITY_SOCKET_FILE: "spire-agent.sock"
  components:
    ingressGateways:
      - name: istio-ingressgateway
        enabled: true
        label:
          istio: ingressgateway
        k8s:
          overlays:
            - apiVersion: apps/v1
              kind: Deployment
              name: istio-ingressgateway
              patches:
                - path: spec.template.spec.volumes.[name:workload-socket]
                  value:
                    name: workload-socket
                    csi:
                      driver: "csi.spiffe.io"
                      readOnly: true
                - path: spec.template.spec.containers.[name:istio-proxy].volumeMounts.[name:workload-socket]
                  value:
                    name: workload-socket
                    mountPath: "/run/secrets/workload-spiffe-uds"
                    readOnly: true
```

The `WORKLOAD_IDENTITY_SOCKET_FILE` ensures that istio-agent will always wait for the SDS socket, instead of trying to create it on its own. That socket name is used by spire-agent by default, so users don't need to customize spire installation to make it work.

## Reviewers

- [ ] Ambient
- [ ] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [X] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation
