### PR TITLE
[release-1.23]:Manual Cherrypick archive banner for v1.23

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -376,3 +376,9 @@ other = "Go to solutions"
 
 [case_study_slogan]
 other = "Read case studies of companies that benefited from implementing Istio"
+
+[archive_banner_text]
+other = "⚠️ This documentation is for an older version (<strong>%s</strong>) and is no longer updated."
+
+[archive_banner_link]
+other = "Read the latest version."

--- a/i18n/zh.toml
+++ b/i18n/zh.toml
@@ -375,3 +375,9 @@ other = "转到解决方案"
 
 [case_study_slogan]
 other = "阅读因实施 Istio 而受益的公司案例"
+
+[archive_banner_text]
+other = "⚠️ 此文档针对过时的版本 (<strong>%s</strong>)，将不在维护和更新。"
+
+[archive_banner_link]
+other = "查看最新文档。"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -40,7 +40,7 @@
             <meta property="og:image" content="https://raw.githubusercontent.com/istio/istio.io/master/static/img/istio-social.png">
             <meta property="og:image:alt" content="The Istio sailboat logo">
             <meta property="og:image:width" content="4096">
-            <meta property="og:image:height" content="2048">    
+            <meta property="og:image:height" content="2048">
         {{ end }}
         <meta property="og:site_name" content="Istio">
 
@@ -157,7 +157,10 @@
         {{ if and (eq .Section "docs") .Site.Data.args.archive}}
         <div class="archive-warning-banner" role="alert">
             {{ (printf (i18n "archive_banner_text") .Site.Data.args.version) | safeHTML }}
-            <a href="/latest{{ .RelPermalink | safeURL }}">{{ i18n "archive_banner_link" }}</a>
+            {{ $rel := .RelPermalink }}
+            {{ $path := replaceRE `^/v[0-9]+\.[0-9]+/` "" $rel | strings.TrimPrefix "/" }}
+            {{ $latestURL := printf "https://istio.io/latest/%s" $path }}
+            <a href="{{ $latestURL | safeURL }}">{{ i18n "archive_banner_link" }}</a>
         </div>
         {{ end }}
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -152,6 +152,15 @@
 
         {{ partial "events.html" (dict "page" . "kind" "sticker") }}
         {{ partial "header.html" . }}
+
+        <!-- Archived Documentation Header -->
+        {{ if and (eq .Section "docs") .Site.Data.args.archive}}
+        <div class="archive-warning-banner" role="alert">
+            {{ (printf (i18n "archive_banner_text") .Site.Data.args.version) | safeHTML }}
+            <a href="/latest{{ .RelPermalink | safeURL }}">{{ i18n "archive_banner_link" }}</a>
+        </div>
+        {{ end }}
+
         {{ partial "events.html" (dict "page" . "kind" "banner") }}
 
         {{ block "main" . }}{{ end }}

--- a/src/sass/_all.scss
+++ b/src/sass/_all.scss
@@ -11,6 +11,7 @@
 
 @import "misc/about";
 @import "misc/analysis-message";
+@import "misc/archive";
 @import "misc/article";
 @import "misc/banners";
 @import "misc/blog";

--- a/src/sass/misc/_archive.scss
+++ b/src/sass/misc/_archive.scss
@@ -1,0 +1,18 @@
+.archive-warning-banner {
+    background-color: #fff3cd;
+    color: #664d03;
+    padding: 1rem;
+    border-bottom: 1px solid #ffecb5;
+    text-align: center;
+
+    p {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+
+    a {
+        font-weight: bold;
+        text-decoration: underline;
+        color: #413002; // Making link slightly darker than banner text for better contrast/visibility
+    }
+}


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

PR #16457 hadn't been cherry-picked in release-1.23 branch , yeah of course it wasn't possible because the folder structure was quiet different.This PR manually cherrypicks commit #16457 and adds the previous regex logic used to generate the banner for archive docs.
 
## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
