### PR TITLE
Fix: Helm Canary Doc Tests

### DIFF
--- a/content/en/docs/ambient/install/multicluster/multi-primary_multi-network/helm_test.sh
+++ b/content/en/docs/ambient/install/multicluster/multi-primary_multi-network/helm_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC1090,SC2154
+# shellcheck disable=SC1090,SC2154,SC2218
 
 # Copyright Istio Authors
 #


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

This PR updates ```helm_test.sh``` to disable Shellcheck warning <b>SC2218</b>.
Fixes #16730 
<ul>
   
   <li>ShellCheck reports <code>SC2218 (This function is only defined later. Move the definition up)</code> for functions like <code>set_multi_network_vars, setup_helm_repo, configure_trust, and verify_load_balancing</code>
However, these functions are not defined inside this script — they are sourced from other scripts <code>(common.sh, gateway-api.sh).</code>
At runtime, the script works as expected. ShellCheck simply cannot follow external sources
   </li>
    <li>Added <code>SC2218</code> to the existing # shellcheck disable directive at the top of the script to avoid false positives.
    </li>
</ul>
See:- <a href="https://storage.googleapis.com/istio-prow/logs/lint_istio.io_postsubmit/1963956546710802432/build-log.txt">Logs</a><br>
<strong>Impact</strong>
No change in functionality
Only lint noise is suppressed


## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
