### PR TITLE
16724 - Correct Ordering of Release Notes

### DIFF
--- a/content/en/news/releases/1.24.x/_index.md
+++ b/content/en/news/releases/1.24.x/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 1.24.x Releases
 description: Announcements for the 1.24 release and its associated patch releases.
-weight: 6
+weight: 5
 list_by_publishdate: true
 layout: release-grid
 decoration: dot

--- a/content/en/news/releases/1.25.x/_index.md
+++ b/content/en/news/releases/1.25.x/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 1.25.x Releases
 description: Announcements for the 1.25 release and its associated patch releases.
-weight: 6
+weight: 4
 list_by_publishdate: true
 layout: release-grid
 decoration: dot

--- a/content/en/news/releases/1.26.x/_index.md
+++ b/content/en/news/releases/1.26.x/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 1.26.x Releases
 description: Announcements for the 1.26 release and its associated patch releases.
-weight: 6
+weight: 3
 list_by_publishdate: true
 layout: release-grid
 decoration: dot

--- a/content/en/news/releases/1.27.x/_index.md
+++ b/content/en/news/releases/1.27.x/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 1.27.x Releases
 description: Announcements for the 1.27 release and its associated patch releases.
-weight: 6
+weight: 2
 list_by_publishdate: true
 layout: release-grid
 decoration: dot


### PR DESCRIPTION
## Description

Closes https://github.com/istio/istio.io/issues/16724.

This PR corrects the `weight` field for the release notes of `v1.23`-`v1.27`. This corrects the ordering on https://istio.io/latest/news/releases/. 

Eric had been catching this prior to the `v1.23` release: https://github.com/istio/istio.io/pull/14634#discussion_r1499569937

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
