### PR TITLE
Update EOL status for release-1.25

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -22,7 +22,7 @@
 - version: "1.25"
   supported: "Yes"
   releaseDate: "March 03, 2025"
-  eolDate: "~Dec 2025 (Expected)"
+  eolDate: "Sep 2025"
   k8sVersions: ["1.29", "1.30", "1.31", "1.32"]
   testedK8sVersions: ["1.24", "1.25", "1.26", "1.27", "1.28"]
 - version: "1.24"


### PR DESCRIPTION
As per the [announcement](https://istio.io/latest/news/support/announcing-1.25-eol/), Istio release-1.25 will reach EOL on Sep 22, 2025. This PR updates the support status matrix accordingly.

