### PR TITLE
Fix Helm values in dual-stack installation page

### DIFF
--- a/content/en/docs/setup/additional-setup/dual-stack/index.md
+++ b/content/en/docs/setup/additional-setup/dual-stack/index.md
@@ -43,6 +43,7 @@ spec:
     pilot:
       env:
         ISTIO_DUAL_STACK: "true"
+      ipFamilyPolicy: RequireDualStack
     # The below values are optional and can be used based on your requirements
     gateways:
       istio-ingressgateway:
@@ -60,16 +61,16 @@ meshConfig:
   defaultConfig:
     proxyMetadata:
       ISTIO_DUAL_STACK: "true"
-values:
-  pilot:
-    env:
-      ISTIO_DUAL_STACK: "true"
-  # The below values are optional and can be used based on your requirements
-  gateways:
-    istio-ingressgateway:
-      ipFamilyPolicy: RequireDualStack
-    istio-egressgateway:
-      ipFamilyPolicy: RequireDualStack
+pilot:
+  env:
+    ISTIO_DUAL_STACK: "true"
+  ipFamilyPolicy: RequireDualStack
+# The below values are optional and can be used based on your requirements
+gateways:
+  istio-ingressgateway:
+    ipFamilyPolicy: RequireDualStack
+  istio-egressgateway:
+    ipFamilyPolicy: RequireDualStack
 {{< /text >}}
 
 {{< /tab >}}


### PR DESCRIPTION
Fix Helm chart sample by moving pilot.env and gateways to the top level instead of under values, matching the actual chart structure.

Related to: https://github.com/istio/istio/discussions/57723
- [x ] Installation
