### PR TITLE
Docs: Correct an error in example config of RequestAuthentication

### DIFF
--- a/content/en/docs/reference/config/security/request_authentication/index.html
+++ b/content/en/docs/reference/config/security/request_authentication/index.html
@@ -413,7 +413,7 @@ the payload will not be emitted.</p>
 <td>
 <p>List of cookie names from which JWT is expected.	//
 For example, if config is:</p>
-<pre><code class="language-yaml">  from_cookies:
+<pre><code class="language-yaml">  fromCookies:
   - auth-token
 </code></pre>
 <p>Then JWT will be extracted from <code>auth-token</code> cookie in the request.</p>

--- a/content/es/docs/reference/config/security/request_authentication/index.html
+++ b/content/es/docs/reference/config/security/request_authentication/index.html
@@ -402,7 +402,7 @@ the payload will not be emitted.</p>
 <td>
 <p>List of cookie names from which JWT is expected.	//
 For example, if config is:</p>
-<pre><code class="language-yaml">  from_cookies:
+<pre><code class="language-yaml">  fromCookies:
   - auth-token
 </code></pre>
 <p>Then JWT will be extracted from <code>auth-token</code> cookie in the request.</p>

--- a/content/zh/docs/reference/config/security/request_authentication/index.html
+++ b/content/zh/docs/reference/config/security/request_authentication/index.html
@@ -413,7 +413,7 @@ the payload will not be emitted.</p>
 <td>
 <p>List of cookie names from which JWT is expected.	//
 For example, if config is:</p>
-<pre><code class="language-yaml">  from_cookies:
+<pre><code class="language-yaml">  fromCookies:
   - auth-token
 </code></pre>
 <p>Then JWT will be extracted from <code>auth-token</code> cookie in the request.</p>


### PR DESCRIPTION
## Description

Corrected an error in the config example.
Confirmed that the validation now passes as shown below.

Invalid when we use `from_cookies` as a field name:
```
k apply --dry-run=server -f test-jwt.yaml
Error from server (BadRequest): error when creating "test-jwt.yaml": RequestAuthentication in version "v1" cannot be handled as a RequestAuthentication: strict decoding error: unknown field "spec.jwtRules[0].from_cookies"
```

Valid when we use `fromCookies`:
```
k apply --dry-run=server -f test-jwt.yaml
requestauthentication.security.istio.io/jwt-on-ingress created (server dry run)
```

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
