### PR TITLE
fix curl output in docs

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -171,6 +171,7 @@ Now, send a request and verify that the auto allocation is no longer happening:
 {{< text bash >}}
 $ kubectl exec deploy/curl -- curl -sS -v auto.internal
 * Could not resolve host: auto.internal
+* Store negative name resolve for auto.internal:80
 * shutting down connection #0
 {{< /text >}}
 

--- a/content/en/docs/ops/configuration/traffic-management/dns-proxy/snips.sh
+++ b/content/en/docs/ops/configuration/traffic-management/dns-proxy/snips.sh
@@ -114,6 +114,7 @@ kubectl exec deploy/curl -- curl -sS -v auto.internal
 
 ! IFS=$'\n' read -r -d '' snip_address_autoallocation_4_out <<\ENDSNIP
 * Could not resolve host: auto.internal
+* Store negative name resolve for auto.internal:80
 * shutting down connection #0
 ENDSNIP
 

--- a/content/es/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/es/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -169,6 +169,7 @@ Now, send a request and verify that the auto allocation is no longer happening:
 {{< text bash >}}
 $ kubectl exec deploy/curl -- curl -sS -v auto.internal
 * Could not resolve host: auto.internal
+* Store negative name resolve for auto.internal:80
 * shutting down connection #0
 {{< /text >}}
 

--- a/content/uk/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/uk/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -167,6 +167,7 @@ EOF
 {{< text bash >}}
 $ kubectl exec deploy/curl -- curl -sS -v auto.internal
 * Could not resolve host: auto.internal
+* Store negative name resolve for auto.internal:80
 * shutting down connection #0
 {{< /text >}}
 
@@ -307,6 +308,7 @@ EOF
 {{< text bash >}}
 $ kubectl exec deploy/curl -- curl -sS -v auto.internal
 * Could not resolve host: auto.internal
+* Store negative name resolve for auto.internal:80
 * shutting down connection #0
 {{< /text >}}
 

--- a/content/zh/docs/ops/configuration/traffic-management/dns-proxy/index.md
+++ b/content/zh/docs/ops/configuration/traffic-management/dns-proxy/index.md
@@ -203,6 +203,7 @@ EOF
 {{< text bash >}}
 $ kubectl exec deploy/curl -- curl -sS -v auto.internal
 * Could not resolve host: auto.internal
+* Store negative name resolve for auto.internal:80
 * shutting down connection #0
 {{< /text >}}
 


### PR DESCRIPTION
## Description

curl now has a slightly different output when it can't resolve a host.

```diff
* Could not resolve host: auto.internal
+ * Store negative name resolve for auto.internal:80
* shutting down connection #0
```

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
