### PR TITLE
update link to grafana helm chart content

### DIFF
--- a/content/en/docs/ops/integrations/grafana/index.md
+++ b/content/en/docs/ops/integrations/grafana/index.md
@@ -81,4 +81,4 @@ Grafana can be installed and configured through other methods. To import Istio d
 refer to the documentation for the installation method. For example:
 
 * [Grafana provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards) official documentation.
-* [Importing dashboards](https://github.com/helm/charts/tree/master/stable/grafana#import-dashboards) for the `stable/grafana` Helm chart.
+* [Importing dashboards](https://github.com/grafana/helm-charts/tree/main/charts/grafana#import-dashboards) for the `stable/grafana` Helm chart.

--- a/content/es/docs/ops/integrations/grafana/index.md
+++ b/content/es/docs/ops/integrations/grafana/index.md
@@ -81,4 +81,4 @@ Grafana can be installed and configured through other methods. To import Istio d
 refer to the documentation for the installation method. For example:
 
 * [Grafana provisioning](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards) official documentation.
-* [Importing dashboards](https://github.com/helm/charts/tree/master/stable/grafana#import-dashboards) for the `stable/grafana` Helm chart.
+* [Importing dashboards](https://github.com/grafana/helm-charts/tree/main/charts/grafana#import-dashboards) for the `stable/grafana` Helm chart.

--- a/content/uk/docs/ops/integrations/grafana/index.md
+++ b/content/uk/docs/ops/integrations/grafana/index.md
@@ -73,4 +73,4 @@ $ done
 Grafana може бути встановлена та налаштована іншими методами. Для імпорту панелей управління Istio, ознайомтеся з документацією для методу встановлення. Наприклад:
 
 * Офіційна документація [Provisioning Grafana](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards).
-* [Імпорт інфопанелей](https://github.com/helm/charts/tree/master/stable/grafana#import-dashboards) для Helm chart `stable/grafana`.
+* [Імпорт інфопанелей](https://github.com/grafana/helm-charts/tree/main/charts/grafana#import-dashboards) для Helm chart `stable/grafana`.

--- a/content/zh/docs/ops/integrations/grafana/index.md
+++ b/content/zh/docs/ops/integrations/grafana/index.md
@@ -74,5 +74,5 @@ Grafana 可以通过其他方法进行安装和配置。要导入 Istio 仪表�
 请参考文档中的安装方法，例如：
 
 * [Grafana 配置](https://grafana.com/docs/grafana/latest/administration/provisioning/#dashboards)官方文档。
-* [导入仪表盘](https://github.com/helm/charts/tree/master/stable/grafana#import-dashboards)
+* [导入仪表盘](https://github.com/grafana/helm-charts/tree/main/charts/grafana#import-dashboards)
   `stable/grafana` Helm Chart 文档。


### PR DESCRIPTION
## Description

Update link to the current repository location for the Grafana helm charts; the currently linked location was archived in 2020.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
