### PR TITLE
Fix incorrect match type descriptions in security docs

### DIFF
--- a/content/en/docs/concepts/security/index.md
+++ b/content/en/docs/concepts/security/index.md
@@ -710,9 +710,9 @@ Most fields in authorization policies support all the following matching
 schemas:
 
 - Exact match: exact string match.
-- Prefix match: a string with an ending `"*"`. For example, `"test.abc.*"`
+- Suffix  match: a string with an ending `"*"`. For example, `"test.abc.*"`
    matches `"test.abc.com"`, `"test.abc.com.cn"`, `"test.abc.org"`, etc.
-- Suffix match: a string with a starting `"*"`. For example, `"*.abc.com"`
+- Prefix match: a string with a starting `"*"`. For example, `"*.abc.com"`
    matches `"eng.abc.com"`, `"test.eng.abc.com"`, etc.
 - Presence match: `*` is used to specify anything but not empty. To specify
    that a field must be present, use the `fieldname: ["*"]`format. This is


### PR DESCRIPTION
## Description

Fix incorrect value matching type descriptions in security docs - Suffix and Prefix

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

https://istio.io/latest/docs/concepts/security/#authorization
