### PR TITLE
Add nftables kernel modules to platform requirements

### DIFF
--- a/content/en/docs/ops/deployment/platform-requirements/index.md
+++ b/content/en/docs/ops/deployment/platform-requirements/index.md
@@ -58,8 +58,8 @@ The following additional modules are used by the above listed modules and should
 
 ### nftables Backend
 
-The `nftables` framework is a modern replacement for iptables, offering improved performance and flexibility.
-Istio relies on the `nft` CLI tool to configure nftables rules. The `nft` binary must be version 1.0.1 or later, and it
+The `nftables` framework is a modern replacement for `iptables`, offering improved performance and flexibility.
+Istio relies on the `nft` CLI tool to configure `nftables` rules. The `nft` binary must be version 1.0.1 or later, and it
 requires Linux kernel version 5.13 or higher. For the `nft` CLI to function correctly, the following kernel modules must
 be available on the host system.
 


### PR DESCRIPTION
This PR reorganizes the platform requirements page to clearly separate the requirements for iptables and nftables, and adds the platform requirements for the nftables backend.

Fixes: https://github.com/istio/istio/issues/57319
- [x] Installation
- [x] Networking