### PR TITLE
fix: update supported version from 1.27 to 1.28

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -7,7 +7,7 @@
   eolDate:
   k8sVersions: ["1.30", "1.31", "1.32", "1.33", "1.34"]
   testedK8sVersions: ["1.24", "1.25", "1.26", "1.27", "1.28", "1.29"]
-- version: "1.27"
+- version: "1.28"
   supported: "Yes"
   releaseDate: "Nov 05, 2025"
   eolDate: "~Jul 2026 (Expected)"


### PR DESCRIPTION
1.28 support details were added, but using 1.27 version instead

## Description

1.28 support details were added, but using 1.27 version instead

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
