### PR TITLE
Fix logic for preliminary label in version selector

### DIFF
--- a/layouts/partials/version-selector.html
+++ b/layouts/partials/version-selector.html
@@ -1,13 +1,12 @@
 {{ $versions := site.Data.versions }}
 {{ $mainVerStr := $versions.main }}
-{{ $preliminaryVerStr := $versions.preliminary }}
 {{ $mainVerParts := split $mainVerStr "." }}
 {{ $major := index $mainVerParts 0 | int }}
 {{ $minor := index $mainVerParts 1 | int }}
 {{ $versionCount := 5 }}
 
 <!-- Preliminary version -->
-{{ $preUrl := printf "https://preliminary.istio.io/v%s/docs" $preliminaryVerStr }}
+{{ $preUrl := printf "https://preliminary.istio.io/latest/docs" }}
 <li class="main-navigation-links-dropdown-item">
   <a href="{{ $preUrl }}"
      class="main-navigation-links-link">


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->
In the version selector drop down when clicking on preliminary it leads to a 404 cause by logical error in partial this PR fixes that issue.

[Screencast From 2025-11-15 14-42-47.webm](https://github.com/user-attachments/assets/7033a879-3684-4f56-8905-d60bbdffa6dc)

After Fix:-

[preliminary.webm](https://github.com/user-attachments/assets/f93f5145-1570-457e-8543-b15fae269dff)

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
