### PR TITLE
add  warning about envoyfilter use in rate limit doc

### DIFF
--- a/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/en/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -16,6 +16,10 @@ up to 4 requests per minute, allowing for any in-mesh traffic.
 
 ## Before you begin
 
+{{< warning >}}
+Rate limits as described in this document are implemented using the EnvoyFilter API. EnvoyFilter exposes internal implementation details that may change at any time. Please use extreme caution, especially around upgrades.
+{{< /warning >}}
+
 1. Setup Istio in a Kubernetes cluster by following the instructions in the
    [Installation Guide](/docs/setup/getting-started/).
 


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

It has been noted that our rate limit doc may be perceived as suggesting EnvoyFilter as a stable API because it does not warn users about the inherit instability of EF. Add a warning to this effect for clarity in the "Before you begin" section.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [X] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
