### PR TITLE
Update/old ambient redirect blog

### DIFF
--- a/content/en/blog/2023/traffic-for-ambient-and-sidecar/index.md
+++ b/content/en/blog/2023/traffic-for-ambient-and-sidecar/index.md
@@ -6,10 +6,6 @@ attribution: "Steve Zhang (Intel), John Howard (Google), Yuxing Zeng(Alibaba), P
 keywords: [traffic,ambient,sidecar,coexistence]
 ---
 
-{{< warning >}}
-Ambient redirection no longer configures the host network namespace as of Istio 1.21.
-See [Ztunnel traffic redirection](/docs/ambient/architecture/traffic-redirection/) for details on the new approach.
-{{< /warning >}}
 {{< idea >}}
 Ambient mode now uses [in-Pod redirection](/blog/2024/inpod-traffic-redirection-ambient/) to redirect traffic between workload pods and ztunnel. The method described in this blog is no longer needed, and this post has been left for historical interest.
 {{< /idea >}}


### PR DESCRIPTION
## Description

We have an old blog post detailing the ambient traffic redirection implementation (before inpod mode). We should add a warning telling users that we no longer configure host traffic.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
