### PR TITLE
Modify Kiali deployment commands and add Prometheus

### DIFF
--- a/content/zh/docs/setup/getting-started/index.md
+++ b/content/zh/docs/setup/getting-started/index.md
@@ -218,7 +218,7 @@ Istio 和[几个遥测应用](/zh/docs/ops/integrations)做了集成。
 
     {{< text bash >}}
     $ kubectl apply -f @samples/addons/kiali.yaml@
-    $ kubectl rollout status deployment/kiali -n istio-system@
+    $ kubectl rollout status deployment/kiali -n istio-system
     Waiting for deployment "kiali" rollout to finish: 0 of 1 updated replicas are available...
     deployment "kiali" successfully rolled out
     $ kubectl apply -f @samples/addons/prometheus.yaml@

--- a/content/zh/docs/setup/getting-started/index.md
+++ b/content/zh/docs/setup/getting-started/index.md
@@ -218,9 +218,13 @@ Istio 和[几个遥测应用](/zh/docs/ops/integrations)做了集成。
 
     {{< text bash >}}
     $ kubectl apply -f @samples/addons/kiali.yaml@
-    $ kubectl rollout status deployment/kiali -n istio-system
+    $ kubectl rollout status deployment/kiali -n istio-system@
     Waiting for deployment "kiali" rollout to finish: 0 of 1 updated replicas are available...
     deployment "kiali" successfully rolled out
+    $ kubectl apply -f @samples/addons/prometheus.yaml@
+    $ kubectl rollout status deployment/prometheus -n istio-system
+    Waiting for deployment "prometheus" rollout to finish: 0 of 1 updated replicas are available...
+    deployment "prometheus" successfully rolled out
     {{< /text >}}
 
 1.  访问 Kiali 仪表板。


### PR DESCRIPTION
## Description

Add Prometheus installation as a default step in the Istio Getting Started documentation. Kiali relies on Prometheus for metrics, so the dashboard does not work without it. This is especially important for kind clusters, where Prometheus must be installed explicitly.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [X] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
