### PR TITLE
Fix order for 1.28.x release

### DIFF
--- a/content/en/news/releases/1.28.x/_index.md
+++ b/content/en/news/releases/1.28.x/_index.md
@@ -1,7 +1,7 @@
 ---
 title: 1.28.x Releases
 description: Announcements for the 1.28 release and its associated patch releases.
-weight: 2
+weight: 1
 list_by_publishdate: true
 layout: release-grid
 decoration: dot


### PR DESCRIPTION
## Description

Fix the ordering of the 1.28.x release, which is currently out of order.

<img width="1171" height="446" alt="Screenshot 2025-12-17 at 5 05 02 PM" src="https://github.com/user-attachments/assets/b43a5ed9-dab1-4b68-b7ce-e5b91bbf1196" />

## Reviewers

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation