### PR TITLE
[zh] Sync #17049 adds domain override example to global rate limit advanced case into Chinese

### DIFF
--- a/content/zh/docs/tasks/policy-enforcement/rate-limit/index.md
+++ b/content/zh/docs/tasks/policy-enforcement/rate-limit/index.md
@@ -212,7 +212,7 @@ Envoy 中的全局速率限制使用 gRPC API 向速率限制服务请求配额�
     EOF
     {{< /text >}}
 
-1. 应用 EnvoyFilter 在结果为 1 到 99 的任一路由级别添加速率限制操作：
+1. 应用 EnvoyFilter 在结果为 1 到 99 的任一路由级别添加速率限制操作并覆盖产品域名：
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF
@@ -238,6 +238,10 @@ Envoy 中的全局速率限制使用 gRPC API 向速率限制服务请求配额�
             operation: MERGE
             value:
               route:
+                typed_per_filter_config:
+                  envoy.filters.http.ratelimit:
+                    "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimitPerRoute
+                    domain: product # 域名覆盖
                 rate_limits:
                 - actions:
                   - header_value_match:


### PR DESCRIPTION

## Description

Sync #17049 adds domain override example to global rate limit advanced case into Chinese

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
