### PR TITLE
docs: clarify Stackdriver provider limitations in Telemetry API

### DIFF
--- a/content/en/docs/tasks/observability/telemetry/index.md
+++ b/content/en/docs/tasks/observability/telemetry/index.md
@@ -68,17 +68,8 @@ For convenience, Istio comes with a few providers configured out of the box with
 | `stackdriver` | Tracing (legacy / limited) |
 | `envoy`       | Access Logging             |
 
-{{< warning >}}
 The `stackdriver` provider is retained for legacy compatibility and limited tracing use.
-It is **not** a Telemetry v2 metrics backend and does **not** export access logs.
-
-Users upgrading from Istio versions prior to 1.17 may observe missing metrics, missing metric
-labels (for example `destination_service_name`), or no access logs being exported to Google Cloud.
-This is expected behavior with Telemetry v2.
-
-For Google Cloud environments, it is recommended to use Prometheus (including Managed Prometheus)
-for metrics and `OTLP`-based providers for tracing.
-{{< /warning >}}
+It is not a Telemetry v2 metrics backend and does not export access logs.
 
 In addition, a [default provider](/docs/reference/config/istio.mesh.v1alpha1/#MeshConfig-DefaultProviders) can be set which
 will be used when the `Telemetry` resources do not specify a provider.


### PR DESCRIPTION
## Description

This PR clarifies the current behavior of the `stackdriver` provider when using the Telemetry API.

Specifically, it:
- corrects the provider capability table to reflect that Stackdriver is not a Telemetry v2 metrics or access-logging backend
- adds a clarification note explaining the legacy / limited nature of Stackdriver support
- documents expected behavior for users upgrading from Istio versions prior to 1.17
- points users to recommended alternatives for Google Cloud environments

This helps avoid confusion where Stackdriver configuration appears valid but metrics or logs are no longer exported.

## Related issue

Fixes istio/istio#58568

## Reviewers

- [x] Docs
- [x] Extensions and Telemetry
