### PR TITLE
docs: clarify DNS client scope and resolution behavior

### DIFF
--- a/content/en/docs/ops/configuration/traffic-management/dns/index.md
+++ b/content/en/docs/ops/configuration/traffic-management/dns/index.md
@@ -100,7 +100,7 @@ Istio offers a feature to [proxy DNS requests](/docs/ops/configuration/traffic-m
 This allows Istio to capture DNS requests sent by the application and return responses directly.
 
 DNS proxying can improve DNS latency, reduce load on upstream DNS servers, and allow
-`ServiceEntry` hostnames that would otherwise be unknown to `kube-dns` to be resolved.
+`ServiceEntry` hostnames that would otherwise be unknown to `kube-dns`/`core-dns` to be resolved.
 
 Note that DNS proxying only applies to DNS requests sent by user applications.
 When `resolution: DNS` type `ServiceEntries` are used, DNS proxying does not affect


### PR DESCRIPTION
## Description

This PR clarifies the DNS documentation by explicitly defining the client scope
(workloads running inside the Istio service mesh), separating DNS resolution from
HTTP request handling, and rewording a confusing paragraph that could be interpreted
as applying to external clients.

The changes address the confusion discussed in issue #16948 and improve the
readability of the document without changing any behavior.

## Reviewers

- [ ] Ambient
- [x] Docs
- [x] Networking
- [ ] Installation
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation


Fixed issue: #16948 