### PR TITLE
docs: clarify L4 load balancer requirement for east-west gateway

### DIFF
--- a/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
+++ b/content/en/docs/setup/install/multicluster/multi-primary_multi-network/index.md
@@ -99,9 +99,7 @@ external attacks. Check with your cloud vendor to see what options are
 available.
 
 {{< warning >}}
-The east-west gateway must be exposed using a Layer 4 (TCP) load balancer.
-Layer 7 (HTTP/HTTPS) load balancers terminate TLS and are incompatible with
-`AUTO_PASSTHROUGH`, which can result in mTLS handshake failures and 503 errors.
+Layer 7 load balancers terminate TLS and are incompatible with `AUTO_PASSTHROUGH`, which can result in mTLS handshake failures and 503 errors. Do not expose an east-west gateway with a Layer 7 load balancer.
 {{< /warning >}}
 
 {{< tabset category-name="east-west-gateway-install-type-cluster-1" >}}


### PR DESCRIPTION
## Description

This PR clarifies that the east-west gateway in multi-primary, multi-network
deployments must be exposed via an L4 (TCP) load balancer.

Using an L7 HTTP/HTTPS load balancer can terminate TLS and break
`AUTO_PASSTHROUGH`, resulting in mTLS handshake failures and 503 responses.

Fixes #16648

## Reviewers

- [x] Docs
- [x] Installation
