### PR TITLE
Add a link to Proxy-Wasm Go SDK

### DIFF
--- a/content/en/docs/concepts/wasm/index.md
+++ b/content/en/docs/concepts/wasm/index.md
@@ -43,6 +43,7 @@ You can follow [this guide](https://github.com/istio-ecosystem/wasm-extensions/b
 - [Istio Ecosystem Wasm Extensions](https://github.com/istio-ecosystem/wasm-extensions)
 - [Proxy-Wasm ABI specification](https://github.com/proxy-wasm/spec)
 - [Proxy-Wasm C++ SDK](https://github.com/proxy-wasm/proxy-wasm-cpp-sdk)
+- [Proxy-Wasm Go SDK](https://github.com/proxy-wasm/proxy-wasm-go-sdk)
 - [Proxy-Wasm Rust SDK](https://github.com/proxy-wasm/proxy-wasm-rust-sdk)
 - [Proxy-Wasm AssemblyScript SDK](https://github.com/solo-io/proxy-runtime)
 - [WebAssembly Hub](https://webassemblyhub.io/)


### PR DESCRIPTION
## Description

Add a link to Proxy-Wasm Go SDK in the documentation.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
