### PR TITLE
Securing Prometheus Scraping for Istio Workloads and Gateways

### DIFF
--- a/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
@@ -9,10 +9,6 @@ test: no
 
 This task demonstrates how to **securely scrape Istio sidecar and gateway metrics** using Prometheus over **Istio mTLS**. By default, Prometheus scrapes metrics from Istio workloads and gateways over HTTP. In this task, you configure Istio and Prometheus so that metrics are scraped securely over encrypted connections. This document focuses specifically on Envoy and Istio-generated telemetry exposed by sidecars and gateways. It does not cover application-level metrics emitted by workloads themselves. For general Prometheus integration with Istio, including application metrics, see the [Prometheus integration](/docs/ops/integrations/prometheus/) documentation.
 
-{{< warning >}}
-This configuration avoids scraping Istio telemetry ports (15020/15090) directly over HTTPS and uses a secure fronting port.
-{{< /warning >}}
-
 ## Understand default metrics scraping
 
 By default, Istio exposes metrics on the `/stats/prometheus` endpoint:


### PR DESCRIPTION
## Description

This PR adds a new task documenting how to securely scrape Prometheus metrics from Istio workloads (sidecars) and gateways using mTLS. It demonstrates the current capabilities in Istio configuration for secure metrics collection before any first-class platform support is implemented.

Related RFC: [Secure Metrics Scraping for Istio](https://docs.google.com/document/d/1BiBOrYU06x5xdsnU0YDlMGOV-iHjZ2m9UVcZ62wKAn8/edit?usp=sharing)

The doc covers: updating Prometheus with a sidecar, creating secure listeners on workloads and gateways, and verifying secure scraping via the Prometheus UI.

## Reviewers

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [X] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
