### PR TITLE
remove confusing warning about ztunnel upgrades

### DIFF
--- a/content/en/docs/ambient/upgrade/helm/index.md
+++ b/content/en/docs/ambient/upgrade/helm/index.md
@@ -14,12 +14,6 @@ test: yes
 Follow this guide to upgrade and configure an ambient mode installation using
 [Helm](https://helm.sh/docs/). This guide assumes you have already performed an [ambient mode installation with Helm](/docs/ambient/install/helm/) with a previous version of Istio.
 
-{{< warning >}}
-In contrast to sidecar mode, ambient mode supports moving application pods to an upgraded ztunnel proxy without a mandatory restart or reschedule of running application pods. However, upgrading ztunnel **will** cause all long-lived TCP connections on the upgraded node to reset, and Istio does not currently support canary upgrades of ztunnel, **even with the use of revisions**.
-
-Node cordoning and blue/green node pools are recommended to limit the blast radius of resets on application traffic during production upgrades. See your Kubernetes provider documentation for details.
-{{< /warning >}}
-
 ## Understanding ambient mode upgrades
 
 All Istio upgrades involve upgrading the control plane, data plane, and Istio CRDs. Because the ambient data plane is split across [two components](/docs/ambient/architecture/data-plane), the ztunnel and gateways (which includes waypoints), upgrades involve separate steps for these components. Upgrading the control plane and CRDs is covered here in brief, but is essentially identical to [the process for upgrading these components in sidecar mode](/docs/setup/upgrade/canary/).


### PR DESCRIPTION
This warning has caused substantial confusion for prospective users, and the issue it describes has been documented as less disruptive than the alternatives.