### PR TITLE
Clarify ResourceQuota from helm

### DIFF
--- a/content/en/docs/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ambient/install/platform-prerequisites/index.md
@@ -43,7 +43,7 @@ spec:
 
 #### Platform profile
 
-When using GKE you must append the correct `platform` value to your installation commands, as GKE uses nonstandard locations for CNI binaries which requires Helm overrides.
+When using GKE you must append the correct `platform` value to your installation commands, as GKE uses nonstandard locations for CNI binaries which requires Helm overrides. This will also automatically add the necessary ResourceQuota mentioned above.
 
 {{< tabset category-name="install-method" >}}
 


### PR DESCRIPTION
## Description
It's not immediately clear from the [values](https://github.com/istio/istio/blob/master/manifests/charts/istio-cni/values.yaml) that setting the platform will create the resourcequota. Maybe this will save someone else trying to deploy duplicate resourcequotas like happened to me.

## Reviewers

- [ x] Docs

