### PR TITLE
[Release-1.29] Add Gateway API Inference Extension beta support to feature status page

### DIFF
--- a/data/features.yaml
+++ b/data/features.yaml
@@ -105,7 +105,7 @@ features:
       maturity: Stable
       nextExpectedPromotion: ""
     area: Traffic Management
-  - name: "Kubernetes Gateway API Inference Extension (`InferencePool`, `InferenceObjective`)"
+  - name: "Kubernetes Gateway API Inference Extension (`InferencePool`)"
     id: "traffic.k8s_gateway_api_inference_extension"
     link: "/docs/tasks/traffic-management/ingress/gateway-api-inference-extension/"
     level:


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

Adding Gateway API Inference Extension beta support to the feature status page for 1.29 release.

See https://github.com/istio/istio/issues/58533#issuecomment-3885744006.

cc @LiorLieberman to confirm beta support looks good for 1.29.

## Reviewers
<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
