### PR TITLE
Add automatic Podman support for containerized make target

### DIFF
--- a/Makefile.overrides.mk
+++ b/Makefile.overrides.mk
@@ -12,11 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Podman requires additional security and networking options to work properly with the build system
+# If using Podman, you can either:
+# 1. Set CONTAINER_CLI=podman (recommended - automatically adds required flags)
+# 2. Or manually set: ADDITIONAL_CONTAINER_OPTIONS="--net=host --security-opt label=disable"
+ifeq ($(CONTAINER_CLI),podman)
+PODMAN_OPTIONS = --net=host --security-opt label=disable
+else
+PODMAN_OPTIONS =
+endif
+
 # expose port 1313 from the container in order to support 'make serve' which runs a Hugo web server
 ifeq ($(filter serve,$(MAKECMDGOALS)),serve)
-CONTAINER_OPTIONS = -p 1313:1313 ${ADDITIONAL_CONTAINER_OPTIONS}
+CONTAINER_OPTIONS = -p 1313:1313 ${PODMAN_OPTIONS} ${ADDITIONAL_CONTAINER_OPTIONS}
 else
-CONTAINER_OPTIONS = ${ADDITIONAL_CONTAINER_OPTIONS}
+CONTAINER_OPTIONS = ${PODMAN_OPTIONS} ${ADDITIONAL_CONTAINER_OPTIONS}
 endif
 
 # this repo is on the container plan by default


### PR DESCRIPTION
Automatically detect when CONTAINER_CLI=podman and add required container options (--net=host --security-opt label=disable) to fix golangci-lint execution issues with Podman

## Description

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [x] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
