### PR TITLE
docs: add SELinux configuration for istio-cni

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -131,6 +131,7 @@ Alexa
 Alibaba
 allowlist
 allow_missing
+AlmaLinux
 alt
 Amalgam8
 ambient.istio.io
@@ -1173,6 +1174,7 @@ Reviewer1
 Reviewer2
 revisioned
 Riskified
+RKE2
 roadmap
 roadmaps
 RocketChat
@@ -1210,6 +1212,7 @@ SecurityGroupPolicy
 SecurityGroups
 security_bulletin
 selinux
+seLinuxOptions
 Sergey
 serverless
 service-apis
@@ -1263,6 +1266,7 @@ SolarWinds
 Solo.io
 Solo.io.
 SongYang
+spc_t
 Specko
 Speedrun
 Speedscale

--- a/content/en/docs/ambient/install/platform-prerequisites/index.md
+++ b/content/en/docs/ambient/install/platform-prerequisites/index.md
@@ -298,3 +298,39 @@ applying any default-DENY `NetworkPolicy` in a Cilium CNI install underlying Ist
     Please see [issue #49277](https://github.com/istio/istio/issues/49277) and [CiliumClusterWideNetworkPolicy](https://docs.cilium.io/en/stable/network/kubernetes/policy/#ciliumclusterwidenetworkpolicy) for more details.
 
 When Cilium is used to replace kube-proxy, take note of the additional configuration options required to ensure proper operation with Istio in ambient mode described in the [Cilium documentation](https://docs.cilium.io/en/stable/network/servicemesh/istio/).
+
+### SELinux
+
+On systems with SELinux enabled (such as RHEL, Rocky Linux, AlmaLinux, or RKE2 nodes), the `istio-cni` DaemonSet pods require special SELinux configuration to function correctly. This is because the CNI plugin needs to interact with node-level resources and pod network namespaces.
+
+If you are running Istio on an SELinux-enabled system, you must configure `seLinuxOptions` with `type: spc_t` (Super Privileged Container) in the `istio-cni` Helm values. This allows the CNI plugin to run with the necessary permissions to manage pod networking.
+
+{{< tabset category-name="install-method" >}}
+
+{{< tab name="Helm" category-value="helm" >}}
+
+    {{< text syntax=bash >}}
+    $ helm install istio-cni istio/cni -n istio-system --set profile=ambient --set global.seLinuxOptions.type=spc_t --wait
+    {{< /text >}}
+
+    Alternatively, you can set this in a values file:
+
+    {{< text syntax=yaml >}}
+    global:
+      seLinuxOptions:
+        type: spc_t
+    {{< /text >}}
+
+{{< /tab >}}
+
+{{< tab name="istioctl" category-value="istioctl" >}}
+
+    {{< text syntax=bash >}}
+    $ istioctl install --set profile=ambient --set values.global.seLinuxOptions.type=spc_t
+    {{< /text >}}
+
+{{< /tab >}}
+
+{{< /tabset >}}
+
+For RKE2 specifically, refer to the [RKE2 SELinux documentation](https://docs.rke2.io/security/selinux) for additional platform-specific SELinux configuration requirements.

--- a/content/en/docs/setup/additional-setup/cni/index.md
+++ b/content/en/docs/setup/additional-setup/cni/index.md
@@ -122,6 +122,7 @@ In addition to the above basic configuration there are additional configuration 
 * `values.cni.cniBinDir` and `values.cni.cniConfDir` configure the directory paths to install the plugin binary and create plugin configuration.
 * `values.cni.cniConfFileName` configures the name of the plugin configuration file.
 * `values.cni.chained` controls whether to configure the plugin as a chained CNI plugin.
+* `values.global.seLinuxOptions` configures SELinux options for the CNI pods. On SELinux-enabled systems (such as RHEL, Rocky Linux, AlmaLinux, or RKE2 nodes), you must set `seLinuxOptions.type` to `spc_t` (Super Privileged Container) to allow the CNI plugin to manage pod networking. See the [SELinux configuration](/docs/ambient/install/platform-prerequisites#selinux) section for details.
 
 Normally, these do not need to be changed, but some platforms may use nonstandard paths. Please check the guidelines for your specific platform, if any, [here](/docs/ambient/install/platform-prerequisites).
 


### PR DESCRIPTION
## Summary

Adds documentation about SELinux configuration for `istio-cni` on SELinux-enabled systems. This addresses the need for users running RKE2 with Cilium CNI on SELinux-enabled systems (like Rocky Linux 9.7) to configure `seLinuxOptions` with `type: spc_t` in the istio-cni helm values.

Fixes #59057

## Changes

1. **Platform Prerequisites page** (`content/en/docs/ambient/install/platform-prerequisites/index.md`):
   - Added a new "SELinux" section under "CNI plugins"
   - Explains when SELinux configuration is needed
   - Provides Helm and istioctl commands with `global.seLinuxOptions.type=spc_t`
   - Includes a reference to RKE2's SELinux documentation

2. **CNI documentation page** (`content/en/docs/setup/additional-setup/cni/index.md`):
   - Added `values.global.seLinuxOptions` to the additional configuration flags list
   - Links to the SELinux configuration section in platform-prerequisites

## Testing

- Documentation follows existing patterns and style
- Links are properly formatted