### PR TITLE
Updating EOL dates in the support status table

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -10,13 +10,13 @@
 - version: "1.29"
   supported: "Yes"
   releaseDate: "Feb 16, 2026"
-  eolDate: "~Oct 2026 (Expected)"
+  eolDate: "~Aug 2026 (Expected)"
   k8sVersions: ["1.31", "1.32", "1.33", "1.34", "1.35"]
   testedK8sVersions: ["1.26", "1.27", "1.28", "1.29", "1.30"]
 - version: "1.28"
   supported: "Yes"
   releaseDate: "Nov 05, 2025"
-  eolDate: "~Jul 2026 (Expected)"
+  eolDate: "~May 2026 (Expected)"
   k8sVersions: ["1.30", "1.31", "1.32", "1.33", "1.34"]
   testedK8sVersions: ["1.25", "1.26", "1.27", "1.28", "1.29"]
 - version: "1.27"


### PR DESCRIPTION
## Description

Updating the EOL dates for 1.28 and 1.29 Releases

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
