### PR TITLE
docs: fix incorrect 'annotation' terminology to 'label' in sidecar injection troubleshooting

### DIFF
--- a/content/en/docs/ops/common-problems/injection/index.md
+++ b/content/en/docs/ops/common-problems/injection/index.md
@@ -103,7 +103,7 @@ of injected sidecar when it was.
     only applies if the webhook’s `namespaceSelector` matches the target
     namespace. Unrecognized policy causes injection to be disabled completely.
 
-1. Check the per-pod override annotation
+1. Check the per-pod override label
 
     The default policy can be overridden with the
     `sidecar.istio.io/inject` label in the _pod template spec’s metadata_.

--- a/content/es/docs/ops/common-problems/injection/index.md
+++ b/content/es/docs/ops/common-problems/injection/index.md
@@ -103,7 +103,7 @@ of injected sidecar when it was.
     only applies if the webhook’s `namespaceSelector` matches the target
     namespace. Unrecognized policy causes injection to be disabled completely.
 
-1. Check the per-pod override annotation
+1. Check the per-pod override label
 
     The default policy can be overridden with the
     `sidecar.istio.io/inject` label in the _pod template spec’s metadata_.


### PR DESCRIPTION
## Description

The heading in step 5 of the [Sidecar Injection Problems](https://istio.io/latest/docs/ops/common-problems/injection/) troubleshooting page incorrectly refers to the `sidecar.istio.io/inject` label as an "annotation". 

The body text and `kubectl` examples on the same page already correctly refer to it as a "label". This fix aligns the heading with the rest of the documentation and the [official injection policy docs](https://istio.io/latest/docs/setup/additional-setup/sidecar-injection/#controlling-the-injection-policy).

### Changes
- Changed "Check the per-pod override annotation" → "Check the per-pod override label" in both English and Spanish versions of the troubleshooting page

Fixes #11118