### PR TITLE
fix: update outdated CNI repair log message in troubleshooting docs

### DIFF
--- a/content/en/docs/ops/diagnostic-tools/cni/index.md
+++ b/content/en/docs/ops/diagnostic-tools/cni/index.md
@@ -2,7 +2,7 @@
 title: Troubleshooting the Istio CNI plugin
 description: Describes tools and techniques to diagnose issues using Istio with the CNI plugin.
 weight: 90
-keywords: [debug,cni]
+keywords: [debug, cni]
 owner: istio/wg-networking-maintainers
 test: n/a
 ---
@@ -33,7 +33,7 @@ You can collect the generated metrics via standard Prometheus configuration.
 ## DaemonSet readiness
 
 Readiness of the CNI DaemonSet indicates that the Istio CNI plugin is properly installed and configured.
-If Istio CNI DaemonSet is unready, it suggests something is wrong. Look at the  `istio-cni-node` DaemonSet logs to diagnose.
+If Istio CNI DaemonSet is unready, it suggests something is wrong. Look at the `istio-cni-node` DaemonSet logs to diagnose.
 You can also track CNI installation readiness via the `istio_cni_install_ready` metric.
 
 ## Race condition repair
@@ -43,7 +43,7 @@ which will evict a pod that was started before the CNI plugin was ready.
 To understand which pods were evicted, look for log lines like the following:
 
 {{< text plain >}}
-2021-07-21T08:32:17.362512Z     info   Deleting broken pod: service-graph00/svc00-0v1-95b5885bf-zhbzm
+2024-01-11T01:19:56.429220Z info Pod detected as broken, deleting: service-graph00/svc00-0v1-95b5885bf-zhbzm
 {{< /text >}}
 
 You can also track pods repaired via the `istio_cni_repair_pods_repaired_total` metric.
@@ -63,13 +63,13 @@ If a pod keeps getting init error, check the init container `istio-validation` l
 {{< text bash >}}
 $ kubectl logs POD_NAME -n POD_NAMESPACE -c istio-validation
 ...
-2021-07-20T05:30:17.111930Z     error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
-2021-07-20T05:30:18.112503Z     error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
+2021-07-20T05:30:17.111930Z error Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
+2021-07-20T05:30:18.112503Z error Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
 ...
-2021-07-20T05:30:22.111676Z     error   validation timeout
+2021-07-20T05:30:22.111676Z error validation timeout
 {{< /text >}}
 
-The  `istio-validation` init container sets up a local dummy server which
+The `istio-validation` init container sets up a local dummy server which
 listens on traffic redirection target inbound/outbound ports,
 and checks whether test traffic can be redirected to the dummy server.
 When pod traffic redirection is not set up correctly by the CNI plugin,
@@ -80,4 +80,4 @@ search the `istio-cni-node` for the pod ID.
 Another symptom of a malfunctioned CNI plugin is that the application pod is continuously evicted at start-up time.
 This is typically because the plugin is not properly installed, thus pod traffic redirection cannot be set up.
 CNI [race repair logic](/docs/setup/additional-setup/cni/#race-condition--mitigation) considers the pod is broken due to the race condition and evicts the pod continuously.
-When running into this issue,  check the CNI DaemonSet log for information on why the plugin could not be properly installed.
+When running into this issue, check the CNI DaemonSet log for information on why the plugin could not be properly installed.

--- a/content/es/docs/ops/diagnostic-tools/cni/index.md
+++ b/content/es/docs/ops/diagnostic-tools/cni/index.md
@@ -2,7 +2,7 @@
 title: Troubleshooting the Istio CNI plugin
 description: Describes tools and techniques to diagnose issues using Istio with the CNI plugin.
 weight: 90
-keywords: [debug,cni]
+keywords: [debug, cni]
 owner: istio/wg-networking-maintainers
 test: n/a
 ---
@@ -33,7 +33,7 @@ You can collect the generated metrics via standard Prometheus configuration.
 ## DaemonSet readiness
 
 Readiness of the CNI DaemonSet indicates that the Istio CNI plugin is properly installed and configured.
-If Istio CNI DaemonSet is unready, it suggests something is wrong. Look at the  `istio-cni-node` DaemonSet logs to diagnose.
+If Istio CNI DaemonSet is unready, it suggests something is wrong. Look at the `istio-cni-node` DaemonSet logs to diagnose.
 You can also track CNI installation readiness via the `istio_cni_install_ready` metric.
 
 ## Race condition repair
@@ -43,7 +43,7 @@ which will evict a pod that was started before the CNI plugin was ready.
 To understand which pods were evicted, look for log lines like the following:
 
 {{< text plain >}}
-2021-07-21T08:32:17.362512Z     info   Deleting broken pod: service-graph00/svc00-0v1-95b5885bf-zhbzm
+2024-01-11T01:19:56.429220Z info Pod detected as broken, deleting: service-graph00/svc00-0v1-95b5885bf-zhbzm
 {{< /text >}}
 
 You can also track pods repaired via the `istio_cni_repair_pods_repaired_total` metric.
@@ -63,13 +63,13 @@ If a pod keeps getting init error, check the init container `istio-validation` l
 {{< text bash >}}
 $ kubectl logs POD_NAME -n POD_NAMESPACE -c istio-validation
 ...
-2021-07-20T05:30:17.111930Z     error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
-2021-07-20T05:30:18.112503Z     error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
+2021-07-20T05:30:17.111930Z error Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
+2021-07-20T05:30:18.112503Z error Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
 ...
-2021-07-20T05:30:22.111676Z     error   validation timeout
+2021-07-20T05:30:22.111676Z error validation timeout
 {{< /text >}}
 
-The  `istio-validation` init container sets up a local dummy server which
+The `istio-validation` init container sets up a local dummy server which
 listens on traffic redirection target inbound/outbound ports,
 and checks whether test traffic can be redirected to the dummy server.
 When pod traffic redirection is not set up correctly by the CNI plugin,
@@ -80,4 +80,4 @@ search the `istio-cni-node` for the pod ID.
 Another symptom of a malfunctioned CNI plugin is that the application pod is continuously evicted at start-up time.
 This is typically because the plugin is not properly installed, thus pod traffic redirection cannot be set up.
 CNI [race repair logic](/es/docs/setup/additional-setup/cni/#race-condition--mitigation) considers the pod is broken due to the race condition and evicts the pod continuously.
-When running into this issue,  check the CNI DaemonSet log for information on why the plugin could not be properly installed.
+When running into this issue, check the CNI DaemonSet log for information on why the plugin could not be properly installed.

--- a/content/uk/docs/ops/diagnostic-tools/cni/index.md
+++ b/content/uk/docs/ops/diagnostic-tools/cni/index.md
@@ -2,7 +2,7 @@
 title: Усунення неполадок втулка Istio CNI
 description: Описує інструменти та техніки для діагностики проблем за допомогою Istio з втулком CNI.
 weight: 95
-keywords: [debug,cni]
+keywords: [debug, cni]
 owner: istio/wg-networking-maintainers
 test: n/a
 ---
@@ -32,7 +32,7 @@ DaemonSet CNI [генерує метрики](/docs/reference/commands/install-c
 Стандартно, DaemonSet Istio CNI має [виправлення стану перегонів](/docs/setup/additional-setup/cni/#race-condition--mitigation), яке видаляє pod, що був запущений до того, як втулок CNI був готовий. Щоб зрозуміти, які podʼи були видалені, шукайте рядки в логах, подібні до наступних:
 
 {{< text plain >}}
-2021-07-21T08:32:17.362512Z     info   Deleting broken pod: service-graph00/svc00-0v1-95b5885bf-zhbzm
+2024-01-11T01:19:56.429220Z info Pod detected as broken, deleting: service-graph00/svc00-0v1-95b5885bf-zhbzm
 {{< /text >}}
 
 Ви також можете відстежувати podʼи, що були виправлені, через метрику `istio_cni_repair_pods_repaired_total`.
@@ -50,10 +50,10 @@ $ kubectl describe pod POD_NAME -n POD_NAMESPACE
 {{< text bash >}}
 $ kubectl logs POD_NAME -n POD_NAMESPACE -c istio-validation
 ...
-2021-07-20T05:30:17.111930Z     error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
-2021-07-20T05:30:18.112503Z     error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
+2021-07-20T05:30:17.111930Z error Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
+2021-07-20T05:30:18.112503Z error Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
 ...
-2021-07-20T05:30:22.111676Z     error   validation timeout
+2021-07-20T05:30:22.111676Z error validation timeout
 {{< /text >}}
 
 Контейнер ініціалізації `istio-validation` налаштовує локальний фальшивий сервер, який слухає порти перенаправлення трафіку на вході/виході, і перевіряє, чи тестовий трафік може бути перенаправлений на фальшивий сервер. Коли перенаправлення трафіку podʼа не налаштоване правильно втулком CNI, контейнер ініціалізації `istio-validation` блокує запуск podʼа, щоб запобігти обходу трафіку. Щоб перевірити, чи були помилки або несподівані поведінки налаштування мережі, пошукайте в `istio-cni-node` за ідентифікатором podʼа.

--- a/content/zh/docs/ops/diagnostic-tools/cni/index.md
+++ b/content/zh/docs/ops/diagnostic-tools/cni/index.md
@@ -2,7 +2,7 @@
 title: Istio CNI 插件故障排除
 description: 描述使用 Istio 和 CNI 插件诊断问题的工具和技术。
 weight: 90
-keywords: [debug,cni]
+keywords: [debug, cni]
 owner: istio/wg-networking-maintainers
 test: n/a
 ---
@@ -44,7 +44,7 @@ Istio CNI DaemonSet 默认启用[竞争条件和缓解措施](/zh/docs/setup/add
 这将驱逐在 CNI 插件准备就绪之前启动的 Pod。要了解哪些 Pod 被驱逐，请查找如下所示的日志行：
 
 {{< text plain >}}
-2021-07-21T08:32:17.362512Z     info   Deleting broken pod: service-graph00/svc00-0v1-95b5885bf-zhbzm
+2024-01-11T01:19:56.429220Z info Pod detected as broken, deleting: service-graph00/svc00-0v1-95b5885bf-zhbzm
 {{< /text >}}
 
 您还可以通过 `istio_cni_repair_pods_repaired_total` 指标追踪修复的 Pod。
@@ -64,10 +64,10 @@ $ kubectl describe pod POD_NAME -n POD_NAMESPACE
 {{< text bash >}}
 $ kubectl logs POD_NAME -n POD_NAMESPACE -c istio-validation
 ...
-2021-07-20T05:30:17.111930Z     error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
-2021-07-20T05:30:18.112503Z     error   Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
+2021-07-20T05:30:17.111930Z error Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
+2021-07-20T05:30:18.112503Z error Error connecting to 127.0.0.6:15002: dial tcp 127.0.0.1:0->127.0.0.6:15002: connect: connection refused
 ...
-2021-07-20T05:30:22.111676Z     error   validation timeout
+2021-07-20T05:30:22.111676Z error validation timeout
 {{< /text >}}
 
 `istio-validation` Init 容器设置一个本地虚拟服务器，该服务器监听流量重定向目标的出入端口，


### PR DESCRIPTION
The CNI repair controller was modernized in https://github.com/istio/istio/pull/44816, changing the log message from `"Deleting broken pod:"` to `"Pod detected as broken, deleting:"`. This PR updates the troubleshooting docs across all language versions (en, es, uk, zh) to match the current Istio source code.

Fixes #16944