### PR TITLE
fix script to automate the last bits of branching, fix Makefile

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -27,7 +27,7 @@ export IN_BUILD_CONTAINER := $(IN_BUILD_CONTAINER)
 
 # ISTIO_IMAGE_VERSION stores the prefix used by default for the Docker images for Istio.
 # For example, a value of 1.6-alpha will assume a default TAG value of 1.6-dev.<SHA>
-ISTIO_IMAGE_VERSION ?= 1.29-alpha
+ISTIO_IMAGE_VERSION ?= 1.30-alpha
 export ISTIO_IMAGE_VERSION
 
 # Determine the SHA for the Istio dependency by parsing the go.mod file.
@@ -87,7 +87,7 @@ export NETLIFY_URL
 
 
 # Which branch of the Istio source code do we fetch stuff from
-export SOURCE_BRANCH_NAME ?= release-1.29
+export SOURCE_BRANCH_NAME ?= master
 
 site:
 	@scripts/gen_site.sh

--- a/scripts/create_minor_version.sh
+++ b/scripts/create_minor_version.sh
@@ -182,7 +182,7 @@ step1() {
     sed -i "
         s/^preliminary: .*$/preliminary: false/;
         s/^doc_branch_name: .*$/doc_branch_name: release-${CURR_MINOR}/;
-    " data/versions.yml
+    " data/args.yml
 
     if [[ $(git status --porcelain) ]]; then
         git add -A
@@ -221,8 +221,8 @@ step2() {
     " data/args.yml
 
     sed -i "
-        s/^export SOURCE_BRANCH_NAME ?=.*$/export SOURCE_BRANCH_NAME ?= master/;
-        s/^ISTIO_IMAGE_VERSION ?=.*$/ISTIO_IMAGE_VERSION ?= ${NEXT_MINOR}-alpha/
+        s/^export SOURCE_BRANCH_NAME [?]=.*$/export SOURCE_BRANCH_NAME ?= master/;
+        s/^ISTIO_IMAGE_VERSION [?]=.*$/ISTIO_IMAGE_VERSION ?= ${NEXT_MINOR}-alpha/
     " Makefile.core.mk
 
     go get istio.io/istio@master


### PR DESCRIPTION
## Description

The create_minor_version.sh script used when .0 is ready to publish has a few issues that require manual intervention afterward, this should address those.

Also fix Makefile so the SOURCE_BRANCH_NAME is correct and we prep master for 1.30.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
