### PR TITLE
Fix port 15020 localhost-only description in security best practices

### DIFF
--- a/content/en/docs/ops/best-practices/security/index.md
+++ b/content/en/docs/ops/best-practices/security/index.md
@@ -678,8 +678,8 @@ See the [Integration Guide](/docs/ops/integrations/integration-guide/debug-endpo
 
 ### Data Plane
 
-The proxy exposes a variety of ports. Exposed externally are port `15090` (telemetry) and port `15021` (health check).
-Ports `15020` and `15000` provide debugging endpoints. These are exposed over `localhost` only.
+The proxy exposes a variety of ports. Exposed externally are port `15090` (telemetry), port `15021` (health check), and port `15020` (merged Prometheus telemetry from Istio agent, Envoy, and the application).
+Port `15000` provides debugging endpoints and is exposed over `localhost` only.
 As a result, the applications running in the same pod as the proxy have access; there is no trust boundary between the sidecar and application.
 
 ## Configure third party service account tokens


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

The current documentation groups port 15020 with port 15000 and states both are exposed over localhost only. 

However, port 15020 binds to all interfaces and is accessible on the pod network, as shown in the [application requirements](/docs/ops/deployment/application-requirements/) port table.

This PR moves port 15020 to the externally exposed ports group alongside 15090 and 15021, and keeps the localhost-only description for port 15000 only.

If the current wording was intentional, I apologize — happy to discuss.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
