### PR TITLE
docs: add note about expected IST0173 warnings when applying Bookinfo destination rules

### DIFF
--- a/content/en/docs/examples/bookinfo/index.md
+++ b/content/en/docs/examples/bookinfo/index.md
@@ -236,6 +236,15 @@ To enforce mutual TLS, use the destination rules in `samples/bookinfo/networking
 
 Wait a few seconds for the destination rules to propagate.
 
+{{< tip >}}
+The `destination-rule-all.yaml` file defines subsets for all Bookinfo service versions,
+including `v2-mysql` and `v2-mysql-vm` variants of the ratings service that are not deployed
+as part of the standard Bookinfo installation. If you run `istioctl analyze` after applying
+this file, you may see `IST0173` warnings indicating these subsets do not select any pods.
+This is expected behavior for a standard Bookinfo deployment and can be safely ignored unless
+you have deployed the MySQL-based ratings variants.
+{{< /tip >}}
+
 You can display the destination rules with the following command:
 
 {{< text bash >}}


### PR DESCRIPTION
## What this PR does

Adds a tip note to the Bookinfo documentation explaining that applying
`destination-rule-all.yaml` may produce IST0173 warnings from
`istioctl analyze` for the `v2-mysql` and `v2-mysql-vm` subsets of
the ratings service.

## Why

These subsets are defined in `destination-rule-all.yaml` but the
corresponding pods (`ratings-v2-mysql`, `ratings-v2-mysql-vm`) are not
deployed as part of the standard Bookinfo installation. Users following
the getting started guide who run `istioctl analyze` will see:

Error [IST0173] (DestinationRule default/ratings) The Subset v2-mysql
defined in the DestinationRule does not select any pods. Which may
lead to 503 UH (NoHealthyUpstream).

Without any explanation, this causes confusion about whether the
installation is healthy. This note clarifies the errors are expected
and safe to ignore for a standard deployment.

## Type of change

- [x] Documentation fix