### PR TITLE
docs: add missing ztunnel Grafana dashboard to integrations page

### DIFF
--- a/content/en/docs/ops/integrations/grafana/index.md
+++ b/content/en/docs/ops/integrations/grafana/index.md
@@ -22,6 +22,7 @@ for all of the most important metrics for the mesh and for the control plane.
 * [Performance Dashboard](https://grafana.com/grafana/dashboards/11829) monitors the resource usage of the mesh.
 * [Control Plane Dashboard](https://grafana.com/grafana/dashboards/7645) monitors the health and performance of the control plane.
 * [WASM Extension Dashboard](https://grafana.com/grafana/dashboards/13277) provides an overview of mesh wide WebAssembly extension runtime and loading state.
+* [Ztunnel Dashboard](https://grafana.com/grafana/dashboards/21306) monitors the ztunnel component used in Istio ambient mode.
 
 There are a few ways to configure Grafana to use these dashboards:
 
@@ -55,7 +56,7 @@ $ GRAFANA_DATASOURCE="Prometheus"
 $ # The version of Istio to deploy
 $ VERSION={{< istio_full_version >}}
 $ # Import all Istio dashboards
-$ for DASHBOARD in 7639 11829 7636 7630 7645 13277; do
+$ for DASHBOARD in 7639 11829 7636 7630 7645 13277 21306; do
 $     REVISION="$(curl -s https://grafana.com/api/dashboards/${DASHBOARD}/revisions -s | jq ".items[] | select(.description | contains(\"${VERSION}\")) | .revision" | tail -n 1)"
 $     curl -s https://grafana.com/api/dashboards/${DASHBOARD}/revisions/${REVISION}/download > /tmp/dashboard.json
 $     echo "Importing $(cat /tmp/dashboard.json | jq -r '.title') (revision ${REVISION}, id ${DASHBOARD})..."


### PR DESCRIPTION
Fixes #15762

## What this PR does
Adds the missing ztunnel Grafana dashboard (ID: 21306) to the Grafana 
integrations documentation page.

## Changes
1. Added ztunnel dashboard to the dashboard list:
   - [Ztunnel Dashboard](https://grafana.com/grafana/dashboards/21306) 
     monitors the ztunnel component used in Istio ambient mode.

2. Added dashboard ID 21306 to the bulk import script loop so users 
   who import all dashboards at once will also get the ztunnel dashboard.

## Why
The ztunnel dashboard was published to Grafana.com when ambient mode 
became stable in Istio 1.24, but was never added to the documentation. 
Issue #15762 reported this gap in October 2024.

## Type of change
- [x] Documentation fix