### PR TITLE
docs: add SAN extension to secure ingress certificate generation commands

### DIFF
--- a/content/en/docs/ops/integrations/grafana/index.md
+++ b/content/en/docs/ops/integrations/grafana/index.md
@@ -22,6 +22,7 @@ for all of the most important metrics for the mesh and for the control plane.
 * [Performance Dashboard](https://grafana.com/grafana/dashboards/11829) monitors the resource usage of the mesh.
 * [Control Plane Dashboard](https://grafana.com/grafana/dashboards/7645) monitors the health and performance of the control plane.
 * [WASM Extension Dashboard](https://grafana.com/grafana/dashboards/13277) provides an overview of mesh wide WebAssembly extension runtime and loading state.
+* [Ztunnel Dashboard](https://grafana.com/grafana/dashboards/21306) monitors the ztunnel component used in Istio ambient mode.
 
 There are a few ways to configure Grafana to use these dashboards:
 
@@ -55,7 +56,7 @@ $ GRAFANA_DATASOURCE="Prometheus"
 $ # The version of Istio to deploy
 $ VERSION={{< istio_full_version >}}
 $ # Import all Istio dashboards
-$ for DASHBOARD in 7639 11829 7636 7630 7645 13277; do
+$ for DASHBOARD in 7639 11829 7636 7630 7645 13277 21306; do
 $     REVISION="$(curl -s https://grafana.com/api/dashboards/${DASHBOARD}/revisions -s | jq ".items[] | select(.description | contains(\"${VERSION}\")) | .revision" | tail -n 1)"
 $     curl -s https://grafana.com/api/dashboards/${DASHBOARD}/revisions/${REVISION}/download > /tmp/dashboard.json
 $     echo "Importing $(cat /tmp/dashboard.json | jq -r '.title') (revision ${REVISION}, id ${DASHBOARD})..."

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/index.md
@@ -43,6 +43,15 @@ This task requires several sets of certificates and keys which are used in the f
 You can use your favorite tool to create them or use the commands below to generate them using
 [openssl](https://man.openbsd.org/openssl.1).
 
+{{< tip >}}
+The certificates generated below are for testing purposes only. The commands include the
+`-extfile` flag to add a Subject Alternative Name (SAN) extension, which is required by
+modern browsers such as Chrome. Without a SAN, browsers will reject the certificate with
+a `ERR_CERT_COMMON_NAME_INVALID` error. These self-signed certificates will not be trusted
+by browsers automatically; you will need to add them to your browser's trust store or use
+`curl` with the `--cacert` flag for testing.
+{{< /tip >}}
+
 1.  Create a root certificate and private key to sign the certificates for your services:
 
     {{< text bash >}}
@@ -54,7 +63,7 @@ You can use your favorite tool to create them or use the commands below to gener
 
     {{< text bash >}}
     $ openssl req -out example_certs1/httpbin.example.com.csr -newkey rsa:2048 -nodes -keyout example_certs1/httpbin.example.com.key -subj "/CN=httpbin.example.com/O=httpbin organization"
-    $ openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 0 -in example_certs1/httpbin.example.com.csr -out example_certs1/httpbin.example.com.crt
+    $ openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 0 -in example_certs1/httpbin.example.com.csr -out example_certs1/httpbin.example.com.crt -extfile <(printf "subjectAltName=DNS:httpbin.example.com")
     {{< /text >}}
 
 1.  Create a second set of the same kind of certificates and keys:
@@ -63,21 +72,21 @@ You can use your favorite tool to create them or use the commands below to gener
     $ mkdir example_certs2
     $ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj '/O=example Inc./CN=example.com' -keyout example_certs2/example.com.key -out example_certs2/example.com.crt
     $ openssl req -out example_certs2/httpbin.example.com.csr -newkey rsa:2048 -nodes -keyout example_certs2/httpbin.example.com.key -subj "/CN=httpbin.example.com/O=httpbin organization"
-    $ openssl x509 -req -sha256 -days 365 -CA example_certs2/example.com.crt -CAkey example_certs2/example.com.key -set_serial 0 -in example_certs2/httpbin.example.com.csr -out example_certs2/httpbin.example.com.crt
+    $ openssl x509 -req -sha256 -days 365 -CA example_certs2/example.com.crt -CAkey example_certs2/example.com.key -set_serial 0 -in example_certs2/httpbin.example.com.csr -out example_certs2/httpbin.example.com.crt -extfile <(printf "subjectAltName=DNS:httpbin.example.com")
     {{< /text >}}
 
 1.  Generate a certificate and a private key for `helloworld.example.com`:
 
     {{< text bash >}}
     $ openssl req -out example_certs1/helloworld.example.com.csr -newkey rsa:2048 -nodes -keyout example_certs1/helloworld.example.com.key -subj "/CN=helloworld.example.com/O=helloworld organization"
-    $ openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 1 -in example_certs1/helloworld.example.com.csr -out example_certs1/helloworld.example.com.crt
+    $ openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 1 -in example_certs1/helloworld.example.com.csr -out example_certs1/helloworld.example.com.crt -extfile <(printf "subjectAltName=DNS:helloworld.example.com")
     {{< /text >}}
 
 1.  Generate a client certificate and private key:
 
     {{< text bash >}}
     $ openssl req -out example_certs1/client.example.com.csr -newkey rsa:2048 -nodes -keyout example_certs1/client.example.com.key -subj "/CN=client.example.com/O=client organization"
-    $ openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 1 -in example_certs1/client.example.com.csr -out example_certs1/client.example.com.crt
+    $ openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 1 -in example_certs1/client.example.com.csr -out example_certs1/client.example.com.crt -extfile <(printf "subjectAltName=DNS:client.example.com")
     {{< /text >}}
 
 {{< tip >}}

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/snips.sh
@@ -40,24 +40,24 @@ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj '/O=example In
 
 snip_generate_client_and_server_certificates_and_keys_2() {
 openssl req -out example_certs1/httpbin.example.com.csr -newkey rsa:2048 -nodes -keyout example_certs1/httpbin.example.com.key -subj "/CN=httpbin.example.com/O=httpbin organization"
-openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 0 -in example_certs1/httpbin.example.com.csr -out example_certs1/httpbin.example.com.crt
+openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 0 -in example_certs1/httpbin.example.com.csr -out example_certs1/httpbin.example.com.crt -extfile <(printf "subjectAltName=DNS:httpbin.example.com")
 }
 
 snip_generate_client_and_server_certificates_and_keys_3() {
 mkdir example_certs2
 openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj '/O=example Inc./CN=example.com' -keyout example_certs2/example.com.key -out example_certs2/example.com.crt
 openssl req -out example_certs2/httpbin.example.com.csr -newkey rsa:2048 -nodes -keyout example_certs2/httpbin.example.com.key -subj "/CN=httpbin.example.com/O=httpbin organization"
-openssl x509 -req -sha256 -days 365 -CA example_certs2/example.com.crt -CAkey example_certs2/example.com.key -set_serial 0 -in example_certs2/httpbin.example.com.csr -out example_certs2/httpbin.example.com.crt
+openssl x509 -req -sha256 -days 365 -CA example_certs2/example.com.crt -CAkey example_certs2/example.com.key -set_serial 0 -in example_certs2/httpbin.example.com.csr -out example_certs2/httpbin.example.com.crt -extfile <(printf "subjectAltName=DNS:httpbin.example.com")
 }
 
 snip_generate_client_and_server_certificates_and_keys_4() {
 openssl req -out example_certs1/helloworld.example.com.csr -newkey rsa:2048 -nodes -keyout example_certs1/helloworld.example.com.key -subj "/CN=helloworld.example.com/O=helloworld organization"
-openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 1 -in example_certs1/helloworld.example.com.csr -out example_certs1/helloworld.example.com.crt
+openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 1 -in example_certs1/helloworld.example.com.csr -out example_certs1/helloworld.example.com.crt -extfile <(printf "subjectAltName=DNS:helloworld.example.com")
 }
 
 snip_generate_client_and_server_certificates_and_keys_5() {
 openssl req -out example_certs1/client.example.com.csr -newkey rsa:2048 -nodes -keyout example_certs1/client.example.com.key -subj "/CN=client.example.com/O=client organization"
-openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 1 -in example_certs1/client.example.com.csr -out example_certs1/client.example.com.crt
+openssl x509 -req -sha256 -days 365 -CA example_certs1/example.com.crt -CAkey example_certs1/example.com.key -set_serial 1 -in example_certs1/client.example.com.csr -out example_certs1/client.example.com.crt -extfile <(printf "subjectAltName=DNS:client.example.com")
 }
 
 snip_generate_client_and_server_certificates_and_keys_6() {


### PR DESCRIPTION
Fixes #11675

## What this PR does
Adds the `-extfile` flag with a Subject Alternative Name (SAN) extension 
to all `openssl x509` certificate signing commands in the secure ingress 
documentation, and adds a note explaining the browser compatibility requirement.

## Why
Since Chrome 58, browsers require certificates to have the domain name in 
the Subject Alternative Name (SAN) extension, not just the Common Name (CN) 
field. The current commands generate certificates without a SAN, which causes:

- `ERR_CERT_COMMON_NAME_INVALID` in Chrome
- `Subject Alternative Name Missing` error

This issue has been open since August 2022 (#11675).

## Changes
1. Added `-extfile <(printf "subjectAltName=DNS:<domain>")` to 4 certificate 
   signing commands:
   - httpbin.example.com (example_certs1)
   - httpbin.example.com (example_certs2)
   - helloworld.example.com
   - client.example.com

2. Added a tip note explaining that the certificates are for testing only, 
   require SAN for modern browsers, and will not be automatically trusted.

## Type of change
- [x] Documentation fix