### PR TITLE
test: improve kubectl context handling in test utilities

### DIFF
--- a/tests/util/debug.sh
+++ b/tests/util/debug.sh
@@ -13,6 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+if [[ -z "${TEST_DEBUG_FILE:-}" ]]; then
+  echo "TEST_DEBUG_FILE must be set before enabling test debug output"
+  exit 1
+fi
 
 echo "Creating test debug file: ${TEST_DEBUG_FILE}"
 

--- a/tests/util/gateway-api.sh
+++ b/tests/util/gateway-api.sh
@@ -18,14 +18,23 @@ source "content/en/boilerplates/snips/args.sh"
 
 K8S_GATEWAY_API_CRDS="github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${bpsnip_args_gateway_api_version}"
 GATEWAY_API="true"
+# Build optional kubectl context argument
+function _gateway_context_arg() {
+    local context="${1:-}"
+    if [[ -n "$context" ]]; then
+        echo "--context=$context"
+    fi
+}
 
 function install_gateway_api_crds() {
-    kubectl kustomize "${K8S_GATEWAY_API_CRDS}" | kubectl apply --server-side -f - --context="$1"
+    kubectl kustomize "${K8S_GATEWAY_API_CRDS}" | kubectl apply --server-side -f - $(_gateway_context_arg "$1")
+
 }
 
 function remove_gateway_api_crds() {
-    kubectl kustomize "${K8S_GATEWAY_API_CRDS}" | kubectl delete -f - --context="$1"
+    kubectl kustomize "${K8S_GATEWAY_API_CRDS}" | kubectl delete -f - $(_gateway_context_arg "$1")
 
-    kubectl get --context="$1" gateways.gateway.networking.k8s.io >/dev/null 2>&1 || true
+
+    kubectl get $(_gateway_context_arg "$1") gateways.gateway.networking.k8s.io >/dev/null 2>&1 || true
     # TODO ^^^ remove this kludge which forces the name "gateway" to not stay bound to the deleted crd
 }

--- a/tests/util/helpers.sh
+++ b/tests/util/helpers.sh
@@ -71,11 +71,18 @@ _set_ingress_environment_variables() {
 
 # Wait for rollout of named deployment
 # usage: _wait_for_deployment <namespace> <deployment name> <optional: context>
+_kubectl_context_args() {
+    local context="${1:-}"
+    if [[ -n "$context" ]]; then
+        echo "--context=$context"
+    fi
+}
+
 _wait_for_deployment() {
     local namespace="$1"
     local name="$2"
     local context="${3:-}"
-    if ! kubectl --context="$context" -n "$namespace" rollout status deployment "$name" --timeout 5m; then
+    if ! kubectl $(_kubectl_context_args "$context") -n "$namespace" rollout status deployment "$name" --timeout 5m; then
         echo "Failed rollout of deployment $name in namespace $namespace"
         exit 1
     fi
@@ -87,7 +94,7 @@ _wait_for_daemonset() {
     local namespace="$1"
     local name="$2"
     local context="${3:-}"
-    if ! kubectl --context="$context" -n "$namespace" rollout status daemonset "$name" --timeout 5m; then
+    if ! kubectl $(_kubectl_context_args "$context") -n "$namespace" rollout status daemonset "$name" --timeout 5m; then
         echo "Failed rollout of daemonset $name in namespace $namespace"
         exit 1
     fi
@@ -99,7 +106,7 @@ _wait_for_statefulset() {
     local namespace="$1"
     local name="$2"
     local context="${3:-}"
-    if ! kubectl --context="$context" -n "$namespace" rollout status statefulset "$name" --timeout 5m; then
+    if ! kubectl $(_kubectl_context_args "$context") -n "$namespace" rollout status statefulset "$name" --timeout 5m; then
         echo "Failed rollout of statefulset $name in namespace $namespace"
         exit 1
     fi
@@ -127,7 +134,7 @@ _wait_for_gateway() {
     local namespace="$1"
     local name="$2"
     local context="${3:-}"
-    if ! kubectl --context="$context" -n "$namespace" wait --for=condition=programmed gtw "$name" --timeout=2m; then
+    if ! kubectl $(_kubectl_context_args "$context") -n "$namespace" wait --for=condition=programmed gtw "$name" --timeout=2m; then
         echo "Failed to deploy gateway $name in namespace $namespace"
         exit 1
     fi

--- a/tests/util/samples.sh
+++ b/tests/util/samples.sh
@@ -70,7 +70,8 @@ cleanup_httpbin_sample() {
 # Example:
 #   response=$(sample_http_request "/productpage" "jason")
 sample_http_request() {
-    local path=$1
+    local path="$1"
+
 
     local user=""
 	if [[ $# -gt 1 ]]; then

--- a/tests/util/verify.sh
+++ b/tests/util/verify.sh
@@ -117,7 +117,7 @@ __cmp_first_line() {
 
 # Returns 0 if $out is "like" $expected. Like implies:
 #   1. Same number of lines
-#   2. Same number of whitespace-seperated tokens per line
+#   2. Same number of whitespace-separated tokens per line
 #   3. Tokens can only differ in the following ways:
 #        - different elapsed time values (e.g. 25s, 2m30s).
 #        - different ip values. Disallows <none> and <pending> by
@@ -442,7 +442,7 @@ _verify_first_line() {
 #
 # Like implies:
 #   1. Same number of lines
-#   2. Same number of whitespace-seperated tokens per line
+#   2. Same number of whitespace-separated tokens per line
 #   3. Tokens can only differ in the following ways:
 #        - different elapsed time values
 #        - different ip values. Disallows <none> and <pending> by


### PR DESCRIPTION
Only pass --context to kubectl when context is provided.

## Description

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
