### PR TITLE
test: factor addon apply and wait helper

### DIFF
--- a/tests/util/addons.sh
+++ b/tests/util/addons.sh
@@ -16,27 +16,32 @@
 # limitations under the License.
 
 source "tests/util/helpers.sh"
+# Apply an addon manifest and wait for the deployment to be ready.
+# usage: _apply_addon_and_wait <manifest> <deployment>
+function _apply_addon_and_wait() {
+  local manifest="$1"
+  local deployment="$2"
+
+  kubectl apply -f "$manifest"
+  _wait_for_deployment istio-system "$deployment"
+}
 
 # Deploy the addons specified and wait for the deployment to complete. Currently
 # Zipkin, Jaeger, Grafana, Kiali and Prometheus are supported.
 function _deploy_and_wait_for_addons() {
   for arg in "$@"; do
     case "$arg" in
-    zipkin)     kubectl apply -f samples/addons/extras/zipkin.yaml
-                 _wait_for_deployment istio-system zipkin
+    zipkin)     _apply_addon_and_wait samples/addons/extras/zipkin.yaml zipkin
                  ;;
-    grafana)    kubectl apply -f samples/addons/grafana.yaml
-                 _wait_for_deployment istio-system grafana
+    grafana)    _apply_addon_and_wait samples/addons/grafana.yaml grafana
                  ;;
-    jaeger)     kubectl apply -f samples/addons/jaeger.yaml
-                 _wait_for_deployment istio-system jaeger
+    jaeger)     _apply_addon_and_wait samples/addons/jaeger.yaml jaeger
                  ;;
     kiali)      kubectl apply -f samples/addons/kiali.yaml || true # ignore first errors
                  kubectl apply -f samples/addons/kiali.yaml # Need to apply twice due to a race condition
                  _wait_for_deployment istio-system kiali
                  ;;
-    prometheus) kubectl apply -f samples/addons/prometheus.yaml
-                 _wait_for_deployment istio-system prometheus
+    prometheus) _apply_addon_and_wait samples/addons/prometheus.yaml prometheus
                  ;;
     skywalking) kubectl apply -f samples/addons/extras/skywalking.yaml
                  _wait_for_deployment istio-system skywalking-oap


### PR DESCRIPTION
This PR factors repeated addon apply-and-wait logic into a small helper.

The change keeps the existing behavior unchanged while reducing duplication in addon deployment test utilities.

## Description

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
