### PR TITLE
add 1.30 entry to support status

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -7,6 +7,12 @@
   eolDate:
   k8sVersions: ["1.31", "1.32", "1.33", "1.34","1.35"]
   testedK8sVersions: ["1.24", "1.25", "1.26", "1.27", "1.28", "1.29","1.30"]
+- version: "1.30"
+  supported: "Yes"
+  releaseDate: "May 14, 2026"
+  eolDate: "~Nov 2026 (Expected)"
+  k8sVersions: ["1.32", "1.33", "1.34", "1.35", "1.36"]
+  testedK8sVersions: ["1.27", "1.28", "1.29", "1.30", "1.31"]
 - version: "1.29"
   supported: "Yes"
   releaseDate: "Feb 16, 2026"


### PR DESCRIPTION
Adds 1.30 entry to compatibility/supportStatus.yml. Min k8s 1.32, range 1.32-1.36, planned release May 14.