### PR TITLE
Update TrafficExtension reference docs and fix stale links

### DIFF
--- a/content/en/docs/ambient/usage/extend-waypoint-lua/index.md
+++ b/content/en/docs/ambient/usage/extend-waypoint-lua/index.md
@@ -11,7 +11,7 @@ status: Alpha
 {{< boilerplate alpha >}}
 
 Istio provides the ability to extend waypoint proxies using inline [Lua](https://www.lua.org/) scripts
-via the [`TrafficExtension`](/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension/) API.
+via the [`TrafficExtension`](/docs/reference/config/proxy_extensions/traffic_extension/) API.
 In ambient mode, `TrafficExtension` resources must be attached to a waypoint proxy using `targetRefs`.
 
 ## Before you begin

--- a/content/en/docs/ambient/usage/extend-waypoint-wasm/index.md
+++ b/content/en/docs/ambient/usage/extend-waypoint-wasm/index.md
@@ -11,7 +11,7 @@ status: Alpha
 {{< boilerplate alpha >}}
 
 Istio provides the ability to extend waypoint proxies using [WebAssembly (Wasm)](/docs/concepts/extensibility/trafficextension/#webassembly-filters)
-modules via the [`TrafficExtension`](/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension/) API.
+modules via the [`TrafficExtension`](/docs/reference/config/proxy_extensions/traffic_extension/) API.
 In ambient mode, `TrafficExtension` resources must be attached to a waypoint proxy using `targetRefs`.
 
 ## Before you begin

--- a/content/en/docs/concepts/extensibility/trafficextension.md
+++ b/content/en/docs/concepts/extensibility/trafficextension.md
@@ -10,7 +10,7 @@ test: n/a
 ---
 
 Istio provides two mechanisms for extending the Istio proxy: WebAssembly (Wasm) and Lua.
-Both are configured using the [`TrafficExtension`](/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension/) API,
+Both are configured using the [`TrafficExtension`](/docs/reference/config/proxy_extensions/traffic_extension/) API,
 which provides a unified way to attach extensions to workloads with consistent targeting and phase/priority ordering.
 
 ## Choosing a filter type

--- a/content/en/docs/reference/config/proxy_extensions/traffic_extension/index.html
+++ b/content/en/docs/reference/config/proxy_extensions/traffic_extension/index.html
@@ -3,11 +3,11 @@ WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL
 source_repo: https://github.com/istio/api
 title: Traffic Extension
 description: Extend the functionality provided by the Istio proxy through WebAssembly or Lua filters.
-location: https://istio.io/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension.html
+location: https://istio.io/docs/reference/config/proxy_extensions/traffic_extension.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
 schema: istio.extensions.v1alpha1.TrafficExtension
-aliases: [/zh/docs/reference/config/extensions/v1alpha1/traffic_extension]
+aliases: [/docs/reference/config/extensions/v1alpha1/traffic_extension]
 number_of_entries: 5
 ---
 <p>TrafficExtension provides a mechanism to extend the functionality provided by
@@ -250,7 +250,7 @@ spec:
 <tbody>
 <tr id="TrafficExtension-selector">
 <td><div class="field"><div class="name"><code><a href="#TrafficExtension-selector">selector</a></code></div>
-<div class="type"><a href="/zh/docs/reference/config/type/workload-selector/#WorkloadSelector">WorkloadSelector</a></div>
+<div class="type"><a href="/docs/reference/config/type/workload-selector/#WorkloadSelector">WorkloadSelector</a></div>
 </div></td>
 <td>
 <p>Criteria used to select the specific set of pods/VMs on which
@@ -265,7 +265,7 @@ namespace.</p>
 </tr>
 <tr id="TrafficExtension-targetRefs">
 <td><div class="field"><div class="name"><code><a href="#TrafficExtension-targetRefs">targetRefs</a></code></div>
-<div class="type"><a href="/zh/docs/reference/config/type/workload-selector/#PolicyTargetReference">PolicyTargetReference[]</a></div>
+<div class="type"><a href="/docs/reference/config/type/workload-selector/#PolicyTargetReference">PolicyTargetReference[]</a></div>
 </div></td>
 <td>
 <p>The targetRefs specifies a list of resources the policy should be
@@ -443,7 +443,7 @@ against the contents of this field after pulling.</p>
 </tr>
 <tr id="WasmConfig-image_pull_policy">
 <td><div class="field"><div class="name"><code><a href="#WasmConfig-image_pull_policy">imagePullPolicy</a></code></div>
-<div class="type"><a href="/zh/docs/reference/config/proxy_extensions/wasm-plugin/#PullPolicy">PullPolicy</a></div>
+<div class="type"><a href="/docs/reference/config/proxy_extensions/wasm-plugin/#PullPolicy">PullPolicy</a></div>
 </div></td>
 <td>
 <p>The pull behaviour to be applied when fetching Wasm module by either
@@ -489,7 +489,7 @@ plugin to execute.</p>
 </tr>
 <tr id="WasmConfig-fail_strategy">
 <td><div class="field"><div class="name"><code><a href="#WasmConfig-fail_strategy">failStrategy</a></code></div>
-<div class="type"><a href="/zh/docs/reference/config/proxy_extensions/wasm-plugin/#FailStrategy">FailStrategy</a></div>
+<div class="type"><a href="/docs/reference/config/proxy_extensions/wasm-plugin/#FailStrategy">FailStrategy</a></div>
 </div></td>
 <td>
 <p>Specifies the failure behavior for the plugin due to fatal errors.</p>
@@ -498,7 +498,7 @@ plugin to execute.</p>
 </tr>
 <tr id="WasmConfig-vm_config">
 <td><div class="field"><div class="name"><code><a href="#WasmConfig-vm_config">vmConfig</a></code></div>
-<div class="type"><a href="/zh/docs/reference/config/proxy_extensions/wasm-plugin/#VmConfig">VmConfig</a></div>
+<div class="type"><a href="/docs/reference/config/proxy_extensions/wasm-plugin/#VmConfig">VmConfig</a></div>
 </div></td>
 <td>
 <p>Configuration for a Wasm VM.
@@ -508,7 +508,7 @@ More details can be found <a href="https://www.envoyproxy.io/docs/envoy/latest/a
 </tr>
 <tr id="WasmConfig-type">
 <td><div class="field"><div class="name"><code><a href="#WasmConfig-type">type</a></code></div>
-<div class="type"><a href="/zh/docs/reference/config/proxy_extensions/wasm-plugin/#PluginType">PluginType</a></div>
+<div class="type"><a href="/docs/reference/config/proxy_extensions/wasm-plugin/#PluginType">PluginType</a></div>
 </div></td>
 <td>
 <p>Specifies the type of Wasm Extension to be used.</p>
@@ -583,7 +583,7 @@ traffic will be selected.</p>
 <tbody>
 <tr id="TrafficSelector-mode">
 <td><div class="field"><div class="name"><code><a href="#TrafficSelector-mode">mode</a></code></div>
-<div class="type"><a href="/zh/docs/reference/config/type/workload-selector/#WorkloadMode">WorkloadMode</a></div>
+<div class="type"><a href="/docs/reference/config/type/workload-selector/#WorkloadMode">WorkloadMode</a></div>
 </div></td>
 <td>
 <p>Criteria for selecting traffic by their direction.
@@ -596,7 +596,7 @@ If not specified, the default value is <code>CLIENT_AND_SERVER</code>.</p>
 </tr>
 <tr id="TrafficSelector-ports">
 <td><div class="field"><div class="name"><code><a href="#TrafficSelector-ports">ports</a></code></div>
-<div class="type"><a href="/zh/docs/reference/config/type/workload-selector/#PortSelector">PortSelector[]</a></div>
+<div class="type"><a href="/docs/reference/config/type/workload-selector/#PortSelector">PortSelector[]</a></div>
 </div></td>
 <td>
 <p>Criteria for selecting traffic by their destination port.

--- a/content/en/docs/tasks/extensibility/lua-scripts/index.md
+++ b/content/en/docs/tasks/extensibility/lua-scripts/index.md
@@ -11,7 +11,7 @@ status: Alpha
 {{< boilerplate alpha >}}
 
 Istio provides the ability to extend proxy functionality using inline [Lua](https://www.lua.org/) scripts
-via the [`TrafficExtension`](/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension/) API.
+via the [`TrafficExtension`](/docs/reference/config/proxy_extensions/traffic_extension/) API.
 Lua filters are a lightweight alternative to [WebAssembly](/docs/tasks/extensibility/wasm-modules/)
 for simple request and response transformations — the script is embedded directly in the resource and
 executed within the Envoy proxy, with no module distribution required.

--- a/content/en/docs/tasks/extensibility/wasm-modules/index.md
+++ b/content/en/docs/tasks/extensibility/wasm-modules/index.md
@@ -135,7 +135,7 @@ which is maintained by the Istio community and used to develop Istio's Telemetry
 - [Write unit tests for C++ Wasm extensions](https://github.com/istio-ecosystem/wasm-extensions/blob/master/doc/write-cpp-unit-test.md)
 - [Write integration tests for Wasm extensions](https://github.com/istio-ecosystem/wasm-extensions/blob/master/doc/write-integration-test.md)
 
-For more details on the API, see the [`TrafficExtension` reference](/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension/).
+For more details on the API, see the [`TrafficExtension` reference](/docs/reference/config/proxy_extensions/traffic_extension/).
 
 ## Limitations
 

--- a/content/zh/docs/ambient/usage/extend-waypoint-lua/index.md
+++ b/content/zh/docs/ambient/usage/extend-waypoint-lua/index.md
@@ -10,7 +10,7 @@ status: Alpha
 
 {{< boilerplate alpha >}}
 
-Istio 提供了通过 [`TrafficExtension`](/zh/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension/)
+Istio 提供了通过 [`TrafficExtension`](/zh/docs/reference/config/proxy_extensions/traffic_extension/)
 API 使用内联 [Lua](https://www.lua.org/) 脚本来扩展 waypoint 代理的能力。在 Ambient 模式下，
 `TrafficExtension` 资源必须通过 `targetRefs` 绑定到 waypoint 代理。
 

--- a/content/zh/docs/ambient/usage/extend-waypoint-wasm/index.md
+++ b/content/zh/docs/ambient/usage/extend-waypoint-wasm/index.md
@@ -10,7 +10,7 @@ status: Alpha
 
 {{< boilerplate alpha >}}
 
-Istio 提供了通过 [`TrafficExtension`](/zh/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension/) API，
+Istio 提供了通过 [`TrafficExtension`](/zh/docs/reference/config/proxy_extensions/traffic_extension/) API，
 利用 [WebAssembly (Wasm)](/zh/docs/concepts/extensibility/trafficextension/#webassembly-filters) 模块来扩展 waypoint 代理的能力。
 在 Ambient 模式下，必须使用 `targetRefs` 将 `TrafficExtension` 资源关联至 waypoint 代理。
 

--- a/content/zh/docs/concepts/extensibility/trafficextension.md
+++ b/content/zh/docs/concepts/extensibility/trafficextension.md
@@ -10,7 +10,7 @@ test: n/a
 ---
 
 Istio 提供了两种用于扩展 Istio 代理的机制：WebAssembly (Wasm) 和 Lua。
-两者均通过 [`TrafficExtension`](/zh/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension/) API 进行配置；
+两者均通过 [`TrafficExtension`](/zh/docs/reference/config/proxy_extensions/traffic_extension/) API 进行配置；
 该 API 提供了一种统一的方式，允许以一致的定位规则以及阶段/优先级顺序，
 将扩展附加到工作负载上。
 

--- a/content/zh/docs/reference/config/proxy_extensions/traffic_extension/index.html
+++ b/content/zh/docs/reference/config/proxy_extensions/traffic_extension/index.html
@@ -3,11 +3,11 @@ WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL
 source_repo: https://github.com/istio/api
 title: Traffic Extension
 description: Extend the functionality provided by the Istio proxy through WebAssembly or Lua filters.
-location: https://istio.io/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension.html
+location: https://istio.io/docs/reference/config/proxy_extensions/traffic_extension.html
 layout: protoc-gen-docs
 generator: protoc-gen-docs
 schema: istio.extensions.v1alpha1.TrafficExtension
-aliases: [/docs/reference/config/extensions/v1alpha1/traffic_extension]
+aliases: [/zh/docs/reference/config/extensions/v1alpha1/traffic_extension]
 number_of_entries: 5
 ---
 <p>TrafficExtension provides a mechanism to extend the functionality provided by
@@ -250,7 +250,7 @@ spec:
 <tbody>
 <tr id="TrafficExtension-selector">
 <td><div class="field"><div class="name"><code><a href="#TrafficExtension-selector">selector</a></code></div>
-<div class="type"><a href="/docs/reference/config/type/workload-selector/#WorkloadSelector">WorkloadSelector</a></div>
+<div class="type"><a href="/zh/docs/reference/config/type/workload-selector/#WorkloadSelector">WorkloadSelector</a></div>
 </div></td>
 <td>
 <p>Criteria used to select the specific set of pods/VMs on which
@@ -265,7 +265,7 @@ namespace.</p>
 </tr>
 <tr id="TrafficExtension-targetRefs">
 <td><div class="field"><div class="name"><code><a href="#TrafficExtension-targetRefs">targetRefs</a></code></div>
-<div class="type"><a href="/docs/reference/config/type/workload-selector/#PolicyTargetReference">PolicyTargetReference[]</a></div>
+<div class="type"><a href="/zh/docs/reference/config/type/workload-selector/#PolicyTargetReference">PolicyTargetReference[]</a></div>
 </div></td>
 <td>
 <p>The targetRefs specifies a list of resources the policy should be
@@ -443,7 +443,7 @@ against the contents of this field after pulling.</p>
 </tr>
 <tr id="WasmConfig-image_pull_policy">
 <td><div class="field"><div class="name"><code><a href="#WasmConfig-image_pull_policy">imagePullPolicy</a></code></div>
-<div class="type"><a href="/docs/reference/config/proxy_extensions/wasm-plugin/#PullPolicy">PullPolicy</a></div>
+<div class="type"><a href="/zh/docs/reference/config/proxy_extensions/wasm-plugin/#PullPolicy">PullPolicy</a></div>
 </div></td>
 <td>
 <p>The pull behaviour to be applied when fetching Wasm module by either
@@ -489,7 +489,7 @@ plugin to execute.</p>
 </tr>
 <tr id="WasmConfig-fail_strategy">
 <td><div class="field"><div class="name"><code><a href="#WasmConfig-fail_strategy">failStrategy</a></code></div>
-<div class="type"><a href="/docs/reference/config/proxy_extensions/wasm-plugin/#FailStrategy">FailStrategy</a></div>
+<div class="type"><a href="/zh/docs/reference/config/proxy_extensions/wasm-plugin/#FailStrategy">FailStrategy</a></div>
 </div></td>
 <td>
 <p>Specifies the failure behavior for the plugin due to fatal errors.</p>
@@ -498,7 +498,7 @@ plugin to execute.</p>
 </tr>
 <tr id="WasmConfig-vm_config">
 <td><div class="field"><div class="name"><code><a href="#WasmConfig-vm_config">vmConfig</a></code></div>
-<div class="type"><a href="/docs/reference/config/proxy_extensions/wasm-plugin/#VmConfig">VmConfig</a></div>
+<div class="type"><a href="/zh/docs/reference/config/proxy_extensions/wasm-plugin/#VmConfig">VmConfig</a></div>
 </div></td>
 <td>
 <p>Configuration for a Wasm VM.
@@ -508,7 +508,7 @@ More details can be found <a href="https://www.envoyproxy.io/docs/envoy/latest/a
 </tr>
 <tr id="WasmConfig-type">
 <td><div class="field"><div class="name"><code><a href="#WasmConfig-type">type</a></code></div>
-<div class="type"><a href="/docs/reference/config/proxy_extensions/wasm-plugin/#PluginType">PluginType</a></div>
+<div class="type"><a href="/zh/docs/reference/config/proxy_extensions/wasm-plugin/#PluginType">PluginType</a></div>
 </div></td>
 <td>
 <p>Specifies the type of Wasm Extension to be used.</p>
@@ -583,7 +583,7 @@ traffic will be selected.</p>
 <tbody>
 <tr id="TrafficSelector-mode">
 <td><div class="field"><div class="name"><code><a href="#TrafficSelector-mode">mode</a></code></div>
-<div class="type"><a href="/docs/reference/config/type/workload-selector/#WorkloadMode">WorkloadMode</a></div>
+<div class="type"><a href="/zh/docs/reference/config/type/workload-selector/#WorkloadMode">WorkloadMode</a></div>
 </div></td>
 <td>
 <p>Criteria for selecting traffic by their direction.
@@ -596,7 +596,7 @@ If not specified, the default value is <code>CLIENT_AND_SERVER</code>.</p>
 </tr>
 <tr id="TrafficSelector-ports">
 <td><div class="field"><div class="name"><code><a href="#TrafficSelector-ports">ports</a></code></div>
-<div class="type"><a href="/docs/reference/config/type/workload-selector/#PortSelector">PortSelector[]</a></div>
+<div class="type"><a href="/zh/docs/reference/config/type/workload-selector/#PortSelector">PortSelector[]</a></div>
 </div></td>
 <td>
 <p>Criteria for selecting traffic by their destination port.

--- a/content/zh/docs/tasks/extensibility/lua-scripts/index.md
+++ b/content/zh/docs/tasks/extensibility/lua-scripts/index.md
@@ -10,7 +10,7 @@ status: Alpha
 
 {{< boilerplate alpha >}}
 
-Istio 提供了通过 [`TrafficExtension`](/zh/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension/) API，
+Istio 提供了通过 [`TrafficExtension`](/zh/docs/reference/config/proxy_extensions/traffic_extension/) API，
 利用内联 [Lua](https://www.lua.org/) 脚本来扩展代理功能的能力。
 对于简单的请求和响应转换场景，Lua 过滤器是 [WebAssembly](/zh/docs/tasks/extensibility/wasm-modules/)
 的一种轻量级替代方案——脚本直接嵌入到资源配置中，并在 Envoy 代理内部执行，无需进行模块分发。

--- a/content/zh/docs/tasks/extensibility/wasm-modules/index.md
+++ b/content/zh/docs/tasks/extensibility/wasm-modules/index.md
@@ -138,7 +138,7 @@ $ kubectl delete trafficextension -n istio-system basic-auth
 - [为 C++ Wasm 扩展编写单元测试](https://github.com/istio-ecosystem/wasm-extensions/blob/master/doc/write-cpp-unit-test.md)
 - [为 Wasm 扩展编写集成测试](https://github.com/istio-ecosystem/wasm-extensions/blob/master/doc/write-integration-test.md)
 
-有关该 API 的更多详情，请参阅 [`TrafficExtension` 参考文档](/zh/docs/reference/config/proxy_extensions/v1alpha1/traffic_extension/)。
+有关该 API 的更多详情，请参阅 [`TrafficExtension` 参考文档](/zh/docs/reference/config/proxy_extensions/traffic_extension/)。
 
 ## 限制 {#limitations}
 


### PR DESCRIPTION
Renames proxy_extensions/v1alpha1/traffic_extension to proxy_extensions/traffic_extension (PR #17354), then updates the five markdown pages (in both en and zh) that still link to the old v1alpha1 path. The linkinator lint job caught the broken link on the trafficextension concepts page; the other four pages have the same stale path and would break next time link-check covers them.

## Description

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
