### PR TITLE
Release 1.28.7 and 1.29.3 notes

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -934,6 +934,7 @@ MeshNetworks
 Mesika
 Mesos
 mesos-dns
+metacharacters
 metadata
 MetalLB
 MetaProtocol
@@ -1467,6 +1468,7 @@ v1.35
 v1.36
 v1.37
 v1.4.
+v1.4.1.
 v1.5
 v1.55
 v1.55.1

--- a/content/en/news/releases/1.28.x/announcing-1.28.7/index.md
+++ b/content/en/news/releases/1.28.x/announcing-1.28.7/index.md
@@ -1,0 +1,61 @@
+---
+title: Announcing Istio 1.28.7
+linktitle: 1.28.7
+subtitle: Patch Release
+description: Istio 1.28.7 patch release.
+publishdate: 2026-05-13
+release: 1.28.7
+aliases:
+    - /news/announcing-1.28.7
+---
+
+{{< warning >}}
+This is an automatically generated rough draft of the release notes and has not yet been reviewed.
+{{< /warning >}}
+
+This release contains bug fixes to improve robustness. This release note describes what’s different between Istio 1.28.6 and 1.28.7.
+
+{{< relnote >}}
+
+## Changes
+
+- **Added** support to Gateway API v1.4.1.
+
+- **Added** an `istioctl analyze` warning (IST0175) when `RequestAuthentication` resources exist
+but `BLOCKED_CIDRS_IN_JWKS_URIS` is not configured on istiod.
+  ([Issue #59523](https://github.com/istio/istio/issues/59523))
+
+- **Added** Initial HTTP/2 stream and connection window sizes for HBONE CONNECT upstream clusters (generated for
+waypoints and east-west gateways) can be configured using feature flags
+`PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE` and `PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE`. These may be used to
+reduce unwanted buffering.
+  ([Issue #59961](https://github.com/istio/istio/issues/59961))
+
+- **Fixed** an issue where waypoints failed to add the TLS inspector
+listener filter when only TLS ports existed, causing SNI-based routing
+to fail for wildcard ServiceEntry with `resolution: DYNAMIC_DNS`.
+  ([Issue #59024](https://github.com/istio/istio/issues/59024))
+
+- **Fixed** an issue where Istiod could issue leaf certificates with a `NotAfter` time beyond
+the signing certificate's expiration.
+  ([Issue #59768](https://github.com/istio/istio/issues/59768))
+
+- **Fixed** an authorization bypass in `AuthorizationPolicy` matching for SPIFFE identities and namespaces. Regex metacharacters in fields like `source.principals` (suffix matching) and `source.namespaces` were not properly escaped in the generated Envoy configuration, potentially allowing unintended identities to match policy rules.
+  ([Issue #59992](https://github.com/istio/istio/issues/59992))
+
+- **Fixed** kubelet health probe failures for ambient mesh pods on AWS EKS when using
+Security Groups for Pods (branch ENI). istio-cni now detects branch ENI pods and
+adds ip rules to route probe traffic via the veth pair instead of VPC fabric.
+Gated behind `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).
+
+- **Fixed** XDS debug endpoints (`istio.io/debug/syncz`, `istio.io/debug/config_dump`) served by `StatusGen` to enforce
+same-namespace authorization for non-system callers. Previously an authenticated workload from any namespace could
+enumerate proxies and retrieve config dumps for workloads in other namespaces.
+
+**Credit**: This vulnerability was discovered and reported by [1seal](https://github.com/1seal).
+
+## Security update
+
+- Fixed an authorization bypass in `AuthorizationPolicy` where regex metacharacters in certain identity fields were embedded in the generated Envoy `SafeRegex` without escaping. As a result, legal Kubernetes names containing characters like `.` or `[` could be treated as regex wildcards, admitting identities beyond the policy author's intent. This issue affected `source.principals` (specifically suffix matches starting with `*`) and `source.namespaces`.
+
+**Credit**: This vulnerability was discovered and reported by [Alex](https://github.com/Alex0Young).

--- a/content/en/news/releases/1.28.x/announcing-1.28.7/index.md
+++ b/content/en/news/releases/1.28.x/announcing-1.28.7/index.md
@@ -25,10 +25,9 @@ This release contains bug fixes to improve robustness. This release note describ
 but `BLOCKED_CIDRS_IN_JWKS_URIS` is not configured on istiod.
   ([Issue #59523](https://github.com/istio/istio/issues/59523))
 
-- **Added** Initial HTTP/2 stream and connection window sizes for HBONE CONNECT upstream clusters (generated for
-waypoints and east-west gateways) can be configured using feature flags
-`PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE` and `PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE`. These may be used to
-reduce unwanted buffering.
+- **Added** feature flags `PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE` and `PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE`.
+They can configure the initial stream and connection window sizes for HBONE connections to upstream clusters
+(generated for waypoints and east-west gateways). These may be used to reduce unwanted buffering.
   ([Issue #59961](https://github.com/istio/istio/issues/59961))
 
 - **Fixed** an issue where waypoints failed to add the TLS inspector
@@ -40,22 +39,20 @@ to fail for wildcard ServiceEntry with `resolution: DYNAMIC_DNS`.
 the signing certificate's expiration.
   ([Issue #59768](https://github.com/istio/istio/issues/59768))
 
-- **Fixed** an authorization bypass in `AuthorizationPolicy` matching for SPIFFE identities and namespaces. Regex metacharacters in fields like `source.principals` (suffix matching) and `source.namespaces` were not properly escaped in the generated Envoy configuration, potentially allowing unintended identities to match policy rules.
-  ([Issue #59992](https://github.com/istio/istio/issues/59992))
-
 - **Fixed** kubelet health probe failures for ambient mesh pods on AWS EKS when using
 Security Groups for Pods (branch ENI). istio-cni now detects branch ENI pods and
-adds ip rules to route probe traffic via the veth pair instead of VPC fabric.
-Gated behind `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).
+adds IP rules to route probe traffic via the veth pair instead of VPC fabric.
+Gated behind the feature flag `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).
 
-- **Fixed** XDS debug endpoints (`istio.io/debug/syncz`, `istio.io/debug/config_dump`) served by `StatusGen` to enforce
+- **Fixed** XDS debug endpoints (`istio.io/debug/syncz` and `istio.io/debug/config_dump`) served by `StatusGen` to enforce
 same-namespace authorization for non-system callers. Previously an authenticated workload from any namespace could
-enumerate proxies and retrieve config dumps for workloads in other namespaces.
+enumerate proxies and retrieve configuration dumps for workloads in other namespaces.
 
 **Credit**: This vulnerability was discovered and reported by [1seal](https://github.com/1seal).
 
 ## Security update
 
 - Fixed an authorization bypass in `AuthorizationPolicy` where regex metacharacters in certain identity fields were embedded in the generated Envoy `SafeRegex` without escaping. As a result, legal Kubernetes names containing characters like `.` or `[` could be treated as regex wildcards, admitting identities beyond the policy author's intent. This issue affected `source.principals` (specifically suffix matches starting with `*`) and `source.namespaces`.
+  ([Issue #59992](https://github.com/istio/istio/issues/59992))
 
 **Credit**: This vulnerability was discovered and reported by [Alex](https://github.com/Alex0Young).

--- a/content/en/news/releases/1.28.x/announcing-1.28.7/index.md
+++ b/content/en/news/releases/1.28.x/announcing-1.28.7/index.md
@@ -3,15 +3,11 @@ title: Announcing Istio 1.28.7
 linktitle: 1.28.7
 subtitle: Patch Release
 description: Istio 1.28.7 patch release.
-publishdate: 2026-05-13
+publishdate: 2026-05-14
 release: 1.28.7
 aliases:
     - /news/announcing-1.28.7
 ---
-
-{{< warning >}}
-This is an automatically generated rough draft of the release notes and has not yet been reviewed.
-{{< /warning >}}
 
 This release contains bug fixes to improve robustness. This release note describes what’s different between Istio 1.28.6 and 1.28.7.
 

--- a/content/en/news/releases/1.28.x/announcing-1.28.7/index.md
+++ b/content/en/news/releases/1.28.x/announcing-1.28.7/index.md
@@ -15,40 +15,40 @@ This release contains bug fixes to improve robustness. This release note describ
 
 ## Changes
 
-- **Added** support to Gateway API v1.4.1.
+- **Added** support for Gateway API v1.4.1.
 
 - **Added** an `istioctl analyze` warning (IST0175) when `RequestAuthentication` resources exist
-but `BLOCKED_CIDRS_IN_JWKS_URIS` is not configured on istiod.
+  but `BLOCKED_CIDRS_IN_JWKS_URIS` is not configured on istiod.
   ([Issue #59523](https://github.com/istio/istio/issues/59523))
 
 - **Added** feature flags `PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE` and `PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE`.
-They can configure the initial stream and connection window sizes for HBONE connections to upstream clusters
-(generated for waypoints and east-west gateways). These may be used to reduce unwanted buffering.
+  They can configure the initial stream and connection window sizes for HBONE connections to upstream clusters
+  (generated for waypoints and east-west gateways). These may be used to reduce unwanted buffering.
   ([Issue #59961](https://github.com/istio/istio/issues/59961))
 
 - **Fixed** an issue where waypoints failed to add the TLS inspector
-listener filter when only TLS ports existed, causing SNI-based routing
-to fail for wildcard ServiceEntry with `resolution: DYNAMIC_DNS`.
+  listener filter when only TLS ports existed, causing SNI-based routing
+  to fail for wildcard `ServiceEntry` resources with `resolution: DYNAMIC_DNS`.
   ([Issue #59024](https://github.com/istio/istio/issues/59024))
 
 - **Fixed** an issue where Istiod could issue leaf certificates with a `NotAfter` time beyond
-the signing certificate's expiration.
+  the signing certificate's expiration.
   ([Issue #59768](https://github.com/istio/istio/issues/59768))
 
 - **Fixed** kubelet health probe failures for ambient mesh pods on AWS EKS when using
-Security Groups for Pods (branch ENI). istio-cni now detects branch ENI pods and
-adds IP rules to route probe traffic via the veth pair instead of VPC fabric.
-Gated behind the feature flag `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).
+  Security Groups for Pods (branch ENI). istio-cni now detects branch ENI pods and
+  adds IP rules to route probe traffic via the veth pair instead of VPC fabric.
+  Gated behind the feature flag `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).
 
 - **Fixed** XDS debug endpoints (`istio.io/debug/syncz` and `istio.io/debug/config_dump`) served by `StatusGen` to enforce
-same-namespace authorization for non-system callers. Previously an authenticated workload from any namespace could
-enumerate proxies and retrieve configuration dumps for workloads in other namespaces.
+  same-namespace authorization for non-system callers. Previously an authenticated workload from any namespace could
+  enumerate proxies and retrieve configuration dumps for workloads in other namespaces.
 
 **Credit**: This vulnerability was discovered and reported by [1seal](https://github.com/1seal).
 
 ## Security update
 
-- Fixed an authorization bypass in `AuthorizationPolicy` where regex metacharacters in certain identity fields were embedded in the generated Envoy `SafeRegex` without escaping. As a result, legal Kubernetes names containing characters like `.` or `[` could be treated as regex wildcards, admitting identities beyond the policy author's intent. This issue affected `source.principals` (specifically suffix matches starting with `*`) and `source.namespaces`.
+- **Fixed** an authorization bypass in `AuthorizationPolicy` where regex metacharacters in certain identity fields were embedded in the generated Envoy `SafeRegex` without escaping. As a result, legal Kubernetes names containing characters like `.` or `[` could be treated as regex wildcards, admitting identities beyond the policy author's intent. This issue affected `source.principals` (specifically suffix matches starting with `*`) and `source.namespaces`.
   ([Issue #59992](https://github.com/istio/istio/issues/59992))
 
 **Credit**: This vulnerability was discovered and reported by [Alex](https://github.com/Alex0Young).

--- a/content/en/news/releases/1.28.x/announcing-1.28.7/index.md
+++ b/content/en/news/releases/1.28.x/announcing-1.28.7/index.md
@@ -3,7 +3,7 @@ title: Announcing Istio 1.28.7
 linktitle: 1.28.7
 subtitle: Patch Release
 description: Istio 1.28.7 patch release.
-publishdate: 2026-05-14
+publishdate: 2026-05-18
 release: 1.28.7
 aliases:
     - /news/announcing-1.28.7

--- a/content/en/news/releases/1.29.x/announcing-1.29.3/index.md
+++ b/content/en/news/releases/1.29.x/announcing-1.29.3/index.md
@@ -1,0 +1,64 @@
+---
+title: Announcing Istio 1.29.3
+linktitle: 1.29.3
+subtitle: Patch Release
+description: Istio 1.29.3 patch release.
+publishdate: 2026-05-13
+release: 1.29.3
+aliases:
+    - /news/announcing-1.29.3
+---
+
+{{< warning >}}
+This is an automatically generated rough draft of the release notes and has not yet been reviewed.
+{{< /warning >}}
+
+This release contains bug fixes to improve robustness. This release note describes what’s different between Istio 1.29.2 and 1.29.3.
+
+{{< relnote >}}
+
+## Changes
+
+- **Added** support to Gateway API v1.4.1.
+
+- **Added** an `istioctl analyze` warning (IST0175) when `RequestAuthentication` resources exist
+but `BLOCKED_CIDRS_IN_JWKS_URIS` is not configured on istiod.
+  ([Issue #59523](https://github.com/istio/istio/issues/59523))
+
+- **Added** Initial HTTP/2 stream and connection window sizes for HBONE CONNECT upstream clusters (generated for
+waypoints and east-west gateways) can be configured using feature flags
+`PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE` and `PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE`. These may be used to
+reduce unwanted buffering.
+  ([Issue #59961](https://github.com/istio/istio/issues/59961))
+
+- **Fixed** an issue where Istiod could issue leaf certificates with a `NotAfter` time beyond
+the signing certificate's expiration.
+  ([Issue #59768](https://github.com/istio/istio/issues/59768))
+
+- **Fixed** a deadlock in the multicluster secret controller that could occur during remote cluster updates.  ([Issue #59875](https://github.com/istio/istio/issues/59875))
+
+- - **Fixed** pilot-agent missing certificate reloads on second and subsequent Kubernetes secret rotations for file-mounted certs.
+  ([Issue #59912](https://github.com/istio/istio/issues/59912))
+
+- **Fixed** an authorization bypass in `AuthorizationPolicy` matching for SPIFFE identities and namespaces. Regex metacharacters in fields like `source.principals` (suffix matching) and `source.namespaces` were not properly escaped in the generated Envoy configuration, potentially allowing unintended identities to match policy rules.
+  ([Issue #59992](https://github.com/istio/istio/issues/59992))
+
+- **Fixed** kubelet health probe failures for ambient mesh pods on AWS EKS when using
+Security Groups for Pods (branch ENI). istio-cni now detects branch ENI pods and
+adds ip rules to route probe traffic via the veth pair instead of VPC fabric.
+Gated behind `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).
+
+- **Fixed** an issue where `istioctl ztunnel-config service` JSON and YAML output did not include the `canonical` field from the ztunnel config dump.
+  ([Issue #59962](https://github.com/istio/istio/issues/59962))
+
+- **Fixed** XDS debug endpoints (`istio.io/debug/syncz`, `istio.io/debug/config_dump`) served by `StatusGen` to enforce
+same-namespace authorization for non-system callers. Previously an authenticated workload from any namespace could
+enumerate proxies and retrieve config dumps for workloads in other namespaces.
+
+**Credit**: This vulnerability was discovered and reported by [1seal](https://github.com/1seal).
+
+## Security update
+
+- Fixed an authorization bypass in `AuthorizationPolicy` where regex metacharacters in certain identity fields were embedded in the generated Envoy `SafeRegex` without escaping. As a result, legal Kubernetes names containing characters like `.` or `[` could be treated as regex wildcards, admitting identities beyond the policy author's intent. This issue affected `source.principals` (specifically suffix matches starting with `*`) and `source.namespaces`.
+
+**Credit**: This vulnerability was discovered and reported by [Alex](https://github.com/Alex0Young).

--- a/content/en/news/releases/1.29.x/announcing-1.29.3/index.md
+++ b/content/en/news/releases/1.29.x/announcing-1.29.3/index.md
@@ -25,40 +25,37 @@ This release contains bug fixes to improve robustness. This release note describ
 but `BLOCKED_CIDRS_IN_JWKS_URIS` is not configured on istiod.
   ([Issue #59523](https://github.com/istio/istio/issues/59523))
 
-- **Added** Initial HTTP/2 stream and connection window sizes for HBONE CONNECT upstream clusters (generated for
-waypoints and east-west gateways) can be configured using feature flags
-`PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE` and `PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE`. These may be used to
-reduce unwanted buffering.
+- **Added** feature flags `PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE` and `PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE`.
+They can configure the initial stream and connection window sizes for HBONE connections to upstream clusters
+(generated for waypoints and east-west gateways). These may be used to reduce unwanted buffering.
   ([Issue #59961](https://github.com/istio/istio/issues/59961))
 
 - **Fixed** an issue where Istiod could issue leaf certificates with a `NotAfter` time beyond
 the signing certificate's expiration.
   ([Issue #59768](https://github.com/istio/istio/issues/59768))
 
-- **Fixed** a deadlock in the multicluster secret controller that could occur during remote cluster updates.  ([Issue #59875](https://github.com/istio/istio/issues/59875))
-
-- - **Fixed** pilot-agent missing certificate reloads on second and subsequent Kubernetes secret rotations for file-mounted certs.
-  ([Issue #59912](https://github.com/istio/istio/issues/59912))
+- **Fixed** a deadlock in the multicluster secret controller that could occur during remote cluster updates.
+  ([Issue #59875](https://github.com/istio/istio/issues/59875))
 
 - **Fixed** an authorization bypass in `AuthorizationPolicy` matching for SPIFFE identities and namespaces. Regex metacharacters in fields like `source.principals` (suffix matching) and `source.namespaces` were not properly escaped in the generated Envoy configuration, potentially allowing unintended identities to match policy rules.
-  ([Issue #59992](https://github.com/istio/istio/issues/59992))
 
 - **Fixed** kubelet health probe failures for ambient mesh pods on AWS EKS when using
 Security Groups for Pods (branch ENI). istio-cni now detects branch ENI pods and
-adds ip rules to route probe traffic via the veth pair instead of VPC fabric.
-Gated behind `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).
+adds IP rules to route probe traffic via the veth pair instead of VPC fabric.
+Gated behind the feature flag `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).
 
-- **Fixed** an issue where `istioctl ztunnel-config service` JSON and YAML output did not include the `canonical` field from the ztunnel config dump.
+- **Fixed** an issue where `istioctl ztunnel-config service` JSON and YAML output did not include the `canonical` field from the ztunnel configuration dump.
   ([Issue #59962](https://github.com/istio/istio/issues/59962))
 
-- **Fixed** XDS debug endpoints (`istio.io/debug/syncz`, `istio.io/debug/config_dump`) served by `StatusGen` to enforce
+- **Fixed** XDS debug endpoints (`istio.io/debug/syncz` and `istio.io/debug/config_dump`) served by `StatusGen` to enforce
 same-namespace authorization for non-system callers. Previously an authenticated workload from any namespace could
-enumerate proxies and retrieve config dumps for workloads in other namespaces.
+enumerate proxies and retrieve configuration dumps for workloads in other namespaces.
 
 **Credit**: This vulnerability was discovered and reported by [1seal](https://github.com/1seal).
 
 ## Security update
 
 - Fixed an authorization bypass in `AuthorizationPolicy` where regex metacharacters in certain identity fields were embedded in the generated Envoy `SafeRegex` without escaping. As a result, legal Kubernetes names containing characters like `.` or `[` could be treated as regex wildcards, admitting identities beyond the policy author's intent. This issue affected `source.principals` (specifically suffix matches starting with `*`) and `source.namespaces`.
+  ([Issue #59992](https://github.com/istio/istio/issues/59992))
 
 **Credit**: This vulnerability was discovered and reported by [Alex](https://github.com/Alex0Young).

--- a/content/en/news/releases/1.29.x/announcing-1.29.3/index.md
+++ b/content/en/news/releases/1.29.x/announcing-1.29.3/index.md
@@ -15,19 +15,19 @@ This release contains bug fixes to improve robustness. This release note describ
 
 ## Changes
 
-- **Added** support to Gateway API v1.4.1.
+- **Added** support for Gateway API v1.4.1.
 
 - **Added** an `istioctl analyze` warning (IST0175) when `RequestAuthentication` resources exist
-but `BLOCKED_CIDRS_IN_JWKS_URIS` is not configured on istiod.
+  but `BLOCKED_CIDRS_IN_JWKS_URIS` is not configured on istiod.
   ([Issue #59523](https://github.com/istio/istio/issues/59523))
 
 - **Added** feature flags `PILOT_HBONE_INITIAL_STREAM_WINDOW_SIZE` and `PILOT_HBONE_INITIAL_CONNECTION_WINDOW_SIZE`.
-They can configure the initial stream and connection window sizes for HBONE connections to upstream clusters
-(generated for waypoints and east-west gateways). These may be used to reduce unwanted buffering.
+  They can configure the initial stream and connection window sizes for HBONE connections to upstream clusters
+  (generated for waypoints and east-west gateways). These may be used to reduce unwanted buffering.
   ([Issue #59961](https://github.com/istio/istio/issues/59961))
 
 - **Fixed** an issue where Istiod could issue leaf certificates with a `NotAfter` time beyond
-the signing certificate's expiration.
+  the signing certificate's expiration.
   ([Issue #59768](https://github.com/istio/istio/issues/59768))
 
 - **Fixed** a deadlock in the multicluster secret controller that could occur during remote cluster updates.
@@ -36,22 +36,22 @@ the signing certificate's expiration.
 - **Fixed** an authorization bypass in `AuthorizationPolicy` matching for SPIFFE identities and namespaces. Regex metacharacters in fields like `source.principals` (suffix matching) and `source.namespaces` were not properly escaped in the generated Envoy configuration, potentially allowing unintended identities to match policy rules.
 
 - **Fixed** kubelet health probe failures for ambient mesh pods on AWS EKS when using
-Security Groups for Pods (branch ENI). istio-cni now detects branch ENI pods and
-adds IP rules to route probe traffic via the veth pair instead of VPC fabric.
-Gated behind the feature flag `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).
+  Security Groups for Pods (branch ENI). istio-cni now detects branch ENI pods and
+  adds IP rules to route probe traffic via the veth pair instead of VPC fabric.
+  Gated behind the feature flag `AMBIENT_ENABLE_AWS_BRANCH_ENI_PROBE` (enabled by default).
 
 - **Fixed** an issue where `istioctl ztunnel-config service` JSON and YAML output did not include the `canonical` field from the ztunnel configuration dump.
   ([Issue #59962](https://github.com/istio/istio/issues/59962))
 
 - **Fixed** XDS debug endpoints (`istio.io/debug/syncz` and `istio.io/debug/config_dump`) served by `StatusGen` to enforce
-same-namespace authorization for non-system callers. Previously an authenticated workload from any namespace could
-enumerate proxies and retrieve configuration dumps for workloads in other namespaces.
+  same-namespace authorization for non-system callers. Previously an authenticated workload from any namespace could
+  enumerate proxies and retrieve configuration dumps for workloads in other namespaces.
 
 **Credit**: This vulnerability was discovered and reported by [1seal](https://github.com/1seal).
 
 ## Security update
 
-- Fixed an authorization bypass in `AuthorizationPolicy` where regex metacharacters in certain identity fields were embedded in the generated Envoy `SafeRegex` without escaping. As a result, legal Kubernetes names containing characters like `.` or `[` could be treated as regex wildcards, admitting identities beyond the policy author's intent. This issue affected `source.principals` (specifically suffix matches starting with `*`) and `source.namespaces`.
+- **Fixed** an authorization bypass in `AuthorizationPolicy` where regex metacharacters in certain identity fields were embedded in the generated Envoy `SafeRegex` without escaping. As a result, legal Kubernetes names containing characters like `.` or `[` could be treated as regex wildcards, admitting identities beyond the policy author's intent. This issue affected `source.principals` (specifically suffix matches starting with `*`) and `source.namespaces`.
   ([Issue #59992](https://github.com/istio/istio/issues/59992))
 
 **Credit**: This vulnerability was discovered and reported by [Alex](https://github.com/Alex0Young).

--- a/content/en/news/releases/1.29.x/announcing-1.29.3/index.md
+++ b/content/en/news/releases/1.29.x/announcing-1.29.3/index.md
@@ -3,15 +3,11 @@ title: Announcing Istio 1.29.3
 linktitle: 1.29.3
 subtitle: Patch Release
 description: Istio 1.29.3 patch release.
-publishdate: 2026-05-13
+publishdate: 2026-05-14
 release: 1.29.3
 aliases:
     - /news/announcing-1.29.3
 ---
-
-{{< warning >}}
-This is an automatically generated rough draft of the release notes and has not yet been reviewed.
-{{< /warning >}}
 
 This release contains bug fixes to improve robustness. This release note describes what’s different between Istio 1.29.2 and 1.29.3.
 

--- a/content/en/news/releases/1.29.x/announcing-1.29.3/index.md
+++ b/content/en/news/releases/1.29.x/announcing-1.29.3/index.md
@@ -3,7 +3,7 @@ title: Announcing Istio 1.29.3
 linktitle: 1.29.3
 subtitle: Patch Release
 description: Istio 1.29.3 patch release.
-publishdate: 2026-05-14
+publishdate: 2026-05-18
 release: 1.29.3
 aliases:
     - /news/announcing-1.29.3


### PR DESCRIPTION
## Description

Adding release notes to 1.28.7 to master. We're timing the 1.28.7 and 1.29.3 releases to be out at the same time as 1.30.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [X] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
