### PR TITLE
fix flaky after_snapshot from bookinfo-gateway-istio cleanup

### DIFF
--- a/pkg/test/istioio/snapshot_validator.go
+++ b/pkg/test/istioio/snapshot_validator.go
@@ -28,14 +28,14 @@ import (
 )
 
 var (
-	snapshotRetryTimeout = retry.Timeout(2 * time.Minute)
+	snapshotRetryTimeout = retry.Timeout(5 * time.Minute)
 	snapshotRetryDelay   = retry.Delay(1 * time.Second)
 )
 
 var _ Step = SnapshotValidator{}
 
 // SnapshotValidator is a Step that compares before and after snapshots. If the
-// comparison fails, it will retry for up to 2 minutes.
+// comparison fails, it will retry for up to 5 minutes.
 type SnapshotValidator struct {
 	Before *Snapshotter
 	After  *Snapshotter

--- a/tests/util/samples.sh
+++ b/tests/util/samples.sh
@@ -39,7 +39,9 @@ cleanup_bookinfo_sample() {
 
     if [ "$GATEWAY_API" == "true" ]; then
         kubectl delete -f samples/bookinfo/platform/kube/bookinfo-versions.yaml || true
-        kubectl delete -f --cascade=foreground samples/bookinfo/gateway-api/bookinfo-gateway.yaml || true
+        kubectl delete --cascade=foreground -f samples/bookinfo/gateway-api/bookinfo-gateway.yaml || true
+        # wait for the gateway controller's auto-created Service to actually be gone
+        kubectl wait --for=delete service/bookinfo-gateway-istio --timeout=2m 2>/dev/null || true
     else
         kubectl delete -f samples/bookinfo/networking/destination-rule-all.yaml || true
         kubectl delete -f samples/bookinfo/networking/bookinfo-gateway.yaml || true


### PR DESCRIPTION
The Gateway controller's auto-created bookinfo-gateway-istio Service sometimes lingers past cleanup_bookinfo_sample, breaking the next test's after_snapshot diff (seen in profile-default request-timeouts/gtwapi_test.sh and traffic-shifting/test.sh). Wait for the Service in cleanup, bump the snapshot retry timeout from 2m to 5m, and fix the kubectl flag order so --cascade=foreground actually applies.