### PR TITLE
fix Fatal -> Fatalf in snapshotter to satisfy printf check

### DIFF
--- a/pkg/test/istioio/snapshotter.go
+++ b/pkg/test/istioio/snapshotter.go
@@ -59,7 +59,7 @@ func (s *Snapshotter) run(ctx framework.TestContext) {
 
 	outputFile := filepath.Join(ctx.WorkDir(), s.StepName+".json")
 	if err := os.WriteFile(outputFile, []byte(snapshotJSON), os.ModePerm); err != nil {
-		ctx.Fatal("failed writing snapshot file: %v", err)
+		ctx.Fatalf("failed writing snapshot file: %v", err)
 	}
 
 	scopes.Framework.Infof("Created mesh snapshot file %s", outputFile)


### PR DESCRIPTION
Latent bug since 2020 (committed in 616f45b1d5). Line 62 called `ctx.Fatal(...)` (non-formatting variant) with a `%v` format string. Line 57 right above uses `Fatalf` correctly. The branch-cut master-bump step's lint is flagging this. Unblocks 1.30 branch-cut work.