### PR TITLE
Update eol date for 1.28 and mark 1.27 as not supported

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -22,11 +22,11 @@
 - version: "1.28"
   supported: "Yes"
   releaseDate: "Nov 05, 2025"
-  eolDate: "~May 2026 (Expected)"
+  eolDate: "Jun 28, 2026"
   k8sVersions: ["1.30", "1.31", "1.32", "1.33", "1.34"]
   testedK8sVersions: ["1.25", "1.26", "1.27", "1.28", "1.29"]
 - version: "1.27"
-  supported: "Yes"
+  supported: "No"
   releaseDate: "Aug 11, 2025"
   eolDate: "April 7, 2026"
   k8sVersions: ["1.29", "1.30", "1.31", "1.32", "1.33"]


### PR DESCRIPTION
## Description
Update values for https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases table

- Added exact date of 1.28 EOL after [1.28 EOL announcement](https://istio.io/latest/news/support/announcing-1.28-eol/) ( since currently, with `~May 2026 (Expected)` value, the [endoflife.date page](https://endoflife.date/istio) shows istio 1.28 as EOL because it uses [that table as the source](https://github.com/endoflife-date/endoflife.date/blob/master/products/istio.md?plain=1#L41))
- Marked 1.27 as not supported since EOL was on April 7, 2026

## Reviewers
- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

