### PR TITLE
fix: correct image tag format to match istio/istio PR #59509

### DIFF
--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -30,8 +30,8 @@ export GOOS_LOCAL := $(TARGET_OS)
 export IN_BUILD_CONTAINER := $(IN_BUILD_CONTAINER)
 
 # ISTIO_IMAGE_VERSION stores the prefix used by default for the Docker images for Istio.
-# For example, a value of 1.6-alpha will assume a default TAG value of 1.6-dev.<SHA>
-ISTIO_IMAGE_VERSION ?= 1.31-alpha
+# For example, a value of 1.6.0-alpha will assume a default TAG value of 1.6.0-alpha.<SHA>
+ISTIO_IMAGE_VERSION ?= 1.31.0-alpha
 export ISTIO_IMAGE_VERSION
 
 # Determine the SHA for the Istio dependency by parsing the go.mod file.
@@ -220,7 +220,7 @@ init: preinit
 	$(eval ISTIO_LONG_SHA := $(shell cd ${ISTIO_GO} && git rev-parse ${ISTIO_SHA}))
 	@echo "ISTIO_LONG_SHA=${ISTIO_LONG_SHA}"
 ifndef TAG
-	$(eval TAG := ${ISTIO_IMAGE_VERSION}.0.${ISTIO_LONG_SHA})
+	$(eval TAG := ${ISTIO_IMAGE_VERSION}.${ISTIO_LONG_SHA})
 endif
 # If a variant is defined, update the tag accordingly
 ifdef VARIANT

--- a/scripts/create_minor_version.sh
+++ b/scripts/create_minor_version.sh
@@ -223,7 +223,7 @@ step2() {
 
     sed -i "
         s/^export SOURCE_BRANCH_NAME [?]=.*$/export SOURCE_BRANCH_NAME ?= master/;
-        s/^ISTIO_IMAGE_VERSION [?]=.*$/ISTIO_IMAGE_VERSION ?= ${NEXT_MINOR}-alpha/
+        s/^ISTIO_IMAGE_VERSION [?]=.*$/ISTIO_IMAGE_VERSION ?= ${NEXT_MINOR}.0-alpha/
     " Makefile.core.mk
 
     go get istio.io/istio@master


### PR DESCRIPTION
## Description

PR #17408 attempted to fix this but inserted .0. in the wrong place,
producing 1.31-alpha.0.<sha> instead of 1.31.0-alpha.<sha>.

Root cause: https://github.com/istio/istio/pull/59509/changes

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
