### PR TITLE
docs: Fix typos in Standard Metrics docs

### DIFF
--- a/content/en/docs/reference/config/metrics/index.md
+++ b/content/en/docs/reference/config/metrics/index.md
@@ -69,7 +69,7 @@ label in configuration is shown in parentheses below.
 *   **Source Workload Namespace** (`source_workload_namespace`): This identifies the namespace of the source
     workload, or `unknown` if the source information is missing.
 
-*   **Source Principal** (`source_princpial`): This identifies the peer principal of the traffic source.
+*   **Source Principal** (`source_principal`): This identifies the peer principal of the traffic source.
     It is set when peer authentication is used.
 
 *   **Source App** (`source_app`): This identifies the source application based on `app` label
@@ -85,7 +85,7 @@ label in configuration is shown in parentheses below.
     [`service.istio.io/workload-name`](/docs/reference/config/labels/index.html)
     and proxy env-var `ISTIO_META_WORKLOAD_NAME`.
 
-*   **Destination Workload Namespace** (`DESTINATION_WORKLOAD_NAMESPACE`): This identifies the namespace of the
+*   **Destination Workload Namespace** (`destination_workload_namespace`): This identifies the namespace of the
     destination workload, or `unknown` if the destination information is
     missing.
 


### PR DESCRIPTION
## Description

This just fixes some typos I noticed in the Standard Metrics docs. The namespace casing change isn't purely cosmetic; the actual series name is lowercase.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
