### PR TITLE
fix ipv6 docs test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ samples/**
 # copied from istio repository
 tests/integration/**
 manifests/**
+tests/util/gen-jwt.py
+tests/util/key.pem
 
 # certs for test framework
 tools/certs/**

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -94,6 +94,10 @@ cp -a "${ISTIO_GO}/tests/integration/iop-integration-test-defaults.yaml" "${ISTI
 cp -a "${ISTIO_GO}/tests/integration/base.yaml" "${ISTIOIO_GO}/tests/integration/"
 sed -i "s/ENABLE_EXTERNAL_NAME_ALIAS: true$/ENABLE_EXTERNAL_NAME_ALIAS: false/" "${ISTIOIO_GO}/tests/integration/base.yaml"
 cp -a "${ISTIO_GO}/manifests" "${ISTIOIO_GO}/manifests"
+# Copy JWT tools from istio/istio (security/tools/jwt/samples/) needed by doc tests
+# in offline/IPv6-only environments where wget from raw.githubusercontent.com fails.
+cp -a "${ISTIO_GO}/security/tools/jwt/samples/gen-jwt.py" "${ISTIOIO_GO}/tests/util/gen-jwt.py"
+cp -a "${ISTIO_GO}/security/tools/jwt/samples/key.pem"    "${ISTIOIO_GO}/tests/util/key.pem"
 
 # For generating junit.xml files
 function install-junit-report() {

--- a/bin/init.sh
+++ b/bin/init.sh
@@ -95,7 +95,8 @@ cp -a "${ISTIO_GO}/tests/integration/base.yaml" "${ISTIOIO_GO}/tests/integration
 sed -i "s/ENABLE_EXTERNAL_NAME_ALIAS: true$/ENABLE_EXTERNAL_NAME_ALIAS: false/" "${ISTIOIO_GO}/tests/integration/base.yaml"
 cp -a "${ISTIO_GO}/manifests" "${ISTIOIO_GO}/manifests"
 # Copy JWT tools from istio/istio (security/tools/jwt/samples/) needed by doc tests
-# in offline/IPv6-only environments where wget from raw.githubusercontent.com fails.
+# in IPv6-only Kind CI: raw.githubusercontent.com is unreachable because Docker's
+# embedded DNS is IPv4-only (kubernetes-sigs/kind#3114).
 cp -a "${ISTIO_GO}/security/tools/jwt/samples/gen-jwt.py" "${ISTIOIO_GO}/tests/util/gen-jwt.py"
 cp -a "${ISTIO_GO}/security/tools/jwt/samples/key.pem"    "${ISTIOIO_GO}/tests/util/key.pem"
 

--- a/content/en/docs/ambient/usage/extend-waypoint-wasm/test.sh
+++ b/content/en/docs/ambient/usage/extend-waypoint-wasm/test.sh
@@ -37,7 +37,7 @@ kubectl label namespace default istio.io/dataplane-mode=ambient
 _verify_like snip_get_gateway "$snip_get_gateway_out"
 
 # Configure WASM plugin for gateway
-snip_apply_wasmplugin_gateway
+_rewrite_oci_registry snip_apply_wasmplugin_gateway
 
 # verify traffic via gateway
 _verify_same snip_test_gateway_productpage_without_credentials "$snip_test_gateway_productpage_without_credentials_out"
@@ -53,7 +53,7 @@ _verify_same snip_verify_traffic "$snip_verify_traffic_out"
 _verify_like snip_get_gateway_waypoint "$snip_get_gateway_waypoint_out"
 
 # apply wasmplugin at waypoint proxy
-snip_apply_wasmplugin_waypoint_all
+_rewrite_oci_registry snip_apply_wasmplugin_waypoint_all
 
 # Display applied trafficextensions and verify output
 _verify_like snip_get_trafficextension "$snip_get_trafficextension_out"
@@ -63,7 +63,7 @@ _verify_same snip_test_waypoint_productpage_without_credentials "$snip_test_wayp
 _verify_same snip_test_waypoint_productpage_with_credentials "$snip_test_waypoint_productpage_with_credentials_out"
 
 # apply wasmplugin for one specific service through the waypoint
-snip_apply_wasmplugin_waypoint_service
+_rewrite_oci_registry snip_apply_wasmplugin_waypoint_service
 
 # verify the traffic targeting the service
 _verify_same snip_test_waypoint_service_productpage_with_credentials "$snip_test_waypoint_service_productpage_with_credentials_out"

--- a/content/en/docs/tasks/extensibility/wasm-modules/test.sh
+++ b/content/en/docs/tasks/extensibility/wasm-modules/test.sh
@@ -27,7 +27,7 @@ _set_ingress_environment_variables
 
 startup_bookinfo_sample
 
-snip_configure_a_wasm_module_1
+_rewrite_oci_registry snip_configure_a_wasm_module_1
 
 _verify_same snip_verify_the_wasm_module_1 "$snip_verify_the_wasm_module_1_out"
 

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
@@ -34,6 +34,10 @@ _wait_for_deployment default httpbin
 
 # Set env vars used by all subsequent verify steps
 snip_enable_on_a_sidecar_workload_2
+# Wrap IPv6 pod IPs in brackets so they're valid in URLs.
+if [[ "$HTTPBIN_IP" == *:* ]]; then
+    HTTPBIN_IP="[$HTTPBIN_IP]"
+fi
 
 # Verify the mTLS listeners (15091, 15092) are active on the httpbin sidecar
 _verify_like snip_enable_on_a_sidecar_workload_3 "$snip_enable_on_a_sidecar_workload_3_out"

--- a/content/en/docs/tasks/security/authentication/authn-policy/test.sh
+++ b/content/en/docs/tasks/security/authentication/authn-policy/test.sh
@@ -73,6 +73,7 @@ snip_cleanup_part_2_1
 if [ "$GATEWAY_API" == "true" ]; then
     snip_enduser_authentication_2
     snip_enduser_authentication_3
+    _normalize_ingress_host
 else
     snip_enduser_authentication_1
     _wait_for_resource gateway foo httpbin-gateway

--- a/content/en/docs/tasks/security/authentication/authn-policy/test.sh
+++ b/content/en/docs/tasks/security/authentication/authn-policy/test.sh
@@ -85,19 +85,22 @@ fi
 _verify_same  snip_enduser_authentication_4 "$snip_enduser_authentication_4_out"
 
 if [ "$GATEWAY_API" == "true" ]; then
-    snip_enduser_authentication_6
+    _rewrite_jwks_uri snip_enduser_authentication_6
     _wait_for_resource requestauthentication foo jwt-example
 else
-    snip_enduser_authentication_5
+    _rewrite_jwks_uri snip_enduser_authentication_5
     _wait_for_resource requestauthentication istio-system jwt-example
 fi
 
 _verify_same  snip_enduser_authentication_7 "$snip_enduser_authentication_7_out"
 _verify_same  snip_enduser_authentication_8 "$snip_enduser_authentication_8_out"
-_verify_same  snip_enduser_authentication_9 "$snip_enduser_authentication_9_out"
+# snip_enduser_authentication_9 fetches demo.jwt from raw.githubusercontent.com;
+# use _rewrite_jwks_uri to substitute the pre-generated token for offline environments.
+_snip_enduser_authentication_9() { _rewrite_jwks_uri snip_enduser_authentication_9; }
+_verify_same  _snip_enduser_authentication_9 "$snip_enduser_authentication_9_out"
 
-snip_enduser_authentication_10
-snip_enduser_authentication_11
+_rewrite_jwks_uri snip_enduser_authentication_10
+_rewrite_jwks_uri snip_enduser_authentication_11
 
 # snip_enduser_authentication_12 is highly timing dependent, so just check
 # that the token times out during the run.

--- a/content/en/docs/tasks/security/authentication/claim-to-header/test.sh
+++ b/content/en/docs/tasks/security/authentication/claim-to-header/test.sh
@@ -29,24 +29,19 @@ snip_before_you_begin_1
 _wait_for_deployment foo httpbin
 _wait_for_deployment foo curl
  
-# Pull the Istio branch from the docs configuration file.
-ISTIO_BRANCH=$(yq '.source_branch_name' "${REPO_ROOT}"/data/args.yml)
- 
-TOKEN_URL="https://raw.githubusercontent.com/istio/istio/${ISTIO_BRANCH}/security/tools/jwt/samples/demo.jwt"
- 
 export TOKEN
 export TOKEN_GROUP
  
 _verify_same  snip_before_you_begin_2 "$snip_before_you_begin_2_out"
  
-snip_allow_requests_with_valid_jwt_and_listtyped_claims_1
+_rewrite_jwks_uri snip_allow_requests_with_valid_jwt_and_listtyped_claims_1
 _wait_for_resource requestauthentication foo jwt-example
  
 _verify_same snip_allow_requests_with_valid_jwt_and_listtyped_claims_2 "$snip_allow_requests_with_valid_jwt_and_listtyped_claims_2_out"
  
 _verify_same snip_allow_requests_with_valid_jwt_and_listtyped_claims_3 "$snip_allow_requests_with_valid_jwt_and_listtyped_claims_3_out"
 
-TOKEN=$(curl "${TOKEN_URL}" -s)
+TOKEN="${_DOCS_DEMO_JWT}"
  
 _verify_same snip_allow_requests_with_valid_jwt_and_listtyped_claims_4 "$snip_allow_requests_with_valid_jwt_and_listtyped_claims_4_out"
  

--- a/content/en/docs/tasks/security/authentication/jwt-route/test.sh
+++ b/content/en/docs/tasks/security/authentication/jwt-route/test.sh
@@ -34,25 +34,18 @@ _set_ingress_environment_variables
 _verify_same snip_before_you_begin_2 "$snip_before_you_begin_2_out"
 
 # Apply the request authentication and virtual service.
-snip_configuring_ingress_routing_based_on_jwt_claims_1
+_rewrite_jwks_uri snip_configuring_ingress_routing_based_on_jwt_claims_1
 snip_configuring_ingress_routing_based_on_jwt_claims_2
 
 _verify_elided snip_validating_ingress_routing_based_on_jwt_claims_1 "$snip_validating_ingress_routing_based_on_jwt_claims_1_out"
 _verify_elided snip_validating_ingress_routing_based_on_jwt_claims_2 "$snip_validating_ingress_routing_based_on_jwt_claims_2_out"
 
-# Pull the Istio branch from the docs configuration file.
-ISTIO_BRANCH=$(yq '.source_branch_name' "${REPO_ROOT}"/data/args.yml)
-
 _verify_same snip_validating_ingress_routing_based_on_jwt_claims_3 "$snip_validating_ingress_routing_based_on_jwt_claims_3_out"
-TOKEN_GROUP_URL="https://raw.githubusercontent.com/istio/istio/${ISTIO_BRANCH}/security/tools/jwt/samples/groups-scope.jwt"
-export TOKEN_GROUP
-TOKEN_GROUP=$(curl "${TOKEN_GROUP_URL}" -s)
+export TOKEN_GROUP="${_DOCS_GROUPS_SCOPE_JWT}"
 _verify_elided snip_validating_ingress_routing_based_on_jwt_claims_4 "$snip_validating_ingress_routing_based_on_jwt_claims_4_out"
 
 _verify_same snip_validating_ingress_routing_based_on_jwt_claims_5 "$snip_validating_ingress_routing_based_on_jwt_claims_5_out"
-TOKEN_NO_GROUP_URL="https://raw.githubusercontent.com/istio/istio/${ISTIO_BRANCH}/security/tools/jwt/samples/demo.jwt"
-export TOKEN_NO_GROUP
-TOKEN_NO_GROUP=$(curl "${TOKEN_NO_GROUP_URL}" -s)
+export TOKEN_NO_GROUP="${_DOCS_DEMO_JWT}"
 _verify_elided snip_validating_ingress_routing_based_on_jwt_claims_6 "$snip_validating_ingress_routing_based_on_jwt_claims_6_out"
 
 # @cleanup

--- a/content/en/docs/tasks/security/authorization/authz-ingress/index.md
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/index.md
@@ -425,14 +425,14 @@ EOF
 ***ipBlocks:***
 
 {{< text bash >}}
-$ CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
+$ CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | sed 's/.*: //;s/:[0-9]*$//;s/[][]//g') && echo "$CLIENT_IP"
 192.168.10.15
 {{< /text >}}
 
 ***remoteIpBlocks:***
 
 {{< text bash >}}
-$ CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system | grep remoteIP; done | tail -1 | awk -F, '{print $4}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
+$ CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system | grep remoteIP; done | tail -1 | awk -F, '{print $4}' | sed 's/.*: //;s/:[0-9]*$//;s/[][]//g') && echo "$CLIENT_IP"
 192.168.10.15
 {{< /text >}}
 
@@ -443,14 +443,14 @@ $ CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway |
 ***ipBlocks:***
 
 {{< text bash >}}
-$ CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway-name=httpbin-gateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n foo | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
+$ CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway-name=httpbin-gateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n foo | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | sed 's/.*: //;s/:[0-9]*$//;s/[][]//g') && echo "$CLIENT_IP"
 192.168.10.15
 {{< /text >}}
 
 ***remoteIpBlocks:***
 
 {{< text bash >}}
-$ CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway-name=httpbin-gateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n foo | grep remoteIP; done | tail -1 | awk -F, '{print $4}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
+$ CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway-name=httpbin-gateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n foo | grep remoteIP; done | tail -1 | awk -F, '{print $4}' | sed 's/.*: //;s/:[0-9]*$//;s/[][]//g') && echo "$CLIENT_IP"
 192.168.10.15
 {{< /text >}}
 

--- a/content/en/docs/tasks/security/authorization/authz-ingress/snips.sh
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/snips.sh
@@ -245,7 +245,7 @@ curl "$INGRESS_HOST:$INGRESS_PORT"/headers -s -o /dev/null -w "%{http_code}\n"
 ENDSNIP
 
 snip_ipbased_allow_list_and_deny_list_6() {
-CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
+CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | sed 's/.*: //;s/:[0-9]*$//;s/[][]//g') && echo "$CLIENT_IP"
 }
 
 ! IFS=$'\n' read -r -d '' snip_ipbased_allow_list_and_deny_list_6_out <<\ENDSNIP
@@ -253,7 +253,7 @@ CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | s
 ENDSNIP
 
 snip_ipbased_allow_list_and_deny_list_7() {
-CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system | grep remoteIP; done | tail -1 | awk -F, '{print $4}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
+CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system | grep remoteIP; done | tail -1 | awk -F, '{print $4}' | sed 's/.*: //;s/:[0-9]*$//;s/[][]//g') && echo "$CLIENT_IP"
 }
 
 ! IFS=$'\n' read -r -d '' snip_ipbased_allow_list_and_deny_list_7_out <<\ENDSNIP
@@ -261,7 +261,7 @@ CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | s
 ENDSNIP
 
 snip_ipbased_allow_list_and_deny_list_8() {
-CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway-name=httpbin-gateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n foo | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
+CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway-name=httpbin-gateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n foo | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | sed 's/.*: //;s/:[0-9]*$//;s/[][]//g') && echo "$CLIENT_IP"
 }
 
 ! IFS=$'\n' read -r -d '' snip_ipbased_allow_list_and_deny_list_8_out <<\ENDSNIP
@@ -269,7 +269,7 @@ CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway
 ENDSNIP
 
 snip_ipbased_allow_list_and_deny_list_9() {
-CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway-name=httpbin-gateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n foo | grep remoteIP; done | tail -1 | awk -F, '{print $4}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
+CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway-name=httpbin-gateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n foo | grep remoteIP; done | tail -1 | awk -F, '{print $4}' | sed 's/.*: //;s/:[0-9]*$//;s/[][]//g') && echo "$CLIENT_IP"
 }
 
 ! IFS=$'\n' read -r -d '' snip_ipbased_allow_list_and_deny_list_9_out <<\ENDSNIP

--- a/content/en/docs/tasks/security/authorization/authz-ingress/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/test.sh
@@ -102,24 +102,21 @@ fi
 _verify_same snip_ipbased_allow_list_and_deny_list_14 "$snip_ipbased_allow_list_and_deny_list_14_out"
 
 # Test client IP denied
+# CLIENT_IP is already set from the ALLOW section above (snip 6/7/8/9 called directly)
 
 if [ "$GATEWAY_API" == "true" ]; then
-    CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway-name=httpbin-gateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n foo | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
     snip_ipbased_allow_list_and_deny_list_17
     _wait_for_resource authorizationpolicy foo ingress-policy
 else
-    CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
     snip_ipbased_allow_list_and_deny_list_15
     _wait_for_resource authorizationpolicy istio-system ingress-policy
 fi
 _verify_same snip_ipbased_allow_list_and_deny_list_19 "$snip_ipbased_allow_list_and_deny_list_19_out"
 
 if [ "$GATEWAY_API" == "true" ]; then
-    CLIENT_IP=$(kubectl get pods -n foo -o name -l gateway.networking.k8s.io/gateway-name=httpbin-gateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n foo | grep remoteIP; done | tail -1 | awk -F, '{print $4}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
     snip_ipbased_allow_list_and_deny_list_18
     _wait_for_resource authorizationpolicy foo ingress-policy
 else
-    CLIENT_IP=$(kubectl get pods -n istio-system -o name -l istio=ingressgateway | sed 's|pod/||' | while read -r pod; do kubectl logs "$pod" -n istio-system | grep remoteIP; done | tail -1 | awk -F, '{print $3}' | awk -F: '{print $2}' | sed 's/ //') && echo "$CLIENT_IP"
     snip_ipbased_allow_list_and_deny_list_16
     _wait_for_resource authorizationpolicy istio-system ingress-policy
 fi

--- a/content/en/docs/tasks/security/authorization/authz-ingress/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-ingress/test.sh
@@ -37,6 +37,7 @@ if [ "$GATEWAY_API" == "true" ]; then
     kubectl wait --for=condition=programmed gtw -n foo httpbin-gateway --timeout=90s
     _verify_contains snip_before_you_begin_6 "rbac: debug"
     snip_before_you_begin_7
+    _normalize_ingress_host
 else
     snip_before_you_begin_2
     _verify_contains snip_before_you_begin_3 "rbac: debug"

--- a/content/en/docs/tasks/security/authorization/authz-jwt/test.sh
+++ b/content/en/docs/tasks/security/authorization/authz-jwt/test.sh
@@ -29,18 +29,12 @@ snip_before_you_begin_1
 _wait_for_deployment foo httpbin
 _wait_for_deployment foo curl
 
-# Pull the Istio branch from the docs configuration file.
-ISTIO_BRANCH=$(yq '.source_branch_name' "${REPO_ROOT}"/data/args.yml)
-
-TOKEN_URL="https://raw.githubusercontent.com/istio/istio/${ISTIO_BRANCH}/security/tools/jwt/samples/demo.jwt"
-TOKEN_GROUP_URL="https://raw.githubusercontent.com/istio/istio/${ISTIO_BRANCH}/security/tools/jwt/samples/groups-scope.jwt"
-
 export TOKEN
 export TOKEN_GROUP
 
 _verify_same  snip_before_you_begin_2 "$snip_before_you_begin_2_out"
 
-snip_allow_requests_with_valid_jwt_and_listtyped_claims_1
+_rewrite_jwks_uri snip_allow_requests_with_valid_jwt_and_listtyped_claims_1
 _wait_for_resource requestauthentication foo jwt-example
 
 _verify_same snip_allow_requests_with_valid_jwt_and_listtyped_claims_2 "$snip_allow_requests_with_valid_jwt_and_listtyped_claims_2_out"
@@ -53,7 +47,7 @@ _wait_for_resource authorizationpolicy foo require-jwt
 _verify_same snip_allow_requests_with_valid_jwt_and_listtyped_claims_5 "$snip_allow_requests_with_valid_jwt_and_listtyped_claims_5_out"
 
 # The previous step stored the JWT in TOKEN, and it's needed in the next step.
-TOKEN=$(curl "${TOKEN_URL}" -s)
+TOKEN="${_DOCS_DEMO_JWT}"
 
 _verify_same snip_allow_requests_with_valid_jwt_and_listtyped_claims_6 "$snip_allow_requests_with_valid_jwt_and_listtyped_claims_6_out"
 
@@ -66,7 +60,7 @@ _verify_same snip_allow_requests_with_valid_jwt_and_listtyped_claims_9 "$snip_al
 
 # The previous step stored the JWT group in TOKEN_GROUP, and it's needed in
 # the next step.
-TOKEN_GROUP=$(curl "${TOKEN_GROUP_URL}" -s)
+TOKEN_GROUP="${_DOCS_GROUPS_SCOPE_JWT}"
 
 _verify_same snip_allow_requests_with_valid_jwt_and_listtyped_claims_10 "$snip_allow_requests_with_valid_jwt_and_listtyped_claims_10_out"
 

--- a/content/en/docs/tasks/traffic-management/circuit-breaking/test.sh
+++ b/content/en/docs/tasks/traffic-management/circuit-breaking/test.sh
@@ -21,6 +21,12 @@ set -o pipefail
 
 source "tests/util/samples.sh"
 
+# CI has some issues with IPv6 DNS resolution, due to which we are not able to
+# directly use the host name in the connectivity tests (see istio/istio:
+# tests/integration/pilot/common/routing.go). Since docs tests must use the
+# documented hostname-based commands, we skip this test on IPv6 Kind clusters.
+_skip_if_kind_ipv6 "fortio Go DNS resolver cannot resolve in-cluster names in IPv6-only Kind (NXDOMAIN for A records treated as authoritative)"
+
 # @setup profile=default
 
 kubectl label namespace default istio-injection=enabled --overwrite

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
@@ -21,6 +21,9 @@ set -e
 set -u
 set -o pipefail
 
+# Skip on IPv6-only Kind clusters: external hosts (e.g. edition.cnn.com) are IPv4-only, no outbound IPv4 in cluster.
+[[ "${KIND_IP_FAMILY:-}" == "ipv6" ]] && { echo "Skipping (KIND_IP_FAMILY=ipv6): test requires IPv4 internet egress"; exit 0; }
+
 GATEWAY_API="${GATEWAY_API:-false}"
 
 source "tests/util/samples.sh"

--- a/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-gateway/test.sh
@@ -21,8 +21,7 @@ set -e
 set -u
 set -o pipefail
 
-# Skip on IPv6-only Kind clusters: external hosts (e.g. edition.cnn.com) are IPv4-only, no outbound IPv4 in cluster.
-[[ "${KIND_IP_FAMILY:-}" == "ipv6" ]] && { echo "Skipping (KIND_IP_FAMILY=ipv6): test requires IPv4 internet egress"; exit 0; }
+_skip_if_kind_ipv6 "test connects to external hosts via egress gateway"
 
 GATEWAY_API="${GATEWAY_API:-false}"
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/tls_test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/tls_test.sh
@@ -19,8 +19,7 @@ set -e
 set -u
 set -o pipefail
 
-# Skip on IPv6-only Kind clusters: edition.cnn.com is IPv4-only, no outbound IPv4 in cluster.
-[[ "${KIND_IP_FAMILY:-}" == "ipv6" ]] && { echo "Skipping (KIND_IP_FAMILY=ipv6): test requires IPv4 internet egress"; exit 0; }
+_skip_if_kind_ipv6 "test connects to edition.cnn.com via TLS origination"
 
 GATEWAY_API="${GATEWAY_API:-false}"
 

--- a/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/tls_test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/egress-tls-origination/tls_test.sh
@@ -19,6 +19,9 @@ set -e
 set -u
 set -o pipefail
 
+# Skip on IPv6-only Kind clusters: edition.cnn.com is IPv4-only, no outbound IPv4 in cluster.
+[[ "${KIND_IP_FAMILY:-}" == "ipv6" ]] && { echo "Skipping (KIND_IP_FAMILY=ipv6): test requires IPv4 internet egress"; exit 0; }
+
 GATEWAY_API="${GATEWAY_API:-false}"
 
 source "tests/util/samples.sh"

--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh
@@ -21,8 +21,7 @@ set -e
 set -u
 set -o pipefail
 
-# Skip on IPv6-only Kind clusters: external hosts are IPv4-only, no outbound IPv4 in cluster.
-[[ "${KIND_IP_FAMILY:-}" == "ipv6" ]] && { echo "Skipping (KIND_IP_FAMILY=ipv6): test requires IPv4 internet egress"; exit 0; }
+_skip_if_kind_ipv6 "test connects to wikipedia.org via wildcard egress"
 
 GATEWAY_API="${GATEWAY_API:-false}"
 

--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/test.sh
@@ -21,6 +21,9 @@ set -e
 set -u
 set -o pipefail
 
+# Skip on IPv6-only Kind clusters: external hosts are IPv4-only, no outbound IPv4 in cluster.
+[[ "${KIND_IP_FAMILY:-}" == "ipv6" ]] && { echo "Skipping (KIND_IP_FAMILY=ipv6): test requires IPv4 internet egress"; exit 0; }
+
 GATEWAY_API="${GATEWAY_API:-false}"
 
 if [ "$GATEWAY_API" == "true" ]; then

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
@@ -39,6 +39,7 @@ if [ "$GATEWAY_API" == "true" ]; then
 
     # set INGRESS_HOST and INGRESS_PORT environment variables
     snip_determining_the_ingress_ip_and_ports_7
+    _normalize_ingress_host
 else
     # create the gateway and routes
     snip_configuring_ingress_using_a_gateway_1

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-control/test.sh
@@ -55,6 +55,7 @@ else
 
     # set INGRESS_HOST, INGRESS_PORT, SECURE_INGRESS_PORT, and TCP_INGRESS_PORT environment variables
     snip_determining_the_ingress_ip_and_ports_5
+    _normalize_ingress_host
 fi
 
 # access the httpbin service

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/index.md
@@ -31,7 +31,7 @@ For this task you can use your favorite tool to generate certificates and keys. 
 1.  Create a root certificate and private key to sign the certificate for your services:
 
     {{< text bash >}}
-    $ mkdir example_certs
+    $ mkdir -p example_certs
     $ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj '/O=example Inc./CN=example.com' -keyout example_certs/example.com.key -out example_certs/example.com.crt
     {{< /text >}}
 
@@ -69,6 +69,7 @@ For this task you can use your favorite tool to generate certificates and keys. 
 
       server {
         listen 443 ssl;
+        listen [::]:443 ssl;
 
         root /usr/share/nginx/html;
         index index.html;

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/snips.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/snips.sh
@@ -22,7 +22,7 @@
 source "content/en/boilerplates/snips/gateway-api-gamma-experimental.sh"
 
 snip_generate_client_and_server_certificates_and_keys_1() {
-mkdir example_certs
+mkdir -p example_certs
 openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj '/O=example Inc./CN=example.com' -keyout example_certs/example.com.key -out example_certs/example.com.crt
 }
 
@@ -51,6 +51,7 @@ http {
 
   server {
     listen 443 ssl;
+    listen [::]:443 ssl;
 
     root /usr/share/nginx/html;
     index index.html;

--- a/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/ingress-sni-passthrough/test.sh
@@ -51,6 +51,7 @@ if [ "$GATEWAY_API" == "true" ]; then
 
     snip_configure_an_ingress_gateway_4
     snip_configure_an_ingress_gateway_5
+    _normalize_ingress_host
 
     echo "addr: ${INGRESS_HOST}:${SECURE_INGRESS_PORT}"
 else

--- a/content/en/docs/tasks/traffic-management/ingress/secure-ingress/test.sh
+++ b/content/en/docs/tasks/traffic-management/ingress/secure-ingress/test.sh
@@ -44,6 +44,7 @@ if [ "$GATEWAY_API" == "true" ]; then
     snip_configure_a_tls_ingress_gateway_for_a_single_host_5
     _wait_for_gateway istio-system mygateway
     snip_configure_a_tls_ingress_gateway_for_a_single_host_6
+    _normalize_ingress_host
 else
     # deploying httpbin gateway
     snip_configure_a_tls_ingress_gateway_for_a_single_host_2

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/index.md
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/index.md
@@ -105,7 +105,7 @@ for `HelloWorld` in `region1.zone1`:
 $ kubectl --context="${CTX_R1_Z1}" exec \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l app=helloworld \
   -l version=region1.zone1 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST localhost:15000/drain_listeners
 {{< /text >}}
 
 Call the `HelloWorld` service from the `curl` pod:
@@ -131,7 +131,7 @@ the `HelloWorld` in `region1.zone2` to fail when called:
 $ kubectl --context="${CTX_R1_Z2}" exec \
   "$(kubectl get pod --context="${CTX_R1_Z2}" -n sample -l app=helloworld \
   -l version=region1.zone2 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST localhost:15000/drain_listeners
 {{< /text >}}
 
 Call the `HelloWorld` service from the `curl` pod:
@@ -157,7 +157,7 @@ the `HelloWorld` in `region2.zone3` to fail when called:
 $ kubectl --context="${CTX_R2_Z3}" exec \
   "$(kubectl get pod --context="${CTX_R2_Z3}" -n sample -l app=helloworld \
   -l version=region2.zone3 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST localhost:15000/drain_listeners
 {{< /text >}}
 
 Call the `HelloWorld` service from the `curl` pod:

--- a/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/snips.sh
+++ b/content/en/docs/tasks/traffic-management/locality-load-balancing/failover/snips.sh
@@ -61,7 +61,7 @@ snip_failover_to_region1zone2_1() {
 kubectl --context="${CTX_R1_Z1}" exec \
   "$(kubectl get pod --context="${CTX_R1_Z1}" -n sample -l app=helloworld \
   -l version=region1.zone1 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST localhost:15000/drain_listeners
 }
 
 snip_failover_to_region1zone2_2() {
@@ -79,7 +79,7 @@ snip_failover_to_region2zone3_1() {
 kubectl --context="${CTX_R1_Z2}" exec \
   "$(kubectl get pod --context="${CTX_R1_Z2}" -n sample -l app=helloworld \
   -l version=region1.zone2 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST localhost:15000/drain_listeners
 }
 
 snip_failover_to_region2zone3_2() {
@@ -97,7 +97,7 @@ snip_failover_to_region3zone4_1() {
 kubectl --context="${CTX_R2_Z3}" exec \
   "$(kubectl get pod --context="${CTX_R2_Z3}" -n sample -l app=helloworld \
   -l version=region2.zone3 -o jsonpath='{.items[0].metadata.name}')" \
-  -n sample -c istio-proxy -- curl -sSL -X POST 127.0.0.1:15000/drain_listeners
+  -n sample -c istio-proxy -- curl -sSL -X POST localhost:15000/drain_listeners
 }
 
 snip_failover_to_region3zone4_2() {

--- a/content/en/docs/tasks/traffic-management/mirroring/index.md
+++ b/content/en/docs/tasks/traffic-management/mirroring/index.md
@@ -60,7 +60,7 @@ you will apply a rule to mirror a portion of traffic to `v2`.
               - image: docker.io/kennethreitz/httpbin
                 imagePullPolicy: IfNotPresent
                 name: httpbin
-                command: ["gunicorn", "--access-logfile", "-", "-b", "0.0.0.0:80", "httpbin:app"]
+                command: ["gunicorn", "--access-logfile", "-", "-b", "[::]:80", "httpbin:app"]
                 ports:
                 - containerPort: 80
         EOF
@@ -90,7 +90,7 @@ you will apply a rule to mirror a portion of traffic to `v2`.
               - image: docker.io/kennethreitz/httpbin
                 imagePullPolicy: IfNotPresent
                 name: httpbin
-                command: ["gunicorn", "--access-logfile", "-", "-b", "0.0.0.0:80", "httpbin:app"]
+                command: ["gunicorn", "--access-logfile", "-", "-b", "[::]:80", "httpbin:app"]
                 ports:
                 - containerPort: 80
         EOF

--- a/content/en/docs/tasks/traffic-management/mirroring/snips.sh
+++ b/content/en/docs/tasks/traffic-management/mirroring/snips.sh
@@ -43,7 +43,7 @@ spec:
       - image: docker.io/kennethreitz/httpbin
         imagePullPolicy: IfNotPresent
         name: httpbin
-        command: ["gunicorn", "--access-logfile", "-", "-b", "0.0.0.0:80", "httpbin:app"]
+        command: ["gunicorn", "--access-logfile", "-", "-b", "[::]:80", "httpbin:app"]
         ports:
         - containerPort: 80
 EOF
@@ -71,7 +71,7 @@ spec:
       - image: docker.io/kennethreitz/httpbin
         imagePullPolicy: IfNotPresent
         name: httpbin
-        command: ["gunicorn", "--access-logfile", "-", "-b", "0.0.0.0:80", "httpbin:app"]
+        command: ["gunicorn", "--access-logfile", "-", "-b", "[::]:80", "httpbin:app"]
         ports:
         - containerPort: 80
 EOF

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -29,10 +29,10 @@ set -u
 # Print commands
 set -x
 
-# shellcheck source=common/scripts/kind_provisioner.sh
-source "${ROOT}/common/scripts/kind_provisioner.sh"
 # shellcheck source=prow/lib.sh
 source "${WD}/lib.sh"
+# shellcheck source=common/scripts/kind_provisioner.sh
+source "${ROOT}/common/scripts/kind_provisioner.sh"
 
 # KinD will not have a LoadBalancer, so we need to disable it
 export TEST_ENV=kind

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -31,6 +31,8 @@ set -x
 
 # shellcheck source=common/scripts/kind_provisioner.sh
 source "${ROOT}/common/scripts/kind_provisioner.sh"
+# shellcheck source=prow/lib.sh
+source "${WD}/lib.sh"
 
 # KinD will not have a LoadBalancer, so we need to disable it
 export TEST_ENV=kind
@@ -140,6 +142,36 @@ if [[ -z "${SKIP_SETUP:-}" ]]; then
     export DOCTEST_NETWORK_TOPOLOGY
     DOCTEST_NETWORK_TOPOLOGY=$(IFS=','; echo "${NETWORK_TOPOLOGIES[*]}")
   fi
+
+  # On IPv6-only clusters, ghcr.io is unreachable (no AAAA records), so set up a
+  # local registry, pre-load the wasm image, and patch CoreDNS so in-cluster
+  # workloads can resolve "kind-registry" (Docker embedded DNS is IPv4-only;
+  # moby#48125 is closed as not planned).
+  if [[ "${KIND_IP_FAMILY:-}" == "ipv6" ]]; then
+    setup_kind_registry
+
+    # Pre-load wasm plugin image used by extensibility/wasm-modules and
+    # ambient/usage/extend-waypoint-wasm doc tests.
+    # Extract the version dynamically from the snips so this stays in sync with the docs.
+    wasm_basic_auth_tag=$(grep -oE 'basic_auth:[0-9][^"]+' \
+      "${WD}/../content/en/docs/tasks/extensibility/wasm-modules/snips.sh" | head -1 | sed 's/basic_auth://')
+    crane copy \
+      "ghcr.io/istio-ecosystem/wasm-extensions/basic_auth:${wasm_basic_auth_tag}" \
+      "localhost:${KIND_REGISTRY_PORT}/istio-ecosystem/wasm-extensions/basic_auth:${wasm_basic_auth_tag}" \
+      --insecure
+
+    kind_registry_ipv6=$(docker inspect \
+      -f '{{range $k, $v := .NetworkSettings.Networks}}{{if eq $k "kind"}}{{.GlobalIPv6Address}}{{end}}{{end}}' \
+      kind-registry)
+    kubectl get -oyaml -n=kube-system configmap/coredns | \
+      sed -e '/^ *ready/i\
+        hosts {\
+            '"${kind_registry_ipv6}"' kind-registry\
+            fallthrough\
+        }' | kubectl apply -f -
+    kubectl rollout restart -n kube-system deployment/coredns
+    kubectl rollout status -n kube-system deployment/coredns --timeout=60s
+  fi
 fi
 
-make "${PARAMS[@]}"
+[[ ${#PARAMS[@]} -gt 0 ]] && make "${PARAMS[@]}"

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -143,10 +143,10 @@ if [[ -z "${SKIP_SETUP:-}" ]]; then
     DOCTEST_NETWORK_TOPOLOGY=$(IFS=','; echo "${NETWORK_TOPOLOGIES[*]}")
   fi
 
-  # On IPv6-only clusters, ghcr.io is unreachable (no AAAA records), so set up a
-  # local registry, pre-load the wasm image, and patch CoreDNS so in-cluster
-  # workloads can resolve "kind-registry" (Docker embedded DNS is IPv4-only;
-  # moby#48125 is closed as not planned).
+  # On IPv6-only clusters, ghcr.io is unreachable because Docker's embedded DNS is
+  # IPv4-only (kubernetes-sigs/kind#3114, moby#48125). Set up a local registry,
+  # pre-load the wasm image, and patch CoreDNS so in-cluster workloads can
+  # resolve "kind-registry".
   if [[ "${KIND_IP_FAMILY:-}" == "ipv6" ]]; then
     setup_kind_registry
 

--- a/prow/lib.sh
+++ b/prow/lib.sh
@@ -85,3 +85,46 @@ function setup_kind_cluster() {
     exit 1
   fi
 }
+
+export KIND_REGISTRY_NAME="kind-registry"
+export KIND_REGISTRY_PORT="5000"
+export KIND_REGISTRY="localhost:${KIND_REGISTRY_PORT}"
+export KIND_REGISTRY_DIR="/etc/containerd/certs.d/localhost:${KIND_REGISTRY_PORT}"
+
+# setup_kind_registry creates a local Docker registry container and connects it
+# to the kind network so that kind nodes can pull images from it.
+# Ported from https://github.com/istio/istio/blob/master/prow/lib.sh#L144
+function setup_kind_registry() {
+  # Create a registry container if it is not running already
+  local running
+  running="$(docker inspect -f '{{.State.Running}}' "${KIND_REGISTRY_NAME}" 2>/dev/null || true)"
+  if [[ "${running}" != 'true' ]]; then
+    docker run \
+      -d --restart=always -p "${KIND_REGISTRY_PORT}:5000" --name "${KIND_REGISTRY_NAME}" \
+      registry.istio.io/testing/registry:2
+
+    # Allow kind nodes to reach the registry
+    docker network connect "kind" "${KIND_REGISTRY_NAME}"
+  fi
+
+  for node in $(kind get nodes --name="istio-testing"); do
+    docker exec "${node}" mkdir -p "${KIND_REGISTRY_DIR}"
+    cat <<EOF | docker exec -i "${node}" cp /dev/stdin "${KIND_REGISTRY_DIR}/hosts.toml"
+[host."http://${KIND_REGISTRY_NAME}:5000"]
+EOF
+    kubectl annotate node "${node}" "kind.x-k8s.io/registry=kind-registry:${KIND_REGISTRY_PORT}" --overwrite
+  done
+
+  # Document the local registry
+  cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-registry-hosting
+  namespace: kube-public
+data:
+  localRegistryHosting.v1: |
+    host: "localhost:${KIND_REGISTRY_PORT}"
+    help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
+EOF
+}

--- a/tests/util/helpers.sh
+++ b/tests/util/helpers.sh
@@ -178,6 +178,8 @@ _DOCS_GROUPS_SCOPE_JWT="eyJhbGciOiJSUzI1NiIsImtpZCI6IkRIRmJwb0lVcXJZOHQyenBBMnFY
 # Rewrite a snip to replace external jwksUri with an inline jwks value, avoiding
 # external network fetches for JWT public keys. Also rewrites inline curl calls
 # that fetch static JWT token files from raw.githubusercontent.com.
+# raw.githubusercontent.com is unreachable in IPv6-only Kind clusters because
+# Docker's embedded DNS is IPv4-only (kubernetes-sigs/kind#3114).
 # usage: _rewrite_jwks_uri <snip_function>
 # shellcheck disable=SC2001
 _rewrite_jwks_uri() {
@@ -194,8 +196,21 @@ _rewrite_jwks_uri() {
   eval "${cmd}"
 }
 
+# Skip the current test if running on an IPv6-only Kind cluster. In such clusters
+# there is no IPv6 internet connectivity because Docker's embedded DNS is IPv4-only
+# (kubernetes-sigs/kind#3114). Pass a short reason string to describe what the
+# test requires (e.g. "test requires internet egress").
+# usage: _skip_if_kind_ipv6 <reason>
+_skip_if_kind_ipv6() {
+  if [[ "${KIND_IP_FAMILY:-}" == "ipv6" ]]; then
+    echo "Skipping (KIND_IP_FAMILY=ipv6): ${1:?reason} (no IPv6 internet connectivity in Kind; kubernetes-sigs/kind#3114)"
+    exit 0
+  fi
+}
+
 # Rewrite a snip to replace oci://ghcr.io/ OCI registry URLs with the local
-# kind-registry when running in IPv6-only Kind CI (ghcr.io has no AAAA records).
+# kind-registry when running in IPv6-only Kind CI. ghcr.io is unreachable because
+# Docker's embedded DNS is IPv4-only (kubernetes-sigs/kind#3114).
 # The kind-registry must be pre-seeded with the required images via crane copy
 # in prow/integ-suite-kind.sh before tests run.
 # usage: _rewrite_oci_registry <snip_function>

--- a/tests/util/helpers.sh
+++ b/tests/util/helpers.sh
@@ -46,6 +46,14 @@ function _set_kube_vars()
   echo "KUBE_CONTEXTS=${KUBE_CONTEXTS[*]}"
 }
 
+# Normalize INGRESS_HOST for IPv6: wrap bare IPv6 addresses in brackets for correct
+# URL and curl --resolve formatting.
+_normalize_ingress_host() {
+    if [[ -n "${INGRESS_HOST:-}" && "$INGRESS_HOST" == *:* && "$INGRESS_HOST" != \[* ]]; then
+        export INGRESS_HOST="[$INGRESS_HOST]"
+    fi
+}
+
 # Set the INGRESS_HOST, INGRESS_PORT, SECURE_INGRESS_PORT, and TCP_INGRESS_PORT environment variables
 _set_ingress_environment_variables() {
     # check for external load balancer
@@ -63,10 +71,7 @@ _set_ingress_environment_variables() {
         export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
         export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].nodePort}')
     fi
-    # Wrap IPv6 addresses in brackets for correct URL and curl --resolve formatting
-    if [[ "$INGRESS_HOST" == *:* ]]; then
-        export INGRESS_HOST="[$INGRESS_HOST]"
-    fi
+    _normalize_ingress_host
 }
 
 # TODO: should we have functions for these?

--- a/tests/util/helpers.sh
+++ b/tests/util/helpers.sh
@@ -63,6 +63,10 @@ _set_ingress_environment_variables() {
         export SECURE_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="https")].nodePort}')
         export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].nodePort}')
     fi
+    # Wrap IPv6 addresses in brackets for correct URL and curl --resolve formatting
+    if [[ "$INGRESS_HOST" == *:* ]]; then
+        export INGRESS_HOST="[$INGRESS_HOST]"
+    fi
 }
 
 # TODO: should we have functions for these?

--- a/tests/util/helpers.sh
+++ b/tests/util/helpers.sh
@@ -165,3 +165,48 @@ _rewrite_helm_repo() {
 
   eval "${cmd}"
 }
+
+# Pre-generated JWT tokens for docs tests, signed with security/tools/jwt/samples/key.pem.
+# demo.jwt: exp 4685989700 (year 2118), iss testing@secure.istio.io, foo=bar
+# shellcheck disable=SC2034
+_DOCS_DEMO_JWT="eyJhbGciOiJSUzI1NiIsImtpZCI6IkRIRmJwb0lVcXJZOHQyenBBMnFYZkNtcjVWTzVaRXI0UnpIVV8tZW52dlEiLCJ0eXAiOiJKV1QifQ.eyJleHAiOjQ2ODU5ODk3MDAsImZvbyI6ImJhciIsImlhdCI6MTUzMjM4OTcwMCwiaXNzIjoidGVzdGluZ0BzZWN1cmUuaXN0aW8uaW8iLCJzdWIiOiJ0ZXN0aW5nQHNlY3VyZS5pc3Rpby5pbyJ9.CfNnxWP2tcnR9q0vxyxweaF3ovQYHYZl82hAUsn21bwQd9zP7c-LS9qd_vpdLG4Tn1A15NxfCjp5f7QNBUo-KC9PJqYpgGbaXhaGx7bEdFWjcwv3nZzvc7M__ZpaCERdwU7igUmJqYGBYQ51vr2njU9ZimyKkfDe3axcyiBZde7G6dabliUosJvvKOPcKIWPccCgefSj_GNfwIip3-SsFdlR7BtbVUcqR-yv-XOxJ3Uc1MI0tz3uMiiZcyPV7sNCU4KRnemRIMHVOfuvHsU60_GhGbiSFzgPTAa9WTltbnarTbxudb_YEOx12JiwYToeX0DCPb43W1tzIBxgm8NxUg"
+
+# groups-scope.jwt: exp 3537391104 (year 2082), iss testing@secure.istio.io, groups=[group1,group2]
+# shellcheck disable=SC2034
+_DOCS_GROUPS_SCOPE_JWT="eyJhbGciOiJSUzI1NiIsImtpZCI6IkRIRmJwb0lVcXJZOHQyenBBMnFYZkNtcjVWTzVaRXI0UnpIVV8tZW52dlEiLCJ0eXAiOiJKV1QifQ.eyJleHAiOjM1MzczOTExMDQsImdyb3VwcyI6WyJncm91cDEiLCJncm91cDIiXSwiaWF0IjoxNTM3MzkxMTA0LCJpc3MiOiJ0ZXN0aW5nQHNlY3VyZS5pc3Rpby5pbyIsInNjb3BlIjpbInNjb3BlMSIsInNjb3BlMiJdLCJzdWIiOiJ0ZXN0aW5nQHNlY3VyZS5pc3Rpby5pbyJ9.EdJnEZSH6X8hcyEii7c8H5lnhgjB5dwo07M5oheC8Xz8mOllyg--AHCFWHybM48reunF--oGaG6IXVngCEpVF0_P5DwsUoBgpPmK1JOaKN6_pe9sh0ZwTtdgK_RP01PuI7kUdbOTlkuUi2AO-qUyOm7Art2POzo36DLQlUXv8Ad7NBOqfQaKjE9ndaPWT7aexUsBHxmgiGbz1SyLH879f7uHYPbPKlpHU6P9S-DaKnGLaEchnoKnov7ajhrEhGXAQRukhDPKUHO9L30oPIr5IJllEQfHYtt6IZvlNUGeLUcif3wpry1R5tBXRicx2sXMQ7LyuDremDbcNy_iE76Upg"
+
+# Rewrite a snip to replace external jwksUri with an inline jwks value, avoiding
+# external network fetches for JWT public keys. Also rewrites inline curl calls
+# that fetch static JWT token files from raw.githubusercontent.com.
+# usage: _rewrite_jwks_uri <snip_function>
+# shellcheck disable=SC2001
+_rewrite_jwks_uri() {
+  local _docs_jwks='{"keys":[{"e":"AQAB","kid":"DHFbpoIUqrY8t2zpA2qXfCmr5VO5ZEr4RzHU_-envvQ","kty":"RSA","n":"xAE7eB6qugXyCAG3yhh7pkDkT65pHymX-P7KfIupjf59vsdo91bSP9C8H07pSAGQO1MV_xFj9VswgsCg4R6otmg5PV2He95lZdHtOcU5DXIg_pbhLdKXbi66GlVeK6ABZOUW3WYtnNHD-91gVuoeJT_DwtGGcp4ignkgXfkiEm4sw-4sfb4qdt5oLbyVpmW6x9cfa7vs2WTfURiCrBoUqgBo_-4WTiULmmHSGZHOjzwa8WtrtOQGsAFjIbno85jp6MnGGGZPYZbDAa_b3y5u-YpW7ypZrvD8BgtKVjgtQgZhLAGezMt0ua3DRrWnKqTZ0BJ_EyxOGuHJrLsn00fnMQ"}]}'
+  cmd="$(type "${1:?snip}" | sed '1,3d;$d')"
+  # Replace jwksUri pointing to raw.githubusercontent.com with inline jwks
+  cmd="$(echo "${cmd}" | sed "s|jwksUri: \"https://raw\.githubusercontent\.com/[^\"]*jwks\.json\"|jwks: '${_docs_jwks}'|g")"
+  # Replace inline curl fetches of demo.jwt with the pre-generated token
+  cmd="$(echo "${cmd}" | sed "s|curl https://raw\.githubusercontent\.com/[^ ]*/demo\.jwt -s|echo \"${_DOCS_DEMO_JWT}\"|g")"
+  # Replace wget fetches of gen-jwt.py and key.pem with copies from tests/util/
+  # (populated by bin/init.sh from security/tools/jwt/samples/ in the istio repo)
+  cmd="$(echo "${cmd}" | sed "s|wget --no-verbose https://raw\.githubusercontent\.com/[^ ]*/gen-jwt\.py|cp \"\${REPO_ROOT}/tests/util/gen-jwt.py\" . #|g")"
+  cmd="$(echo "${cmd}" | sed "s|wget --no-verbose https://raw\.githubusercontent\.com/[^ ]*/key\.pem|cp \"\${REPO_ROOT}/tests/util/key.pem\" . #|g")"
+  eval "${cmd}"
+}
+
+# Rewrite a snip to replace oci://ghcr.io/ OCI registry URLs with the local
+# kind-registry when running in IPv6-only Kind CI (ghcr.io has no AAAA records).
+# The kind-registry must be pre-seeded with the required images via crane copy
+# in prow/integ-suite-kind.sh before tests run.
+# usage: _rewrite_oci_registry <snip_function>
+# shellcheck disable=SC2001
+_rewrite_oci_registry() {
+  if [[ "${KIND_IP_FAMILY:-}" != "ipv6" ]]; then
+    "${1:?snip}"
+    return
+  fi
+  local registry="kind-registry:${KIND_REGISTRY_PORT:-5000}"
+  cmd="$(type "${1:?snip}" | sed '1,3d;$d')"
+  cmd="$(echo "${cmd}" | sed "s|oci://ghcr\.io/|oci://${registry}/|g")"
+  eval "${cmd}"
+}

--- a/tests/util/verify.sh
+++ b/tests/util/verify.sh
@@ -133,6 +133,7 @@ __cmp_like() {
     local out="${1//$'\r'}"
     local expected=$2
     local ipregex="^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$"
+    local ip6regex="^[0-9a-fA-F:]*:[0-9a-fA-F:]*$"
     local durationregex="^([0-9]+[smhd])+$"
     local versionregex="^[0-9]+\.[0-9]+\.[0-9]+$"
     local dateregex="^[0-9]{4}\-(0?[1-9]|1[012])\-(0?[1-9]|[12][0-9]|3[01])$"
@@ -210,9 +211,9 @@ __cmp_like() {
                 fi
 
                 # Check for IP addresses.
-                if [[ "$etok" =~ $ipregex ]]; then
-                    if [[ "$otok" =~ $ipregex ]]; then
-                      # We got an IP address. It's a match.
+                if [[ "$etok" =~ $ipregex || "$etok" =~ $ip6regex ]]; then
+                    if [[ "$otok" =~ $ipregex || "$otok" =~ $ip6regex ]]; then
+                      # We got an IP address (IPv4 or IPv6). It's a match.
                       continue
                     fi
 


### PR DESCRIPTION
**Changes to enable IPv6 docs tests**

- **`prow/integ-suite-kind.sh` + `prow/lib.sh`**: IPv6 Kind cluster setup :  local registry,
  CoreDNS `hosts` entry for `kind-registry`, wasm image pre-load via `crane copy`.
  Same pattern as `istio/istio` [`common/scripts/kind_provisioner.sh`](https://github.com/istio/istio/blob/master/common/scripts/kind_provisioner.sh).

- **`tests/util/helpers.sh`**: New helpers added:
  `_normalize_ingress_host` (bracket IPv6 IPs for curl),
  `_skip_if_kind_ipv6`,
  `_rewrite_oci_registry` (ghcr.io to local registry),
  `_rewrite_jwks_uri` (offline JWT/JWKS),
  pre-generated JWT tokens.

- **Skipped tests** (`_skip_if_kind_ipv6`):
  - `egress-gateway`, `egress-tls-origination`, `wildcard-egress-hosts` as there is no internet egress
    in IPv6-only Kind clusters ([kubernetes-sigs/kind#3114](https://github.com/kubernetes-sigs/kind/issues/3114)).
  - `circuit-breaking` : Go DNS resolver treats NXDOMAIN-for-A as authoritative in IPv6-only
    clusters, making in-cluster hostname resolution fail. Same known issue in
    `istio/istio` [`tests/integration/pilot/common/routing.go`](https://github.com/istio/istio/blob/master/tests/integration/pilot/common/routing.go)
    (the workaround there is using IP addresses directly; not applicable here as docs tests
    must use the documented hostname-based commands).

- **Fixed: ingress tests** : `_normalize_ingress_host` after setting `INGRESS_HOST`.

- **Fixed: authn/authz tests** : `_rewrite_jwks_uri` to avoid `raw.githubusercontent.com`

- **Fixed: wasm tests** : `_rewrite_oci_registry` to use local registry instead of `ghcr.io`

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
