### PR TITLE
fix: correct android favicon size metadata

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -99,7 +99,7 @@
         <link rel="icon" type="image/png" href="/favicons/android-36x36.png" sizes="36x36">
         <link rel="icon" type="image/png" href="/favicons/android-48x48.png" sizes="48x48">
         <link rel="icon" type="image/png" href="/favicons/android-72x72.png" sizes="72x72">
-        <link rel="icon" type="image/png" href="/favicons/android-96x96.png" sizes="96xW96">
+        <link rel="icon" type="image/png" href="/favicons/android-96x96.png" sizes="96x96">
         <link rel="icon" type="image/png" href="/favicons/android-144x144.png" sizes="144x144">
         <link rel="icon" type="image/png" href="/favicons/android-192x192.png" sizes="192x192">
         <link rel="icon" type="image/svg+xml" href="/favicons/favicon.svg">


### PR DESCRIPTION
## Description
Fixes a typo in the favicon metadata for `android-96x96.png`.

Right now the built site renders `sizes="96xW96"`, so the icon size hint is invalid. This patch changes it to `96x96`. Tiny fix, but it ships on every page rn.

Repro:
1. Run `hugo -d /tmp/istioio-public`
2. Open `/tmp/istioio-public/index.html`
3. Find `android-96x96.png` and note `sizes="96xW96"`

After this change, the same line renders `sizes="96x96"`.

## Reviewers
- [x] Docs
- [x] User Experience
