### PR TITLE
fix docs: remove duplicated Helm next-steps link

### DIFF
--- a/content/en/docs/setup/install/helm/index.md
+++ b/content/en/docs/setup/install/helm/index.md
@@ -95,7 +95,6 @@ You can display the default values of configuration parameters using the `helm s
         * https://istio.io/latest/docs/tasks/traffic-management
         * https://istio.io/latest/docs/tasks/security/
         * https://istio.io/latest/docs/tasks/policy-enforcement/
-        * https://istio.io/latest/docs/tasks/policy-enforcement/
       * Review the list of actively supported releases, CVE publications and our hardening guide:
         * https://istio.io/latest/docs/releases/supported-releases/
         * https://istio.io/latest/news/security/

--- a/content/en/docs/setup/install/helm/snips.sh
+++ b/content/en/docs/setup/install/helm/snips.sh
@@ -72,7 +72,6 @@ Next steps:
     * https://istio.io/latest/docs/tasks/traffic-management
     * https://istio.io/latest/docs/tasks/security/
     * https://istio.io/latest/docs/tasks/policy-enforcement/
-    * https://istio.io/latest/docs/tasks/policy-enforcement/
   * Review the list of actively supported releases, CVE publications and our hardening guide:
     * https://istio.io/latest/docs/releases/supported-releases/
     * https://istio.io/latest/news/security/

--- a/content/es/docs/setup/install/helm/index.md
+++ b/content/es/docs/setup/install/helm/index.md
@@ -94,7 +94,6 @@ Puedes mostrar los valores por defecto de los parámetros de configuración usan
         * https://istio.io/latest/docs/tasks/traffic-management
         * https://istio.io/latest/docs/tasks/security/
         * https://istio.io/latest/docs/tasks/policy-enforcement/
-        * https://istio.io/latest/docs/tasks/policy-enforcement/
       * Revisa la lista de releases soportados, publicaciones de CVE y nuestra guía de fortalecimiento:
         * https://istio.io/latest/docs/releases/supported-releases/
         * https://istio.io/latest/news/security/

--- a/content/uk/docs/setup/install/helm/index.md
+++ b/content/uk/docs/setup/install/helm/index.md
@@ -94,7 +94,6 @@ $ helm install <release> <chart> --namespace <namespace> --create-namespace [--s
         * https://istio.io/latest/docs/tasks/traffic-management
         * https://istio.io/latest/docs/tasks/security/
         * https://istio.io/latest/docs/tasks/policy-enforcement/
-        * https://istio.io/latest/docs/tasks/policy-enforcement/
       * Review the list of actively supported releases, CVE publications and our hardening guide:
         * https://istio.io/latest/docs/releases/supported-releases/
         * https://istio.io/latest/news/security/

--- a/content/zh/docs/setup/install/helm/index.md
+++ b/content/zh/docs/setup/install/helm/index.md
@@ -100,7 +100,6 @@ $ helm install <release> <chart> --namespace <namespace> --create-namespace [--s
         * https://istio.io/latest/docs/tasks/traffic-management
         * https://istio.io/latest/docs/tasks/security/
         * https://istio.io/latest/docs/tasks/policy-enforcement/
-        * https://istio.io/latest/docs/tasks/policy-enforcement/
       * Review the list of actively supported releases, CVE publications and our hardening guide:
         * https://istio.io/latest/docs/releases/supported-releases/
         * https://istio.io/latest/news/security/


### PR DESCRIPTION
## Description

Helm install docs show the `policy-enforcement` link twice in the sample `Next steps` output. Kinda noisy, and stale too.

Repro:
1. Open `content/en/docs/setup/install/helm/index.md` or the rendered Helm install page.
2. Find `Next steps` in the sample output.
3. See `https://istio.io/latest/docs/tasks/policy-enforcement/` listed twice.

Current upstream chart notes in `istio/istio` print that line once in `manifests/charts/istio-control/istio-discovery/templates/NOTES.txt`, so this syncs the docs back up. Also regenerates `content/en/docs/setup/install/helm/snips.sh`.

## Reviewers

- [x] Docs
- [x] Installation
- [x] Localization/Translation
