### PR TITLE
add docs test for secure-metrics task and simplify Prometheus setup

### DIFF
--- a/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
@@ -4,7 +4,7 @@ description: This task shows how to securely scrape Istio workload and gateway m
 weight: 50
 keywords: [telemetry,metrics,prometheus,istio,mtls,secure-metrics]
 owner: istio/wg-policies-and-telemetry-maintainers
-test: no
+test: yes
 ---
 
 This task demonstrates how to **securely scrape Istio sidecar and gateway metrics** using Prometheus over **Istio mTLS**. By default, Prometheus scrapes metrics from Istio workloads and gateways over plain HTTP. In this task, you configure Istio and Prometheus so that metrics are scraped securely over mutually-authenticated TLS connections. This document focuses on Envoy and Istio-generated telemetry exposed by sidecars and gateways. For general Prometheus integration with Istio, including application metrics, see the [Prometheus integration](/docs/ops/integrations/prometheus/) documentation.
@@ -31,85 +31,26 @@ The approach in this task adds dedicated mTLS-protected listeners so that Promet
 
 Prometheus must present a valid certificate trusted by the mesh CA when scraping the secure ports. The simplest way to provision those credentials is to inject an Istio sidecar into the Prometheus pod and use `OUTPUT_CERTS` to write the workload certificate to a shared volume.
 
-The steps below use the Istio sample Prometheus addon (`samples/addons/prometheus.yaml`), which deploys Prometheus into the `istio-system` namespace. The sidecar is injected via a pod-level annotation, so no namespace-level injection label is needed.
+The `prometheus-secure-metrics` sample (`samples/addons/extras/prometheus-secure-metrics.yaml`) is a standalone Prometheus deployment with sidecar injection, certificate export, and the mTLS scrape jobs pre-configured. Use it **instead of** `samples/addons/prometheus.yaml` - do not apply both files, as they define the same resource names.
 
-1. Deploy Prometheus and inject the sidecar
-
-    Apply the Istio sample Prometheus addon, then patch the `prometheus` Deployment to enable sidecar injection and certificate export:
+1. Deploy Prometheus with mTLS scraping pre-configured:
 
     {{< text bash >}}
-    $ kubectl apply -f @samples/addons/prometheus.yaml@
-    $ cat <<'EOF' > /tmp/prometheus-secure-patch.yaml
-    spec:
-      template:
-        metadata:
-          labels:
-            sidecar.istio.io/inject: "true"
-          annotations:
-            sidecar.istio.io/userVolumeMount: '[{"name": "istio-certs", "mountPath": "/etc/istio-certs"}]'
-            proxy.istio.io/config: |
-              proxyMetadata:
-                OUTPUT_CERTS: /etc/istio-certs
-                INBOUND_CAPTURE_PORTS: ""
-        spec:
-          containers:
-          - name: prometheus-server
-            volumeMounts:
-            - name: istio-certs
-              mountPath: /etc/istio-certs
-          volumes:
-          - name: istio-certs
-            emptyDir: {}
-    EOF
-    $ kubectl patch deployment prometheus -n istio-system --type=strategic --patch-file=/tmp/prometheus-secure-patch.yaml
+    $ kubectl apply -n istio-system -f @samples/addons/extras/prometheus-secure-metrics.yaml@
     $ kubectl rollout status deployment/prometheus -n istio-system
     {{< /text >}}
 
+    The sample configures the following key settings compared to the standard Prometheus addon:
+
+    * `sidecar.istio.io/inject: "true"` **label** - overrides the `"false"` default on the Prometheus pod, enabling sidecar injection.
+    * `OUTPUT_CERTS: /etc/istio-certs` - instructs the sidecar to write the workload certificate, key, and root CA to a shared volume so Prometheus can read them for mTLS scraping.
+    * `INBOUND_CAPTURE_PORTS: ""` - prevents the sidecar from intercepting inbound Prometheus traffic; the sidecar is used solely for certificate provisioning.
+    * `sidecar.istio.io/userVolumeMount` - mounts the certificate volume into the `istio-proxy` container so it can write certificates. The same volume is also mounted into `prometheus-server` so it can read them. Both mounts are required.
+    * **Scrape jobs** - the ConfigMap contains two pre-configured mTLS scrape jobs (`istio-secure-merged-metrics` on port `15092`, `istio-secure-envoy-metrics` on port `15091`) that discover pods via the `prometheus.istio.io/secure-port` and `prometheus.istio.io/secure-envoy-port` annotations.
+
     {{< tip >}}
-    The Istio sidecar injected into the Prometheus pod is used only to provision an Istio workload certificate for mTLS authentication. Traffic interception is explicitly disabled via `INBOUND_CAPTURE_PORTS: ""` and Prometheus continues to operate as a standard Kubernetes workload. As an alternative, Istio can be integrated with [cert-manager](/docs/ops/integrations/certmanager/) to provision certificates for Prometheus. In that model, an Istio sidecar is not required.
+    As an alternative to sidecar-based certificate provisioning, Istio can be integrated with [cert-manager](/docs/ops/integrations/certmanager/) to provision certificates for Prometheus. In that model, an Istio sidecar is not required.
     {{< /tip >}}
-
-    **Notes:**
-
-    * The `sidecar.istio.io/inject: "true"` **label** overrides the `"false"` label set by the Prometheus Helm chart, enabling sidecar injection.
-    * `OUTPUT_CERTS` instructs the sidecar to write the workload certificate, key, and root CA to `/etc/istio-certs` so Prometheus can read them.
-    * `INBOUND_CAPTURE_PORTS: ""` prevents the sidecar from intercepting inbound Prometheus traffic.
-    * `userVolumeMount` mounts the certificate directory into the sidecar (`istio-proxy`) so it can write certificates via `OUTPUT_CERTS`. The explicit `volumeMounts` entry on `prometheus-server` mounts the same volume into the Prometheus container so it can read those certificates. Both mounts are required.
-
-1. Add a secure scrape job to the Prometheus configuration
-
-    Edit the `prometheus` ConfigMap in the `istio-system` namespace and add the following job to `scrape_configs`:
-
-    {{< text bash >}}
-    $ kubectl edit configmap prometheus -n istio-system
-    {{< /text >}}
-
-    Locate the `scrape_configs:` key inside `prometheus.yml` and insert the job below it:
-
-    {{< text yaml >}}
-    - job_name: 'istio-secure-metrics'
-      kubernetes_sd_configs:
-      - role: pod
-      relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_istio_io_secure_port]
-        action: keep
-        regex: .+
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-        action: replace
-        target_label: __metrics_path__
-        regex: (.+)
-      - source_labels: [__meta_kubernetes_pod_ip, __meta_kubernetes_pod_annotation_prometheus_istio_io_secure_port]
-        action: replace
-        target_label: __address__
-        regex: (.+);(.+)
-        replacement: $1:$2
-      scheme: https
-      tls_config:
-        ca_file: /etc/istio-certs/root-cert.pem
-        cert_file: /etc/istio-certs/cert-chain.pem
-        key_file: /etc/istio-certs/key.pem
-        insecure_skip_verify: true
-    {{< /text >}}
 
 1. Verify the Prometheus pod has an Istio sidecar injected and is running:
 
@@ -121,7 +62,7 @@ The steps below use the Istio sample Prometheus addon (`samples/addons/prometheu
 
 ## Enable native mTLS metrics ports (Istio 1.31+)
 
-Istio 1.31 introduced two environment variables that inject mTLS-protected static bootstrap listeners directly into every Envoy proxy — both sidecar and gateway proxies:
+Istio 1.31 introduced two environment variables that inject mTLS-protected static bootstrap listeners directly into every Envoy proxy - both sidecar and gateway proxies:
 
 | Variable | Default | Description |
 | -------- | ------- | ----------- |
@@ -184,7 +125,7 @@ The same variables work identically on gateway proxies since they use the same `
 1. Patch the ingress gateway Deployment:
 
     {{< text bash >}}
-    $ cat <<'EOF' > /tmp/gateway-secure-metrics-patch.yaml
+    $ cat <<EOF > /tmp/gateway-secure-metrics-patch.yaml
     spec:
       template:
         metadata:
@@ -223,7 +164,7 @@ The same variables work identically on gateway proxies since they use the same `
 1. Patch the `Gateway` resource to enable the secure listeners:
 
     {{< text bash >}}
-    $ cat <<'EOF' > /tmp/gateway-api-secure-metrics-patch.yaml
+    $ cat <<EOF > /tmp/gateway-api-secure-metrics-patch.yaml
     spec:
       infrastructure:
         annotations:
@@ -303,7 +244,7 @@ EOF
 $ istioctl install -f ./istio-secure-metrics.yaml
 {{< /text >}}
 
-When installed this way, `istioctl` renders the gateway Deployment with the `proxyMetadata` values as container env vars directly, activating the secure listeners on both sidecars and gateways. The `components.ingressGateways.k8s.podAnnotations` block adds the Prometheus discovery annotations to gateway pods. For sidecar workloads, `prometheus.istio.io/secure-port` is automatically set by the sidecar injector to the value of `ENVOY_SECURE_MERGED_METRICS_PORT` — no per-Deployment annotation is needed.
+When installed this way, `istioctl` renders the gateway Deployment with the `proxyMetadata` values as container env vars directly, activating the secure listeners on both sidecars and gateways. The `components.ingressGateways.k8s.podAnnotations` block adds the Prometheus discovery annotations to gateway pods. For sidecar workloads, `prometheus.istio.io/secure-port` is automatically set by the sidecar injector to the value of `ENVOY_SECURE_MERGED_METRICS_PORT` - no per-Deployment annotation is needed.
 {{< /tip >}}
 
 ## Verification
@@ -312,20 +253,26 @@ When installed this way, `istioctl` renders the gateway Deployment with the `pro
 
 After completing the configuration, verify that Prometheus is successfully scraping metrics over **mutual TLS**.
 
-1. Open the Prometheus dashboard
+1. Verify mTLS scraping succeeds by curling the secure port from the Prometheus pod using its workload certificate:
 
     {{< text bash >}}
-    $ istioctl dashboard prometheus
+    $ export PROM_POD=$(kubectl get pod -n istio-system -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
+    $ export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
+    $ kubectl exec -n istio-system $PROM_POD -c istio-proxy -- \
+        curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
+        --cacert /etc/istio-certs/root-cert.pem \
+        --cert /etc/istio-certs/cert-chain.pem \
+        --key /etc/istio-certs/key.pem \
+        --insecure \
+        https://$HTTPBIN_IP:15092/stats/prometheus
+    200
     {{< /text >}}
 
-    This command opens the Prometheus dashboard in your default browser.
+    An HTTP `200` response confirms that the Prometheus pod successfully completed an mTLS handshake with httpbin's port `15092` and retrieved metrics. The `--insecure` flag skips hostname verification only - Istio workload certificates use SPIFFE URI SANs (e.g. `spiffe://cluster.local/ns/default/sa/httpbin`) rather than IP addresses, so curl cannot match the pod IP against the cert. The mutual TLS handshake and certificate exchange still occur, which is why `--cacert`, `--cert`, and `--key` are still required. This is also why the Prometheus scrape job uses `insecure_skip_verify: true`.
 
-1. Verify scrape targets
+1. Verify scrape targets in the Prometheus UI
 
-    1. In the Prometheus UI, navigate to **Status → Targets**.
-    1. Locate the job named `istio-secure-metrics`.
-
-    Verify that the targets for the httpbin workload and the Istio Ingress Gateway are listed with endpoints similar to `https://<pod-ip>:15092/stats/prometheus` and a status of **UP**.
+    Open the Prometheus dashboard with `istioctl dashboard prometheus -n istio-system`, then navigate to **Status → Targets**. Verify that the `istio-secure-merged-metrics` and `istio-secure-envoy-metrics` jobs list the `httpbin` pod with a status of **UP** and endpoints in the form `https://<pod-ip>:15092/stats/prometheus`.
 
 1. Verify mTLS is enforced by confirming that a plain HTTP request to the secure port is rejected:
 
@@ -336,13 +283,40 @@ After completing the configuration, verify that Prometheus is successfully scrap
     upstream connect error or disconnect/reset before headers. reset reason: connection termination
     {{< /text >}}
 
-    The connection termination error confirms the port only accepts TLS connections — a plain HTTP request is rejected immediately.
+    The connection termination error confirms the port only accepts TLS connections - a plain HTTP request is rejected immediately.
 
 This confirms that Prometheus is scraping metrics using **HTTPS over Istio mTLS** via the native secure ports, rather than directly accessing the plaintext telemetry ports (`15020` or `15090`).
 
+## Cleanup
+
+{{< tabset category-name="config-api" >}}
+
+{{< tab name="Istio APIs" category-value="istio-apis" >}}
+
+{{< text bash >}}
+$ kubectl delete -n istio-system -f @samples/addons/extras/prometheus-secure-metrics.yaml@
+$ kubectl delete -f @samples/httpbin/httpbin.yaml@
+$ kubectl label namespace default istio-injection-
+{{< /text >}}
+
+{{< /tab >}}
+
+{{< tab name="Gateway API" category-value="gateway-api" >}}
+
+{{< text bash >}}
+$ kubectl delete -n istio-system -f @samples/addons/extras/prometheus-secure-metrics.yaml@
+$ kubectl delete -f @samples/httpbin/httpbin.yaml@
+$ kubectl delete gateway istio-ingressgateway -n istio-system
+$ kubectl label namespace default istio-injection-
+{{< /text >}}
+
+{{< /tab >}}
+
+{{< /tabset >}}
+
 ## Legacy workaround (Istio < 1.31)
 
-If you are running Istio older than 1.31, the native env-var approach is not available. The steps below demonstrate one way to achieve secure metrics scraping using Istio CRDs: a secure TLS frontend is created on port `15091` (exposed to Prometheus) that routes internally to either port `15020` (merged metrics — Envoy + application + agent) or `15090` (Envoy-only metrics). Scrapers connect to `15091` over `ISTIO_MUTUAL` TLS; the `ServiceEntry` and `VirtualService` handle the internal routing to the plaintext backend.
+If you are running Istio older than 1.31, the native env-var approach is not available. The steps below demonstrate one way to achieve secure metrics scraping using Istio CRDs: a secure TLS frontend is created on port `15091` (exposed to Prometheus) that routes internally to either port `15020` (merged metrics - Envoy + application + agent) or `15090` (Envoy-only metrics). Scrapers connect to `15091` over `ISTIO_MUTUAL` TLS; the `ServiceEntry` and `VirtualService` handle the internal routing to the plaintext backend.
 
 ### Legacy: Secure metrics for sidecars
 
@@ -461,42 +435,14 @@ If you are running Istio older than 1.31, the native env-var approach is not ava
       --overwrite
     {{< /text >}}
 
-## Cleanup
-
-### Cleanup: native mTLS metrics ports (Istio 1.31+)
-
-{{< tabset category-name="config-api" >}}
-
-{{< tab name="Istio APIs" category-value="istio-apis" >}}
-
-{{< text bash >}}
-$ kubectl delete -f @samples/addons/prometheus.yaml@
-$ kubectl delete -f @samples/httpbin/httpbin.yaml@
-$ killall istioctl
-{{< /text >}}
-
-{{< /tab >}}
-
-{{< tab name="Gateway API" category-value="gateway-api" >}}
-
-{{< text bash >}}
-$ kubectl delete -f @samples/addons/prometheus.yaml@
-$ kubectl delete -f @samples/httpbin/httpbin.yaml@
-$ kubectl delete gateway istio-ingressgateway -n istio-system
-$ killall istioctl
-{{< /text >}}
-
-{{< /tab >}}
-
-{{< /tabset >}}
-
-### Cleanup: legacy workaround (Istio < 1.31)
+### Cleanup
 
 {{< text bash >}}
 $ kubectl delete sidecar secure-metrics -n default
 $ kubectl delete gateway metrics-gateway -n istio-system
 $ kubectl delete serviceentry gateway-admin -n istio-system
 $ kubectl delete virtualservice gateway-metrics -n istio-system
-$ kubectl delete -f @samples/addons/prometheus.yaml@
+$ kubectl delete -n istio-system -f @samples/addons/extras/prometheus-secure-metrics.yaml@
 $ kubectl delete -f @samples/httpbin/httpbin.yaml@
+$ kubectl label namespace default istio-injection-
 {{< /text >}}

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
@@ -31,7 +31,7 @@ The approach in this task adds dedicated mTLS-protected listeners so that Promet
 
 Prometheus must present a valid certificate trusted by the mesh CA when scraping the secure ports. The simplest way to provision those credentials is to inject an Istio sidecar into the Prometheus pod and use `OUTPUT_CERTS` to write the workload certificate to a shared volume.
 
-The `prometheus-secure-metrics` sample (`samples/addons/extras/prometheus-secure-metrics.yaml`) is a standalone Prometheus deployment with sidecar injection, certificate export, and the mTLS scrape jobs pre-configured. Use it **instead of** `samples/addons/prometheus.yaml` - do not apply both files, as they define the same resource names.
+The `prometheus-secure-metrics` sample (`samples/addons/extras/prometheus-secure-metrics.yaml`) is a standalone replacement for `samples/addons/prometheus.yaml` with sidecar injection, certificate export, and the mTLS scrape jobs pre-configured.
 
 1. Deploy Prometheus with mTLS scraping pre-configured:
 
@@ -102,10 +102,17 @@ This example uses `httpbin` as the workload.
     * The value of `ENVOY_SECURE_METRICS_PORT` (`15091`) is the mTLS listener port for **Envoy-only** stats.
     * The value of `ENVOY_SECURE_MERGED_METRICS_PORT` (`15092`) is the mTLS listener port for **merged** metrics (Envoy + application + agent).
 
-1. Verify the secure listeners are configured on the `httpbin` sidecar:
+1. Set environment variables used in the following verification steps:
 
     {{< text bash >}}
     $ export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].metadata.name}')
+    $ export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
+    $ export PROM_POD=$(kubectl get pod -n istio-system -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
+    {{< /text >}}
+
+1. Verify the secure listeners are configured on the `httpbin` sidecar:
+
+    {{< text bash >}}
     $ istioctl proxy-config listeners $HTTPBIN_POD -n default | grep -E "15090|15091|15092"
     0.0.0.0       15090 ALL                                                                                     Inline Route: /stats/prometheus*
     0.0.0.0       15091 Trans: tls                                                                              Inline Route: /stats/prometheus*
@@ -256,8 +263,6 @@ After completing the configuration, verify that Prometheus is successfully scrap
 1. Verify mTLS scraping succeeds by curling the secure port from the Prometheus pod using its workload certificate:
 
     {{< text bash >}}
-    $ export PROM_POD=$(kubectl get pod -n istio-system -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
-    $ export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
     $ kubectl exec -n istio-system $PROM_POD -c istio-proxy -- \
         curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
         --cacert /etc/istio-certs/root-cert.pem \
@@ -277,8 +282,6 @@ After completing the configuration, verify that Prometheus is successfully scrap
 1. Verify mTLS is enforced by confirming that a plain HTTP request to the secure port is rejected:
 
     {{< text bash >}}
-    $ export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].metadata.name}')
-    $ export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
     $ kubectl exec -n default $HTTPBIN_POD -c istio-proxy -- curl -s --max-time 3 http://$HTTPBIN_IP:15091/stats/prometheus
     upstream connect error or disconnect/reset before headers. reset reason: connection termination
     {{< /text >}}

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
@@ -31,9 +31,9 @@ The approach in this task adds dedicated mTLS-protected listeners so that Promet
 
 Prometheus must present a valid certificate trusted by the mesh CA when scraping the secure ports. The simplest way to provision those credentials is to inject an Istio sidecar into the Prometheus pod and use `OUTPUT_CERTS` to write the workload certificate to a shared volume.
 
-The `prometheus-secure-metrics` sample (`samples/addons/extras/prometheus-secure-metrics.yaml`) is a standalone replacement for `samples/addons/prometheus.yaml` with sidecar injection, certificate export, and the mTLS scrape jobs pre-configured.
+The `prometheus-secure-metrics` sample (`samples/addons/extras/prometheus-secure-metrics.yaml`) is a standalone replacement for `samples/addons/prometheus.yaml` with sidecar injection, certificate export, and the mTLS scrape jobs preconfigured.
 
-1. Deploy Prometheus with mTLS scraping pre-configured:
+1. Deploy Prometheus with mTLS scraping preconfigured:
 
     {{< text bash >}}
     $ kubectl apply -n istio-system -f @samples/addons/extras/prometheus-secure-metrics.yaml@
@@ -46,7 +46,7 @@ The `prometheus-secure-metrics` sample (`samples/addons/extras/prometheus-secure
     * `OUTPUT_CERTS: /etc/istio-certs` - instructs the sidecar to write the workload certificate, key, and root CA to a shared volume so Prometheus can read them for mTLS scraping.
     * `INBOUND_CAPTURE_PORTS: ""` - prevents the sidecar from intercepting inbound Prometheus traffic; the sidecar is used solely for certificate provisioning.
     * `sidecar.istio.io/userVolumeMount` - mounts the certificate volume into the `istio-proxy` container so it can write certificates. The same volume is also mounted into `prometheus-server` so it can read them. Both mounts are required.
-    * **Scrape jobs** - the ConfigMap contains two pre-configured mTLS scrape jobs (`istio-secure-merged-metrics` on port `15092`, `istio-secure-envoy-metrics` on port `15091`) that discover pods via the `prometheus.istio.io/secure-port` and `prometheus.istio.io/secure-envoy-port` annotations.
+    * **Scrape jobs** - the ConfigMap contains two preconfigured mTLS scrape jobs (`istio-secure-merged-metrics` on port `15092`, `istio-secure-envoy-metrics` on port `15091`) that discover pods via the `prometheus.istio.io/secure-port` and `prometheus.istio.io/secure-envoy-port` annotations.
 
     {{< tip >}}
     As an alternative to sidecar-based certificate provisioning, Istio can be integrated with [cert-manager](/docs/ops/integrations/certmanager/) to provision certificates for Prometheus. In that model, an Istio sidecar is not required.
@@ -438,7 +438,7 @@ If you are running Istio older than 1.31, the native env-var approach is not ava
       --overwrite
     {{< /text >}}
 
-### Cleanup
+### Legacy cleanup
 
 {{< text bash >}}
 $ kubectl delete sidecar secure-metrics -n default

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
@@ -296,7 +296,7 @@ This confirms that Prometheus is scraping metrics using **HTTPS over Istio mTLS*
 
 {{< tab name="Istio APIs" category-value="istio-apis" >}}
 
-{{< text bash snip_id=none >}}
+{{< text syntax=bash snip_id=none >}}
 $ kubectl delete -n istio-system -f @samples/addons/extras/prometheus-secure-metrics.yaml@
 $ kubectl delete -f @samples/httpbin/httpbin.yaml@
 $ kubectl label namespace default istio-injection-

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
@@ -74,8 +74,7 @@ When set, Envoy adds the configured listeners at bootstrap time. Scrapers must p
 ### Enable on a sidecar workload
 
 This example uses `httpbin` as the workload. The manifest below is based on
-[samples/httpbin/httpbin.yaml]({{< github_file >}}/samples/httpbin/httpbin.yaml)
-with the secure metrics annotations added to the Deployment.
+the [httpbin]({{< github_tree >}}/samples/httpbin) sample with the secure metrics annotations added to the Deployment.
 
 1. Deploy `httpbin` with secure metrics ports enabled:
 

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
@@ -73,34 +73,69 @@ When set, Envoy adds the configured listeners at bootstrap time. Scrapers must p
 
 ### Enable on a sidecar workload
 
-This example uses `httpbin` as the workload.
+This example uses `httpbin` as the workload. The manifest below is based on
+[samples/httpbin/httpbin.yaml]({{< github_file >}}/samples/httpbin/httpbin.yaml)
+with the secure metrics annotations added to the Deployment.
 
-1. Deploy `httpbin` with secure metrics ports enabled
+1. Deploy `httpbin` with secure metrics ports enabled:
 
     {{< text bash >}}
     $ kubectl label namespace default istio-injection=enabled --overwrite
-    $ kubectl apply -f @samples/httpbin/httpbin.yaml@
-    {{< /text >}}
-
-1. Patch the `httpbin` deployment to enable the secure listeners
-
-    {{< text bash >}}
-    $ cat <<EOF > /tmp/httpbin-secure-metrics-patch.yaml
+    $ kubectl apply -f - <<EOF
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: httpbin
+    ---
+    apiVersion: v1
+    kind: Service
+    metadata:
+      name: httpbin
+      labels:
+        app: httpbin
+        service: httpbin
     spec:
+      ports:
+      - name: http
+        port: 8000
+        targetPort: 8080
+      selector:
+        app: httpbin
+    ---
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: httpbin
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: httpbin
+          version: v1
       template:
         metadata:
+          labels:
+            app: httpbin
+            version: v1
           annotations:
             proxy.istio.io/config: |
               proxyMetadata:
                 ENVOY_SECURE_METRICS_PORT: "15091"
                 ENVOY_SECURE_MERGED_METRICS_PORT: "15092"
             prometheus.io/path: "/stats/prometheus"
+        spec:
+          serviceAccountName: httpbin
+          containers:
+          - image: docker.io/mccutchen/go-httpbin:v2.15.0
+            imagePullPolicy: IfNotPresent
+            name: httpbin
+            ports:
+            - containerPort: 8080
     EOF
-    $ kubectl patch deployment httpbin -n default --type=merge --patch-file=/tmp/httpbin-secure-metrics-patch.yaml
     {{< /text >}}
 
-    * The value of `ENVOY_SECURE_METRICS_PORT` (`15091`) is the mTLS listener port for **Envoy-only** stats.
-    * The value of `ENVOY_SECURE_MERGED_METRICS_PORT` (`15092`) is the mTLS listener port for **merged** metrics (Envoy + application + agent).
+    * `ENVOY_SECURE_METRICS_PORT` (`15091`) is the mTLS listener port for **Envoy-only** stats.
+    * `ENVOY_SECURE_MERGED_METRICS_PORT` (`15092`) is the mTLS listener port for **merged** metrics (Envoy + application + agent).
 
 1. Set environment variables used in the following verification steps:
 

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/index.md
@@ -113,7 +113,7 @@ This example uses `httpbin` as the workload.
 1. Verify the secure listeners are configured on the `httpbin` sidecar:
 
     {{< text bash >}}
-    $ istioctl proxy-config listeners $HTTPBIN_POD -n default | grep -E "15090|15091|15092"
+    $ istioctl proxy-config listeners "$HTTPBIN_POD" -n default | grep -E "15090|15091|15092"
     0.0.0.0       15090 ALL                                                                                     Inline Route: /stats/prometheus*
     0.0.0.0       15091 Trans: tls                                                                              Inline Route: /stats/prometheus*
     0.0.0.0       15092 Trans: tls                                                                              Inline Route: /stats/prometheus*, /metrics*
@@ -156,7 +156,7 @@ The same variables work identically on gateway proxies since they use the same `
 
     {{< text bash >}}
     $ export GW_POD=$(kubectl get pod -n istio-system -l app=istio-ingressgateway -o jsonpath='{.items[0].metadata.name}')
-    $ istioctl proxy-config listeners $GW_POD -n istio-system | grep -E "15090|15091|15092"
+    $ istioctl proxy-config listeners "$GW_POD" -n istio-system | grep -E "15090|15091|15092"
     0.0.0.0   15090 ALL        Inline Route: /stats/prometheus*
     0.0.0.0   15091 Trans: tls Inline Route: /stats/prometheus*
     0.0.0.0   15092 Trans: tls Inline Route: /stats/prometheus*, /metrics*
@@ -189,7 +189,7 @@ The same variables work identically on gateway proxies since they use the same `
 
     {{< text bash >}}
     $ export GW_POD=$(kubectl get pod -n istio-system -l gateway.networking.k8s.io/gateway-name=istio-ingressgateway -o jsonpath='{.items[0].metadata.name}')
-    $ istioctl proxy-config listeners $GW_POD -n istio-system | grep -E "15090|15091|15092"
+    $ istioctl proxy-config listeners "$GW_POD" -n istio-system | grep -E "15090|15091|15092"
     0.0.0.0   15090 ALL        Inline Route: /stats/prometheus*
     0.0.0.0   15091 Trans: tls Inline Route: /stats/prometheus*
     0.0.0.0   15092 Trans: tls Inline Route: /stats/prometheus*, /metrics*
@@ -263,13 +263,13 @@ After completing the configuration, verify that Prometheus is successfully scrap
 1. Verify mTLS scraping succeeds by curling the secure port from the Prometheus pod using its workload certificate:
 
     {{< text bash >}}
-    $ kubectl exec -n istio-system $PROM_POD -c istio-proxy -- \
+    $ kubectl exec -n istio-system "$PROM_POD" -c istio-proxy -- \
         curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
         --cacert /etc/istio-certs/root-cert.pem \
         --cert /etc/istio-certs/cert-chain.pem \
         --key /etc/istio-certs/key.pem \
         --insecure \
-        https://$HTTPBIN_IP:15092/stats/prometheus
+        https://"$HTTPBIN_IP":15092/stats/prometheus
     200
     {{< /text >}}
 
@@ -282,7 +282,7 @@ After completing the configuration, verify that Prometheus is successfully scrap
 1. Verify mTLS is enforced by confirming that a plain HTTP request to the secure port is rejected:
 
     {{< text bash >}}
-    $ kubectl exec -n default $HTTPBIN_POD -c istio-proxy -- curl -s --max-time 3 http://$HTTPBIN_IP:15091/stats/prometheus
+    $ kubectl exec -n default "$HTTPBIN_POD" -c istio-proxy -- curl -s --max-time 3 http://"$HTTPBIN_IP":15091/stats/prometheus
     upstream connect error or disconnect/reset before headers. reset reason: connection termination
     {{< /text >}}
 
@@ -296,7 +296,7 @@ This confirms that Prometheus is scraping metrics using **HTTPS over Istio mTLS*
 
 {{< tab name="Istio APIs" category-value="istio-apis" >}}
 
-{{< text bash >}}
+{{< text bash snip_id=none >}}
 $ kubectl delete -n istio-system -f @samples/addons/extras/prometheus-secure-metrics.yaml@
 $ kubectl delete -f @samples/httpbin/httpbin.yaml@
 $ kubectl label namespace default istio-injection-

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/snips.sh
@@ -1,0 +1,313 @@
+#!/bin/bash
+# shellcheck disable=SC2034,SC2153,SC2155,SC2164
+
+# Copyright Istio Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+####################################################################################################
+# WARNING: THIS IS AN AUTO-GENERATED FILE, DO NOT EDIT. PLEASE MODIFY THE ORIGINAL MARKDOWN FILE:
+#          docs/tasks/observability/metrics/secure-metrics/index.md
+####################################################################################################
+
+snip_configure_prometheus_for_mtls_scraping_1() {
+kubectl apply -n istio-system -f samples/addons/extras/prometheus-secure-metrics.yaml
+kubectl rollout status deployment/prometheus -n istio-system
+}
+
+snip_configure_prometheus_for_mtls_scraping_2() {
+kubectl get pod -n istio-system -l app.kubernetes.io/name=prometheus
+}
+
+! IFS=$'\n' read -r -d '' snip_configure_prometheus_for_mtls_scraping_2_out <<\ENDSNIP
+NAME                          READY   STATUS    RESTARTS   AGE
+prometheus-6c647c84c8-gpxt4   3/3     Running   0          75s
+ENDSNIP
+
+snip_enable_on_a_sidecar_workload_1() {
+kubectl label namespace default istio-injection=enabled --overwrite
+kubectl apply -f samples/httpbin/httpbin.yaml
+}
+
+snip_enable_on_a_sidecar_workload_2() {
+cat <<EOF > /tmp/httpbin-secure-metrics-patch.yaml
+spec:
+  template:
+    metadata:
+      annotations:
+        proxy.istio.io/config: |
+          proxyMetadata:
+            ENVOY_SECURE_METRICS_PORT: "15091"
+            ENVOY_SECURE_MERGED_METRICS_PORT: "15092"
+        prometheus.io/path: "/stats/prometheus"
+EOF
+kubectl patch deployment httpbin -n default --type=merge --patch-file=/tmp/httpbin-secure-metrics-patch.yaml
+}
+
+snip_enable_on_a_sidecar_workload_3() {
+export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].metadata.name}')
+istioctl proxy-config listeners $HTTPBIN_POD -n default | grep -E "15090|15091|15092"
+}
+
+! IFS=$'\n' read -r -d '' snip_enable_on_a_sidecar_workload_3_out <<\ENDSNIP
+0.0.0.0       15090 ALL                                                                                     Inline Route: /stats/prometheus*
+0.0.0.0       15091 Trans: tls                                                                              Inline Route: /stats/prometheus*
+0.0.0.0       15092 Trans: tls                                                                              Inline Route: /stats/prometheus*, /metrics*
+ENDSNIP
+
+snip_enable_on_a_gateway_1() {
+cat <<EOF > /tmp/gateway-secure-metrics-patch.yaml
+spec:
+  template:
+    metadata:
+      annotations:
+        prometheus.istio.io/secure-port: "15092"
+        prometheus.io/path: "/stats/prometheus"
+    spec:
+      containers:
+      - name: istio-proxy
+        env:
+        - name: ENVOY_SECURE_METRICS_PORT
+          value: "15091"
+        - name: ENVOY_SECURE_MERGED_METRICS_PORT
+          value: "15092"
+EOF
+kubectl patch deployment istio-ingressgateway -n istio-system --type=strategic --patch-file=/tmp/gateway-secure-metrics-patch.yaml
+kubectl rollout status deployment/istio-ingressgateway -n istio-system
+}
+
+snip_enable_on_a_gateway_2() {
+export GW_POD=$(kubectl get pod -n istio-system -l app=istio-ingressgateway -o jsonpath='{.items[0].metadata.name}')
+istioctl proxy-config listeners $GW_POD -n istio-system | grep -E "15090|15091|15092"
+}
+
+! IFS=$'\n' read -r -d '' snip_enable_on_a_gateway_2_out <<\ENDSNIP
+0.0.0.0   15090 ALL        Inline Route: /stats/prometheus*
+0.0.0.0   15091 Trans: tls Inline Route: /stats/prometheus*
+0.0.0.0   15092 Trans: tls Inline Route: /stats/prometheus*, /metrics*
+ENDSNIP
+
+snip_enable_on_a_gateway_3() {
+cat <<EOF > /tmp/gateway-api-secure-metrics-patch.yaml
+spec:
+  infrastructure:
+    annotations:
+      proxy.istio.io/config: |
+        proxyMetadata:
+          ENVOY_SECURE_METRICS_PORT: "15091"
+          ENVOY_SECURE_MERGED_METRICS_PORT: "15092"
+      prometheus.istio.io/secure-port: "15092"
+      prometheus.io/path: "/stats/prometheus"
+EOF
+kubectl patch gateway istio-ingressgateway -n istio-system --type=merge --patch-file=/tmp/gateway-api-secure-metrics-patch.yaml
+}
+
+snip_enable_on_a_gateway_4() {
+export GW_POD=$(kubectl get pod -n istio-system -l gateway.networking.k8s.io/gateway-name=istio-ingressgateway -o jsonpath='{.items[0].metadata.name}')
+istioctl proxy-config listeners $GW_POD -n istio-system | grep -E "15090|15091|15092"
+}
+
+! IFS=$'\n' read -r -d '' snip_enable_on_a_gateway_4_out <<\ENDSNIP
+0.0.0.0   15090 ALL        Inline Route: /stats/prometheus*
+0.0.0.0   15091 Trans: tls Inline Route: /stats/prometheus*
+0.0.0.0   15092 Trans: tls Inline Route: /stats/prometheus*, /metrics*
+ENDSNIP
+
+snip_fully_hardened_setup_1() {
+cat <<EOF > /tmp/httpbin-hardened-patch.yaml
+spec:
+  template:
+    metadata:
+      annotations:
+        proxy.istio.io/config: |
+          proxyMetadata:
+            ENVOY_SECURE_METRICS_PORT: "15091"
+            ENVOY_SECURE_MERGED_METRICS_PORT: "15092"
+            METRICS_LOCALHOST_ACCESS_ONLY: "true"
+        prometheus.io/path: "/stats/prometheus"
+EOF
+kubectl patch deployment httpbin -n default --type=merge --patch-file=/tmp/httpbin-hardened-patch.yaml
+}
+
+snip_fully_hardened_setup_2() {
+cat <<EOF > ./istio-secure-metrics.yaml
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  meshConfig:
+    defaultConfig:
+      proxyMetadata:
+        ENVOY_SECURE_METRICS_PORT: "15091"
+        ENVOY_SECURE_MERGED_METRICS_PORT: "15092"
+        METRICS_LOCALHOST_ACCESS_ONLY: "true"
+  components:
+    ingressGateways:
+    - name: istio-ingressgateway
+      enabled: true
+      k8s:
+        podAnnotations:
+          prometheus.istio.io/secure-port: "15092"
+          prometheus.io/path: "/stats/prometheus"
+EOF
+istioctl install -f ./istio-secure-metrics.yaml
+}
+
+snip_verify_secure_metrics_scraping_with_prometheus_1() {
+export PROM_POD=$(kubectl get pod -n istio-system -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
+export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
+kubectl exec -n istio-system $PROM_POD -c istio-proxy -- \
+    curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
+    --cacert /etc/istio-certs/root-cert.pem \
+    --cert /etc/istio-certs/cert-chain.pem \
+    --key /etc/istio-certs/key.pem \
+    --insecure \
+    https://$HTTPBIN_IP:15092/stats/prometheus
+}
+
+! IFS=$'\n' read -r -d '' snip_verify_secure_metrics_scraping_with_prometheus_1_out <<\ENDSNIP
+200
+ENDSNIP
+
+snip_verify_secure_metrics_scraping_with_prometheus_2() {
+export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].metadata.name}')
+export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
+kubectl exec -n default $HTTPBIN_POD -c istio-proxy -- curl -s --max-time 3 http://$HTTPBIN_IP:15091/stats/prometheus
+}
+
+! IFS=$'\n' read -r -d '' snip_verify_secure_metrics_scraping_with_prometheus_2_out <<\ENDSNIP
+upstream connect error or disconnect/reset before headers. reset reason: connection termination
+ENDSNIP
+
+snip_cleanup_1() {
+kubectl delete -n istio-system -f samples/addons/extras/prometheus-secure-metrics.yaml
+kubectl delete -f samples/httpbin/httpbin.yaml
+kubectl label namespace default istio-injection-
+}
+
+snip_cleanup_2() {
+kubectl delete -n istio-system -f samples/addons/extras/prometheus-secure-metrics.yaml
+kubectl delete -f samples/httpbin/httpbin.yaml
+kubectl delete gateway istio-ingressgateway -n istio-system
+kubectl label namespace default istio-injection-
+}
+
+snip_legacy_secure_metrics_for_sidecars_1() {
+kubectl label namespace default istio-injection=enabled --overwrite
+kubectl apply -f samples/httpbin/httpbin.yaml
+}
+
+snip_legacy_secure_metrics_for_sidecars_2() {
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: Sidecar
+metadata:
+  name: secure-metrics
+  namespace: default
+spec:
+  ingress:
+  - port:
+      number: 15091
+      name: https-metrics
+      protocol: HTTP
+    defaultEndpoint: 127.0.0.1:15020 # Change to 15090 for Envoy-only metrics
+EOF
+}
+
+snip_legacy_secure_metrics_for_sidecars_3() {
+kubectl annotate pod -n default \
+  -l app=httpbin \
+  prometheus.io/scrape="true" \
+  prometheus.io/path="/stats/prometheus" \
+  prometheus.istio.io/secure-port="15091" \
+  --overwrite
+}
+
+snip_legacy_secure_metrics_for_gateways_1() {
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: metrics-gateway
+  namespace: istio-system
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 15091
+      name: https-metrics
+      protocol: HTTPS
+    tls:
+      mode: ISTIO_MUTUAL
+    hosts: ["*"]
+EOF
+}
+
+snip_legacy_secure_metrics_for_gateways_2() {
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: ServiceEntry
+metadata:
+  name: gateway-admin
+  namespace: istio-system
+spec:
+  hosts: [gateway-admin.local]
+  location: MESH_INTERNAL
+  ports:
+  - number: 15020  # Change to 15090 for Envoy-only metrics
+    name: http-metrics
+    protocol: HTTP
+  resolution: STATIC
+  endpoints:
+  - address: 127.0.0.1
+EOF
+}
+
+snip_legacy_secure_metrics_for_gateways_3() {
+cat <<EOF | kubectl apply -f -
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: gateway-metrics
+  namespace: istio-system
+spec:
+  hosts: ["*"]
+  gateways: [metrics-gateway]
+  http:
+  - match:
+    - uri:
+        prefix: /stats/prometheus
+    route:
+    - destination:
+        host: gateway-admin.local
+        port:
+          number: 15020  # Change to 15090 for Envoy-only metrics
+EOF
+}
+
+snip_legacy_secure_metrics_for_gateways_4() {
+kubectl annotate pod -n istio-system \
+  -l app=istio-ingressgateway \
+  prometheus.istio.io/secure-port=15091 \
+  --overwrite
+}
+
+snip_cleanup_1() {
+kubectl delete sidecar secure-metrics -n default
+kubectl delete gateway metrics-gateway -n istio-system
+kubectl delete serviceentry gateway-admin -n istio-system
+kubectl delete virtualservice gateway-metrics -n istio-system
+kubectl delete -n istio-system -f samples/addons/extras/prometheus-secure-metrics.yaml
+kubectl delete -f samples/httpbin/httpbin.yaml
+kubectl label namespace default istio-injection-
+}

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/snips.sh
@@ -36,35 +36,70 @@ ENDSNIP
 
 snip_enable_on_a_sidecar_workload_1() {
 kubectl label namespace default istio-injection=enabled --overwrite
-kubectl apply -f samples/httpbin/httpbin.yaml
-}
-
-snip_enable_on_a_sidecar_workload_2() {
-cat <<EOF > /tmp/httpbin-secure-metrics-patch.yaml
+kubectl apply -f - <<EOF
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: httpbin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+    service: httpbin
 spec:
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 8080
+  selector:
+    app: httpbin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
   template:
     metadata:
+      labels:
+        app: httpbin
+        version: v1
       annotations:
         proxy.istio.io/config: |
           proxyMetadata:
             ENVOY_SECURE_METRICS_PORT: "15091"
             ENVOY_SECURE_MERGED_METRICS_PORT: "15092"
         prometheus.io/path: "/stats/prometheus"
+    spec:
+      serviceAccountName: httpbin
+      containers:
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
+        imagePullPolicy: IfNotPresent
+        name: httpbin
+        ports:
+        - containerPort: 8080
 EOF
-kubectl patch deployment httpbin -n default --type=merge --patch-file=/tmp/httpbin-secure-metrics-patch.yaml
 }
 
-snip_enable_on_a_sidecar_workload_3() {
+snip_enable_on_a_sidecar_workload_2() {
 export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].metadata.name}')
 export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
 export PROM_POD=$(kubectl get pod -n istio-system -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
 }
 
-snip_enable_on_a_sidecar_workload_4() {
+snip_enable_on_a_sidecar_workload_3() {
 istioctl proxy-config listeners "$HTTPBIN_POD" -n default | grep -E "15090|15091|15092"
 }
 
-! IFS=$'\n' read -r -d '' snip_enable_on_a_sidecar_workload_4_out <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_enable_on_a_sidecar_workload_3_out <<\ENDSNIP
 0.0.0.0       15090 ALL                                                                                     Inline Route: /stats/prometheus*
 0.0.0.0       15091 Trans: tls                                                                              Inline Route: /stats/prometheus*
 0.0.0.0       15092 Trans: tls                                                                              Inline Route: /stats/prometheus*, /metrics*

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/snips.sh
@@ -61,7 +61,7 @@ export PROM_POD=$(kubectl get pod -n istio-system -l app.kubernetes.io/name=prom
 }
 
 snip_enable_on_a_sidecar_workload_4() {
-istioctl proxy-config listeners $HTTPBIN_POD -n default | grep -E "15090|15091|15092"
+istioctl proxy-config listeners "$HTTPBIN_POD" -n default | grep -E "15090|15091|15092"
 }
 
 ! IFS=$'\n' read -r -d '' snip_enable_on_a_sidecar_workload_4_out <<\ENDSNIP
@@ -93,7 +93,7 @@ kubectl rollout status deployment/istio-ingressgateway -n istio-system
 
 snip_enable_on_a_gateway_2() {
 export GW_POD=$(kubectl get pod -n istio-system -l app=istio-ingressgateway -o jsonpath='{.items[0].metadata.name}')
-istioctl proxy-config listeners $GW_POD -n istio-system | grep -E "15090|15091|15092"
+istioctl proxy-config listeners "$GW_POD" -n istio-system | grep -E "15090|15091|15092"
 }
 
 ! IFS=$'\n' read -r -d '' snip_enable_on_a_gateway_2_out <<\ENDSNIP
@@ -119,7 +119,7 @@ kubectl patch gateway istio-ingressgateway -n istio-system --type=merge --patch-
 
 snip_enable_on_a_gateway_4() {
 export GW_POD=$(kubectl get pod -n istio-system -l gateway.networking.k8s.io/gateway-name=istio-ingressgateway -o jsonpath='{.items[0].metadata.name}')
-istioctl proxy-config listeners $GW_POD -n istio-system | grep -E "15090|15091|15092"
+istioctl proxy-config listeners "$GW_POD" -n istio-system | grep -E "15090|15091|15092"
 }
 
 ! IFS=$'\n' read -r -d '' snip_enable_on_a_gateway_4_out <<\ENDSNIP
@@ -168,13 +168,13 @@ istioctl install -f ./istio-secure-metrics.yaml
 }
 
 snip_verify_secure_metrics_scraping_with_prometheus_1() {
-kubectl exec -n istio-system $PROM_POD -c istio-proxy -- \
+kubectl exec -n istio-system "$PROM_POD" -c istio-proxy -- \
     curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
     --cacert /etc/istio-certs/root-cert.pem \
     --cert /etc/istio-certs/cert-chain.pem \
     --key /etc/istio-certs/key.pem \
     --insecure \
-    https://$HTTPBIN_IP:15092/stats/prometheus
+    https://"$HTTPBIN_IP":15092/stats/prometheus
 }
 
 ! IFS=$'\n' read -r -d '' snip_verify_secure_metrics_scraping_with_prometheus_1_out <<\ENDSNIP
@@ -182,18 +182,12 @@ kubectl exec -n istio-system $PROM_POD -c istio-proxy -- \
 ENDSNIP
 
 snip_verify_secure_metrics_scraping_with_prometheus_2() {
-kubectl exec -n default $HTTPBIN_POD -c istio-proxy -- curl -s --max-time 3 http://$HTTPBIN_IP:15091/stats/prometheus
+kubectl exec -n default "$HTTPBIN_POD" -c istio-proxy -- curl -s --max-time 3 http://"$HTTPBIN_IP":15091/stats/prometheus
 }
 
 ! IFS=$'\n' read -r -d '' snip_verify_secure_metrics_scraping_with_prometheus_2_out <<\ENDSNIP
 upstream connect error or disconnect/reset before headers. reset reason: connection termination
 ENDSNIP
-
-snip_cleanup_1() {
-kubectl delete -n istio-system -f samples/addons/extras/prometheus-secure-metrics.yaml
-kubectl delete -f samples/httpbin/httpbin.yaml
-kubectl label namespace default istio-injection-
-}
 
 snip_cleanup_2() {
 kubectl delete -n istio-system -f samples/addons/extras/prometheus-secure-metrics.yaml

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/snips.sh
@@ -56,10 +56,15 @@ kubectl patch deployment httpbin -n default --type=merge --patch-file=/tmp/httpb
 
 snip_enable_on_a_sidecar_workload_3() {
 export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].metadata.name}')
+export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
+export PROM_POD=$(kubectl get pod -n istio-system -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
+}
+
+snip_enable_on_a_sidecar_workload_4() {
 istioctl proxy-config listeners $HTTPBIN_POD -n default | grep -E "15090|15091|15092"
 }
 
-! IFS=$'\n' read -r -d '' snip_enable_on_a_sidecar_workload_3_out <<\ENDSNIP
+! IFS=$'\n' read -r -d '' snip_enable_on_a_sidecar_workload_4_out <<\ENDSNIP
 0.0.0.0       15090 ALL                                                                                     Inline Route: /stats/prometheus*
 0.0.0.0       15091 Trans: tls                                                                              Inline Route: /stats/prometheus*
 0.0.0.0       15092 Trans: tls                                                                              Inline Route: /stats/prometheus*, /metrics*
@@ -163,8 +168,6 @@ istioctl install -f ./istio-secure-metrics.yaml
 }
 
 snip_verify_secure_metrics_scraping_with_prometheus_1() {
-export PROM_POD=$(kubectl get pod -n istio-system -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
-export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
 kubectl exec -n istio-system $PROM_POD -c istio-proxy -- \
     curl -s -o /dev/null -w "%{http_code}" --max-time 5 \
     --cacert /etc/istio-certs/root-cert.pem \
@@ -179,8 +182,6 @@ kubectl exec -n istio-system $PROM_POD -c istio-proxy -- \
 ENDSNIP
 
 snip_verify_secure_metrics_scraping_with_prometheus_2() {
-export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].metadata.name}')
-export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
 kubectl exec -n default $HTTPBIN_POD -c istio-proxy -- curl -s --max-time 3 http://$HTTPBIN_IP:15091/stats/prometheus
 }
 

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/snips.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/snips.sh
@@ -297,7 +297,7 @@ kubectl annotate pod -n istio-system \
   --overwrite
 }
 
-snip_cleanup_1() {
+snip_legacy_cleanup_1() {
 kubectl delete sidecar secure-metrics -n default
 kubectl delete gateway metrics-gateway -n istio-system
 kubectl delete serviceentry gateway-admin -n istio-system

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1090,SC2154,SC2155
+
+# Copyright Istio Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# @setup profile=default
+
+set -e
+set -u
+set -o pipefail
+
+# Deploy Prometheus with mTLS scraping pre-configured
+snip_configure_prometheus_for_mtls_scraping_1
+_wait_for_deployment istio-system prometheus
+
+# Verify Prometheus has sidecar injected (3/3 ready)
+_verify_like snip_configure_prometheus_for_mtls_scraping_2 "$snip_configure_prometheus_for_mtls_scraping_2_out"
+
+# Deploy httpbin
+kubectl label namespace default istio-injection=enabled --overwrite
+kubectl apply -f samples/httpbin/httpbin.yaml
+_wait_for_deployment default httpbin
+
+# Patch httpbin to enable the mTLS metrics listeners
+snip_enable_on_a_sidecar_workload_2
+_wait_for_deployment default httpbin
+
+# Set env vars used by subsequent snips
+export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].metadata.name}')
+export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
+export PROM_POD=$(kubectl get pod -n istio-system -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
+
+# Verify the mTLS listeners (15091, 15092) are active on the httpbin sidecar
+_verify_like snip_enable_on_a_sidecar_workload_3 "$snip_enable_on_a_sidecar_workload_3_out"
+
+# Verify mTLS scraping succeeds: Prometheus pod's sidecar curls httpbin with workload certs → HTTP 200
+_verify_same snip_verify_secure_metrics_scraping_with_prometheus_1 "$snip_verify_secure_metrics_scraping_with_prometheus_1_out"
+
+# Verify mTLS is enforced: plain HTTP to the secure port must be rejected
+_verify_contains snip_verify_secure_metrics_scraping_with_prometheus_2 "connection termination"
+
+# @cleanup
+snip_cleanup_1

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
@@ -28,22 +28,15 @@ _wait_for_deployment istio-system prometheus
 # Verify Prometheus has sidecar injected (3/3 ready)
 _verify_like snip_configure_prometheus_for_mtls_scraping_2 "$snip_configure_prometheus_for_mtls_scraping_2_out"
 
-# Deploy httpbin
-kubectl label namespace default istio-injection=enabled --overwrite
-kubectl apply -f samples/httpbin/httpbin.yaml
-_wait_for_deployment default httpbin
-
-# Patch httpbin to enable the mTLS metrics listeners
-snip_enable_on_a_sidecar_workload_2
+# Deploy httpbin with secure metrics ports enabled in one shot
+snip_enable_on_a_sidecar_workload_1
 _wait_for_deployment default httpbin
 
 # Set env vars used by all subsequent verify steps
-snip_enable_on_a_sidecar_workload_3
-# Override HTTPBIN_POD to ensure we have the new running pod, not a stale terminating one
-export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}')
+snip_enable_on_a_sidecar_workload_2
 
 # Verify the mTLS listeners (15091, 15092) are active on the httpbin sidecar
-_verify_like snip_enable_on_a_sidecar_workload_4 "$snip_enable_on_a_sidecar_workload_4_out"
+_verify_like snip_enable_on_a_sidecar_workload_3 "$snip_enable_on_a_sidecar_workload_3_out"
 
 # Verify mTLS scraping succeeds: Prometheus pod's sidecar curls httpbin with workload certs -> HTTP 200
 _verify_same snip_verify_secure_metrics_scraping_with_prometheus_1 "$snip_verify_secure_metrics_scraping_with_prometheus_1_out"
@@ -53,5 +46,5 @@ _verify_contains snip_verify_secure_metrics_scraping_with_prometheus_2 "connecti
 
 # @cleanup
 kubectl delete -n istio-system -f samples/addons/extras/prometheus-secure-metrics.yaml
-kubectl delete -f samples/httpbin/httpbin.yaml
+kubectl delete deployment,service,serviceaccount httpbin -n default
 kubectl label namespace default istio-injection-

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
@@ -50,4 +50,6 @@ _verify_same snip_verify_secure_metrics_scraping_with_prometheus_1 "$snip_verify
 _verify_contains snip_verify_secure_metrics_scraping_with_prometheus_2 "connection termination"
 
 # @cleanup
-snip_cleanup_1
+kubectl delete -n istio-system -f samples/addons/extras/prometheus-secure-metrics.yaml
+kubectl delete -f samples/httpbin/httpbin.yaml
+kubectl label namespace default istio-injection-

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
@@ -21,7 +21,7 @@ set -e
 set -u
 set -o pipefail
 
-# Deploy Prometheus with mTLS scraping pre-configured
+# Deploy Prometheus with mTLS scraping preconfigured
 snip_configure_prometheus_for_mtls_scraping_1
 _wait_for_deployment istio-system prometheus
 

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
@@ -37,15 +37,13 @@ _wait_for_deployment default httpbin
 snip_enable_on_a_sidecar_workload_2
 _wait_for_deployment default httpbin
 
-# Set env vars used by subsequent snips
-export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].metadata.name}')
-export HTTPBIN_IP=$(kubectl get pod -n default -l app=httpbin -o jsonpath='{.items[0].status.podIP}')
-export PROM_POD=$(kubectl get pod -n istio-system -l app.kubernetes.io/name=prometheus -o jsonpath='{.items[0].metadata.name}')
+# Set env vars used by all subsequent verify steps
+snip_enable_on_a_sidecar_workload_3
 
 # Verify the mTLS listeners (15091, 15092) are active on the httpbin sidecar
-_verify_like snip_enable_on_a_sidecar_workload_3 "$snip_enable_on_a_sidecar_workload_3_out"
+_verify_like snip_enable_on_a_sidecar_workload_4 "$snip_enable_on_a_sidecar_workload_4_out"
 
-# Verify mTLS scraping succeeds: Prometheus pod's sidecar curls httpbin with workload certs → HTTP 200
+# Verify mTLS scraping succeeds: Prometheus pod's sidecar curls httpbin with workload certs -> HTTP 200
 _verify_same snip_verify_secure_metrics_scraping_with_prometheus_1 "$snip_verify_secure_metrics_scraping_with_prometheus_1_out"
 
 # Verify mTLS is enforced: plain HTTP to the secure port must be rejected

--- a/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
+++ b/content/en/docs/tasks/observability/metrics/secure-metrics/test.sh
@@ -39,6 +39,8 @@ _wait_for_deployment default httpbin
 
 # Set env vars used by all subsequent verify steps
 snip_enable_on_a_sidecar_workload_3
+# Override HTTPBIN_POD to ensure we have the new running pod, not a stale terminating one
+export HTTPBIN_POD=$(kubectl get pod -n default -l app=httpbin --field-selector=status.phase=Running -o jsonpath='{.items[0].metadata.name}')
 
 # Verify the mTLS listeners (15091, 15092) are active on the httpbin sidecar
 _verify_like snip_enable_on_a_sidecar_workload_4 "$snip_enable_on_a_sidecar_workload_4_out"


### PR DESCRIPTION
Rewrites the secure-metrics task to use the new standalone samples/addons/extras/prometheus-secure-metrics.yaml from istio/istio#<PR>, instead of patching the base addon. Adds test: yes with a test.sh that verifies mTLS scraping succeeds and plain HTTP is rejected.

Requires: https://github.com/istio/istio/pull/60602

<!-- Please replace this line with a description of the PR. -->

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
