### PR TITLE
Add docusign to tagline in traffic extension blog

### DIFF
--- a/content/en/blog/2026/traffic-extension-api/index.md
+++ b/content/en/blog/2026/traffic-extension-api/index.md
@@ -2,7 +2,7 @@
 title: "Introducing the TrafficExtension API"
 description: A new unified API for extending Envoy proxies in Istio with WebAssembly and Lua, supporting both sidecar and ambient mode.
 publishdate: 2026-05-18
-attribution: "Liam White"
+attribution: "Liam White - Docusign"
 keywords: [istio, wasm, lua, extensibility, ambient, traffic extension]
 target_release: "1.30"
 ---


### PR DESCRIPTION
## Description

Adding Docusign to tagline in traffic extension blog as I now have legal sign off to do so.

## Reviewers

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation