### PR TITLE
docs: replace PodSecurityPolicy with Pod Security Standards for istio-cni

### DIFF
--- a/content/en/docs/ops/common-problems/observability-issues/index.md
+++ b/content/en/docs/ops/common-problems/observability-issues/index.md
@@ -52,7 +52,7 @@ The Istio CNI plugin performs the Istio mesh pod traffic redirection in the Kube
 1. Verify that the `istio-cni-node` pods are running:
 
     {{< text bash >}}
-    $ kubectl -n kube-system get pod -l k8s-app=istio-cni-node
+    $ kubectl -n istio-system get pod -l k8s-app=istio-cni-node
     {{< /text >}}
 
-1. If `PodSecurityPolicy` is being enforced in your cluster, ensure the `istio-cni` service account can use a `PodSecurityPolicy` which [allows the `NET_ADMIN` and `NET_RAW` capabilities](/docs/ops/deployment/application-requirements/).
+1. If [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) is enforced in your cluster, ensure the namespace where `istio-cni-node` pods run (by default `istio-system`) uses the `privileged` [Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/#privileged) profile to allow the `NET_ADMIN` and `NET_RAW` capabilities.


### PR DESCRIPTION
## Description

<!-- Please replace this line with a description of the PR. -->

Replace the deprecated PodSecurityPolicy (PSP) references in the Istio CNI troubleshooting section with the current Pod Security Standards (PSS) approach. PSP was removed in Kubernetes 1.25.

### Changes:
- Update kubectl command namespace from kube-system to istio-system (default CNI install namespace in current Istio)
- Replace PSP guidance with Pod Security Admission: the namespace where istio-cni-node runs must use the privileged PSS profile, since baseline does not allow NET_ADMIN, NET_RAW, or hostPath volumes


## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [x] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
