### PR TITLE
Announcing Istio 1.28.10

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1205,6 +1205,7 @@ rearchitect
 rebalance
 rebalances
 recomposition
+recomputations
 redeployments
 RedHat
 Redis

--- a/content/en/news/releases/1.28.x/announcing-1.28.10/index.md
+++ b/content/en/news/releases/1.28.x/announcing-1.28.10/index.md
@@ -1,0 +1,21 @@
+---
+title: Announcing Istio 1.28.10
+linktitle: 1.28.10
+subtitle: Patch Release
+description: Istio 1.28.10 patch release.
+publishdate: 2026-06-30
+release: 1.28.10
+aliases:
+    - /news/announcing-1.28.10
+---
+
+This release contains bug fixes to improve robustness. This release note describes what’s different between Istio 1.28.9 and 1.28.10.
+
+{{< relnote >}}
+
+## Changes
+
+- **Fixed** a memory leak in the `krt` controller framework where changing the key used in a `Fetch` filter
+  (for example, relabeling a pod to point to a different waypoint) left stale reverse-index entries that were 
+  never cleaned up. Over time this could grow memory usage and cause unnecessary recomputations.
+

--- a/content/en/news/releases/1.28.x/announcing-1.28.10/index.md
+++ b/content/en/news/releases/1.28.x/announcing-1.28.10/index.md
@@ -3,7 +3,7 @@ title: Announcing Istio 1.28.10
 linktitle: 1.28.10
 subtitle: Patch Release
 description: Istio 1.28.10 patch release.
-publishdate: 2026-06-30
+publishdate: 2026-07-01
 release: 1.28.10
 aliases:
     - /news/announcing-1.28.10
@@ -16,6 +16,5 @@ This release contains bug fixes to improve robustness. This release note describ
 ## Changes
 
 - **Fixed** a memory leak in the `krt` controller framework where changing the key used in a `Fetch` filter
-  (for example, relabeling a pod to point to a different waypoint) left stale reverse-index entries that were 
+  (for example, relabeling a pod to point to a different waypoint) left stale reverse-index entries that were
   never cleaned up. Over time this could grow memory usage and cause unnecessary recomputations.
-


### PR DESCRIPTION
Manual cherry-pick of #17464 (announcing 1.28.10) onto master, since the automated cherry-pick PR was failing lint.

First commit is the original release note, picked from Gustavo with authorship retained. Second commit carries the lint fixes: add "recomputations" to `.spelling`, remove trailing whitespace and a trailing blank line, and set `publishdate` to 2026-07-01.