### PR TITLE
Fix markdown style issues in English content

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1587,7 +1587,6 @@ whitelists
 whitespace
 Wikipedia
 wikipedia.org
-www.wikipedia.org
 wildcard
 wildcarded
 wildcards
@@ -1599,6 +1598,7 @@ workload
 WorkloadEntry
 workstream
 www.google.com
+www.wikipedia.org
 x-envoy-upstream-rq-timeout-ms
 X.509
 X.509.

--- a/.spelling
+++ b/.spelling
@@ -1587,6 +1587,7 @@ whitelists
 whitespace
 Wikipedia
 wikipedia.org
+www.wikipedia.org
 wildcard
 wildcarded
 wildcards

--- a/content/en/blog/2019/announcing-discuss.istio.io/index.md
+++ b/content/en/blog/2019/announcing-discuss.istio.io/index.md
@@ -12,7 +12,7 @@ to get help from other users, and to engage with developers working on the proje
 
 We’ve tried several different avenues, but each has had some downsides. RocketChat was our most recent endeavor, but the lack of certain
 features (for example, threading) meant it wasn’t ideal for any longer discussions around a single issue. It also led to a dilemma for
-some users -- when should I email istio-users@googlegroups.com and when should I use RocketChat?
+some users -- when should I email <istio-users@googlegroups.com> and when should I use RocketChat?
 
 We think we’ve found the right balance of features in a single platform, and we’re happy to announce
 [discuss.istio.io](https://discuss.istio.io). It’s a full-featured forum where we will have discussions about Istio from here on out.

--- a/content/en/blog/2019/data-plane-setup/index.md
+++ b/content/en/blog/2019/data-plane-setup/index.md
@@ -114,20 +114,20 @@ To use modified configmaps or local configmaps:
 - Create `inject-config.yaml` and `mesh-config.yaml` from the configmaps
 
     {{< text bash >}}
-$ kubectl -n istio-system get configmap istio-sidecar-injector -o=jsonpath='{.data.config}' > inject-config.yaml
-$ kubectl -n istio-system get configmap istio -o=jsonpath='{.data.mesh}' > mesh-config.yaml
+    $ kubectl -n istio-system get configmap istio-sidecar-injector -o=jsonpath='{.data.config}' > inject-config.yaml
+    $ kubectl -n istio-system get configmap istio -o=jsonpath='{.data.mesh}' > mesh-config.yaml
     {{< /text >}}
 
 - Modify the existing pod template, in my case, `demo-red.yaml`:
 
     {{< text bash >}}
-$ istioctl kube-inject --injectConfigFile inject-config.yaml --meshConfigFile mesh-config.yaml --filename demo-red.yaml --output demo-red-injected.yaml
+    $ istioctl kube-inject --injectConfigFile inject-config.yaml --meshConfigFile mesh-config.yaml --filename demo-red.yaml --output demo-red-injected.yaml
     {{< /text >}}
 
 - Apply the `demo-red-injected.yaml`
 
     {{< text bash >}}
-$ kubectl apply -f demo-red-injected.yaml
+    $ kubectl apply -f demo-red-injected.yaml
     {{< /text >}}
 
 As seen above, we create a new template using the `sidecar-injector` and the mesh configuration to then apply that new template using `kubectl`. If we look at the injected YAML file, it has the configuration of the Istio-specific containers, as we discussed above. Once we apply the injected YAML file, we see two containers running. One of them is the actual application container, and the other is the `istio-proxy` sidecar.

--- a/content/en/blog/2021/external-locality-failover/index.md
+++ b/content/en/blog/2021/external-locality-failover/index.md
@@ -12,8 +12,8 @@ Similar to services running inside the service mesh, you can configure Istio to 
 
 |Routing|Endpoint|
 |--- |--- |
-|Primary|http://dynamodb.us-east-1.amazonaws.com|
-|Failover|http://dynamodb.us-west-1.amazonaws.com|
+|Primary|<http://dynamodb.us-east-1.amazonaws.com>|
+|Failover|<http://dynamodb.us-west-1.amazonaws.com>|
 
 ![failover](./external-locality-failover.png)
 

--- a/content/en/blog/2021/simple-vms/index.md
+++ b/content/en/blog/2021/simple-vms/index.md
@@ -81,7 +81,7 @@ Maybe installing envoy on every virtual machine is still too complex. An alterna
 
 ## Part 2…
 
-In part 2, I will explain how to configure Istio as well as a virtual machine to communicate within the mesh. If you would like a preview, feel free to reach out to nick.nellis@solo.io
+In part 2, I will explain how to configure Istio as well as a virtual machine to communicate within the mesh. If you would like a preview, feel free to reach out to <nick.nellis@solo.io>
 
 ### Special Thanks
 

--- a/content/en/blog/2023/istioday-kubecon-na-cfp/index.md
+++ b/content/en/blog/2023/istioday-kubecon-na-cfp/index.md
@@ -49,7 +49,7 @@ Accepted speakers will receive a complimentary All-Access In-Person ticket for *
 
 ## Sponsor the event
 
-Do you want to put your product or service in front of the most discerning Cloud Native users: those who demand _25% more conference_ than the crowd? Check out [page 19 of the CNCF events prospectus](https://events.linuxfoundation.org/wp-content/uploads/2023/06/sponsor-cncf-2023-061523.pdf) to learn more. Contact sponsor@cncf.io to secure your sponsorship today! Signed contracts must be received by September 20.
+Do you want to put your product or service in front of the most discerning Cloud Native users: those who demand _25% more conference_ than the crowd? Check out [page 19 of the CNCF events prospectus](https://events.linuxfoundation.org/wp-content/uploads/2023/06/sponsor-cncf-2023-061523.pdf) to learn more. Contact <sponsor@cncf.io> to secure your sponsorship today! Signed contracts must be received by September 20.
 
 ## Register to attend
 

--- a/content/en/blog/2024/inpod-traffic-redirection-ambient/index.md
+++ b/content/en/blog/2024/inpod-traffic-redirection-ambient/index.md
@@ -160,17 +160,17 @@ every popular CNI?
 
 In the new ambient model, this is how application pod is added to the ambient mesh:
 - The `istio-cni` node agent detects a Kubernetes pod (existing or newly-started) with its namespace labeled with `istio.io/dataplane-mode=ambient`, indicating that it should be included in the ambient mesh.
-  - If a *new* pod is started that should be added to the ambient mesh, a CNI plugin (as installed and managed by the `istio-cni` agent) is triggered by the CRI.
+    - If a *new* pod is started that should be added to the ambient mesh, a CNI plugin (as installed and managed by the `istio-cni` agent) is triggered by the CRI.
   This plugin is used to push a new pod event to the node’s `istio-cni` agent, and block pod startup until the agent successfully configures
   redirection. Since CNI plugins are invoked by the CRI as early as possible in the Kubernetes pod creation process, this ensures that we can
   establish traffic redirection early enough to prevent traffic escaping during startup, without relying on things like init containers.
-  - If an *already-running* pod becomes added to the ambient mesh, a new pod event is triggered. The `istio-cni` node agent’s Kubernetes
+    - If an *already-running* pod becomes added to the ambient mesh, a new pod event is triggered. The `istio-cni` node agent’s Kubernetes
   API watcher detects this, and redirection is configured in the same manner.
 - The `istio-cni` node agent enters the pod’s network namespace and establishes network redirection rules inside the pod network namespace, such that packets entering and leaving the pod are intercepted and transparently redirected to the node-local ztunnel proxy instance listening on [well-known ports](https://github.com/istio/ztunnel/blob/master/ARCHITECTURE.md#ports) (15008, 15006, 15001).
 - The `istio-cni` node agent then informs the node ztunnel over a Unix domain socket that it should establish local proxy
 listening ports inside the pod’s network namespace, (on 15008, 15006, and 15001), and provides ztunnel with a low-level
 Linux [file descriptor](https://en.wikipedia.org/wiki/File_descriptor) representing the pod’s network namespace.
-  - While typically sockets are created within a Linux network namespace by the process actually running inside that
+    - While typically sockets are created within a Linux network namespace by the process actually running inside that
 network namespace, it is perfectly possible to leverage Linux’s low-level socket API to allow a process running in one
 network namespace to create listening sockets in another network namespace, assuming the target network namespace is known
 at creation time.

--- a/content/en/blog/2025/ambient-performance/index.md
+++ b/content/en/blog/2025/ambient-performance/index.md
@@ -43,9 +43,9 @@ Implementations under test:
 * Istio: version 1.26 (prerelease), default settings
 * <a href="https://linkerd.io/">Linkerd</a>: version `edge-25.2.2`, default settings
 * <a href="https://cilium.io/">Cilium</a>: version `v1.16.6` with `kubeProxyReplacement=true`
-  * WireGuard uses `encryption.type=wireguard`
-  * IPsec uses `encryption.type=ipsec` with the `GCM-128-AES` algorithm
-  * Additionally, both modes were tested with all of the recommendations in <a href="https://docs.cilium.io/en/stable/operations/performance/tuning/">Cilium's tuning guide</a> (including `netkit`, `native` routing mode, BIGTCP (for WireGuard; IPsec is incompatible), BPF masquerade, and BBR bandwidth manager). However, the results were the same with and without these settings applied, so only one result is reported.
+    * WireGuard uses `encryption.type=wireguard`
+    * IPsec uses `encryption.type=ipsec` with the `GCM-128-AES` algorithm
+    * Additionally, both modes were tested with all of the recommendations in <a href="https://docs.cilium.io/en/stable/operations/performance/tuning/">Cilium's tuning guide</a> (including `netkit`, `native` routing mode, BIGTCP (for WireGuard; IPsec is incompatible), BPF masquerade, and BBR bandwidth manager). However, the results were the same with and without these settings applied, so only one result is reported.
 * <a href="https://www.tigera.io/project-calico/">Calico</a>: version `v3.29.2` with `calicoNetwork.linuxDataplane=BPF` and `wireguardEnabled=true`
 * <a href="https://kindnet.es/">Kindnet</a>: version `v1.8.5` with `--ipsec-overlay=true`.
 

--- a/content/en/blog/2025/ambient-performance/index.md
+++ b/content/en/blog/2025/ambient-performance/index.md
@@ -40,14 +40,14 @@ Over the last 4 releases, the performance of Ztunnel has improved by 75%!
 <summary>Testing Details</summary>
 
 Implementations under test:
-* Istio: version 1.26 (prerelease), default settings
-* <a href="https://linkerd.io/">Linkerd</a>: version `edge-25.2.2`, default settings
-* <a href="https://cilium.io/">Cilium</a>: version `v1.16.6` with `kubeProxyReplacement=true`
-    * WireGuard uses `encryption.type=wireguard`
-    * IPsec uses `encryption.type=ipsec` with the `GCM-128-AES` algorithm
-    * Additionally, both modes were tested with all of the recommendations in <a href="https://docs.cilium.io/en/stable/operations/performance/tuning/">Cilium's tuning guide</a> (including `netkit`, `native` routing mode, BIGTCP (for WireGuard; IPsec is incompatible), BPF masquerade, and BBR bandwidth manager). However, the results were the same with and without these settings applied, so only one result is reported.
-* <a href="https://www.tigera.io/project-calico/">Calico</a>: version `v3.29.2` with `calicoNetwork.linuxDataplane=BPF` and `wireguardEnabled=true`
-* <a href="https://kindnet.es/">Kindnet</a>: version `v1.8.5` with `--ipsec-overlay=true`.
+- Istio: version 1.26 (prerelease), default settings
+- <a href="https://linkerd.io/">Linkerd</a>: version `edge-25.2.2`, default settings
+- <a href="https://cilium.io/">Cilium</a>: version `v1.16.6` with `kubeProxyReplacement=true`
+    - WireGuard uses `encryption.type=wireguard`
+    - IPsec uses `encryption.type=ipsec` with the `GCM-128-AES` algorithm
+    - Additionally, both modes were tested with all of the recommendations in <a href="https://docs.cilium.io/en/stable/operations/performance/tuning/">Cilium's tuning guide</a> (including `netkit`, `native` routing mode, BIGTCP (for WireGuard; IPsec is incompatible), BPF masquerade, and BBR bandwidth manager). However, the results were the same with and without these settings applied, so only one result is reported.
+- <a href="https://www.tigera.io/project-calico/">Calico</a>: version `v3.29.2` with `calicoNetwork.linuxDataplane=BPF` and `wireguardEnabled=true`
+- <a href="https://kindnet.es/">Kindnet</a>: version `v1.8.5` with `--ipsec-overlay=true`.
 
 Some implementations only encrypt traffic cross-node, so are excluded from the same-node tests.
 
@@ -73,15 +73,15 @@ In contrast, user-space implementations are able to rapidly change and adapt to 
 Ztunnel is a great example of this effect in action, with substantial performance improvements coming in each quarterly release.
 A few of the most impactful changes:
 
-* Migrating to `rustls`, a high performance TLS library focusing on safety ([#820](https://github.com/istio/ztunnel/pull/820)).
-* Reducing data copying on outbound traffic ([#1012](https://github.com/istio/ztunnel/pull/1012)).
-* Dynamically tuning buffer sizes of active connections ([#1024](https://github.com/istio/ztunnel/pull/1024)).
-* Optimizing memory copies ([#1169](https://github.com/istio/ztunnel/pull/1169)).
-* Moving the cryptography library to `AWS-LC`, a high-performance cryptography library optimized for modern hardware ([#1466](https://github.com/istio/ztunnel/pull/1466)).
+- Migrating to `rustls`, a high performance TLS library focusing on safety ([#820](https://github.com/istio/ztunnel/pull/820)).
+- Reducing data copying on outbound traffic ([#1012](https://github.com/istio/ztunnel/pull/1012)).
+- Dynamically tuning buffer sizes of active connections ([#1024](https://github.com/istio/ztunnel/pull/1024)).
+- Optimizing memory copies ([#1169](https://github.com/istio/ztunnel/pull/1169)).
+- Moving the cryptography library to `AWS-LC`, a high-performance cryptography library optimized for modern hardware ([#1466](https://github.com/istio/ztunnel/pull/1466)).
 
 Some other factors include:
-* WireGuard and Linkerd use the `ChaCha20-Poly1305` encryption algorithm, while Istio uses `AES-GCM`. The latter is highly optimized on modern hardware.
-* WireGuard and IPsec operate on individual packets (typically at most 1500 bytes, bound by the network MTU) while TLS operates on records of up to 16KB.
+- WireGuard and Linkerd use the `ChaCha20-Poly1305` encryption algorithm, while Istio uses `AES-GCM`. The latter is highly optimized on modern hardware.
+- WireGuard and IPsec operate on individual packets (typically at most 1500 bytes, bound by the network MTU) while TLS operates on records of up to 16KB.
 
 ## Try ambient mode today
 

--- a/content/en/blog/2025/sail-operator-ga/index.md
+++ b/content/en/blog/2025/sail-operator-ga/index.md
@@ -15,11 +15,11 @@ The Sail Operator is engineered to cut down the complexity of installing and run
 We encourage users to go through our [documentation](https://github.com/istio-ecosystem/sail-operator/tree/main/docs) to learn more about this new way to manage your Istio environment.
 
 The main resources that are part of the Sail Operator are:
-* `Istio`: manages an Istio control plane.
-* `IstioRevision`: represents a revision of the control plane.
-* `IstioRevisionTag`: represents a stable revision tag, which functions as an alias for an Istio control plane revision.
-* `IstioCNI`: manages Istio's CNI node agent.
-* `ZTunnel`: manage the ambient mode ztunnel DaemonSet (Alpha feature).
+- `Istio`: manages an Istio control plane.
+- `IstioRevision`: represents a revision of the control plane.
+- `IstioRevisionTag`: represents a stable revision tag, which functions as an alias for an Istio control plane revision.
+- `IstioCNI`: manages Istio's CNI node agent.
+- `ZTunnel`: manage the ambient mode ztunnel DaemonSet (Alpha feature).
 
 {{< idea >}}
 If you are migrating from the [since-removed Istio in-cluster operator](/blog/2024/in-cluster-operator-deprecation-announcement/), you can check this section in our [documentation](https://github.com/istio-ecosystem/sail-operator/tree/main/docs#migrating-from-istio-in-cluster-operator) where we explain the equivalence of resources, or you can also try our [resource converter](https://github.com/istio-ecosystem/sail-operator/tree/main/docs#converter-script) to easily convert your `IstioOperator` resource to an `Istio` resource.
@@ -27,12 +27,12 @@ If you are migrating from the [since-removed Istio in-cluster operator](/blog/20
 
 ## Main features and support
 
-* Each component of the Istio control plane is managed independently by the Sail Operator through dedicated Kubernetes Custom Resources (CRs). The Sail Operator provides separate CRDs for components such as `Istio`, `IstioCNI`, and `ZTunnel`, allowing you to configure, manage, and upgrade them individually. Additionally, there are CRDs for `IstioRevision` and `IstioRevisionTag` to manage Istio control plane revisions.
-* Support for multiple Istio versions. Currently the 1.0.0 version supports: 1.24.3, 1.24.2, 1.24.1, 1.23.5, 1.23.4, 1.23.3, 1.23.0.
-* Two update strategies are supported: `InPlace` and `RevisionBased`. Check our documentation for more information about the update types supported.
-* Support for multicluster Istio [deployment models](/docs/setup/install/multicluster/): multi-primary, primary-remote, external control plane. More information and examples in our [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/README.md#multi-cluster).
-* Ambient mode support is Alpha: check our specific [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/common/istio-ambient-mode.md).
-* Addons are managed separately from the Sail Operator. They can be easily integrated with the Sail Operator, check this section for the [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/README.md#addons) for examples and more information.
+- Each component of the Istio control plane is managed independently by the Sail Operator through dedicated Kubernetes Custom Resources (CRs). The Sail Operator provides separate CRDs for components such as `Istio`, `IstioCNI`, and `ZTunnel`, allowing you to configure, manage, and upgrade them individually. Additionally, there are CRDs for `IstioRevision` and `IstioRevisionTag` to manage Istio control plane revisions.
+- Support for multiple Istio versions. Currently the 1.0.0 version supports: 1.24.3, 1.24.2, 1.24.1, 1.23.5, 1.23.4, 1.23.3, 1.23.0.
+- Two update strategies are supported: `InPlace` and `RevisionBased`. Check our documentation for more information about the update types supported.
+- Support for multicluster Istio [deployment models](/docs/setup/install/multicluster/): multi-primary, primary-remote, external control plane. More information and examples in our [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/README.md#multi-cluster).
+- Ambient mode support is Alpha: check our specific [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/common/istio-ambient-mode.md).
+- Addons are managed separately from the Sail Operator. They can be easily integrated with the Sail Operator, check this section for the [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/README.md#addons) for examples and more information.
 
 ## Why now?
 
@@ -44,10 +44,10 @@ Would you like to try out Sail Operator?
 This example will show you how to safely do an update of your Istio control plane by using the revision-based upgrade strategy. This means you will have two Istio control planes running at the same time, allowing you to migrate workloads easily, minimizing the risk of traffic disruptions.
 
 Prerequisites:
-* Running cluster
-* Helm
-* Kubectl
-* Istioctl
+- Running cluster
+- Helm
+- Kubectl
+- Istioctl
 
 ### Install the Sail Operator using Helm
 
@@ -109,7 +109,7 @@ EOF
 Note that the `IstioRevisionTag` has a target reference to the `Istio` resource with the name `default`
 
 Check the state of the resources created:
-* `istiod` pods are running
+- `istiod` pods are running
 
     {{< text bash >}}
     $ kubectl get pods -n istio-system
@@ -117,7 +117,7 @@ Check the state of the resources created:
     istiod-default-v1-24-2-bd8458c4-jl8zm   1/1     Running   0          3m45s
     {{< /text >}}
 
-* `Istio` resource created
+- `Istio` resource created
 
     {{< text bash >}}
     $ kubectl get istio
@@ -125,7 +125,7 @@ Check the state of the resources created:
     default   1           1       1        default-v1-24-2   Healthy   v1.24.2   4m27s
     {{< /text >}}
 
-* `IstioRevisionTag` resource created
+- `IstioRevisionTag` resource created
 
     {{< text bash >}}
     $ kubectl get istiorevisiontag
@@ -200,9 +200,9 @@ default-v1-24-3          True    Healthy   True     v1.24.3   92s
 {{< /text >}}
 
 The Sail Operator automatically detects whether a given Istio control plane is being used and writes this information in the "In Use" status condition that you see above. Right now, all `IstioRevisions` and our `IstioRevisionTag` are considered "In Use":
-* The old revision `default-v1-24-2` is considered in use because it is referenced by the sample application’s sidecar.
-* The new revision `default-v1-24-3` is considered in use because it is referenced by the tag.
-* The tag is considered in use because it is referenced by the sample namespace.
+- The old revision `default-v1-24-2` is considered in use because it is referenced by the sample application’s sidecar.
+- The new revision `default-v1-24-3` is considered in use because it is referenced by the tag.
+- The tag is considered in use because it is referenced by the sample namespace.
 
 Confirm there are two control plane pods running, one for each revision:
 
@@ -237,7 +237,7 @@ sleep-6f87fcf556-k9nh9.sample     Kubernetes     SYNCED (29s)     SYNCED (29s)  
 
 When an `IstioRevision` is no longer in use and is not the active revision of an `Istio` resource (for example, when it is not the version that is set in the `spec.version` field), the Sail Operator will delete it after a grace period, which defaults to 30 seconds. Confirm the deletion of the old control plane and `IstioRevision`:
 
-* The old control plane pod is deleted
+- The old control plane pod is deleted
 
     {{< text bash >}}
     $ kubectl get pods -n istio-system
@@ -245,7 +245,7 @@ When an `IstioRevision` is no longer in use and is not the active revision of an
     istiod-default-v1-24-3-68df97dfbb-v7ndm   1/1     Running   0          10m
     {{< /text >}}
 
-* The old `IstioRevision` is deleted
+- The old `IstioRevision` is deleted
 
     {{< text bash >}}
     $ kubectl get istiorevision
@@ -253,7 +253,7 @@ When an `IstioRevision` is no longer in use and is not the active revision of an
     default-v1-24-3          True    Healthy   True     v1.24.3   13m
     {{< /text >}}
 
-* The `Istio` resource now only has one revision
+- The `Istio` resource now only has one revision
 
     {{< text bash >}}
     $ kubectl get istio

--- a/content/en/blog/2025/sail-operator-ga/index.md
+++ b/content/en/blog/2025/sail-operator-ga/index.md
@@ -27,12 +27,12 @@ If you are migrating from the [since-removed Istio in-cluster operator](/blog/20
 
 ## Main features and support
 
-- Each component of the Istio control plane is managed independently by the Sail Operator through dedicated Kubernetes Custom Resources (CRs). The Sail Operator provides separate CRDs for components such as `Istio`, `IstioCNI`, and `ZTunnel`, allowing you to configure, manage, and upgrade them individually. Additionally, there are CRDs for `IstioRevision` and `IstioRevisionTag` to manage Istio control plane revisions.
-- Support for multiple Istio versions. Currently the 1.0.0 version supports: 1.24.3, 1.24.2, 1.24.1, 1.23.5, 1.23.4, 1.23.3, 1.23.0.
-- Two update strategies are supported: `InPlace` and `RevisionBased`. Check our documentation for more information about the update types supported.
-- Support for multicluster Istio [deployment models](/docs/setup/install/multicluster/): multi-primary, primary-remote, external control plane. More information and examples in our [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/README.md#multi-cluster).
-- Ambient mode support is Alpha: check our specific [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/common/istio-ambient-mode.md).
-- Addons are managed separately from the Sail Operator. They can be easily integrated with the Sail Operator, check this section for the [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/README.md#addons) for examples and more information.
+* Each component of the Istio control plane is managed independently by the Sail Operator through dedicated Kubernetes Custom Resources (CRs). The Sail Operator provides separate CRDs for components such as `Istio`, `IstioCNI`, and `ZTunnel`, allowing you to configure, manage, and upgrade them individually. Additionally, there are CRDs for `IstioRevision` and `IstioRevisionTag` to manage Istio control plane revisions.
+* Support for multiple Istio versions. Currently the 1.0.0 version supports: 1.24.3, 1.24.2, 1.24.1, 1.23.5, 1.23.4, 1.23.3, 1.23.0.
+* Two update strategies are supported: `InPlace` and `RevisionBased`. Check our documentation for more information about the update types supported.
+* Support for multicluster Istio [deployment models](/docs/setup/install/multicluster/): multi-primary, primary-remote, external control plane. More information and examples in our [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/README.md#multi-cluster).
+* Ambient mode support is Alpha: check our specific [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/common/istio-ambient-mode.md).
+* Addons are managed separately from the Sail Operator. They can be easily integrated with the Sail Operator, check this section for the [documentation](https://github.com/istio-ecosystem/sail-operator/blob/main/docs/README.md#addons) for examples and more information.
 
 ## Why now?
 
@@ -44,10 +44,10 @@ Would you like to try out Sail Operator?
 This example will show you how to safely do an update of your Istio control plane by using the revision-based upgrade strategy. This means you will have two Istio control planes running at the same time, allowing you to migrate workloads easily, minimizing the risk of traffic disruptions.
 
 Prerequisites:
-- Running cluster
-- Helm
-- Kubectl
-- Istioctl
+* Running cluster
+* Helm
+* Kubectl
+* Istioctl
 
 ### Install the Sail Operator using Helm
 
@@ -109,7 +109,7 @@ EOF
 Note that the `IstioRevisionTag` has a target reference to the `Istio` resource with the name `default`
 
 Check the state of the resources created:
-- `istiod` pods are running
+* `istiod` pods are running
 
     {{< text bash >}}
     $ kubectl get pods -n istio-system
@@ -117,7 +117,7 @@ Check the state of the resources created:
     istiod-default-v1-24-2-bd8458c4-jl8zm   1/1     Running   0          3m45s
     {{< /text >}}
 
-- `Istio` resource created
+* `Istio` resource created
 
     {{< text bash >}}
     $ kubectl get istio
@@ -125,7 +125,7 @@ Check the state of the resources created:
     default   1           1       1        default-v1-24-2   Healthy   v1.24.2   4m27s
     {{< /text >}}
 
-- `IstioRevisionTag` resource created
+* `IstioRevisionTag` resource created
 
     {{< text bash >}}
     $ kubectl get istiorevisiontag
@@ -237,7 +237,7 @@ sleep-6f87fcf556-k9nh9.sample     Kubernetes     SYNCED (29s)     SYNCED (29s)  
 
 When an `IstioRevision` is no longer in use and is not the active revision of an `Istio` resource (for example, when it is not the version that is set in the `spec.version` field), the Sail Operator will delete it after a grace period, which defaults to 30 seconds. Confirm the deletion of the old control plane and `IstioRevision`:
 
-- The old control plane pod is deleted
+* The old control plane pod is deleted
 
     {{< text bash >}}
     $ kubectl get pods -n istio-system
@@ -245,7 +245,7 @@ When an `IstioRevision` is no longer in use and is not the active revision of an
     istiod-default-v1-24-3-68df97dfbb-v7ndm   1/1     Running   0          10m
     {{< /text >}}
 
-- The old `IstioRevision` is deleted
+* The old `IstioRevision` is deleted
 
     {{< text bash >}}
     $ kubectl get istiorevision
@@ -253,7 +253,7 @@ When an `IstioRevision` is no longer in use and is not the active revision of an
     default-v1-24-3          True    Healthy   True     v1.24.3   13m
     {{< /text >}}
 
-- The `Istio` resource now only has one revision
+* The `Istio` resource now only has one revision
 
     {{< text bash >}}
     $ kubectl get istio

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -32,12 +32,12 @@ Before you begin, please do the following:
    architecture, as well as its signature.
 1. Validate the `cosign` binary signature:
 
-   {{< text bash >}}
-   $ openssl dgst -sha256 \
-       -verify <(curl -ssL https://raw.githubusercontent.com/sigstore/cosign/main/release/release-cosign.pub) \
-       -signature <(cat /path/to/cosign.sig | base64 -d) \
-       /path/to/cosign-binary
-    {{< /text >}}
+    {{< text bash >}}
+    $ openssl dgst -sha256 \
+        -verify <(curl -ssL https://raw.githubusercontent.com/sigstore/cosign/main/release/release-cosign.pub) \
+        -signature <(cat /path/to/cosign.sig | base64 -d) \
+        /path/to/cosign-binary
+     {{< /text >}}
 
 1. Make the binary executable (`chmod +x`) and move to a location on the `PATH`
 

--- a/content/en/docs/ops/best-practices/image-signing-validation/index.md
+++ b/content/en/docs/ops/best-practices/image-signing-validation/index.md
@@ -33,10 +33,10 @@ Before you begin, please do the following:
 1. Validate the `cosign` binary signature:
 
    {{< text bash >}}
-$ openssl dgst -sha256 \
-    -verify <(curl -ssL https://raw.githubusercontent.com/sigstore/cosign/main/release/release-cosign.pub) \
-    -signature <(cat /path/to/cosign.sig | base64 -d) \
-    /path/to/cosign-binary
+   $ openssl dgst -sha256 \
+       -verify <(curl -ssL https://raw.githubusercontent.com/sigstore/cosign/main/release/release-cosign.pub) \
+       -signature <(cat /path/to/cosign.sig | base64 -d) \
+       /path/to/cosign-binary
     {{< /text >}}
 
 1. Make the binary executable (`chmod +x`) and move to a location on the `PATH`

--- a/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
+++ b/content/en/docs/tasks/observability/metrics/classify-metrics/index.md
@@ -44,43 +44,43 @@ You can classify requests based on their type, for example `ListReview`,
     service-specific.
 
     {{< text yaml >}}
-apiVersion: extensions.istio.io/v1alpha1
-kind: WasmPlugin
-metadata:
-  name: istio-attributegen-filter
-spec:
-  selector:
-    matchLabels:
-      app: reviews
-  url: https://storage.googleapis.com/istio-build/proxy/attributegen-359dcd3a19f109c50e97517fe6b1e2676e870c4d.wasm
-  imagePullPolicy: Always
-  phase: AUTHN
-  pluginConfig:
-    attributes:
-    - output_attribute: "istio_operationId"
-      match:
-        - value: "ListReviews"
-          condition: "request.url_path == '/reviews' && request.method == 'GET'"
-        - value: "GetReview"
-          condition: "request.url_path.matches('^/reviews/[[:alnum:]]*$') && request.method == 'GET'"
-        - value: "CreateReview"
-          condition: "request.url_path == '/reviews/' && request.method == 'POST'"
----
-apiVersion: telemetry.istio.io/v1
-kind: Telemetry
-metadata:
-  name: custom-tags
-spec:
-  metrics:
-    - overrides:
-        - match:
-            metric: REQUEST_COUNT
-            mode: CLIENT_AND_SERVER
-          tagOverrides:
-            request_operation:
-              value: filter_state['wasm.istio_operationId']
-      providers:
-        - name: prometheus
+    apiVersion: extensions.istio.io/v1alpha1
+    kind: WasmPlugin
+    metadata:
+      name: istio-attributegen-filter
+    spec:
+      selector:
+        matchLabels:
+          app: reviews
+      url: https://storage.googleapis.com/istio-build/proxy/attributegen-359dcd3a19f109c50e97517fe6b1e2676e870c4d.wasm
+      imagePullPolicy: Always
+      phase: AUTHN
+      pluginConfig:
+        attributes:
+        - output_attribute: "istio_operationId"
+          match:
+            - value: "ListReviews"
+              condition: "request.url_path == '/reviews' && request.method == 'GET'"
+            - value: "GetReview"
+              condition: "request.url_path.matches('^/reviews/[[:alnum:]]*$') && request.method == 'GET'"
+            - value: "CreateReview"
+              condition: "request.url_path == '/reviews/' && request.method == 'POST'"
+    ---
+    apiVersion: telemetry.istio.io/v1
+    kind: Telemetry
+    metadata:
+      name: custom-tags
+    spec:
+      metrics:
+        - overrides:
+            - match:
+                metric: REQUEST_COUNT
+                mode: CLIENT_AND_SERVER
+              tagOverrides:
+                request_operation:
+                  value: filter_state['wasm.istio_operationId']
+          providers:
+            - name: prometheus
     {{< /text >}}
 
 1. Apply your changes using the following command:
@@ -105,51 +105,51 @@ The example below will change how it is populated.
     codes in the `200` range as a `2xx` dimension.
 
     {{< text yaml >}}
-apiVersion: extensions.istio.io/v1alpha1
-kind: WasmPlugin
-metadata:
-  name: istio-attributegen-filter
-spec:
-  selector:
-    matchLabels:
-      app: productpage
-  url: https://storage.googleapis.com/istio-build/proxy/attributegen-359dcd3a19f109c50e97517fe6b1e2676e870c4d.wasm
-  imagePullPolicy: Always
-  phase: AUTHN
-  pluginConfig:
-    attributes:
-      - output_attribute: istio_responseClass
-        match:
-          - value: 2xx
-            condition: response.code >= 200 && response.code <= 299
-          - value: 3xx
-            condition: response.code >= 300 && response.code <= 399
-          - value: "404"
-            condition: response.code == 404
-          - value: "429"
-            condition: response.code == 429
-          - value: "503"
-            condition: response.code == 503
-          - value: 5xx
-            condition: response.code >= 500 && response.code <= 599
-          - value: 4xx
-            condition: response.code >= 400 && response.code <= 499
----
-apiVersion: telemetry.istio.io/v1
-kind: Telemetry
-metadata:
-  name: custom-tags
-spec:
-  metrics:
-    - overrides:
-        - match:
-            metric: REQUEST_COUNT
-            mode: CLIENT_AND_SERVER
-          tagOverrides:
-            response_code:
-              value: filter_state['wasm.istio_responseClass']
-      providers:
-        - name: prometheus
+    apiVersion: extensions.istio.io/v1alpha1
+    kind: WasmPlugin
+    metadata:
+      name: istio-attributegen-filter
+    spec:
+      selector:
+        matchLabels:
+          app: productpage
+      url: https://storage.googleapis.com/istio-build/proxy/attributegen-359dcd3a19f109c50e97517fe6b1e2676e870c4d.wasm
+      imagePullPolicy: Always
+      phase: AUTHN
+      pluginConfig:
+        attributes:
+          - output_attribute: istio_responseClass
+            match:
+              - value: 2xx
+                condition: response.code >= 200 && response.code <= 299
+              - value: 3xx
+                condition: response.code >= 300 && response.code <= 399
+              - value: "404"
+                condition: response.code == 404
+              - value: "429"
+                condition: response.code == 429
+              - value: "503"
+                condition: response.code == 503
+              - value: 5xx
+                condition: response.code >= 500 && response.code <= 599
+              - value: 4xx
+                condition: response.code >= 400 && response.code <= 499
+    ---
+    apiVersion: telemetry.istio.io/v1
+    kind: Telemetry
+    metadata:
+      name: custom-tags
+    spec:
+      metrics:
+        - overrides:
+            - match:
+                metric: REQUEST_COUNT
+                mode: CLIENT_AND_SERVER
+              tagOverrides:
+                response_code:
+                  value: filter_state['wasm.istio_responseClass']
+          providers:
+            - name: prometheus
     {{< /text >}}
 
 1. Apply your changes using the following command:

--- a/content/en/docs/tasks/traffic-management/circuit-breaking/index.md
+++ b/content/en/docs/tasks/traffic-management/circuit-breaking/index.md
@@ -87,7 +87,7 @@ Create a client to send traffic to the `httpbin` service. The client is
 a simple load-testing client called [fortio](https://github.com/istio/fortio).
 Fortio lets you control the number of connections, concurrency, and
 delays for outgoing HTTP calls. You will use this client to "trip" the circuit breaker
-policies you set in the `DestinationRule`. 
+policies you set in the `DestinationRule`.
 
 1. Inject the client with the Istio sidecar proxy so network interactions are
 governed by Istio.

--- a/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/wildcard-egress-hosts/index.md
@@ -291,7 +291,7 @@ EOF
 
 {{< /tabset >}}
 
-2)  Create a `ServiceEntry` for the destination server, _www.wikipedia.org_:
+2)  Create a `ServiceEntry` for the destination server, _[www.wikipedia.org](https://www.wikipedia.org)_:
 
     {{< text bash >}}
     $ kubectl apply -f - <<EOF

--- a/content/en/news/releases/1.1.x/announcing-1.1.13/index.md
+++ b/content/en/news/releases/1.1.x/announcing-1.1.13/index.md
@@ -22,13 +22,13 @@ This release contains fixes for the security vulnerabilities described in [ISTIO
 [ISTIO-SECURITY-2019-004](/news/security/istio-security-2019-004/). Specifically:
 
 __ISTIO-SECURITY-2019-003__: An Envoy user reported publicly an issue (c.f. [Envoy Issue 7728](https://github.com/envoyproxy/envoy/issues/7728)) about regular expressions matching that crashes Envoy with very large URIs.
-  * __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
+* __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
 
 __ISTIO-SECURITY-2019-004__: Envoy, and subsequently Istio are vulnerable to a series of trivial HTTP/2-based DoS attacks:
-  * __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
-  * __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
-  * __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
-  * __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using `SETTINGS` frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
-  * __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
+* __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+* __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
+* __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
+* __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using `SETTINGS` frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+* __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
 
 Nothing else is included in this release except for the above security fixes.

--- a/content/en/news/releases/1.1.x/announcing-1.1.13/index.md
+++ b/content/en/news/releases/1.1.x/announcing-1.1.13/index.md
@@ -22,13 +22,13 @@ This release contains fixes for the security vulnerabilities described in [ISTIO
 [ISTIO-SECURITY-2019-004](/news/security/istio-security-2019-004/). Specifically:
 
 __ISTIO-SECURITY-2019-003__: An Envoy user reported publicly an issue (c.f. [Envoy Issue 7728](https://github.com/envoyproxy/envoy/issues/7728)) about regular expressions matching that crashes Envoy with very large URIs.
-* __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
+- __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
 
 __ISTIO-SECURITY-2019-004__: Envoy, and subsequently Istio are vulnerable to a series of trivial HTTP/2-based DoS attacks:
-* __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
-* __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
-* __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
-* __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using `SETTINGS` frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
-* __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
+- __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+- __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
+- __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
+- __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using `SETTINGS` frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+- __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
 
 Nothing else is included in this release except for the above security fixes.

--- a/content/en/news/releases/1.1.x/announcing-1.1.16/index.md
+++ b/content/en/news/releases/1.1.x/announcing-1.1.16/index.md
@@ -19,6 +19,6 @@ We're pleased to announce the availability of Istio 1.1.16. Please see below for
 This release contains fixes for the security vulnerability described in [our October 8th, 2019 news post](/news/security/istio-security-2019-005).  Specifically:
 
 __ISTIO-SECURITY-2019-005__:  A DoS vulnerability has been discovered by the Envoy community.
-  * __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker uses a high quantity of very small headers.
+* __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker uses a high quantity of very small headers.
 
 Nothing else is included in this release except for the above security fix.

--- a/content/en/news/releases/1.1.x/announcing-1.1.16/index.md
+++ b/content/en/news/releases/1.1.x/announcing-1.1.16/index.md
@@ -19,6 +19,6 @@ We're pleased to announce the availability of Istio 1.1.16. Please see below for
 This release contains fixes for the security vulnerability described in [our October 8th, 2019 news post](/news/security/istio-security-2019-005).  Specifically:
 
 __ISTIO-SECURITY-2019-005__:  A DoS vulnerability has been discovered by the Envoy community.
-* __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker uses a high quantity of very small headers.
+- __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker uses a high quantity of very small headers.
 
 Nothing else is included in this release except for the above security fix.

--- a/content/en/news/releases/1.19.x/announcing-1.19.8/index.md
+++ b/content/en/news/releases/1.19.x/announcing-1.19.8/index.md
@@ -22,17 +22,17 @@ This release note describes what’s different between Istio 1.19.7 and 1.19.8.
   curves to `P-256`.
 
     These restrictions apply on the following data paths:
-    * mTLS communication between Envoy proxies;
-    * regular TLS on the downstream and the upstream of Envoy proxies (e.g. gateway);
-    * Google gRPC side requests from Envoy proxies (e.g. Stackdriver extensions);
-    * Istiod xDS server;
-    * Istiod injection and validation webhook servers.
+    - mTLS communication between Envoy proxies;
+    - regular TLS on the downstream and the upstream of Envoy proxies (e.g. gateway);
+    - Google gRPC side requests from Envoy proxies (e.g. Stackdriver extensions);
+    - Istiod xDS server;
+    - Istiod injection and validation webhook servers.
 
     The restrictions are not applied on the following data paths:
-    * Istiod to Kubernetes API server;
-    * JWK fetch from Istiod;
-    * Wasm image and URL fetch from Istio Proxy containers;
-    * ztunnel.
+    - Istiod to Kubernetes API server;
+    - JWK fetch from Istiod;
+    - Wasm image and URL fetch from Istio Proxy containers;
+    - ztunnel.
 
   Note that Istio injector will propagate the value of `COMPLIANCE_POLICY` to the
   injected proxy container, when set.

--- a/content/en/news/releases/1.2.x/announcing-1.2.4/index.md
+++ b/content/en/news/releases/1.2.x/announcing-1.2.4/index.md
@@ -22,13 +22,13 @@ This release contains fixes for the security vulnerabilities described in [ISTIO
 [ISTIO-SECURITY-2019-004](/news/security/istio-security-2019-004/).  Specifically:
 
 __ISTIO-SECURITY-2019-003__: An Envoy user reported publicly an issue (c.f. [Envoy Issue 7728](https://github.com/envoyproxy/envoy/issues/7728)) about regular expressions matching that crashes Envoy with very large URIs.
-  * __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
+* __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
 
 __ISTIO-SECURITY-2019-004__: Envoy, and subsequently Istio are vulnerable to a series of trivial HTTP/2-based DoS attacks:
-  * __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
-  * __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
-  * __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
-  * __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using `SETTINGS` frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
-  * __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
+* __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+* __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
+* __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
+* __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using `SETTINGS` frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+* __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
 
 Nothing else is included in this release except for the above security fixes.

--- a/content/en/news/releases/1.2.x/announcing-1.2.4/index.md
+++ b/content/en/news/releases/1.2.x/announcing-1.2.4/index.md
@@ -22,13 +22,13 @@ This release contains fixes for the security vulnerabilities described in [ISTIO
 [ISTIO-SECURITY-2019-004](/news/security/istio-security-2019-004/).  Specifically:
 
 __ISTIO-SECURITY-2019-003__: An Envoy user reported publicly an issue (c.f. [Envoy Issue 7728](https://github.com/envoyproxy/envoy/issues/7728)) about regular expressions matching that crashes Envoy with very large URIs.
-* __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
+- __[CVE-2019-14993](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-14993)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio, if users are employing regular expressions in some of the Istio APIs: `JWT`, `VirtualService`, `HTTPAPISpecBinding`, `QuotaSpecBinding`.
 
 __ISTIO-SECURITY-2019-004__: Envoy, and subsequently Istio are vulnerable to a series of trivial HTTP/2-based DoS attacks:
-* __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
-* __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
-* __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
-* __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using `SETTINGS` frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
-* __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
+- __[CVE-2019-9512](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9512)__: HTTP/2 flood using `PING` frames and queuing of response `PING` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+- __[CVE-2019-9513](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9513)__: HTTP/2 flood using PRIORITY frames that results in excessive CPU usage and starvation of other clients.
+- __[CVE-2019-9514](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9514)__: HTTP/2 flood using `HEADERS` frames with invalid HTTP headers and queuing of response `RST_STREAM` frames that results in unbounded memory growth (which can lead to out of memory conditions).
+- __[CVE-2019-9515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9515)__: HTTP/2 flood using `SETTINGS` frames and queuing of `SETTINGS` ACK frames that results in unbounded memory growth (which can lead to out of memory conditions).
+- __[CVE-2019-9518](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-9518)__: HTTP/2 flood using frames with an empty payload that results in excessive CPU usage and starvation of other clients.
 
 Nothing else is included in this release except for the above security fixes.

--- a/content/en/news/releases/1.2.x/announcing-1.2.7/index.md
+++ b/content/en/news/releases/1.2.x/announcing-1.2.7/index.md
@@ -19,8 +19,8 @@ We're pleased to announce the availability of Istio 1.2.7. Please see below for 
 This release contains fixes for the security vulnerability described in [our October 8th, 2019 news post](/news/security/istio-security-2019-005).  Specifically:
 
 __ISTIO-SECURITY-2019-005__:  A DoS vulnerability has been discovered by the Envoy community.
-* __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker uses a high quantity of very small headers.
+- __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker uses a high quantity of very small headers.
 
 ## Bug fix
 
-* Fix a bug where `nodeagent` was failing to start when using citadel ([Issue 15876](https://github.com/istio/istio/issues/17108))
+- Fix a bug where `nodeagent` was failing to start when using citadel ([Issue 15876](https://github.com/istio/istio/issues/17108))

--- a/content/en/news/releases/1.2.x/announcing-1.2.7/index.md
+++ b/content/en/news/releases/1.2.x/announcing-1.2.7/index.md
@@ -19,8 +19,8 @@ We're pleased to announce the availability of Istio 1.2.7. Please see below for 
 This release contains fixes for the security vulnerability described in [our October 8th, 2019 news post](/news/security/istio-security-2019-005).  Specifically:
 
 __ISTIO-SECURITY-2019-005__:  A DoS vulnerability has been discovered by the Envoy community.
-  * __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker uses a high quantity of very small headers.
+* __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker uses a high quantity of very small headers.
 
 ## Bug fix
 
-- Fix a bug where `nodeagent` was failing to start when using citadel ([Issue 15876](https://github.com/istio/istio/issues/17108))
+* Fix a bug where `nodeagent` was failing to start when using citadel ([Issue 15876](https://github.com/istio/istio/issues/17108))

--- a/content/en/news/releases/1.20.x/announcing-1.20.4/index.md
+++ b/content/en/news/releases/1.20.x/announcing-1.20.4/index.md
@@ -22,17 +22,17 @@ This release note describes what’s different between Istio 1.20.3 and 1.20.4.
   curves to `P-256`.
 
     These restrictions apply on the following data paths:
-    * mTLS communication between Envoy proxies;
-    * regular TLS on the downstream and the upstream of Envoy proxies (e.g. gateway);
-    * Google gRPC side requests from Envoy proxies (e.g. Stackdriver extensions);
-    * Istiod xDS server;
-    * Istiod injection and validation webhook servers.
+    - mTLS communication between Envoy proxies;
+    - regular TLS on the downstream and the upstream of Envoy proxies (e.g. gateway);
+    - Google gRPC side requests from Envoy proxies (e.g. Stackdriver extensions);
+    - Istiod xDS server;
+    - Istiod injection and validation webhook servers.
 
     The restrictions are not applied on the following data paths:
-    * Istiod to Kubernetes API server;
-    * JWK fetch from Istiod;
-    * Wasm image and URL fetch from Istio Proxy containers;
-    * ztunnel.
+    - Istiod to Kubernetes API server;
+    - JWK fetch from Istiod;
+    - Wasm image and URL fetch from Istio Proxy containers;
+    - ztunnel.
 
   Note that Istio injector will propagate the value of `COMPLIANCE_POLICY` to the
   injected proxy container, when set.

--- a/content/en/news/releases/1.3.x/announcing-1.3.2/index.md
+++ b/content/en/news/releases/1.3.x/announcing-1.3.2/index.md
@@ -19,6 +19,6 @@ We're pleased to announce the availability of Istio 1.3.2. Please see below for 
 This release contains fixes for the security vulnerability described in [our October 8th, 2019 news post](/news/security/istio-security-2019-005).  Specifically:
 
 __ISTIO-SECURITY-2019-005__:  A DoS vulnerability has been discovered by the Envoy community.
-  * __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker  uses a high quantity of very small headers.
+* __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker  uses a high quantity of very small headers.
 
 Nothing else is included in this release except for the above security fix. Distroless images will be available in a few days.

--- a/content/en/news/releases/1.3.x/announcing-1.3.2/index.md
+++ b/content/en/news/releases/1.3.x/announcing-1.3.2/index.md
@@ -19,6 +19,6 @@ We're pleased to announce the availability of Istio 1.3.2. Please see below for 
 This release contains fixes for the security vulnerability described in [our October 8th, 2019 news post](/news/security/istio-security-2019-005).  Specifically:
 
 __ISTIO-SECURITY-2019-005__:  A DoS vulnerability has been discovered by the Envoy community.
-* __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker  uses a high quantity of very small headers.
+- __[CVE-2019-15226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-15226)__: After investigation, the Istio team has found that this issue could be leveraged for a DoS attack in Istio if an attacker  uses a high quantity of very small headers.
 
 Nothing else is included in this release except for the above security fix. Distroless images will be available in a few days.

--- a/content/en/news/security/istio-security-2021-005/index.md
+++ b/content/en/news/security/istio-security-2021-005/index.md
@@ -75,9 +75,9 @@ Your cluster is **NOT impacted** by this vulnerability if:
 
 1. Update your cluster to the latest supported version.
    These versions support configuring the Envoy proxies in the system with more normalization options:
-  * Istio 1.8.6, if using 1.8.x
-  * Istio 1.9.5 or up
-  * The patch version specified by your cloud provider
+* Istio 1.8.6, if using 1.8.x
+* Istio 1.9.5 or up
+* The patch version specified by your cloud provider
 1. Follow the [security best practices](/docs/ops/best-practices/security/#authorization-policies)
    to configure your authorization policies.
 

--- a/content/en/news/security/istio-security-2021-005/index.md
+++ b/content/en/news/security/istio-security-2021-005/index.md
@@ -66,18 +66,18 @@ The following is another example of vulnerable policy that uses `ALLOW action + 
 
 Your cluster is **NOT impacted** by this vulnerability if:
 
-* You don’t have authorization policies
-* Your authorization policies don’t define `paths` or `notPaths` fields.
-* Your authorization policies use `ALLOW action + paths field` or `DENY action + notPaths field` patterns.
+- You don’t have authorization policies
+- Your authorization policies don’t define `paths` or `notPaths` fields.
+- Your authorization policies use `ALLOW action + paths field` or `DENY action + notPaths field` patterns.
   These patterns could only cause unexpected rejection instead of policy bypasses. The upgrade is optional for these cases.
 
 ## Mitigation
 
 1. Update your cluster to the latest supported version.
    These versions support configuring the Envoy proxies in the system with more normalization options:
-* Istio 1.8.6, if using 1.8.x
-* Istio 1.9.5 or up
-* The patch version specified by your cloud provider
+- Istio 1.8.6, if using 1.8.x
+- Istio 1.9.5 or up
+- The patch version specified by your cloud provider
 1. Follow the [security best practices](/docs/ops/best-practices/security/#authorization-policies)
    to configure your authorization policies.
 


### PR DESCRIPTION
Part of #15148. First batch of the plan described there: content fixes that are valid under both the current mdl linter and markdownlint-cli2, so they can land ahead of the engine swap. Covers list marker consistency (MD004), list nesting depth (MD007), code block shortcode bodies that weren't aligned with their list indentation, and a handful of bare URLs and email addresses.