### PR TITLE
Add blog post: Istio Gives You Progressive Delivery. Who Gives It to Istio?

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -601,6 +601,7 @@ fine-grained
 FIPS
 Firebase
 FitStation
+Flagger
 Fluentd
 foo.yaml
 Forbe
@@ -1074,6 +1075,7 @@ OneCloud
 onramp
 onsite
 onwards
+OpAMP
 OpenAPI
 OpenCensus
 OpenID

--- a/.spelling
+++ b/.spelling
@@ -1266,6 +1266,7 @@ Salmond
 sandboxed
 sandboxing
 sanitization
+Santhosh
 Sathish
 Savcı
 sayin
@@ -1335,6 +1336,7 @@ SoC2
 SolarWinds
 Solo.io
 Solo.io.
+Somarapu
 SongYang
 Specko
 Speedrun

--- a/content/en/blog/2026/who-gives-progressive-delivery-to-istio/index.md
+++ b/content/en/blog/2026/who-gives-progressive-delivery-to-istio/index.md
@@ -138,7 +138,3 @@ The asymmetry gets worse with scale. A mesh spanning many namespaces and cluster
 We built progressive delivery because shipping code straight to 100% of traffic turned out to be a bad idea. Mesh configuration is shipped straight to 100% of the mesh, several times a day, by a pipeline that checks whether the YAML parses.
 
 The tooling to fix this mostly exists. The metrics are already emitted. What's missing is treating configuration as a deployment that deserves the same care as the ones it governs.
-
----
-
-*Santhosh Kumar Somarapu is a senior infrastructure engineer working on platform reliability. He has spent most of the last decade on configuration-change safety and progressive delivery for large-scale infrastructure at Amazon, Microsoft, Meta and eBay.*

--- a/content/en/blog/2026/who-gives-progressive-delivery-to-istio/index.md
+++ b/content/en/blog/2026/who-gives-progressive-delivery-to-istio/index.md
@@ -1,0 +1,82 @@
+---
+title: "Istio Gives You Progressive Delivery. Who Gives It to Istio?"
+description: "Istio makes it easy to roll application changes out gradually. Changes to the mesh's own configuration get none of that protection."
+publishdate: 2026-08-04
+attribution: "Santhosh Kumar Somarapu"
+keywords: [Istio, traffic management, operations, reliability, configuration, progressive delivery]
+---
+
+Istio is very good at not letting a bad application deployment take down your service. You shift 5% of traffic to the new version, watch it, and shift the rest or roll it back. Flagger automates the whole loop. This is one of the main reasons teams adopt a mesh.
+
+Now consider the `VirtualService` that expresses that rollout.
+
+It is a Kubernetes resource. You apply it with `kubectl`, istiod picks it up, and the new routing rules are distributed to proxies across the mesh. There is no percentage. There is no bake time. There is no automatic revert if error rates move. The change that governs how carefully your application is rolled out is itself rolled out in one shot, everywhere, immediately.
+
+That asymmetry is worth sitting with. We have built careful machinery for the changes that ship weekly and none for the changes that ship several times a day.
+
+## The failure that doesn't look like a failure
+
+The mesh-config incidents I have seen are rarely dramatic at the moment they happen. Nothing crashes. Nothing pages. The config was valid YAML, it passed admission, `istioctl analyze` was happy with it, and istiod accepted and distributed it without complaint.
+
+A `VirtualService` with a host that doesn't match what callers actually use routes nowhere. A `DestinationRule` declaring a subset whose labels no longer match any pod produces no endpoints. A tightened `PeerAuthentication` silently strands the one workload that wasn't ready for strict mTLS. In each case every individual component did exactly what it was told. The change was well-formed and it was permitted. What was wrong was its *effect*, and nothing in the path from `kubectl apply` to the data plane was looking at effect.
+
+This is the general shape of configuration incidents, and it is why they behave differently from code incidents. A bad binary usually announces itself — it panics, it fails a health check, the container restarts. A bad configuration is frequently a *correct system doing the wrong thing*, and correctness checks do not catch that.
+
+## What we validate, and what we don't
+
+Every config pipeline I have worked on validates two things:
+
+- **Is this change well-formed?** Schema, CRD validation, admission webhooks, `istioctl analyze`.
+- **Is this change permitted?** RBAC, policy engines, review requirements.
+
+Neither asks the third question: **is the effect of this change plausible?**
+
+Going from a `VirtualService` that routes to three subsets to one that routes to zero is well-formed and permitted. It is also almost certainly a mistake. Nothing looks at that transition, because "plausible" isn't a property of the YAML — it's a property of the delta between the current state and the proposed one, and of what happens to traffic afterwards.
+
+## Borrowing the ladder we already built
+
+Application rollouts climbed a maturity ladder over the last decade. Configuration hasn't started.
+
+**Manual.** Someone reviews the diff and applies it. This is where most mesh config lives today. Review catches typos; it does not catch a label selector that stopped matching three weeks ago.
+
+**Health-gated.** Apply the change, then watch system health — proxy error rates, 5xx, connection failures — and revert if something moves. Better, and it catches the loud failures.
+
+**Outcome-gated.** Watch what the traffic is *doing*, not just whether the proxies are healthy. This is the rung that matters and the one almost nobody builds. A routing change that sends a service's traffic to a stale subset produces perfectly healthy proxies serving perfectly successful responses from the wrong place. Error rate is flat. Latency may even improve. The only signal that something is wrong lives at the level of "are requests reaching the workload that should be handling them" — request volume per destination, per-subset distribution, the shape of who is talking to whom.
+
+**Autonomous.** The guardrail reverts without a human, and the blast radius is bounded by construction rather than by how quickly someone notices.
+
+The interesting jump is health-gated to outcome-gated, and it is hard for a reason that isn't architectural. You need enough signal, inside a window short enough that the check is worth running, to tell a real regression from ordinary variance. That is a statistical problem before it is an engineering one, and it is where most of the work actually goes.
+
+## What you can do in Istio today
+
+None of this requires waiting for new features.
+
+**Diff before apply, and look at the delta rather than the document.** `istioctl analyze` tells you whether a config is coherent. It does not tell you that you just went from four subsets to one. Compute that in CI and make a large reduction fail the pipeline unless the change is annotated as intentional. The point is not the specific threshold — it is separating two questions that usually get conflated: *is this change large?*, which you can compute, and *was a large change expected?*, which only the author knows and should have to say out loud. A guardrail that trips only when those two disagree stays quiet in normal operation, and quiet is what determines whether a guardrail survives contact with a real team. Guardrails that fire on legitimate changes get disabled.
+
+**Give mesh config its own canary namespace.** Apply routing changes to a low-traffic namespace or a single cluster first, with the same manifest, and watch real traffic through it before it goes anywhere else. Istio's per-namespace scoping makes this straightforward and almost nobody uses it this way.
+
+**Watch destination distribution, not just error rate.** `istio_requests_total` broken down by `destination_workload` and `destination_version` will show you a subset that quietly stopped receiving traffic. A dashboard of request share per destination is the single most useful mesh-config canary signal I know of, and it is available out of the box.
+
+**Treat config rollback as a first-class path.** Keep the previous known-good config ready to apply in one command, and rehearse doing it. Most teams can roll back a deployment in seconds and take minutes to work out what the routing looked like yesterday.
+
+## The gap is not just Istio's
+
+This is worth naming as an ecosystem problem rather than a project one. It shows up wherever configuration is applied automatically.
+
+The OpenTelemetry OpAMP protocol manages configuration for agent fleets. Its specification describes in detail how a server delivers configuration and how agents report status — including health — but says nothing about staged rollout, or about halting when part of the fleet reports unhealthy. The signals a gate would need are already in the protocol. Nothing closes the loop. I [raised this recently](https://github.com/open-telemetry/opamp-spec/issues/384) with the OpAMP SIG.
+
+In GitOps the same gap has a sharper edge. A [long-standing Flux issue](https://github.com/fluxcd/flux2/issues/5512) describes a user who pointed a source at an empty path and watched the reconciler delete everything it managed — valid, permitted, and catastrophic.
+
+Different projects, same missing check.
+
+## Why this matters more as meshes grow
+
+The asymmetry gets worse with scale. A mesh spanning many namespaces and clusters means a single config change has a blast radius measured in services rather than pods, and the distance between the person applying it and the traffic it affects keeps growing. Meanwhile the frequency goes up: mesh config changes far more often than the applications underneath it.
+
+We built progressive delivery because shipping code straight to 100% of traffic turned out to be a bad idea. Mesh configuration is shipped straight to 100% of the mesh, several times a day, by a pipeline that checks whether the YAML parses.
+
+The tooling to fix this mostly exists. The metrics are already emitted. What's missing is treating configuration as a deployment that deserves the same care as the ones it governs.
+
+---
+
+*Santhosh Kumar Somarapu is a senior infrastructure engineer working on platform reliability. He has spent most of the last decade on configuration-change safety and progressive delivery for large-scale infrastructure at Amazon, Microsoft, Meta and eBay.*

--- a/content/en/blog/2026/who-gives-progressive-delivery-to-istio/index.md
+++ b/content/en/blog/2026/who-gives-progressive-delivery-to-istio/index.md
@@ -6,7 +6,7 @@ attribution: "Santhosh Kumar Somarapu"
 keywords: [Istio, traffic management, operations, reliability, configuration, progressive delivery]
 ---
 
-Istio is very good at not letting a bad application deployment take down your service. You shift 5% of traffic to the new version, watch it, and shift the rest or roll it back. Flagger automates the whole loop. This is one of the main reasons teams adopt a mesh.
+Istio is very good at not letting a bad application deployment take down your service. You shift 5% of traffic to the new version, watch it, and shift the rest or roll it back. [Flagger](https://fluxcd.io/flagger/) automates the whole loop. This is one of the main reasons teams adopt a mesh.
 
 Now consider the `VirtualService` that expresses that rollout.
 
@@ -18,7 +18,9 @@ That asymmetry is worth sitting with. We have built careful machinery for the ch
 
 The mesh-config incidents I have seen are rarely dramatic at the moment they happen. Nothing crashes. Nothing pages. The config was valid YAML, it passed admission, `istioctl analyze` was happy with it, and istiod accepted and distributed it without complaint.
 
-A `VirtualService` with a host that doesn't match what callers actually use routes nowhere. A `DestinationRule` declaring a subset whose labels no longer match any pod produces no endpoints. A tightened `PeerAuthentication` silently strands the one workload that wasn't ready for strict mTLS. In each case every individual component did exactly what it was told. The change was well-formed and it was permitted. What was wrong was its *effect*, and nothing in the path from `kubectl apply` to the data plane was looking at effect.
+A `VirtualService` whose `hosts` don't match what callers actually use never applies at all, so traffic quietly keeps taking the route you thought you had just changed. A `DestinationRule` subset that still matches pods, but the wrong ones, sends traffic somewhere plausible and wrong. A tightened `PeerAuthentication` silently strands the one workload that wasn't ready for strict mTLS.
+
+The loud version of this is easier: a subset whose labels match *no* pod produces a cluster with no endpoints, and that announces itself as a 503 more or less immediately. It is the changes that leave the mesh in a valid, serving, subtly wrong state that go unnoticed. In each case every individual component did exactly what it was told. The change was well-formed and it was permitted. What was wrong was its *effect*, and nothing in the path from `kubectl apply` to the data plane was looking at effect.
 
 This is the general shape of configuration incidents, and it is why they behave differently from code incidents. A bad binary usually announces itself — it panics, it fails a health check, the container restarts. A bad configuration is frequently a *correct system doing the wrong thing*, and correctness checks do not catch that.
 
@@ -56,9 +58,28 @@ None of this requires waiting for new features.
 In CI, that check can be as small as this:
 
 {{< text plain >}}
+set -euo pipefail
 FILE=networking/reviews-destinationrule.yaml
-before=$(git show "origin/main:$FILE" | yq '.spec.subsets | length')
-after=$(yq '.spec.subsets | length' "$FILE")
+
+# Count subsets across every document in the file. Manifests are often
+# multi-document, and yq evaluates once per document, so reading the result as a
+# single number silently breaks the comparison below. Collecting them into one
+# array first gives a single count, and an absent file yields zero rather than
+# an empty string.
+count() {
+  yq ea '[.. | select(has("subsets")).subsets[]] | length' -
+}
+
+# A file added on this branch has no previous version. Test for that explicitly:
+# letting git fail here would abort the check under `set -e` rather than
+# reporting anything.
+if git cat-file -e "origin/main:$FILE" 2>/dev/null; then
+  before=$(git show "origin/main:$FILE" | count)
+else
+  before=0
+fi
+
+after=$(count < "$FILE")
 
 if [ "$after" -lt "$before" ] &&
    ! git log -1 --format=%B | grep -q 'mesh-config: intentional reduction'; then
@@ -71,7 +92,7 @@ The commit-message marker is the out-of-band declaration. It costs the author on
 
 **Give mesh config its own canary namespace.** Apply routing changes to a low-traffic namespace or a single cluster first, with the same manifest, and watch real traffic through it before it goes anywhere else. Istio's per-namespace scoping makes this straightforward and almost nobody uses it this way.
 
-**Watch destination distribution, not just error rate.** `istio_requests_total` broken down by `destination_workload` and `destination_version` will show you a subset that quietly stopped receiving traffic. A dashboard of request share per destination is the single most useful mesh-config canary signal I know of, and it is available out of the box.
+**Watch destination distribution, not just error rate.** `istio_requests_total` broken down by `destination_workload` and `destination_version` will show you a destination that quietly stopped receiving traffic. One caveat worth knowing: `destination_version` reports the version of the destination *workload*, taken from its `service.istio.io/canonical-revision` or `version` label — it is not the `DestinationRule` subset name. It tracks your subsets only when those subsets select on the version label, which is the common convention but not a guarantee, and it reads `unknown` for workloads carrying no version label at all. A dashboard of request share per destination is the most useful mesh-config canary signal I know of, and it is available out of the box.
 
 Share of mesh traffic per destination, in PromQL:
 
@@ -102,11 +123,13 @@ Neither of these looks at error rate at all, which is the point.
 
 This is worth naming as an ecosystem problem rather than a project one. It shows up wherever configuration is applied automatically.
 
-The OpenTelemetry OpAMP protocol manages configuration for agent fleets. Its specification describes in detail how a server delivers configuration and how agents report status — including health — but says nothing about staged rollout, or about halting when part of the fleet reports unhealthy. The signals a gate would need are already in the protocol. Nothing closes the loop. I [raised this recently](https://github.com/open-telemetry/opamp-spec/issues/384) with the OpAMP SIG.
+The OpenTelemetry OpAMP protocol manages configuration for agent fleets. Its specification describes in detail how a server delivers configuration and how agents report status — including health — but says nothing about staged rollout, or about halting when part of the fleet reports unhealthy. I [asked the OpAMP SIG whether that was in scope](https://github.com/open-telemetry/opamp-spec/issues/384), and the answer was clear: it is deliberately out of scope. The specification covers the protocol only, and how to sequence a rollout, when to canary and when to roll back are decisions each implementation makes for itself.
+
+That is the right call, and it locates the problem precisely. The signals a gate would need are already in the protocol. What is missing is not protocol surface — it is an implementation that reads those signals and refuses to continue.
 
 In GitOps the same gap has a sharper edge. A [long-standing Flux issue](https://github.com/fluxcd/flux2/issues/5512) describes a user who pointed a source at an empty path and watched the reconciler delete everything it managed — valid, permitted, and catastrophic.
 
-Different projects, same missing check.
+Different projects, same missing layer: the gate belongs to whatever applies the configuration, and in each case nothing applies one.
 
 ## Why this matters more as meshes grow
 

--- a/content/en/blog/2026/who-gives-progressive-delivery-to-istio/index.md
+++ b/content/en/blog/2026/who-gives-progressive-delivery-to-istio/index.md
@@ -53,9 +53,48 @@ None of this requires waiting for new features.
 
 **Diff before apply, and look at the delta rather than the document.** `istioctl analyze` tells you whether a config is coherent. It does not tell you that you just went from four subsets to one. Compute that in CI and make a large reduction fail the pipeline unless the change is annotated as intentional. The point is not the specific threshold — it is separating two questions that usually get conflated: *is this change large?*, which you can compute, and *was a large change expected?*, which only the author knows and should have to say out loud. A guardrail that trips only when those two disagree stays quiet in normal operation, and quiet is what determines whether a guardrail survives contact with a real team. Guardrails that fire on legitimate changes get disabled.
 
+In CI, that check can be as small as this:
+
+{{< text plain >}}
+FILE=networking/reviews-destinationrule.yaml
+before=$(git show "origin/main:$FILE" | yq '.spec.subsets | length')
+after=$(yq '.spec.subsets | length' "$FILE")
+
+if [ "$after" -lt "$before" ] &&
+   ! git log -1 --format=%B | grep -q 'mesh-config: intentional reduction'; then
+  echo "subsets go from $before to $after; say so in the commit message if that is intended"
+  exit 1
+fi
+{{< /text >}}
+
+The commit-message marker is the out-of-band declaration. It costs the author one line when they mean it, and it fails the build when they don't.
+
 **Give mesh config its own canary namespace.** Apply routing changes to a low-traffic namespace or a single cluster first, with the same manifest, and watch real traffic through it before it goes anywhere else. Istio's per-namespace scoping makes this straightforward and almost nobody uses it this way.
 
 **Watch destination distribution, not just error rate.** `istio_requests_total` broken down by `destination_workload` and `destination_version` will show you a subset that quietly stopped receiving traffic. A dashboard of request share per destination is the single most useful mesh-config canary signal I know of, and it is available out of the box.
+
+Share of mesh traffic per destination, in PromQL:
+
+{{< text plain >}}
+sum by (destination_workload, destination_version) (
+  rate(istio_requests_total{reporter="destination"}[5m])
+)
+/ scalar(sum(rate(istio_requests_total{reporter="destination"}[5m])))
+{{< /text >}}
+
+And the version of it that catches the silent case — a destination that was receiving traffic an hour ago and receives none now:
+
+{{< text plain >}}
+sum by (destination_workload, destination_version) (
+  rate(istio_requests_total{reporter="destination"}[5m])
+) == 0
+and
+sum by (destination_workload, destination_version) (
+  rate(istio_requests_total{reporter="destination"}[5m] offset 1h)
+) > 0
+{{< /text >}}
+
+Neither of these looks at error rate at all, which is the point.
 
 **Treat config rollback as a first-class path.** Keep the previous known-good config ready to apply in one command, and rehearse doing it. Most teams can roll back a deployment in seconds and take minutes to work out what the routing looked like yesterday.
 


### PR DESCRIPTION
## Description

This PR adds a new blog post: **"Istio Gives You Progressive Delivery. Who Gives It to Istio?"**

Istio makes it straightforward to roll application changes out gradually — shift a percentage of traffic, watch, promote or roll back. Changes to the mesh's *own* configuration get none of that. A `VirtualService` or `DestinationRule` applies mesh-wide as soon as istiod accepts it: no percentage, no bake time, no automatic revert. The resource that expresses a careful rollout is itself rolled out in one shot.

The post argues that config pipelines validate whether a change is well-formed and whether it is permitted, but never whether its *effect* is plausible — and that this is why mesh-config incidents so often present as a healthy system doing the wrong thing rather than as an outage.

It then walks a four-rung maturity ladder (manual → health-gated → outcome-gated → autonomous) in Istio terms, and closes with four things a reader can do today with no new features:

- diff the delta rather than the document, and separate "is this change large?" from "was a large change expected?"
- give mesh config its own canary namespace
- watch `istio_requests_total` by `destination_workload` / `destination_version` rather than error rate, since a stale subset produces healthy proxies and flat error rates
- treat config rollback as a rehearsed path

It also notes the same gap in OpenTelemetry's OpAMP protocol and in Flux, linking the live discussions, to frame it as an ecosystem problem rather than an Istio-specific criticism.

Written from experience building configuration-safety and progressive-delivery systems for large-scale infrastructure. No vendor content and no product references.

## Notes

- `.spelling` updated with `Flagger` and `OpAMP`.
- Happy to adjust the framing, trim length, or add diagrams if reviewers would prefer.
