### PR TITLE
Pull the KinD node image from registry.istio.io

### DIFF
--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -52,6 +52,8 @@ This example uses [Squid](http://www.squid-cache.org) but you can use any HTTPS 
     http_access allow all
 
     coredump_dir /var/spool/squid
+
+    max_filedescriptors 1024
     EOF
     {{< /text >}}
 

--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/snips.sh
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/snips.sh
@@ -38,6 +38,8 @@ http_access deny manager
 http_access allow all
 
 coredump_dir /var/spool/squid
+
+max_filedescriptors 1024
 EOF
 }
 

--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/test.sh
@@ -42,20 +42,6 @@ snip_deploy_an_https_proxy_3
 snip_deploy_an_https_proxy_4
 _wait_for_deployment external squid
 
-# DEBUG (temporary, do not merge): confirm whether squid ever binds 3128.
-# Suspected cause of the CI failure is an unbounded RLIMIT_NOFILE on the AWS
-# prow nodes, which makes squid 3.5 size its fd table to ~2^31 and hang before
-# it starts listening. Every command is best-effort so it cannot fail the test.
-echo "=== DEBUG: squid pod state ==="
-kubectl get pods -n external -o wide || true
-echo "=== DEBUG: squid RLIMIT_NOFILE ==="
-kubectl exec -n external deploy/squid -- cat /proc/1/limits || true
-echo "=== DEBUG: squid process ==="
-kubectl exec -n external deploy/squid -- ps aux || true
-echo "=== DEBUG: squid logs ==="
-kubectl logs -n external -l app=squid --tail=50 || true
-echo "=== DEBUG: end ==="
-
 # create curl
 snip_deploy_an_https_proxy_5
 _wait_for_deployment external curl

--- a/content/en/docs/tasks/traffic-management/egress/http-proxy/test.sh
+++ b/content/en/docs/tasks/traffic-management/egress/http-proxy/test.sh
@@ -42,6 +42,20 @@ snip_deploy_an_https_proxy_3
 snip_deploy_an_https_proxy_4
 _wait_for_deployment external squid
 
+# DEBUG (temporary, do not merge): confirm whether squid ever binds 3128.
+# Suspected cause of the CI failure is an unbounded RLIMIT_NOFILE on the AWS
+# prow nodes, which makes squid 3.5 size its fd table to ~2^31 and hang before
+# it starts listening. Every command is best-effort so it cannot fail the test.
+echo "=== DEBUG: squid pod state ==="
+kubectl get pods -n external -o wide || true
+echo "=== DEBUG: squid RLIMIT_NOFILE ==="
+kubectl exec -n external deploy/squid -- cat /proc/1/limits || true
+echo "=== DEBUG: squid process ==="
+kubectl exec -n external deploy/squid -- ps aux || true
+echo "=== DEBUG: squid logs ==="
+kubectl logs -n external -l app=squid --tail=50 || true
+echo "=== DEBUG: end ==="
+
 # create curl
 snip_deploy_an_https_proxy_5
 _wait_for_deployment external curl

--- a/content/es/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/es/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -51,6 +51,8 @@ Este ejemplo utiliza [Squid](http://www.squid-cache.org) pero puede usar cualqui
     http_access allow all
 
     coredump_dir /var/spool/squid
+
+    max_filedescriptors 1024
     EOF
     {{< /text >}}
 

--- a/content/uk/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/uk/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -42,6 +42,8 @@ test: yes
     http_access allow all
 
     coredump_dir /var/spool/squid
+
+    max_filedescriptors 1024
     EOF
     {{< /text >}}
 

--- a/content/zh/docs/tasks/traffic-management/egress/http-proxy/index.md
+++ b/content/zh/docs/tasks/traffic-management/egress/http-proxy/index.md
@@ -49,6 +49,8 @@ test: yes
     http_access allow all
 
     coredump_dir /var/spool/squid
+
+    max_filedescriptors 1024
     EOF
     {{< /text >}}
 

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -53,6 +53,8 @@ TOPOLOGY="SINGLE_CLUSTER"
 # This is relevant only when multicluster topology is picked
 CLUSTER_TOPOLOGY_CONFIG_FILE="./prow/config/topology/multi-cluster.json"
 
+export NOMETALBINSTALL="${NOMETALBINSTALL:-}"
+
 PARAMS=()
 
 while (( "$#" )); do

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -115,7 +115,7 @@ elif [[ "$IP_FAMILIES" =~ "IPv6" ]] && [[ "$IP_FAMILIES" =~ "IPv4" ]]; then
    KIND_IP_FAMILY="dual"
 fi
 export KIND_IP_FAMILY
-export NODE_IMAGE="gcr.io/istio-testing/kind-node:v1.35.0"
+export NODE_IMAGE="registry.istio.io/testing/kind-node:v1.35.0"
 
 if [[ -z "${SKIP_SETUP:-}" ]]; then
   export ARTIFACTS="${ARTIFACTS:-$(mktemp -d)}"


### PR DESCRIPTION
Every `doc.test.*` job fails during KinD cluster creation:

```
ERROR: failed to create cluster: failed to pull image "gcr.io/istio-testing/kind-node:v1.35.0"
Command Output: error getting credentials - err: exit status 1, out: `You do not currently have an active account selected.`
```

Since istio/test-infra#5991 moved these jobs to the AWS Prow cluster, there is no
active GCP account, so the gcloud credential helper registered for `gcr.io` exits
non-zero and the pull fails rather than falling back to anonymous.

`registry.istio.io/testing/kind-node:v1.35.0` pulls without credentials, and it is
already the default in `common/scripts/kind_provisioner.sh` — this override was
defeating it. Matches istio/istio#59364.
