### PR TITLE
Replace PSP references with Pod Security Admission in application req

### DIFF
--- a/content/en/docs/ops/deployment/application-requirements/index.md
+++ b/content/en/docs/ops/deployment/application-requirements/index.md
@@ -39,26 +39,28 @@ To be part of a mesh, Kubernetes pods must satisfy the following requirements:
 - **`NET_ADMIN` and `NET_RAW` capabilities**: Unless you use the
     [Istio CNI Plugin](/docs/setup/additional-setup/cni/), the `istio-init` container requires
     `NET_ADMIN` and `NET_RAW` capabilities to configure iptables traffic redirection. The
-    namespace must use the `baseline` or `privileged`
+    namespace must use the `privileged`
     [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/)
-    enforcement level. The `restricted` level blocks these capabilities and will prevent the
-    `istio-init` container from running.
+    enforcement level. Both the `baseline` and `restricted` levels block these capabilities and
+    will prevent the `istio-init` container from running.
 
-    To check the current enforcement level on a namespace and set it if needed:
+    To check the `pod-security.kubernetes.io/enforce` label on a namespace:
 
     {{< text bash >}}
     $ kubectl get namespace <your namespace> --show-labels
-    $ kubectl label namespace <your namespace> pod-security.kubernetes.io/enforce=baseline
+    NAME       STATUS   AGE   LABELS
+    myapp      Active   3d    pod-security.kubernetes.io/enforce=privileged,...
     {{< /text >}}
 
-    If your security policy requires `restricted` enforcement on the namespace, use the
+    To set the namespace to `privileged` enforcement:
+
+    {{< text bash >}}
+    $ kubectl label namespace <your namespace> pod-security.kubernetes.io/enforce=privileged --overwrite
+    {{< /text >}}
+
+    If your security policy does not allow `privileged` enforcement on the namespace, use the
     [Istio CNI Plugin](/docs/setup/additional-setup/cni/) instead, which handles traffic
     redirection without requiring elevated capabilities in the pod.
-
-    {{< tip >}}
-    [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) was
-    removed in Kubernetes 1.25 and replaced by Pod Security Admission.
-    {{< /tip >}}
 
 - **Pod labels**: We recommend explicitly declaring pods with an application identifier and version by using a pod label.
   These labels add contextual information to the metrics and telemetry that Istio collects.

--- a/content/en/docs/ops/deployment/application-requirements/index.md
+++ b/content/en/docs/ops/deployment/application-requirements/index.md
@@ -36,34 +36,29 @@ To be part of a mesh, Kubernetes pods must satisfy the following requirements:
 - **Application UIDs**: Ensure your pods do **not** run applications as a user
   with the user ID (UID) value of `1337` because `1337` is reserved for the sidecar proxy.
 
-- **`NET_ADMIN` and `NET_RAW` capabilities**: If [pod security policies](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
-    are [enforced](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#enabling-pod-security-policies)
-    in your cluster and unless you use the [Istio CNI Plugin](/docs/setup/additional-setup/cni/), your pods must have the
-    `NET_ADMIN` and `NET_RAW` capabilities allowed. The initialization containers of the Envoy
-    proxies require these capabilities.
+- **`NET_ADMIN` and `NET_RAW` capabilities**: Unless you use the
+    [Istio CNI Plugin](/docs/setup/additional-setup/cni/), the `istio-init` container requires
+    `NET_ADMIN` and `NET_RAW` capabilities to configure iptables traffic redirection. The
+    namespace must use the `baseline` or `privileged`
+    [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/)
+    enforcement level. The `restricted` level blocks these capabilities and will prevent the
+    `istio-init` container from running.
 
-    To check if the `NET_ADMIN` and `NET_RAW` capabilities are allowed for your pods, you need to check if their
-    [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
-    can use a pod security policy that allows the `NET_ADMIN` and `NET_RAW` capabilities.
-    If you haven't specified a service account in your pods' deployment, the pods run using
-    the `default` service account in their deployment's namespace.
-
-    To list the capabilities for a service account, replace `<your namespace>` and `<your service account>`
-    with your values in the following command:
+    To check the current enforcement level on a namespace and set it if needed:
 
     {{< text bash >}}
-    $ for psp in $(kubectl get psp -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}"); do if [ $(kubectl auth can-i use psp/$psp --as=system:serviceaccount:<your namespace>:<your service account>) = yes ]; then kubectl get psp/$psp --no-headers -o=custom-columns=NAME:.metadata.name,CAPS:.spec.allowedCapabilities; fi; done
+    $ kubectl get namespace <your namespace> --show-labels
+    $ kubectl label namespace <your namespace> pod-security.kubernetes.io/enforce=baseline
     {{< /text >}}
 
-    For example, to check for the `default` service account in the `default` namespace, run the following command:
+    If your security policy requires `restricted` enforcement on the namespace, use the
+    [Istio CNI Plugin](/docs/setup/additional-setup/cni/) instead, which handles traffic
+    redirection without requiring elevated capabilities in the pod.
 
-    {{< text bash >}}
-    $ for psp in $(kubectl get psp -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}"); do if [ $(kubectl auth can-i use psp/$psp --as=system:serviceaccount:default:default) = yes ]; then kubectl get psp/$psp --no-headers -o=custom-columns=NAME:.metadata.name,CAPS:.spec.allowedCapabilities; fi; done
-    {{< /text >}}
-
-    If you see `NET_ADMIN` and `NET_RAW` or `*` in the list of capabilities of one of the allowed
-    policies for your service account, your pods have permission to run the Istio init containers.
-    Otherwise, you will need to [provide the permission](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#authorizing-policies).
+    {{< tip >}}
+    [PodSecurityPolicy](https://kubernetes.io/docs/concepts/policy/pod-security-policy/) was
+    removed in Kubernetes 1.25 and replaced by Pod Security Admission.
+    {{< /tip >}}
 
 - **Pod labels**: We recommend explicitly declaring pods with an application identifier and version by using a pod label.
   These labels add contextual information to the metrics and telemetry that Istio collects.


### PR DESCRIPTION
## Description

The NET_ADMIN/NET_RAW capabilities section referenced PodSecurityPolicy
(PSP) which was removed in Kubernetes 1.25, including `kubectl get psp` commands that no longer work.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
