### PR TITLE
Manually cherrypick the missing release notes for versions 1.28.8 and 1.28.9 with security update

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -123,6 +123,8 @@ Acmeair
 addon
 addons
 Aeraki
+AES-256-CBC
+AES-256-GCM
 AES-NI
 Agentgateway
 agentgateway
@@ -235,6 +237,7 @@ Bottlerocket
 bring-your-own-CA
 bring-your-own-identity
 Brooks
+brotli
 bt
 Budinsky
 buildah
@@ -271,6 +274,7 @@ Chun
 CIDRs
 Cilium
 CIOs
+ciphertext
 Circonus
 Ciążyński
 Cleartext
@@ -469,6 +473,21 @@ CVE-2026-31837
 CVE-2026-31838
 CVE-2026-39350
 CVE-2026-41413
+CVE-2026-47204
+CVE-2026-47205
+CVE-2026-47207
+CVE-2026-47220
+CVE-2026-47221
+CVE-2026-47692
+CVE-2026-47774
+CVE-2026-47775
+CVE-2026-47778
+CVE-2026-48042
+CVE-2026-48044
+CVE-2026-48090
+CVE-2026-48497
+CVE-2026-48706
+CVE-2026-48743
 CVEs
 cves
 cvss
@@ -582,6 +601,8 @@ ext-authz
 extensibility
 extensionProviders
 ExternalName
+ext_authz
+ext_proc
 Ezequiel
 facto
 failover
@@ -621,6 +642,7 @@ Gather.town
 Gaudet
 GB
 gbd
+gcm
 GCP
 GCP-IAM
 GCP_OPTS
@@ -634,6 +656,7 @@ GHSA-8mq4-c2v5-3h39
 GHSA-974c-2wxh-g4ww
 GHSA-9gcg-w975-3rjh
 GHSA-fgw5-hp8f-xfhc
+GHSA-p7c7-7c47-pwch
 GHSA-v75c-crr9-733c
 GiB
 GIDs
@@ -743,6 +766,7 @@ ipBlock
 ipBlocks
 IPs
 IPsec
+ipset
 ipsets
 iptables
 IPv4
@@ -789,6 +813,7 @@ ISTIO-SECURITY-2024-007
 ISTIO-SECURITY-2025-001
 ISTIO-SECURITY-2026-001
 ISTIO-SECURITY-2026-002
+ISTIO-SECURITY-2026-005
 istio-system
 istio.io
 istio.io.
@@ -946,6 +971,7 @@ Manolache
 Mansing
 Marshalers
 Mattix
+MaxInflateRatio
 MB
 McAllister
 Meetup
@@ -1052,6 +1078,7 @@ non-sandboxed
 non-UTF8
 noop
 normalization
+notTrustDomains
 ns
 nsenter
 NUL
@@ -1070,6 +1097,7 @@ Onboard
 onboard
 Onboarding
 onboarding
+onDestroy
 OneCloud
 onramp
 onsite
@@ -1159,6 +1187,7 @@ prepending
 prepends
 PriorityClass
 prober
+ProcessingResponses
 programmatically
 Prometheus
 PromQL
@@ -1206,6 +1235,7 @@ rearchitect
 rebalance
 rebalances
 recomposition
+recomputations
 recomputations
 redeployments
 RedHat
@@ -1395,6 +1425,7 @@ TCP
 tcp
 TCP-level
 Tcpdump
+TcpStatsdSync
 team1
 team1-ns
 team2
@@ -1418,6 +1449,7 @@ timestamps
 TLS
 TLS-secured
 TLSRoute
+TLVs
 ToC
 Tokio
 tolerations
@@ -1437,6 +1469,7 @@ Trivedi
 Trulia
 trunked
 trustability
+trustDomains
 tunneling
 U.S.
 UID
@@ -1645,6 +1678,7 @@ Zipkin
 Ziyang
 Zolotusky
 Zsh
+Zstd
 ztunnel
 ztunnels
 Zufar

--- a/content/en/news/releases/1.28.x/announcing-1.28.8/index.md
+++ b/content/en/news/releases/1.28.x/announcing-1.28.8/index.md
@@ -1,0 +1,29 @@
+---
+title: Announcing Istio 1.28.8
+linktitle: 1.28.8
+subtitle: Patch Release
+description: Istio 1.28.8 patch release.
+publishdate: 2026-06-04
+release: 1.28.8
+aliases:
+    - /news/announcing-1.28.8
+---
+
+This release contains bug fixes to improve robustness. This release note describes what’s different between Istio 1.28.7 and 1.28.8.
+
+{{< relnote >}}
+
+## Security Update
+
+- [CVE-2026-47774](https://github.com/envoyproxy/envoy/security/advisories/GHSA-22m2-hvr2-xqc8) (CVSS score 7.5, High): An unauthenticated remote attacker can cause denial of service by exhausting memory in the Envoy process. Cookie header bytes are not fully accounted for during request header size validation, and HPACK header block limits are enforced on encoded bytes without a corresponding limit on total decoded header size, allowing attackers to trigger excessive memory consumption through specially crafted HTTP/2 requests.
+
+## Changes
+
+- **Fixed** an issue where HTTPS listeners defined via `ListenerSet` failed to deliver TLS certificates when the parent `Gateway` used manual deployment.
+  ([Issue #59535](https://github.com/istio/istio/issues/59535))
+
+- **Fixed** an issue where `HTTPRoute` and `GRPCRoute` filters with invalid header values were silently dropped from the Envoy config instead of reporting an invalid filter status.
+  ([Issue #59933](https://github.com/istio/istio/issues/59933))
+
+- **Fixed** an ambient mode bug where a single `Service` combining `publishNotReadyAddresses: true` with a `PreferSameZone` or `PreferSameNode` traffic distribution caused ztunnel to receive `healthPolicy: AllowAll` for every other `Service` using the same traffic-distribution preset, leading to traffic being routed to not-ready endpoints cluster-wide.
+  ([Issue #60422](https://github.com/istio/istio/issues/60422))

--- a/content/en/news/releases/1.28.x/announcing-1.28.9/index.md
+++ b/content/en/news/releases/1.28.x/announcing-1.28.9/index.md
@@ -1,0 +1,35 @@
+---
+title: Announcing Istio 1.28.9
+linktitle: 1.28.9
+subtitle: Patch Release
+description: Istio 1.28.9 patch release.
+publishdate: 2026-06-24
+release: 1.28.9
+aliases:
+    - /news/announcing-1.28.9
+---
+
+This release contains bug fixes to improve robustness. This release note describes what’s different between Istio 1.28.8 and 1.28.9.
+
+{{< relnote >}}
+
+## Security update
+
+For more information, see [ISTIO-SECURITY-2026-005](/news/security/istio-security-2026-005).
+
+### Envoy CVEs
+
+- __[GHSA-p7c7-7c47-pwch](https://github.com/envoyproxy/envoy/security/advisories/GHSA-p7c7-7c47-pwch)__: (CVSS score 7.5): Fixed a denial-of-service vulnerability in the HTTP/3 stack via QPACK blocked decoding. When a QPACK header block was blocked waiting for dynamic table updates, the HEADERS payload bytes were released from QUIC receive-flow-control accounting while still retained in an internal decoder heap buffer, allowing a remote attacker to drive unbounded memory growth and trigger an out-of-memory condition.
+- __[CVE-2026-47692](https://nvd.nist.gov/vuln/detail/CVE-2026-47692)__: (CVSS score 4.8): Fixed a bug where passthrough TLVs combined with added TLVs could exceed the maximum length, resulting in a mismatch between the size reported in the header and the number of bytes written. This could allow a smuggled request from the host writing the PROXY protocol header to the upstream host.
+- __[CVE-2026-47207](https://nvd.nist.gov/vuln/detail/CVE-2026-47207)__: (CVSS score 6.5): Fixed a bug where the `ext_proc` server sends unexpected `ProcessingResponses` to Envoy.
+- __[CVE-2026-47205](https://nvd.nist.gov/vuln/detail/CVE-2026-47205)__: (CVSS score 5.9): Fixed a use-after-free crash in the ext_authz filter when per-route service overrides are active and the downstream connection resets during an in-flight authorization check.
+- __[CVE-2026-47221](https://nvd.nist.gov/vuln/detail/CVE-2026-47221)__: (CVSS score 5.9): Fixed an issue when handling HTTP 303 internal redirects for body-less requests. The redirect handling code attempted to drain a request body buffer that was never allocated, causing a segmentation fault.
+- __[CVE-2026-48044](https://nvd.nist.gov/vuln/detail/CVE-2026-48044)__: (CVSS score 7.5): Fixed a memory exhaustion vulnerability in the Zstd decompressor where the `MaxInflateRatio` limit was only checked after each input slice was fully processed, allowing a maliciously crafted compressed payload to expand to hundreds of MB within a single `process()` call. The inflate ratio limit is now enforced inside the inner decompression loop, matching the gzip and brotli decompressors and aborting decompression as soon as the threshold is breached.
+- __[CVE-2026-48090](https://nvd.nist.gov/vuln/detail/CVE-2026-48090)__: (CVSS score 5.9): Fixed a bug where the asynchronous token change callback could be triggered after the filter had been torn down (`onDestroy()` had been called), which could lead to accessing dangling pointers and result in UAF/crash.
+- __[CVE-2026-47778](https://nvd.nist.gov/vuln/detail/CVE-2026-47778)__: (CVSS score 4.4): Fixed an issue where Envoy could fail to validate the Subject Alternative Name (SAN) of a peer certificate if the SAN contained an embedded NUL byte. Previously, the SAN parsing was vulnerable to NUL byte truncation in some configurations, potentially leading to incorrect trust decisions.
+- __[CVE-2026-47204](https://nvd.nist.gov/vuln/detail/CVE-2026-47204)__: (CVSS score 6.5): Fixed a crash or use-after-free when gRPC stats filter performs stat tracking on a direct response route.
+- __[CVE-2026-48497](https://nvd.nist.gov/vuln/detail/CVE-2026-48497)__: (CVSS score 5.9): Fixed sanity checking of the query name length to avoid abnormal process termination. Use `ENVOY_BUG` in case the sanity check fails.
+- __[CVE-2026-48706](https://nvd.nist.gov/vuln/detail/CVE-2026-48706)__: (CVSS score 5.9): Fixed a `TcpStatsdSink` buffer overflow issue with a large stats name.
+- __[CVE-2026-48743](https://nvd.nist.gov/vuln/detail/CVE-2026-48743)__: (CVSS score 7.5): Fixed HTTP/3 headers-only request and response content-length validation and reset stream if inconsistent. The change is guarded by runtime guard `envoy.reloadable_features.quic_validate_headers_only_content_length`.
+- __[CVE-2026-47775](https://nvd.nist.gov/vuln/detail/CVE-2026-47775)__: (CVSS score 6.8): Addressed a padding oracle in the OAuth2 filter's AES-256-CBC cookie decryption. The filter now supports AES-256-GCM encryption with a `gcm.` algorithm marker, which authenticates the ciphertext and removes the oracle.
+- __[CVE-2026-48042](https://nvd.nist.gov/vuln/detail/CVE-2026-48042)__: (CVSS score 7.5): Limited JSON nesting depth to 1000. The limit could be relaxed to 10K by setting the `envoy.reloadable_features.limit_json_parser_nesting_depth` to `false`.

--- a/content/en/news/security/istio-security-2026-005/index.md
+++ b/content/en/news/security/istio-security-2026-005/index.md
@@ -1,0 +1,34 @@
+---
+title: ISTIO-SECURITY-2026-005
+subtitle: Security Bulletin
+description: CVEs reported by Envoy and Istio security fixes.
+cves: [CVE-2026-47692, CVE-2026-47207, CVE-2026-47205, CVE-2026-47220, CVE-2026-47221, CVE-2026-48044, CVE-2026-48090, CVE-2026-47778, CVE-2026-47204, CVE-2026-48497, CVE-2026-48706, CVE-2026-48743, CVE-2026-47775, CVE-2026-48042]
+cvss: "7.5"
+vector: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:L/A:N"
+releases: ["1.30.1 to 1.30.2", "1.29.4 to 1.29.5", "1.28.8 to 1.28.9"]
+publishdate: 2026-06-24
+keywords: [CVE]
+skip_seealso: true
+---
+
+{{< security_bulletin >}}
+
+## CVE
+
+### Envoy CVEs
+
+- __[GHSA-p7c7-7c47-pwch](https://github.com/envoyproxy/envoy/security/advisories/GHSA-p7c7-7c47-pwch)__: (CVSS score 7.5): Fixed a denial-of-service vulnerability in the HTTP/3 stack via QPACK blocked decoding. When a QPACK header block was blocked waiting for dynamic table updates, the HEADERS payload bytes were released from QUIC receive-flow-control accounting while still retained in an internal decoder heap buffer, allowing a remote attacker to drive unbounded memory growth and trigger an out-of-memory condition.
+- __[CVE-2026-47692](https://nvd.nist.gov/vuln/detail/CVE-2026-47692)__: (CVSS score 4.8): Fixed a bug where passthrough TLVs combined with added TLVs could exceed the maximum length, resulting in a mismatch between the size reported in the header and the number of bytes written. This could allow a smuggled request from the host writing the PROXY protocol header to the upstream host.
+- __[CVE-2026-47207](https://nvd.nist.gov/vuln/detail/CVE-2026-47207)__: (CVSS score 6.5): Fixed a bug where the `ext_proc` server sends unexpected `ProcessingResponses` to Envoy.
+- __[CVE-2026-47205](https://nvd.nist.gov/vuln/detail/CVE-2026-47205)__: (CVSS score 5.9): Fixed a use-after-free crash in the ext_authz filter when per-route service overrides are active and the downstream connection resets during an in-flight authorization check.
+- __[CVE-2026-47220](https://nvd.nist.gov/vuln/detail/CVE-2026-47220)__: (CVSS score 7.5): Fixed a crash bug in the `%REQUESTED_SERVER_NAME%` formatter where the host or original host is not set correctly but the formatter is configured to access the host value.
+- __[CVE-2026-47221](https://nvd.nist.gov/vuln/detail/CVE-2026-47221)__: (CVSS score 5.9): Fixed an issue when handling HTTP 303 internal redirects for body-less requests. The redirect handling code attempted to drain a request body buffer that was never allocated, causing a segmentation fault.
+- __[CVE-2026-48044](https://nvd.nist.gov/vuln/detail/CVE-2026-48044)__: (CVSS score 7.5): Fixed a memory exhaustion vulnerability in the Zstd decompressor where the `MaxInflateRatio` limit was only checked after each input slice was fully processed, allowing a maliciously crafted compressed payload to expand to hundreds of MB within a single `process()` call. The inflate ratio limit is now enforced inside the inner decompression loop, matching the gzip and brotli decompressors and aborting decompression as soon as the threshold is breached.
+- __[CVE-2026-48090](https://nvd.nist.gov/vuln/detail/CVE-2026-48090)__: (CVSS score 5.9): Fixed a bug where the asynchronous token change callback could be triggered after the filter had been torn down (`onDestroy()` had been called), which could lead to accessing dangling pointers and result in UAF/crash.
+- __[CVE-2026-47778](https://nvd.nist.gov/vuln/detail/CVE-2026-47778)__: (CVSS score 4.4): Fixed an issue where Envoy could fail to validate the Subject Alternative Name (SAN) of a peer certificate if the SAN contained an embedded NUL byte. Previously, the SAN parsing was vulnerable to NUL byte truncation in some configurations, potentially leading to incorrect trust decisions.
+- __[CVE-2026-47204](https://nvd.nist.gov/vuln/detail/CVE-2026-47204)__: (CVSS score 6.5): Fixed a crash or use-after-free when gRPC stats filter performs stat tracking on a direct response route.
+- __[CVE-2026-48497](https://nvd.nist.gov/vuln/detail/CVE-2026-48497)__: (CVSS score 5.9): Fixed sanity checking of the query name length to avoid abnormal process termination. Use `ENVOY_BUG` in case the sanity check fails.
+- __[CVE-2026-48706](https://nvd.nist.gov/vuln/detail/CVE-2026-48706)__: (CVSS score 5.9): Fixed a `TcpStatsdSink` buffer overflow issue with a large stats name.
+- __[CVE-2026-48743](https://nvd.nist.gov/vuln/detail/CVE-2026-48743)__: (CVSS score 7.5): Fixed HTTP/3 headers-only request and response content-length validation and reset stream if inconsistent. The change is guarded by runtime guard `envoy.reloadable_features.quic_validate_headers_only_content_length`.
+- __[CVE-2026-47775](https://nvd.nist.gov/vuln/detail/CVE-2026-47775)__: (CVSS score 6.8): Addressed a padding oracle in the OAuth2 filter's AES-256-CBC cookie decryption. The filter now supports AES-256-GCM encryption with a `gcm.` algorithm marker, which authenticates the ciphertext and removes the oracle.
+- __[CVE-2026-48042](https://nvd.nist.gov/vuln/detail/CVE-2026-48042)__: (CVSS score 7.5): Limited JSON nesting depth to 1000. The limit could be relaxed to 10K by setting the `envoy.reloadable_features.limit_json_parser_nesting_depth` to `false`.


### PR DESCRIPTION

## Description

Manually cherrypick the missing release notes for versions 1.28.8 and 1.28.9 with security update

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
