### PR TITLE
added sections on requiring traffic to traverse a waypoint

### DIFF
--- a/content/en/docs/ambient/usage/l7-features/index.md
+++ b/content/en/docs/ambient/usage/l7-features/index.md
@@ -52,7 +52,7 @@ In ambient mode, authorization policies can either be *targeted* (for ztunnel en
 
 The ztunnel cannot enforce L7 policies. If a policy with rules matching L7 attributes is targeted with a workload selector (rather than attached with a `targetRef`), such that it is enforced by a ztunnel, it will fail safe by becoming a `DENY` policy.
 
-A policy attached to a waypoint is only enforced for traffic that actually reaches the waypoint. If a service or namespace is labeled with `istio.io/use-waypoint` but the waypoint does not exist or is not ready, ztunnel sends traffic straight to the destination and the waypoint's Layer 7 policies are not applied. To require that traffic traverses the waypoint, pair the waypoint policy with an `AuthorizationPolicy` enforced by ztunnel that admits only the waypoint's identity. See [Require traffic to traverse the waypoint](/docs/ambient/usage/waypoint/#require-waypoint).
+A policy attached to a waypoint is only enforced for traffic that actually reaches the waypoint. Traffic can bypass the waypoint, and its Layer 7 policies, when the waypoint does not exist or is not ready, or when a client addresses a workload directly rather than the service that a default (service-scoped) waypoint fronts. To require that traffic traverses the waypoint, pair the waypoint policy with an `AuthorizationPolicy` enforced by ztunnel that admits only the waypoint's identity. See [Require traffic to traverse the waypoint](/docs/ambient/usage/waypoint/#require-waypoint).
 
 See [the L4 policy guide](/docs/ambient/usage/l4-policy/) for more information, including when to attach policies to waypoints for TCP-only use cases.
 

--- a/content/en/docs/ambient/usage/l7-features/index.md
+++ b/content/en/docs/ambient/usage/l7-features/index.md
@@ -52,6 +52,8 @@ In ambient mode, authorization policies can either be *targeted* (for ztunnel en
 
 The ztunnel cannot enforce L7 policies. If a policy with rules matching L7 attributes is targeted with a workload selector (rather than attached with a `targetRef`), such that it is enforced by a ztunnel, it will fail safe by becoming a `DENY` policy.
 
+A policy attached to a waypoint is only enforced for traffic that actually reaches the waypoint. If a service or namespace is labeled with `istio.io/use-waypoint` but the waypoint does not exist or is not ready, ztunnel sends traffic straight to the destination and the waypoint's Layer 7 policies are not applied. To require that traffic traverses the waypoint, pair the waypoint policy with an `AuthorizationPolicy` enforced by ztunnel that admits only the waypoint's identity. See [Require traffic to traverse the waypoint](/docs/ambient/usage/waypoint/#require-waypoint).
+
 See [the L4 policy guide](/docs/ambient/usage/l4-policy/) for more information, including when to attach policies to waypoints for TCP-only use cases.
 
 ## Observability

--- a/content/en/docs/ambient/usage/l7-features/index.md
+++ b/content/en/docs/ambient/usage/l7-features/index.md
@@ -52,7 +52,7 @@ In ambient mode, authorization policies can either be *targeted* (for ztunnel en
 
 The ztunnel cannot enforce L7 policies. If a policy with rules matching L7 attributes is targeted with a workload selector (rather than attached with a `targetRef`), such that it is enforced by a ztunnel, it will fail safe by becoming a `DENY` policy.
 
-A policy attached to a waypoint is only enforced for traffic that actually reaches the waypoint. Traffic can bypass the waypoint, and its Layer 7 policies, when the waypoint does not exist or is not ready, or when a client addresses a workload directly rather than the service that a default (service-scoped) waypoint fronts. To require that traffic traverses the waypoint, pair the waypoint policy with an `AuthorizationPolicy` enforced by ztunnel that admits only the waypoint's identity. See [Require traffic to traverse the waypoint](/docs/ambient/usage/waypoint/#require-waypoint).
+A policy attached to a waypoint is only enforced for traffic that actually reaches the waypoint. Traffic can bypass the waypoint, and its Layer 7 policies, when the waypoint does not exist or has no address, or when the traffic type does not match the traffic the waypoint handles (see [Waypoint traffic types](/docs/ambient/usage/waypoint/#waypoint-traffic-types)). To require that traffic traverses the waypoint, pair the waypoint policy with an `AuthorizationPolicy` enforced by ztunnel that allows only the waypoint's identity. See [Require traffic to traverse the waypoint](/docs/ambient/usage/waypoint/#require-waypoint).
 
 See [the L4 policy guide](/docs/ambient/usage/l4-policy/) for more information, including when to attach policies to waypoints for TCP-only use cases.
 

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -213,6 +213,32 @@ The original destination type of the traffic is used to determine if a service o
 For instance, traffic which is addressed to a service, even though ultimately resolved to a pod IP, is always treated by the ambient mesh as to-service and would use a service-attached waypoint.
 {{< /tip >}}
 
+### Require traffic to traverse the waypoint {#require-waypoint}
+
+The `istio.io/use-waypoint` label records your intent to send traffic through a waypoint, but on its own it does not guarantee that this happens. If the named waypoint does not exist or is not ready, ztunnel routes traffic directly to the destination rather than failing the request. Any Layer 7 policy that the waypoint would have enforced never takes effect, and traffic flows as though no waypoint were configured.
+
+If enforcing a waypoint's Layer 7 policies is a security requirement, make the waypoint mandatory with an `AuthorizationPolicy` that admits only the waypoint's identity. A waypoint uses the service account named after its `Gateway`, so a policy on the destination workloads that allows only that identity denies any client that reaches them without first passing through the waypoint. Continuing with the `reviews-svc-waypoint` waypoint from above:
+
+{{< text syntax=yaml >}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: require-waypoint
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: reviews
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        principals:
+        - cluster.local/ns/default/sa/reviews-svc-waypoint
+{{< /text >}}
+
+This policy uses a workload `selector` rather than a `targetRef`, so it is enforced at Layer 4 by ztunnel and takes effect even when the waypoint itself is unavailable.
+
 ### Shift traffic between waypoints {#waypoint-canary}
 
 {{< warning >}}

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -217,7 +217,7 @@ For instance, traffic which is addressed to a service, even though ultimately re
 
 The `istio.io/use-waypoint` label records your intent to send traffic through a waypoint, but on its own it does not guarantee that this happens. If the named waypoint does not exist or is not ready, ztunnel routes traffic directly to the destination rather than failing the request. Any Layer 7 policy that the waypoint would have enforced never takes effect, and traffic flows as though no waypoint were configured.
 
-If enforcing a waypoint's Layer 7 policies is a security requirement, make the waypoint mandatory with an `AuthorizationPolicy` that admits only the waypoint's identity. A waypoint uses the service account named after its `Gateway`, so a policy on the destination workloads that allows only that identity denies any client that reaches them without first passing through the waypoint. Continuing with the `reviews-svc-waypoint` waypoint from above:
+If enforcing a waypoint's Layer 7 policies is a security requirement, make the waypoint mandatory with an `AuthorizationPolicy` that allows only the waypoint's identity. A waypoint uses the service account named after its `Gateway`, so a policy on the destination workloads that allows only that identity denies any client that reaches them without first passing through the waypoint. Continuing with the `reviews-svc-waypoint` waypoint from above:
 
 {{< text syntax=yaml >}}
 apiVersion: security.istio.io/v1

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -217,8 +217,8 @@ For instance, traffic which is addressed to a service, even though ultimately re
 
 The `istio.io/use-waypoint` label records your intent to send traffic through a waypoint, but on its own it does not guarantee that this happens. ztunnel routes traffic directly to the destination, rather than failing the request, when:
 
-* the named waypoint does not exist or is not ready; or
-* the traffic is addressed to a workload (a pod or VM IP) rather than to a service, and the waypoint only handles service traffic, which is the [default](#waypoint-traffic-types).
+* the named waypoint does not exist or has no address; or
+* the traffic type does not match the traffic the waypoint handles; for example, a request sent directly to a workload (a pod or VM IP) when the waypoint only handles service traffic, which is the [default](#waypoint-traffic-types).
 
 In either case, any Layer 7 policy that the waypoint would have enforced never takes effect, and traffic flows as though no waypoint were configured.
 

--- a/content/en/docs/ambient/usage/waypoint/index.md
+++ b/content/en/docs/ambient/usage/waypoint/index.md
@@ -215,7 +215,12 @@ For instance, traffic which is addressed to a service, even though ultimately re
 
 ### Require traffic to traverse the waypoint {#require-waypoint}
 
-The `istio.io/use-waypoint` label records your intent to send traffic through a waypoint, but on its own it does not guarantee that this happens. If the named waypoint does not exist or is not ready, ztunnel routes traffic directly to the destination rather than failing the request. Any Layer 7 policy that the waypoint would have enforced never takes effect, and traffic flows as though no waypoint were configured.
+The `istio.io/use-waypoint` label records your intent to send traffic through a waypoint, but on its own it does not guarantee that this happens. ztunnel routes traffic directly to the destination, rather than failing the request, when:
+
+* the named waypoint does not exist or is not ready; or
+* the traffic is addressed to a workload (a pod or VM IP) rather than to a service, and the waypoint only handles service traffic, which is the [default](#waypoint-traffic-types).
+
+In either case, any Layer 7 policy that the waypoint would have enforced never takes effect, and traffic flows as though no waypoint were configured.
 
 If enforcing a waypoint's Layer 7 policies is a security requirement, make the waypoint mandatory with an `AuthorizationPolicy` that allows only the waypoint's identity. A waypoint uses the service account named after its `Gateway`, so a policy on the destination workloads that allows only that identity denies any client that reaches them without first passing through the waypoint. Continuing with the `reviews-svc-waypoint` waypoint from above:
 
@@ -237,7 +242,7 @@ spec:
         - cluster.local/ns/default/sa/reviews-svc-waypoint
 {{< /text >}}
 
-This policy uses a workload `selector` rather than a `targetRef`, so it is enforced at Layer 4 by ztunnel and takes effect even when the waypoint itself is unavailable.
+This policy uses a workload `selector` rather than a `targetRef`, so it is enforced at Layer 4 by ztunnel. It therefore takes effect in both bypass cases: when the waypoint is unavailable, and when a client dials the workload directly.
 
 ### Shift traffic between waypoints {#waypoint-canary}
 

--- a/content/en/docs/ambient/usage/waypoint/snips.sh
+++ b/content/en/docs/ambient/usage/waypoint/snips.sh
@@ -135,6 +135,24 @@ kubectl label pod -l version=v2,app=reviews istio.io/use-waypoint=reviews-v2-pod
 pod/reviews-v2-5b667bcbf8-spnnh labeled
 ENDSNIP
 
+! IFS=$'\n' read -r -d '' snip_require_traffic_to_traverse_the_waypoint_1 <<\ENDSNIP
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: require-waypoint
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: reviews
+  action: ALLOW
+  rules:
+  - from:
+    - source:
+        principals:
+        - cluster.local/ns/default/sa/reviews-svc-waypoint
+ENDSNIP
+
 snip_shift_traffic_between_waypoints_1() {
 istioctl waypoint apply -n default --name reviews-svc-waypoint-v2
 }


### PR DESCRIPTION
## Description

Added sections on requiring traffic to traverse a Waypoint using AuthorizationPolicies. This was discussed during the July 29th WG call.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [x] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
