### PR TITLE
fix: replace dead feedback links

### DIFF
--- a/content/en/boilerplates/work-in-progress.md
+++ b/content/en/boilerplates/work-in-progress.md
@@ -1,5 +1,5 @@
 ---
 ---
 {{< warning >}}
-This is work in progress. We will add its sections in pieces. Your feedback is welcome at [discuss.istio.io](https://discuss.istio.io).
+This is work in progress. We will add its sections in pieces. Your feedback is welcome at [GitHub Discussions](https://github.com/istio/istio/discussions).
 {{< /warning >}}

--- a/content/es/boilerplates/work-in-progress.md
+++ b/content/es/boilerplates/work-in-progress.md
@@ -1,5 +1,5 @@
 ---
 ---
 {{< warning >}}
-Esto es un trabajo en progreso. Agregaremos sus secciones en partes. Tus comentarios son bienvenidos en [discuss.istio.io](https://discuss.istio.io).
+Esto es un trabajo en progreso. Agregaremos sus secciones en partes. Tus comentarios son bienvenidos en [GitHub Discussions](https://github.com/istio/istio/discussions).
 {{< /warning >}}

--- a/content/uk/boilerplates/work-in-progress.md
+++ b/content/uk/boilerplates/work-in-progress.md
@@ -1,5 +1,5 @@
 ---
 ---
 {{< warning >}}
-Це ще не завершена робота. Ми будемо додавати розділи частинами. Ми будемо раді вашим відгукам на [discuss.istio.io](https://discuss.istio.io).
+Це ще не завершена робота. Ми будемо додавати розділи частинами. Ми будемо раді вашим відгукам на [GitHub Discussions](https://github.com/istio/istio/discussions).
 {{< /warning >}}

--- a/content/zh/boilerplates/work-in-progress.md
+++ b/content/zh/boilerplates/work-in-progress.md
@@ -1,5 +1,5 @@
 ---
 ---
 {{< warning >}}
-这项工作正在进行中，我们将逐段添加其内容。欢迎您在 [discuss.istio.io](https://discuss.istio.io) 网站上提供反馈。
+这项工作正在进行中，我们将逐段添加其内容。欢迎您在 [GitHub Discussions](https://github.com/istio/istio/discussions) 网站上提供反馈。
 {{< /warning >}}


### PR DESCRIPTION
## Description

Fixes #16696

Yep the old feedback domain no longer resolves. This updates the shared WIP boilerplates to GitHub Discussions, tiny fix.

Repro: `curl -L https://discuss.istio.io/` fails DNS lookup.

## Reviewers

- [x] Docs
- [x] Localization/Translation