### PR TITLE
Manually cherrypick the missing release notes for versions 1.30.1 and 1.30.2

### DIFF
--- a/content/en/news/releases/1.30.x/announcing-1.30.1/index.md
+++ b/content/en/news/releases/1.30.x/announcing-1.30.1/index.md
@@ -1,0 +1,88 @@
+---
+title: Announcing Istio 1.30.1
+linktitle: 1.30.1
+subtitle: Patch Release
+description: Istio 1.30.1 patch release.
+publishdate: 2026-06-04
+release: 1.30.1
+aliases:
+    - /news/announcing-1.30.1
+---
+
+This release contains bug fixes to improve robustness. This release note describes what’s different between Istio 1.30.0 and 1.30.1.
+
+{{< relnote >}}
+
+## Security Update
+
+- [CVE-2026-47774](https://github.com/envoyproxy/envoy/security/advisories/GHSA-22m2-hvr2-xqc8) (CVSS score 7.5, High): An unauthenticated remote attacker can cause denial of service by exhausting memory in the Envoy process. Cookie header bytes are not fully accounted for during request header size validation, and HPACK header block limits are enforced on encoded bytes without a corresponding limit on total decoded header size, allowing attackers to trigger excessive memory consumption through specially crafted HTTP/2 requests.
+
+## Changes
+
+- **Updated** Kiali addon to version `v2.26.0`.
+
+- **Added** support for excluding policy configuration from Istio when the
+  `istio.io/ignore-policy-attachment` annotation is set to `"true"` on a
+  `BackendTLSPolicy` or `XBackendTrafficPolicy` object. This allows users to
+  prevent specific policies from being translated into Istio configuration
+  when the policy is intended for a different gateway controller than Istio.
+  ([Issue #60122](https://github.com/istio/istio/issues/60122))
+
+- **Added** an initialization check that verifies the bundled `nft` binary
+  supports JSON output. The native nftables backend requires JSON to read
+  configuration during pod removal. On hosts whose `nft` binary doesn't
+  support JSON, those calls fail with `Error: JSON support not compiled-in` on
+  every removal, and the CNI agent retries indefinitely. The new check detects
+  this error at startup and falls back to the iptables backend.
+  ([Issue #60328](https://github.com/istio/istio/issues/60328))
+
+- **Added** `istioctl analyze` check `IST0176` that flags Gateway API CRDs installed at a
+  version below the minimum required by the current Istio version. Resources backed by such
+  CRDs are silently filtered by istiod, which previously made it hard to discover TLS
+  passthrough breakage after upgrading to Istio 1.30 with stale Gateway API CRDs.
+
+- **Fixed** `BackendTLSPolicy` conflict resolution on Gateway API.
+  ([Issue #57817](https://github.com/istio/istio/issues/57817))
+
+- **Fixed** an issue where HTTPS listeners defined via `ListenerSet` failed to deliver TLS certificates when the parent `Gateway` used manual deployment.
+  ([Issue #59535](https://github.com/istio/istio/issues/59535))
+
+- **Fixed** an issue where `HTTPRoute` and `GRPCRoute` filters with invalid header values were silently dropped from the Envoy config instead of reporting an invalid filter status.
+  ([Issue #59933](https://github.com/istio/istio/issues/59933))
+
+- **Fixed** an issue where multi-network ambient did not route to the waypoint
+  when the ingress on one network called a service on a different network, even
+  when the `Service` was configured with `istio.io/ingress-use-waypoint`.
+
+- **Fixed** an issue where `consistentHash` load balancing in `DestinationRule` would not send traffic
+  to new endpoints after scaling, due to an Envoy regression (`envoyproxy/envoy#45212`) where the
+  `RING_HASH` ring was not rebuilt on endpoint changes during batched updates.
+  ([Issue #60312](https://github.com/istio/istio/issues/60312))
+
+- **Fixed** a fatal `concurrent map writes` panic in the istio-cni agent when
+  two pods were added to the ambient mesh on the same node at the same time.
+  ([Issue #60328](https://github.com/istio/istio/issues/60328))
+
+- **Fixed** an ambient mode bug where a single `Service` combining `publishNotReadyAddresses: true` with a `PreferSameZone` or `PreferSameNode` traffic distribution caused ztunnel to receive `healthPolicy: AllowAll` for every other `Service` using the same traffic-distribution preset, leading to traffic being routed to not-ready endpoints cluster-wide.
+  ([Issue #60422](https://github.com/istio/istio/issues/60422))
+
+- **Fixed** an issue where pilot generated configuration for the agentgateway ignored
+  `ListenerSet` resources and routes attached to them. Pilot now correctly includes
+  `ListenerSet` resources in agentgateway configuration, enabling agentgateway in Istio
+  to handle `ListenerSet` resources properly.
+
+- **Fixed** `ListenerSet` status reporting when `ListenerSet` is not allowed by the parent
+  `Gateway` resource for agentgateway. When `ListenerSet` is not allowed by the parent `Gateway`,
+  the `Accepted` condition status is now correctly reported as `False`. Additionally, given
+  that the `ListenerSet` feature is not experimental as of Gateway API `v1.5.0`, it is no
+  longer guarded by the `PILOT_ENABLE_ALPHA_GATEWAY_API` feature flag.
+
+- **Fixed** the external SDS provider for gateways to use the credential name (after stripping the `sds://`
+  prefix) as the SDS resource name instead of the provider name. This allows multiple gateways using the
+  same SDS provider to request different certificates. For mutual TLS, the CA certificate resource name
+  is correctly derived as `<credential-name>-cacert`. When neither a UDS socket nor an SDS extension
+  provider is configured, the gateway now falls back to fetching certificates via ADS (Kubernetes `Secrets`)
+  instead of failing silently.
+  ([Issue #57080](https://github.com/istio/istio/issues/57080))
+
+- **Fixed** a deadlock in the multicluster `ClusterStore` where `AllReady` could recursively acquire the store `RWMutex` for read via `triggerRecomputeOnSync` -> `GetByID` while a writer was waiting, blocking further reads and writes against the store.

--- a/content/en/news/releases/1.30.x/announcing-1.30.2/index.md
+++ b/content/en/news/releases/1.30.x/announcing-1.30.2/index.md
@@ -1,0 +1,75 @@
+---
+title: Announcing Istio 1.30.2
+linktitle: 1.30.2
+subtitle: Patch Release
+description: Istio 1.30.2 patch release.
+publishdate: 2026-06-24
+release: 1.30.2
+aliases:
+    - /news/announcing-1.30.2
+---
+
+This release contains bug fixes to improve robustness. This release note describes what’s different between Istio 1.30.1 and 1.30.2.
+
+{{< relnote >}}
+
+## Changes
+
+- **Improved** logging when a Gateway API CRD installed in the cluster is below the minimum version
+  required by this Istio version. The message is now logged at `warn` level and explains that
+  resources of that kind will not be processed until the CRDs are upgraded. Previously, this was
+  logged at `info` level and easy to miss, which made TLS passthrough breakage after upgrading to
+  1.30 with stale CRDs hard to diagnose.
+
+- **Added** `trustDomains` and `notTrustDomains` fields to the `Source` in `AuthorizationPolicy`,
+  allowing users to match or exclude requests based on the trust domain derived from the peer certificate.
+
+- **Added** a new environment variable `PILOT_AGENT_MERGE_ENVOY_STATS` to control whether pilot-agent merges Envoy stats
+  into its stats endpoint. Set to `false` to disable merging Envoy stats with agent stats.
+
+- **Fixed** a brief traffic outage when changing the `istio.io/rev` label on a Kubernetes
+  `Gateway` (or `ListenerSet`). The previously-owning control plane no longer drops the
+  resource and pushes empty xDS config to gateway pods that are still running on the old
+  revision. Status writes for non-owning revisions are still suppressed, so revisions do
+  not flap on each other's status.
+  ([Issue #59959](https://github.com/istio/istio/issues/59959))
+
+- **Fixed** duplicate and excessive pushes when using `WasmPlugin` resources due to `TrafficExtension` conversions.
+
+- **Fixed** an issue where an ambient-enrolled pod could be left out of the host health-probe ipset following a
+  node or kubelet restart, causing kubelet probes to be redirected to ztunnel and rejected until the `istio-cni`
+  node agent restarted. On startup the node agent could evict still-enrolled pods from the ipset when their IP
+  was not yet observable, and it now re-asserts probe ipset membership for enrolled pods during reconciliation.
+
+- **Fixed** config generation for sidecars prior to 1.29.2.
+
+- **Fixed** a memory leak in the `krt` controller framework where changing the key used in a `Fetch` filter
+  (for example, relabeling a pod to point to a different waypoint) left stale reverse-index entries that were
+  never cleaned up. Over time this could grow memory usage and cause unnecessary recomputations.
+
+- **Fixed** an issue where pilot-agent metric merging produced incorrect results when Envoy reported metrics
+  using the protobuf content type. pilot-agent could not handle the protobuf content type correctly, so allowed
+  content types are now restricted to `text/plain` and `application/openmetrics-text` only.
+  ([Issue #60322](https://github.com/istio/istio/issues/60322))
+
+## Security update
+
+For more information, see [ISTIO-SECURITY-2026-005](/news/security/istio-security-2026-005).
+
+### Envoy CVEs
+
+- __[GHSA-p7c7-7c47-pwch](https://github.com/envoyproxy/envoy/security/advisories/GHSA-p7c7-7c47-pwch)__: (CVSS score 7.5): Fixed a denial-of-service vulnerability in the HTTP/3 stack via QPACK blocked decoding. When a QPACK header block was blocked waiting for dynamic table updates, the HEADERS payload bytes were released from QUIC receive-flow-control accounting while still retained in an internal decoder heap buffer, allowing a remote attacker to drive unbounded memory growth and trigger an out-of-memory condition.
+- __[CVE-2026-47692](https://nvd.nist.gov/vuln/detail/CVE-2026-47692)__: (CVSS score 4.8): Fixed a bug where passthrough TLVs combined with added TLVs could exceed the maximum length, resulting in a mismatch between the size reported in the header and the number of bytes written. This could allow a smuggled request from the host writing the PROXY protocol header to the upstream host.
+- __[CVE-2026-47207](https://nvd.nist.gov/vuln/detail/CVE-2026-47207)__: (CVSS score 6.5): Fixed a bug where the `ext_proc` server sends unexpected `ProcessingResponses` to Envoy.
+- __[CVE-2026-47205](https://nvd.nist.gov/vuln/detail/CVE-2026-47205)__: (CVSS score 5.9): Fixed a use-after-free crash in the ext_authz filter when per-route service overrides are active and the downstream connection resets during an in-flight authorization check.
+- __[CVE-2026-47220](https://nvd.nist.gov/vuln/detail/CVE-2026-47220)__: (CVSS score 7.5): Fixed a crash bug in the `%REQUESTED_SERVER_NAME%` formatter where the host or original host is not set correctly but the formatter is configured to access the host value.
+- __[CVE-2026-47221](https://nvd.nist.gov/vuln/detail/CVE-2026-47221)__: (CVSS score 5.9): Fixed an issue when handling HTTP 303 internal redirects for body-less requests. The redirect handling code attempted to drain a request body buffer that was never allocated, causing a segmentation fault.
+- __[CVE-2026-48044](https://nvd.nist.gov/vuln/detail/CVE-2026-48044)__: (CVSS score 7.5): Fixed a memory exhaustion vulnerability in the Zstd decompressor where the `MaxInflateRatio` limit was only checked after each input slice was fully processed, allowing a maliciously crafted compressed payload to expand to hundreds of MB within a single `process()` call. The inflate ratio limit is now enforced inside the inner decompression loop, matching the gzip and brotli decompressors and aborting decompression as soon as the threshold is breached.
+- __[CVE-2026-48090](https://nvd.nist.gov/vuln/detail/CVE-2026-48090)__: (CVSS score 5.9): Fixed a bug where the asynchronous token change callback could be triggered after the filter had been torn down (`onDestroy()` had been called), which could lead to accessing dangling pointers and result in UAF/crash.
+- __[CVE-2026-47778](https://nvd.nist.gov/vuln/detail/CVE-2026-47778)__: (CVSS score 4.4): Fixed an issue where Envoy could fail to validate the Subject Alternative Name (SAN) of a peer certificate if the SAN contained an embedded NUL byte. Previously, the SAN parsing was vulnerable to NUL byte truncation in some configurations, potentially leading to incorrect trust decisions.
+- __[CVE-2026-47204](https://nvd.nist.gov/vuln/detail/CVE-2026-47204)__: (CVSS score 6.5): Fixed a crash or use-after-free when gRPC stats filter performs stat tracking on a direct response route.
+- __[CVE-2026-48497](https://nvd.nist.gov/vuln/detail/CVE-2026-48497)__: (CVSS score 5.9): Fixed sanity checking of the query name length to avoid abnormal process termination. Use `ENVOY_BUG` in case the sanity check fails.
+- __[CVE-2026-48706](https://nvd.nist.gov/vuln/detail/CVE-2026-48706)__: (CVSS score 5.9): Fixed a `TcpStatsdSink` buffer overflow issue with a large stats name.
+- __[CVE-2026-48743](https://nvd.nist.gov/vuln/detail/CVE-2026-48743)__: (CVSS score 7.5): Fixed HTTP/3 headers-only request and response content-length validation and reset stream if inconsistent. The change is guarded by runtime guard `envoy.reloadable_features.quic_validate_headers_only_content_length`.
+- __[CVE-2026-47775](https://nvd.nist.gov/vuln/detail/CVE-2026-47775)__: (CVSS score 6.8): Addressed a padding oracle in the OAuth2 filter's AES-256-CBC cookie decryption. The filter now supports AES-256-GCM encryption with a `gcm.` algorithm marker, which authenticates the ciphertext and removes the oracle.
+- __[CVE-2026-48042](https://nvd.nist.gov/vuln/detail/CVE-2026-48042)__: (CVSS score 7.5): Limited JSON nesting depth to 1000. The limit could be relaxed to 10K by setting the `envoy.reloadable_features.limit_json_parser_nesting_depth` to `false`.


### PR DESCRIPTION
## Description

Manually cherrypick the missing release notes for versions 1.30.1 and 1.30.2

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
