### PR TITLE
fix expected eol dates for 1.29 and 1.30

### DIFF
--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -16,7 +16,7 @@
 - version: "1.30"
   supported: "Yes"
   releaseDate: "May 14, 2026"
-  eolDate: "~Jan 2027 (Expected)"
+  eolDate: "~Dec 2026 (Expected)"
   k8sVersions: ["1.32", "1.33", "1.34", "1.35", "1.36"]
   testedK8sVersions: ["1.27", "1.28", "1.29", "1.30", "1.31"]
 - version: "1.29"

--- a/data/compatibility/supportStatus.yml
+++ b/data/compatibility/supportStatus.yml
@@ -16,13 +16,13 @@
 - version: "1.30"
   supported: "Yes"
   releaseDate: "May 14, 2026"
-  eolDate: "~Nov 2026 (Expected)"
+  eolDate: "~Jan 2027 (Expected)"
   k8sVersions: ["1.32", "1.33", "1.34", "1.35", "1.36"]
   testedK8sVersions: ["1.27", "1.28", "1.29", "1.30", "1.31"]
 - version: "1.29"
   supported: "Yes"
   releaseDate: "Feb 16, 2026"
-  eolDate: "~Aug 2026 (Expected)"
+  eolDate: "~Oct 2026 (Expected)"
   k8sVersions: ["1.31", "1.32", "1.33", "1.34", "1.35"]
   testedK8sVersions: ["1.26", "1.27", "1.28", "1.29", "1.30"]
 - version: "1.28"


### PR DESCRIPTION
1.29 is supported until 6 weeks after 1.31.0 (scheduled Aug 31, 2026), so expected EOL is ~Oct 2026. Same math for 1.30 puts it at ~Jan 2027 assuming 1.32 follows the quarterly cadence.