### PR TITLE
typo in scream tests

### DIFF
--- a/content/en/blog/2026/retirement-of-gcp/index.md
+++ b/content/en/blog/2026/retirement-of-gcp/index.md
@@ -43,7 +43,7 @@ We expect the following signing keys to be used for each release:
 
 ## Scream Tests and What You Need to Do
 
-We will be conducting a series of "scream tests" where we will temporarily disable access to `gcr.io/istio-release`, `registry.istio.io/release`, and `https://blob.istio.io/istio-release/charts`.
+We will be conducting a series of "scream tests" where we will temporarily disable access to `gcr.io/istio-release`, `registry.istio.io/release`, and `https://istio-release.storage.googleapis.com/`.
 The first scream test will be September 15th, 2026 from 3:00 PM to 4:00 PM UTC.
 The second scream test will be October 13th, 2026 from 3:00 PM to 6:00 PM UTC.
 The third scream test will be November 17th, 2026 from 3:00 PM to 9:00 PM UTC.


### PR DESCRIPTION
## Description

Small typo. We are disabling GCS not our R2 endpoint

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [ ] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
