### PR TITLE
fix: avoid duplicate slashes when switching to English

### DIFF
--- a/src/ts/lang.ts
+++ b/src/ts/lang.ts
@@ -58,7 +58,7 @@ function handleLanguageSwitch(): void {
         if (newLang === "en") {
             newLang = "";
             // remove the trailing slash
-            versionString = versionString.substr(0, versionString.length);
+            versionString = versionString.substr(0, versionString.length - 1);
         }
         url.pathname = versionString + newLang + path;
 


### PR DESCRIPTION
## Description

Switching a versioned translated page back to English creates `/latest//docs/...`. 
every extra click adds another slash. 
this is still live through the footer language links. Related to #14087

This removes the trailing slash before building the English URL, tiny fix

Repro is pretty simple:

1. Open `https://preliminary.istio.io/latest/zh/docs/overview/what-is-istio/`
2. Click `English` in the footer
3. The URL becomes `/latest//docs/overview/what-is-istio/`
4. Click again, another slash appears

After this change both clicks keep `/latest/docs/overview/what-is-istio/`

Tested with `make lint-fast` and Playwright on preliminary, current, and archived pages.

## Reviewers

- [ ] Ambient
- [x] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [x] User Experience
- [ ] Developer Infrastructure
- [x] Localization/Translation
