### PR TITLE
fix oci helm charts url

### DIFF
--- a/content/en/news/releases/1.31.x/announcing-1.31/upgrade-notes/index.md
+++ b/content/en/news/releases/1.31.x/announcing-1.31/upgrade-notes/index.md
@@ -16,7 +16,7 @@ From Istio 1.31 forwards, we will no longer publish artifacts to `gcr.io/istio-r
 - Docker images will still be available on Docker Hub.
 - Helm charts will be available on `blob.istio.io/istio-release/charts`.
 - Other artifacts will be available on `blob.istio.io/istio-release`.
-- OCI Helm charts will be available at `ghcr.io/istio/release/charts](http://ghcr.io/istio/release/charts`.
+- OCI Helm charts will be available at `ghcr.io/istio/release/charts`.
 
 We will have scream tests where we will disable all GCP hosted artifacts for brief periods of time.
 


### PR DESCRIPTION
## Description

Fix oci helm charts URL in 1.31 upgrade notes

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
