### PR TITLE
remove spanish and ukranian from supported languages

### DIFF
--- a/data/args.yml
+++ b/data/args.yml
@@ -45,12 +45,8 @@ archive_analytics_id: "G-5XBWY4YJ1E"
 supported_languages:
   - name: "English"
     code: "en"
-  - name: "Español"
-    code: "es"
   - name: "中文"
     code: "zh"
-  - name: "Українська"
-    code: "uk"
 
 # Kubernetes Gateway API
 k8s_gateway_api_version: "v1.6.0"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -80,8 +80,6 @@
                     {{ end }}
                     {{ if eq $home.Lang "zh" }}
                         <a class="footer-policies-link" href="https://github.com/istio/istio.io/edit/{{ .Site.Data.args.doc_branch_name }}/content/zh/{{ $file }}">{{ i18n "edit_on_github" }}</a>
-                    {{ else if eq $home.Lang "es" }}
-                        <a class="footer-policies-link" href="https://github.com/istio/istio.io/edit/{{ .Site.Data.args.doc_branch_name }}/content/es/{{ $file }}">{{ i18n "edit_on_github" }}</a>
                     {{ else }}
                         <a class="footer-policies-link" href="https://github.com/istio/istio.io/edit/{{ .Site.Data.args.doc_branch_name }}/content/en/{{ $file }}">{{ i18n "edit_on_github" }}</a>
                     {{ end }}


### PR DESCRIPTION
## Description

The Spanish and Ukranian documentation has not been updated in 6 and 12 months, respectively, outside of a few minor picks now and then. This leaves us in a bad situation where the documents are missing vital and critical updates.

The Spanish documents, for example, are missing 5 security advisories that have been released since March of 2026 as well as release notes for every release made after 10 March, 2026 (https://istio.io/latest/es/news/). A lot of work has been done to multicluster ambient that is largely or even completely undocumented. This also blocks PRs from going in that fix infra issues waiting on `es` maintainers that are not keeping up.

The Ukrainian documentation are in a worse state, having not been touched since about 11 August, 2025 (13 months ago). *Every* security release since then, all 6 for 2026, are completely missing and every release since 1.27.0 is missing. This does not have a codeowner, so it doesn't block PRs, but offering it up leaves old and bad configurations available and lacks any of the features that have been added in 1.28 through 1.31.

I did not remove the documentation files themselves, this merely just hides their existence as links, so as to move to work toward either decommissioning or revitalizing. If we can get these back in order, we can restore the links. I'd say we should set a deadline, say EOY for both languages, to either catch up and come up with a plan to stay up to date, or we fully decommission these languages.

## Reviewers

<!-- To help us figure out who should review this PR, please 
     put an X in all the areas that this PR affects. -->

- [ ] Ambient
- [X] Docs
- [ ] Installation
- [ ] Networking
- [ ] Performance and Scalability
- [ ] Extensions and Telemetry
- [ ] Security
- [ ] Test and Release
- [ ] User Experience
- [ ] Developer Infrastructure
- [ ] Localization/Translation

<!-- If this is a localization PR, please replace this line with the URL of the original English document. -->
