### PR TITLE
[release-1.31] Point doc tests at registry.istio.io/testing

### DIFF
--- a/content/en/docs/setup/install/virtual-machine/common.sh
+++ b/content/en/docs/setup/install/virtual-machine/common.sh
@@ -69,7 +69,7 @@ function setup_vm() {
     snip_configure_the_virtual_machine_1
     snip_configure_the_virtual_machine_2
     # TODO: we should probably have a better way to get the debian package
-    curl -LO https://storage.googleapis.com/istio-build/dev/${TAG}/deb/istio-sidecar.deb
+    curl -fLO https://blob.istio.io/istio-build/dev/${TAG}/deb/istio-sidecar.deb
     sudo dpkg -i istio-sidecar.deb
     snip_configure_the_virtual_machine_5
     snip_configure_the_virtual_machine_6

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	golang.org/x/sync v0.22.0
-	istio.io/istio v0.0.0-20260827124520-eed52ebb66ad
+	istio.io/istio v0.0.0-20260905085801-1f7f1ae06d63
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
 )

--- a/go.sum
+++ b/go.sum
@@ -430,8 +430,8 @@ istio.io/api v1.31.0-rc.0.0.20260824154656-b943409680a7 h1:xAyXvpHQLGIMd5enneW/4
 istio.io/api v1.31.0-rc.0.0.20260824154656-b943409680a7/go.mod h1:+brQWcBHoROuyA6fv8rbgg8Kfn0RCGuqoY0duCMuSLA=
 istio.io/client-go v1.31.0-rc.0.0.20260824155257-512e1cfc6c15 h1:XULJ/rXO9rJ+wvckIpWzOfh7KhOeV8FhLL/C/I5w5cw=
 istio.io/client-go v1.31.0-rc.0.0.20260824155257-512e1cfc6c15/go.mod h1:38zHhC9caf9LHE2eXJxtweMqh2CrR70sjmf5CQipe/8=
-istio.io/istio v0.0.0-20260827124520-eed52ebb66ad h1:ui9TJjRMAV/hb5ehQaZDq7IUGxuQP6dra9lapT/VjHI=
-istio.io/istio v0.0.0-20260827124520-eed52ebb66ad/go.mod h1:krub19xO5up6m9fUbvLGBgcAlHN4QuhVCGly52A4i4I=
+istio.io/istio v0.0.0-20260905085801-1f7f1ae06d63 h1:FsdQYi0Tj7izRhG+045JW3hhWjRkacleCkA7Gsyl3Xw=
+istio.io/istio v0.0.0-20260905085801-1f7f1ae06d63/go.mod h1:krub19xO5up6m9fUbvLGBgcAlHN4QuhVCGly52A4i4I=
 k8s.io/api v0.36.1 h1:XbL/EMj8K2aJpJtePmqUyQMsM0D4QI2pvl7YKJ20FTY=
 k8s.io/api v0.36.1/go.mod h1:KOWo4ey3TINlXjeHVuwB3i+tXXnu+UcwFBHlI/9dvEo=
 k8s.io/apiextensions-apiserver v0.36.1 h1:6JfYmPUsuUIHuN+3QxutXYWj492RqF5fBSx67GYK5Ks=

--- a/prow/integ-suite-kind.sh
+++ b/prow/integ-suite-kind.sh
@@ -40,7 +40,9 @@ export TEST_ENV=kind
 # KinD will have the images loaded into it; it should not attempt to pull them
 # See https://kind.sigs.k8s.io/docs/user/quick-start/#loading-an-image-into-your-cluster
 export PULL_POLICY=IfNotPresent
-export HUB=${HUB:-"gcr.io/istio-testing"}
+# Do not default HUB here. Makefile.core.mk owns the value (registry.istio.io/testing).
+# A default in this script wins over the Makefile's `?=`, so a stale value here
+# silently sends every doc test to a registry that no longer holds dev images.
 
 # Setup junit report and verbose logging
 export T="${T:-"-v"}"


### PR DESCRIPTION
Same fix as #17594, written against release-1.31 rather than cherry-picked (different
istio@ ref and image tags).

Also bumps istio@ to 1f7f1ae06d63. The pinned eed52ebb66ad only has images on gcr.io,
so flipping HUB without the bump would break the branch. And the VM tests now get the
sidecar deb from blob.istio.io, since the same istio change dropped the GCS upload.

```release-note
NONE
```
